### PR TITLE
Fix artist verification to check correct DB slug

### DIFF
--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -4,7 +4,7 @@
 //   action: 'verify' — scrape website, verify link-back, discover platform links
 
 import { createClient } from '@supabase/supabase-js';
-import { artistSlug, getClient } from './db';
+import { getClient } from './db';
 
 const PLATFORM_PATTERNS: [string, RegExp][] = [
   ['bandcamp', /([a-z0-9-]+)\.bandcamp\.com/i],
@@ -473,13 +473,14 @@ export async function handler(event: {
       };
     }
 
-    // Check for Unstream link-back
-    const unstreamSlug = artistSlug(artist.name);
+    // Check for Unstream link-back using the DB slug (same one shown to the user in verifyUrl)
+    // Note: artistSlug(artist.name) can differ from the DB slug (e.g. apostrophes in names),
+    // so we use the DB slug to match exactly what we told the user to link to.
     const hasUnstreamLink = links.some(link => {
       try {
         const url = new URL(link);
         return url.hostname.includes('unstream.stream') &&
-          url.pathname.includes(unstreamSlug);
+          url.pathname.includes(slug);
       } catch {
         return false;
       }


### PR DESCRIPTION
## Summary
When verifying artist claims, the verification was regenerating the slug from the artist name using `artistSlug()`, but the verify URL shown to users uses the DB slug. These can differ when artist names contain apostrophes or special characters (e.g., "Bard's Tale" → slug `bard-s-tale` vs DB `bards-tale`), causing verification to fail even when users link to the exact URL we showed them.

## Changes
Use the DB slug (from the request) instead of regenerating it during verification. This ensures we check for the exact URL path the user was instructed to link to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)