### PR TITLE
Fix artist profile photo bugs

### DIFF
--- a/api/functions/artist-auth.ts
+++ b/api/functions/artist-auth.ts
@@ -212,7 +212,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
         artistId: p.artist_id,
         name: artist?.name || 'Unknown',
         slug: artist?.slug || '',
-        imageUrl: artist?.image_url || p.custom_image_url,
+        imageUrl: p.custom_image_url || artist?.image_url,
         websiteUrl: p.website_url,
         bio: p.bio,
         claimedAt: p.claimed_at,

--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -182,15 +182,17 @@ async function scrapeAvatarFromPlatform(platform: string, pageUrl: string): Prom
     const html = await response.text();
 
     if (platform === 'bandcamp') {
-      // Try band-photo img first
-      const bandPhoto = html.match(/<img[^>]*class="[^"]*band-photo[^"]*"[^>]*src="([^"]+)"/i);
+      // Try band-photo img first (handle src before or after class)
+      const bandPhoto = html.match(/<img[^>]*class="[^"]*band-photo[^"]*"[^>]*src="([^"]+)"/i)
+        || html.match(/<img[^>]*src="([^"]+)"[^>]*class="[^"]*band-photo[^"]*"/i);
       if (bandPhoto) return bandPhoto[1];
-      // Fallback: og:image (usually the band photo on artist pages)
-      const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i);
+      // Fallback: og:image, but filter out album art
+      const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i)
+        || html.match(/<meta[^>]*content="([^"]+)"[^>]*property="og:image"/i);
       if (ogImage) {
-        // Filter out album art — Bandcamp band photos are on f4.bcbits.com
         const src = ogImage[1];
-        if (src.includes('f4.bcbits.com') || !src.includes('bcbits.com/img/a')) {
+        // Only use og:image if it's NOT album art (album art URLs contain /img/a)
+        if (!src.includes('/img/a')) {
           return src;
         }
       }
@@ -209,14 +211,30 @@ async function scrapeAvatarFromPlatform(platform: string, pageUrl: string): Prom
 
     if (platform === 'mirlo') {
       // Mirlo artist pages have og:image with the artist photo
-      const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i);
-      if (ogImage) return ogImage[1];
+      const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i)
+        || html.match(/<meta[^>]*content="([^"]+)"[^>]*property="og:image"/i);
+      if (ogImage) {
+        // Resolve relative URLs against the page URL
+        try {
+          return new URL(ogImage[1], pageUrl).href;
+        } catch {
+          return ogImage[1];
+        }
+      }
       return null;
     }
 
     // Generic fallback: try og:image
-    const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i);
-    return ogImage ? ogImage[1] : null;
+    const ogImage = html.match(/<meta[^>]*property="og:image"[^>]*content="([^"]+)"/i)
+      || html.match(/<meta[^>]*content="([^"]+)"[^>]*property="og:image"/i);
+    if (ogImage) {
+      try {
+        return new URL(ogImage[1], pageUrl).href;
+      } catch {
+        return ogImage[1];
+      }
+    }
+    return null;
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
## Summary
- **Mirlo broken images**: Resolve relative `og:image` URLs against the page URL so they become valid absolute HTTPS URLs
- **Bandcamp album art**: Fix filter logic (`||` → stricter check) that let album art URLs through, and improve band-photo regex to handle either attribute order
- **Dashboard stale image**: Swap priority so `custom_image_url` takes precedence over auto-discovered `image_url`

## Test plan
- [ ] Edit a claimed artist page → click "Use Mirlo photo" → verify image loads and saves
- [ ] Click "Use Bandcamp photo" → verify it pulls the artist photo, not album art
- [ ] Save a custom photo → go to dashboard → verify the new photo appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)