### PR TITLE
Fix recurring artist login failures

### DIFF
--- a/netlify/functions/artist-auth.ts
+++ b/netlify/functions/artist-auth.ts
@@ -10,7 +10,10 @@ function getServiceClient() {
 }
 
 async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
+  if (!authHeader?.startsWith('Bearer ')) {
+    console.log('[artist-auth] Missing or invalid Authorization header');
+    return null;
+  }
   const token = authHeader.slice(7);
 
   const url = process.env.SUPABASE_URL;
@@ -19,7 +22,10 @@ async function authenticateRequest(authHeader: string | undefined): Promise<{ us
 
   const anonClient = createClient(url, anonKey);
   const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
+  if (error || !data.user) {
+    console.log(`[artist-auth] Token validation failed: ${error?.message || 'no user'}`);
+    return null;
+  }
   return { userId: data.user.id, email: data.user.email || '' };
 }
 
@@ -49,6 +55,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
       }
 
       const normalizedEmail = email.toLowerCase().trim();
+      console.log(`[artist-auth] Login check for email: ${normalizedEmail}`);
 
       // Check 1: Direct email match in artist_profiles
       const { data: profiles } = await client
@@ -59,6 +66,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
         .limit(1);
 
       if (profiles && profiles.length > 0) {
+        console.log(`[artist-auth] Found profile by email match: ${profiles[0].id}`);
         return { statusCode: 200, headers, body: JSON.stringify({ hasAccount: true }) };
       }
 
@@ -69,12 +77,11 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
       const serviceKey = process.env.SUPABASE_SERVICE_KEY;
       if (url && serviceKey) {
         const adminClient = createClient(url, serviceKey);
-        const { data: userList } = await adminClient.auth.admin.listUsers();
-        const matchingUser = userList?.users?.find(
-          u => u.email?.toLowerCase() === normalizedEmail
-        );
+        const { data: userData } = await adminClient.auth.admin.getUserByEmail(normalizedEmail);
+        const matchingUser = userData?.user ?? null;
 
         if (matchingUser) {
+          console.log(`[artist-auth] Found auth user by email, checking profiles by user_id: ${matchingUser.id}`);
           const { data: profilesByUser } = await client
             .from('artist_profiles')
             .select('id, email')
@@ -93,9 +100,12 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
             }
             return { statusCode: 200, headers, body: JSON.stringify({ hasAccount: true }) };
           }
+        } else {
+          console.log(`[artist-auth] No auth user found for email: ${normalizedEmail}`);
         }
       }
 
+      console.log(`[artist-auth] No verified profiles found for: ${normalizedEmail}`);
       return { statusCode: 200, headers, body: JSON.stringify({ hasAccount: false }) };
     } catch {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid request' }) };

--- a/src/pages/ArtistDashboardPage.tsx
+++ b/src/pages/ArtistDashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSession, getSupabaseClient } from '../services/auth';
+import { getSession, waitForMagicLinkSession } from '../services/auth';
 import { ArtistAuthBar } from '../components/ArtistAuthBar';
 import { Footer } from '../components/Footer';
 
@@ -23,18 +23,22 @@ export function ArtistDashboardPage() {
 
   useEffect(() => {
     async function loadDashboard() {
-      const supabase = getSupabaseClient();
-      if (!supabase) {
-        navigate('/artist-login', { replace: true });
-        return;
-      }
+      let session;
 
       // Handle magic link callback hash
       if (window.location.hash.includes('access_token')) {
-        await supabase.auth.getSession();
+        const { session: magicSession, error: authError } = await waitForMagicLinkSession();
+        if (authError || !magicSession) {
+          // Redirect to login with the error visible there
+          navigate('/artist-login', { replace: true });
+          return;
+        }
+        window.history.replaceState(null, '', window.location.pathname);
+        session = magicSession;
+      } else {
+        session = await getSession();
       }
 
-      const session = await getSession();
       if (!session) {
         navigate('/artist-login', { replace: true });
         return;

--- a/src/pages/ArtistLoginPage.tsx
+++ b/src/pages/ArtistLoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { signInWithMagicLink, getSession, getSupabaseClient } from '../services/auth';
+import { signInWithMagicLink, getSession, waitForMagicLinkSession } from '../services/auth';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { ArtistAuthBar } from '../components/ArtistAuthBar';
 import { Footer } from '../components/Footer';
@@ -18,19 +18,22 @@ export function ArtistLoginPage() {
   // If already authenticated, redirect to dashboard
   useEffect(() => {
     async function checkAuth() {
-      const supabase = getSupabaseClient();
-      if (!supabase) {
-        setCheckingSession(false);
-        return;
-      }
-
       // Handle magic link callback hash
       if (window.location.hash.includes('access_token')) {
-        const { data, error } = await supabase.auth.getSession();
-        if (!error && data.session) {
+        const { session, error: authError } = await waitForMagicLinkSession();
+        if (session) {
+          // Clear the hash to avoid re-processing on refresh
+          window.history.replaceState(null, '', window.location.pathname);
           navigate('/artist-dashboard', { replace: true });
           return;
         }
+        if (authError) {
+          setError(authError);
+          // Clear the hash so the user doesn't keep hitting the expired token
+          window.history.replaceState(null, '', window.location.pathname);
+        }
+        setCheckingSession(false);
+        return;
       }
 
       const session = await getSession();

--- a/src/pages/ClaimPage.tsx
+++ b/src/pages/ClaimPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { signInWithMagicLink, getSession, getSupabaseClient } from '../services/auth';
+import { signInWithMagicLink, getSession, waitForMagicLinkSession } from '../services/auth';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { ArtistAuthBar } from '../components/ArtistAuthBar';
 import { Footer } from '../components/Footer';
@@ -60,20 +60,21 @@ export function ClaimPage() {
   // Check if user is already authenticated (returning from magic link)
   useEffect(() => {
     async function checkAuth() {
-      // Handle the auth callback hash from magic link
-      const supabase = getSupabaseClient();
-      if (!supabase) return;
-
       // Check for hash params from magic link redirect
       if (window.location.hash.includes('access_token')) {
-        const { data, error } = await supabase.auth.getSession();
-        if (!error && data.session) {
+        const { session, error: authError } = await waitForMagicLinkSession();
+        if (session) {
           setAuthenticated(true);
-          // Restore email from session (lost on page reload after magic link)
-          if (data.session.user.email) setEmail(data.session.user.email);
+          if (session.user.email) setEmail(session.user.email);
+          window.history.replaceState(null, '', window.location.pathname + window.location.search);
           setStep('website');
           return;
         }
+        if (authError) {
+          setError(authError);
+          window.history.replaceState(null, '', window.location.pathname + window.location.search);
+        }
+        return;
       }
 
       const session = await getSession();

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -37,6 +37,44 @@ export async function getSession(): Promise<Session | null> {
   return data.session;
 }
 
+/**
+ * Wait for a session to be established from a magic link callback.
+ * Uses onAuthStateChange to reliably detect when Supabase processes the
+ * access_token hash fragment, with a timeout fallback.
+ */
+export function waitForMagicLinkSession(timeoutMs = 5000): Promise<{ session: Session | null; error: string | null }> {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Promise.resolve({ session: null, error: 'Auth not configured' });
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      subscription.unsubscribe();
+      resolve({ session: null, error: 'Sign-in link may have expired or already been used. Please request a new one.' });
+    }, timeoutMs);
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        clearTimeout(timeout);
+        subscription.unsubscribe();
+        resolve({ session, error: null });
+      } else if (event === 'TOKEN_REFRESHED' && session) {
+        clearTimeout(timeout);
+        subscription.unsubscribe();
+        resolve({ session, error: null });
+      }
+    });
+
+    // Also check if a session is already available (processed before listener attached)
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) {
+        clearTimeout(timeout);
+        subscription.unsubscribe();
+        resolve({ session: data.session, error: null });
+      }
+    });
+  });
+}
+
 export async function signOut(): Promise<void> {
   const supabase = getSupabaseClient();
   if (!supabase) return;


### PR DESCRIPTION
## Summary
- Fix magic link session race condition by adding `waitForMagicLinkSession()` using Supabase `onAuthStateChange` listener instead of one-shot `getSession()` calls
- Show error messages when magic links expire or are already used (previously failed silently, bouncing users back to login with no explanation)
- Replace `admin.listUsers()` O(n) scan with `admin.getUserByEmail()` direct lookup in pre-login check
- Add diagnostic logging to all auth code paths for future debugging
- Clear URL hash after magic link processing to prevent re-triggering on refresh

## Test plan
- [ ] Claim a new artist profile via magic link — verify redirect works and session is established
- [ ] Log in as an existing claimed artist — verify dashboard loads
- [ ] Click an expired/already-used magic link — verify error message appears instead of silent redirect
- [ ] Check Netlify function logs for new `[artist-auth]` log lines on login attempts

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)