### PR TITLE
Update platform count from 23+/20+ to 15 across all references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Unstream helps music listeners find their favorite artists on alternative platforms outside streaming, so they can support artists directly. It searches 23+ platforms (Bandcamp, Mirlo, Ampwall, Qobuz, Faircamp, Patreon, etc.) and shows verified links grouped by category with artist payout percentages.
+Unstream helps music listeners find their favorite artists on alternative platforms outside streaming, so they can support artists directly. It searches 15 platforms (Bandcamp, Mirlo, Ampwall, Qobuz, Faircamp, Patreon, etc.) and shows verified links grouped by category with artist payout percentages.
 
 The product runs at [unstream.stream](https://unstream.stream).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [unstream.stream](https://unstream.stream)
 
-Unstream searches 23+ platforms to find where your favorite artists sell music, accept patronage, or share music for free outside the streaming ecosystem. It shows artist payout percentages so you can make informed choices about where your money goes.
+Unstream searches 15 platforms to find where your favorite artists sell music, accept patronage, or share music for free outside the streaming ecosystem. It shows artist payout percentages so you can make informed choices about where your money goes.
 
 ## How it works
 

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -13,7 +13,7 @@
       "strict_min_version": "120.0"
     }
   },
-  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 23+ platforms. Free, open source, no tracking.",
+  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 15 platforms. Free, open source, no tracking.",
   "version": "2.1.0",
   "icons": {
     "16": "icons/icon16.png",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Unstream - Support Music Directly",
-  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 23+ platforms. Free and open source.",
+  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 15 platforms. Free and open source.",
   "version": "2.1.0",
   "icons": {
     "16": "icons/icon16.png",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,9 +6,9 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unstream - Support Artists Directly</title>
-    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 23+ platforms. Free and open source." />
+    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 15 platforms. Free and open source." />
     <meta property="og:title" content="Unstream - Support Artists Directly" />
-    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 23+ platforms. Free and open source." />
+    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 15 platforms. Free and open source." />
     <meta property="og:image" content="https://unstream.stream/og-image.png" />
     <meta property="og:url" content="https://unstream.stream" />
     <meta property="og:type" content="website" />

--- a/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
+++ b/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
@@ -57,4 +57,4 @@ Don't sleep on your local library. **[Hoopla](https://www.hoopladigital.com)** a
 
 The biggest pain point with this whole ecosystem is fragmentation. Your favorite artist might be on Bandcamp, Mirlo, *and* Ko-fi — but you'd have no idea unless you checked each platform separately.
 
-That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 23+ platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.
+That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 15 platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.

--- a/data/guides/how-to-build-a-music-library-without-streaming.md
+++ b/data/guides/how-to-build-a-music-library-without-streaming.md
@@ -29,7 +29,7 @@ Over a year that's 12–24 albums you permanently own, with $100+ going directly
 
 This used to be the annoying part. Artists sell across tons of platforms — [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), their own websites, [Ko-fi](https://ko-fi.com) — and checking each one individually is tedious enough that most people just don't bother.
 
-[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 23+ platforms, with how much of your money reaches them on each one. Free, no account needed.
+[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 15 platforms, with how much of your money reaches them on each one. Free, no account needed.
 
 ## Pick a music player
 

--- a/data/guides/the-real-cost-of-free-music.md
+++ b/data/guides/the-real-cost-of-free-music.md
@@ -53,6 +53,6 @@ This isn't theoretical. Bandcamp alone has paid artists over a billion dollars. 
 You don't have to quit streaming. But a few things go a long way:
 
 1. **Pick the artists you care about most** and buy their music directly. One $10 album purchase on Bandcamp gives an artist more than thousands of streams.
-2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 23+ platforms and see how much of your money reaches them on each one.
+2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 15 platforms and see how much of your money reaches them on each one.
 3. **Buy on Bandcamp Fridays** (first Friday of every month) when artists keep ~97%.
 4. **Tell people.** Most listeners have no idea how any of this works. The streaming experience is so smooth that it's easy to assume the artists behind it are being taken care of. They're mostly not.

--- a/data/guides/where-your-money-goes-streaming-vs-buying.md
+++ b/data/guides/where-your-money-goes-streaming-vs-buying.md
@@ -50,7 +50,7 @@ And it compounds in a way streaming doesn't. After three years of streaming you 
 You don't need to cancel streaming — plenty of people keep it for casual listening and convenience while also buying from artists they care about. That's fine. Even small shifts matter:
 
 - **Buy from one or two artists a month** instead of just streaming them. Prioritize the ones who seem like they need it most — independent, unsigned, small following.
-- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 23+ platforms and see exactly how much reaches them on each one.
+- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 15 platforms and see exactly how much reaches them on each one.
 - **Buy on Bandcamp Fridays** to maximize what goes to the artist.
 - **Check your library's music services** — [Hoopla](https://www.hoopladigital.com) and [Freegal](https://www.freegalmusic.com) are free with a library card and good for exploring new stuff without spending.
 

--- a/scripts/generate-social-posts.ts
+++ b/scripts/generate-social-posts.ts
@@ -519,9 +519,9 @@ function generatePromoPost(weekNumber: number): { posts: PostDraft['posts']; fea
 
   switch (angle) {
     case 0: // what it does
-      threads = `i built a free tool that searches 20+ platforms to help you find where to buy music directly from artists. no account, no tracking, no paywall.\n\n${url}`;
-      bluesky = `Free tool that searches 20+ platforms to find where to buy music directly from artists. No account needed.\n\n${url}`;
-      instagram = `Unstream searches 20+ alternative music platforms to help you find where to buy music directly from artists.\n\nNo account. No tracking. No paywall. Just a way to get more money to the people who make the music.\n\n${url}`;
+      threads = `i built a free tool that searches 15 platforms to help you find where to buy music directly from artists. no account, no tracking, no paywall.\n\n${url}`;
+      bluesky = `Free tool that searches 15 platforms to find where to buy music directly from artists. No account needed.\n\n${url}`;
+      instagram = `Unstream searches 15 alternative music platforms to help you find where to buy music directly from artists.\n\nNo account. No tracking. No paywall. Just a way to get more money to the people who make the music.\n\n${url}`;
       break;
 
     case 1: // the why
@@ -543,9 +543,9 @@ function generatePromoPost(weekNumber: number): { posts: PostDraft['posts']; fea
       break;
 
     case 4: // how it works
-      threads = `search for any artist on Unstream and it checks Bandcamp, Faircamp, Mirlo, Qobuz, and 20+ other platforms in a few seconds. shows you where to buy their music directly — with payout percentages so you know where your money goes.\n\n${url}`;
-      bluesky = `Search any artist on Unstream → it checks 20+ platforms and shows where to buy their music directly, with payout percentages.\n\n${url}`;
-      instagram = `Search for any artist on Unstream.\n\nIt checks Bandcamp, Faircamp, Mirlo, Qobuz, and 20+ other platforms in seconds — and shows you where to buy their music directly, with transparent payout percentages.\n\n${url}`;
+      threads = `search for any artist on Unstream and it checks 15 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in a few seconds. shows you where to buy their music directly — with payout percentages so you know where your money goes.\n\n${url}`;
+      bluesky = `Search any artist on Unstream → it checks 15 platforms and shows where to buy their music directly, with payout percentages.\n\n${url}`;
+      instagram = `Search for any artist on Unstream.\n\nIt checks 15 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in seconds — and shows you where to buy their music directly, with transparent payout percentages.\n\n${url}`;
       break;
 
     default: // the pitch, earnest


### PR DESCRIPTION
The codebase incorrectly claimed support for 23+ or 20+ platforms.
Updated all references in docs, metadata, guides, extension manifests,
and social post templates to reflect the actual count of 15 platforms.

https://claude.ai/code/session_012iBUv12QgMvxPHk7wGnC5P