### PR TITLE
Fix claimed artist links being overwritten by MusicBrainz enrichment

### DIFF
--- a/netlify/functions/artist-lookup.ts
+++ b/netlify/functions/artist-lookup.ts
@@ -39,6 +39,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
         'Access-Control-Allow-Origin': '*',
         'Cache-Control': 'public, max-age=0, must-revalidate',
         'Netlify-CDN-Cache-Control': 's-maxage=60, stale-while-revalidate=60',
+        'Cache-Tag': `artist-${slug}`,
       },
       body: JSON.stringify(artist),
     };

--- a/netlify/functions/db.ts
+++ b/netlify/functions/db.ts
@@ -289,12 +289,18 @@ export async function persistEnrichment(
     // Find the artist
     const { data: artist, error: findError } = await client
       .from('artists')
-      .select('id')
+      .select('id, match_confidence')
       .eq('slug', slug)
       .single();
 
     if (findError || !artist) {
       // Artist not in DB yet (search hasn't been persisted). That's OK.
+      return;
+    }
+
+    // Never overwrite links for claimed artists — they manage their own links
+    if (artist.match_confidence === 'claimed') {
+      console.log(`[DB] Skipping enrichment for claimed artist "${artistName}"`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- `persistEnrichment()` had no guard for claimed artists, so every time someone searched for a claimed artist, stale MusicBrainz data would overwrite the artist's manually-set links (e.g., Lime Bar's official site reverting from limebar.space to limebar.net)
- Added claimed artist check to `persistEnrichment` (matching the existing guard in `persistSearchResults`)
- Added `Cache-Tag` to `/api/artist` endpoint so CDN cache purge on profile update covers both the edge function HTML and API JSON responses

## Root cause
1. Artist updates official site to `limebar.space` via profile editor
2. Someone searches "Lime Bar" → MusicBrainz enrichment runs → `persistEnrichment()` upserts `officialsite` with stale `limebar.net` from MusicBrainz
3. Edge function and API both read from the now-corrupted database

## Test plan
- [x] All 172 tests pass
- [ ] After deploy: have Lime Bar re-save their profile, then search for "Lime Bar" and verify the official site stays as limebar.space
- [ ] Verify CDN purge works by checking Netlify function logs for the `[Profile] Purged CDN cache` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)