### PR TITLE
Update README with recent features and project changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,39 +11,44 @@ Unstream searches 23+ platforms to find where your favorite artists sell music, 
 Search for any artist, album, or track. Unstream checks platforms like Bandcamp, Mirlo, Faircamp, Patreon, Qobuz, and more, then shows you verified links grouped by category:
 
 - **Music Marketplaces** - Buy music directly (Bandcamp, Mirlo, Ampwall, Qobuz, Jam.coop, Discogs)
-- **Patronage** - Support artists directly (Patreon, Buy Me a Coffee, Ko-fi)
-- **Decentralized** - Community alternatives (Bandwagon, Faircamp)
+- **Patronage** - Support artists directly (Patreon, Buy Me a Coffee, Ko-fi, Liberapay)
+- **Decentralized** - Community alternatives (Bandwagon, Faircamp, PeerTube)
 - **Library Services** - Free access through your library (Hoopla, Freegal)
-- **Official** - Artist websites, social links
+- **Official** - Artist websites, social links, newsletter
 
-Results are enriched with MusicBrainz data for official websites, social profiles, and release verification.
+Results are enriched with MusicBrainz data for official websites, social profiles, and release verification. On Bandcamp Fridays, results highlight which platforms pay artists 100% of the purchase price.
+
+## Artist profiles
+
+Artists can claim and verify their Unstream profile to customize their page with a photo, bio, featured release embed, social links, and direct support options. Verified profiles appear in the [Artist Index](https://unstream.stream/artists).
+
+To claim a profile, search for your artist name and click "Is this you?" on your result card.
 
 ## Apps
 
 - **Web** - [unstream.stream](https://unstream.stream) (free, no account needed)
-- **macOS menu bar app** - Detects what's playing in Spotify or Apple Music and shows support options
+- **macOS menu bar app** - Detects what's playing in Spotify, Apple Music, Radiccio, or Parachord and shows support options. Includes a global keyboard shortcut, tabbed settings, and social sharing.
 - **Chrome extension** - [Chrome Web Store](https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf)
 - **Firefox extension** - [Mozilla Add-ons](https://addons.mozilla.org/en-US/firefox/addon/unstream/)
 - **iOS Shortcut** - Share from Spotify or Apple Music to search on Unstream
 
-The [Yearly Pass](https://bgreenlol.lemonsqueezy.com/checkout/buy/d4e127a7-2cef-4013-80b8-5d0de691f332) ($4.99/year) unlocks saved artist lists, new release alerts, and more in the desktop and browser apps.
+All apps are free with no paywall. If Unstream is useful to you, you can [donate via Liberapay](https://liberapay.com/brandonlucasgreen/donate).
 
 ## Project structure
 
 ```
 unstream/
-├── src/                    # React + Vite web app (SPA)
-│   ├── components/         # UI components (SearchBar, ResultCard, SourceBadge)
-│   ├── pages/              # Route pages (ArtistPage, PrivacyPolicy, Roadmap)
-│   ├── services/           # Platform definitions, analytics
-│   └── types/              # TypeScript type definitions
+├── apps/
+│   ├── web/                # React + Vite web app (SPA)
+│   │   ├── src/            # Components, pages, services, types
+│   │   └── tests/          # Unit and integration tests
+│   ├── mac/                # macOS Swift menu bar app (SwiftUI)
+│   └── extension/          # Browser extension (Chrome + Firefox)
 ├── netlify/
 │   ├── functions/          # Serverless API (search, embed, cache, version check)
 │   └── edge-functions/     # Edge middleware (OG metadata, artist page SSR)
 ├── api/                    # Shared API modules (search logic, embeds)
-├── server/                 # Vite dev server API handler
-├── chrome-extension/       # Browser extension (Chrome + Firefox)
-├── UnstreamMenubar/        # macOS Swift menu bar app
+├── supabase/               # Database migrations and config
 ├── scripts/                # Data generation (artist list, artist data, sitemap)
 ├── data/                   # Pre-generated artist SEO data
 ├── docs/                   # Specs and planning documents
@@ -57,6 +62,7 @@ npm install
 npm run dev          # Start Vite dev server
 npm run build        # Build for production (includes sitemap generation)
 npm run lint         # Run ESLint
+npm run test         # Run unit and integration tests
 ```
 
 ### Data generation
@@ -70,9 +76,9 @@ npm run generate:data       # Generate artist page data via APIs
 
 - **Frontend**: React 19, Tailwind CSS v4, Vite, TypeScript
 - **Backend**: Netlify Functions + Edge Functions
+- **Database**: Supabase (artist profiles and verification)
 - **Data**: MusicBrainz, Wikidata, Bandcamp API
 - **Analytics**: GoatCounter (privacy-friendly, public dashboard)
-- **Payments**: Lemon Squeezy
 - **macOS app**: Swift, SwiftUI
 
 ## Links


### PR DESCRIPTION
Update README to reflect recent product changes including artist profiles with verification, Supabase database integration, Bandcamp Friday feature highlighting 100% artist payouts, and expanded macOS app capabilities (Radiccio/Parachord playback detection, global keyboard shortcut, tabbed settings).

Remove outdated Yearly Pass reference and update project structure to reflect apps/ reorganization. Update tech stack to include Supabase and remove Lemon Squeezy (paywall removed in v2.0). Add new social platforms (PeerTube, Liberapay, Newsletter) available for artist profiles.