### PR TITLE
Fix MusicBrainz links duplicating across same-name artists

### DIFF
--- a/netlify/functions/search-musicbrainz.ts
+++ b/netlify/functions/search-musicbrainz.ts
@@ -26,6 +26,7 @@ interface MusicBrainzSearchResponse {
   hasPre2005Release: boolean;
   socialLinks: SocialLink[];
   discoveredPlatforms: DiscoveredPlatformLink[];
+  platformUrls: string[]; // Known platform URLs from MusicBrainz relations (bandcamp, mirlo, etc.)
 }
 
 // Known Mastodon/Fediverse instances (non-exhaustive, but covers popular ones)
@@ -339,6 +340,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     hasPre2005Release: false,
     socialLinks: [],
     discoveredPlatforms: [],
+    platformUrls: [],
   };
 
   try {
@@ -395,6 +397,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     let linktreeUrl: string | null = null;
     const socialLinks: SocialLink[] = [];
     const seenPlatforms = new Set<SocialPlatform>();
+    const platformUrls: string[] = [];
 
     if (artistResponse.ok) {
       const artistData = await artistResponse.json() as {
@@ -442,6 +445,22 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
             socialLinks.push(socialLink);
           }
         }
+      }
+
+      // Extract known music platform URLs from relations for disambiguation.
+      // These let us match MusicBrainz data to the correct search result
+      // when multiple same-name artists exist.
+      const platformRelTypes = new Set([
+        'bandcamp', 'streaming music', 'purchase for download',
+        'download for free', 'free streaming',
+      ]);
+      for (const rel of relations) {
+        if (rel.url?.resource && platformRelTypes.has(rel.type)) {
+          platformUrls.push(rel.url.resource);
+        }
+      }
+      if (platformUrls.length > 0) {
+        console.log(`[MusicBrainz] Found ${platformUrls.length} platform URLs: ${platformUrls.join(', ')}`);
       }
     }
 
@@ -500,6 +519,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       hasPre2005Release,
       socialLinks: allSocialLinks,
       discoveredPlatforms: officialSiteResult.discoveredPlatforms,
+      platformUrls,
     };
   } catch (error: unknown) {
     const err = error as { name?: string; message?: string };

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -476,22 +476,46 @@ export function mergeWithMusicBrainzData(
     if (isMatch) matchingIndices.push(i);
   }
 
-  // If multiple results match, only enrich the best one (most platforms = most likely the right artist).
-  // MusicBrainz only returns data for one artist, so attaching to all same-name results is wrong.
+  // Disambiguate: use MusicBrainz platform URLs (bandcamp, streaming, etc.) to find
+  // the correct result by direct URL matching. Falls back to heuristic scoring only
+  // when no platform URLs are available.
   let bestMatchIndex = -1;
   if (matchingIndices.length === 1) {
     bestMatchIndex = matchingIndices[0];
   } else if (matchingIndices.length > 1) {
-    let bestScore = -1;
-    for (const idx of matchingIndices) {
-      const r = results[idx];
-      // Prefer: verified/claimed > more platforms > earlier in list
-      const confidenceScore = r.matchConfidence === 'claimed' ? 100 : r.matchConfidence === 'verified' ? 50 : 0;
-      const platformScore = r.platforms.filter(p => !['kofi', 'buymeacoffee', 'ampwall'].includes(p.sourceId)).length;
-      const score = confidenceScore + platformScore;
-      if (score > bestScore) {
-        bestScore = score;
-        bestMatchIndex = idx;
+    const mbPlatformUrls = mbData.platformUrls || [];
+
+    // Try direct URL matching first: check if any result has a platform URL
+    // that matches one of the MusicBrainz relation URLs
+    if (mbPlatformUrls.length > 0) {
+      // Normalize MB URLs for comparison (strip trailing slashes, lowercase hostname)
+      const normalizedMbUrls = new Set(mbPlatformUrls.map(u => u.replace(/\/+$/, '').toLowerCase()));
+
+      for (const idx of matchingIndices) {
+        const r = results[idx];
+        const hasDirectMatch = r.platforms.some(p => {
+          const normalized = p.url.replace(/\/+$/, '').toLowerCase();
+          return normalizedMbUrls.has(normalized);
+        });
+        if (hasDirectMatch) {
+          bestMatchIndex = idx;
+          break;
+        }
+      }
+    }
+
+    // Fallback: score by confidence + platform count if no direct URL match found
+    if (bestMatchIndex === -1) {
+      let bestScore = -1;
+      for (const idx of matchingIndices) {
+        const r = results[idx];
+        const confidenceScore = r.matchConfidence === 'claimed' ? 100 : r.matchConfidence === 'verified' ? 50 : 0;
+        const platformScore = r.platforms.filter(p => !['kofi', 'buymeacoffee', 'ampwall'].includes(p.sourceId)).length;
+        const score = confidenceScore + platformScore;
+        if (score > bestScore) {
+          bestScore = score;
+          bestMatchIndex = idx;
+        }
       }
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export interface MusicBrainzData {
   discogsUrl: string | null;
   hasPre2005Release: boolean;
   socialLinks: SocialLink[];
+  platformUrls?: string[];
 }
 
 // Search state

--- a/tests/unit/sources-service.test.ts
+++ b/tests/unit/sources-service.test.ts
@@ -394,7 +394,7 @@ describe('mergeWithMusicBrainzData', () => {
     expect(merged[1].platforms.find(p => p.sourceId === 'officialsite')).toBeUndefined();
   });
 
-  it('only enriches the best match when multiple results share the same name', () => {
+  it('only enriches the result whose platform URL matches MusicBrainz relation URLs', () => {
     const results = [
       makeArtistResult('Sockpuppet', [
         { sourceId: 'bandcamp', url: 'https://sockpuppet.bandcamp.com' },
@@ -411,17 +411,47 @@ describe('mergeWithMusicBrainzData', () => {
         { platform: 'kofi', url: 'https://ko-fi.com/fluffy' },
         { platform: 'patreon', url: 'https://patreon.com/fluffy' },
       ],
+      // MusicBrainz knows this artist's Bandcamp URL
+      platformUrls: ['https://sockpuppet.bandcamp.com'],
     });
 
     const merged = mergeWithMusicBrainzData(results, mbData);
 
-    // First result has more platforms, so it should get the enrichment
+    // First result's bandcamp URL matches the MB platform URL → gets enrichment
     expect(merged[0].platforms.find(p => p.sourceId === 'officialsite')).toBeDefined();
     expect(merged[0].platforms.find(p => p.sourceId === 'kofi')?.url).toBe('https://ko-fi.com/fluffy');
     expect(merged[0].platforms.find(p => p.sourceId === 'patreon')?.url).toBe('https://patreon.com/fluffy');
 
-    // Second result should NOT get the enrichment
+    // Second result has a different bandcamp URL → no enrichment
     expect(merged[1].platforms.find(p => p.sourceId === 'officialsite')).toBeUndefined();
     expect(merged[1].platforms.find(p => p.sourceId === 'patreon')).toBeUndefined();
+  });
+
+  it('falls back to heuristic scoring when no platformUrls are available', () => {
+    const results = [
+      makeArtistResult('Sockpuppet', [
+        { sourceId: 'bandcamp', url: 'https://sockpuppet.bandcamp.com' },
+        { sourceId: 'qobuz', url: 'https://qobuz.com/sockpuppet' },
+      ]),
+      makeArtistResult('Sockpuppet', [
+        { sourceId: 'bandcamp', url: 'https://sockpuppet-il.bandcamp.com' },
+      ]),
+    ];
+    const mbData = makeMBData({
+      artistName: 'Sockpuppet',
+      officialUrl: 'https://sockpuppet.com',
+      socialLinks: [
+        { platform: 'kofi', url: 'https://ko-fi.com/fluffy' },
+      ],
+      // No platformUrls — falls back to scoring heuristic
+    });
+
+    const merged = mergeWithMusicBrainzData(results, mbData);
+
+    // First result has more platforms, wins the heuristic
+    expect(merged[0].platforms.find(p => p.sourceId === 'officialsite')).toBeDefined();
+    expect(merged[0].platforms.find(p => p.sourceId === 'kofi')?.url).toBe('https://ko-fi.com/fluffy');
+    // Second result should NOT get enrichment
+    expect(merged[1].platforms.find(p => p.sourceId === 'kofi')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Extract platform URLs (bandcamp, streaming, purchase, free streaming) from MusicBrainz URL relations and pass them to the client
- Use direct URL matching to disambiguate same-name artists: if a search result's Bandcamp URL matches the MusicBrainz artist's known Bandcamp URL, that's the correct match
- Falls back to confidence + platform count heuristic when MusicBrainz has no platform URLs
- Covers all enrichment sources (MusicBrainz social links, official site scraping, Discogs, Linktree) since they all flow through the same `mergeWithMusicBrainzData` merge point

## Example
Searching "Sockpuppet" returns two Bandcamp results (US and Israel). MusicBrainz knows the US artist's Bandcamp URL (`sockpuppet.bandcamp.com`), so ko-fi/patreon links only attach to that result, not the Israeli artist (`sockpuppet-il.bandcamp.com`).

## Test plan
- [x] Unit tests pass (41/41) including new direct URL matching test and fallback heuristic test
- [x] TypeScript compiles cleanly
- [ ] Manual test: search "Sockpuppet" and verify ko-fi/patreon only appear on the first result

🤖 Generated with [Claude Code](https://claude.com/claude-code)