### PR TITLE
Fix artist directory to use custom profile photos

### DIFF
--- a/api/edge/artist-directory-page.ts
+++ b/api/edge/artist-directory-page.ts
@@ -15,7 +15,7 @@ export default async function handler(request: Request, context: Context) {
   // Fetch verified artist profiles
   const { data: profiles } = await supabase
     .from('artist_profiles')
-    .select('artist_id')
+    .select('artist_id, custom_image_url')
     .not('verified_at', 'is', null);
 
   if (!profiles || profiles.length === 0) {
@@ -30,10 +30,14 @@ export default async function handler(request: Request, context: Context) {
     .select('id, name, slug, image_url')
     .in('id', artistIds);
 
-  const artists = (artistRows || []).map((a: { slug: string; name: string; image_url?: string }) => ({
+  const customImageMap = new Map(
+    profiles.filter((p: { custom_image_url?: string }) => p.custom_image_url).map((p: { artist_id: string; custom_image_url: string }) => [p.artist_id, p.custom_image_url])
+  );
+
+  const artists = (artistRows || []).map((a: { id: string; slug: string; name: string; image_url?: string }) => ({
     slug: a.slug,
     name: a.name,
-    imageUrl: a.image_url || null,
+    imageUrl: customImageMap.get(a.id) || a.image_url || null,
   })).sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name));
 
   // Group by first letter

--- a/api/functions/artist-directory.ts
+++ b/api/functions/artist-directory.ts
@@ -13,7 +13,7 @@ export async function handler() {
   // Fetch all verified (claimed) artist profiles
   const { data: profiles, error: profileError } = await supabase
     .from('artist_profiles')
-    .select('artist_id')
+    .select('artist_id, custom_image_url')
     .not('verified_at', 'is', null);
 
   if (profileError || !profiles || profiles.length === 0) {
@@ -35,11 +35,15 @@ export async function handler() {
     return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
   }
 
+  const customImageMap = new Map(
+    profiles.filter(p => p.custom_image_url).map(p => [p.artist_id, p.custom_image_url])
+  );
+
   const artists = (artistRows || [])
     .map(a => ({
       slug: a.slug,
       name: a.name,
-      imageUrl: a.image_url || null,
+      imageUrl: customImageMap.get(a.id) || a.image_url || null,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 


### PR DESCRIPTION
Both the serverless and edge functions now fetch `custom_image_url` from `artist_profiles` and prefer it over the base `image_url`. This fixes the issue where artists updating their profile photo via the dashboard wasn't reflected on the /artists directory page. The image priority now matches claimed artist pages: `custom_image_url || image_url || null`.