### PR TITLE
Add two new guide drafts on label economics and platform payout transparency

### DIFF
--- a/data/guides/labels-vs-independence-what-artists-actually-keep.md
+++ b/data/guides/labels-vs-independence-what-artists-actually-keep.md
@@ -1,0 +1,98 @@
+---
+title: "Labels vs. independence: what artists actually keep"
+description: How the label-artist relationship shapes payouts, and why more musicians are finding that staying independent can mean earning more from every sale and stream.
+pillar: artist-economics
+published: 2026-03-29
+draft: true
+---
+
+
+The music industry runs on a simple premise: labels invest in artists, artists make music, everyone gets paid. In practice, the split is a lot less even than that sounds.
+
+Understanding how labels and independent distribution actually work helps explain why so many artists are going it alone — and why the ones who do often earn more per fan, even if they reach fewer fans overall.
+
+## The traditional label deal
+
+When an artist signs with a major label (Universal, Sony, Warner) or one of their subsidiaries, the label typically covers recording costs, marketing, distribution, and sometimes tour support. In exchange, the label takes ownership of the master recordings — usually forever — and pays the artist a royalty on sales and streams.
+
+The standard royalty rate for a new artist on a major label is **15–20% of revenue**. That sounds low, and it is, but it gets worse. Most deals are structured so that recording costs, advances, marketing spend, and various fees are *recouped* from the artist's royalty share before they see a dollar. An artist might sell 100,000 copies of an album and still owe the label money.
+
+Here's a rough breakdown of where a $10 album sale goes under a typical major label deal:
+
+| Slice | Amount |
+|-------|--------|
+| Retailer/platform cut | $3.00 |
+| Label share | $5.50 |
+| Artist royalty (pre-recoupment) | $1.50 |
+| After recoupment deductions | Often $0 |
+
+Streaming makes this even more dramatic. If a major-label track earns $0.004 per stream, the artist's 15–20% share is **$0.0006–0.0008 per stream**. An artist needs over a million streams to earn $800. And that's before the label recoups whatever they spent.
+
+## Why labels still exist
+
+Given those numbers, why would anyone sign? Because labels offer things that are genuinely hard to replicate on your own:
+
+- **Upfront money.** Advances let artists pay rent and make music without a day job. Even if the advance is recoupable, it's cash now versus royalties maybe later.
+- **Scale.** Major labels have relationships with playlist curators, radio programmers, sync licensing teams, and international distributors that independent artists can't easily access.
+- **Infrastructure.** Marketing campaigns, press outreach, physical distribution, legal teams — all of this costs money and expertise that most artists don't have.
+- **Credibility signal.** Fair or not, being on a known label still opens doors in parts of the industry.
+
+For some artists, especially those aiming for mainstream pop or hip-hop where massive reach matters most, the trade-off can make sense. The label takes most of the money, but the total pie is so much bigger that the artist's small slice is still substantial.
+
+## The indie label middle ground
+
+Independent labels — [Sub Pop](https://www.subpop.com), [Merge](https://www.mergerecords.com), [Secretly Group](https://secretlygroup.com), [Jagjaguwar](https://jagjaguwar.com), and hundreds of others — typically offer better terms. Artist royalty rates at indie labels are often **40–50%**, sometimes higher. Many indie deals let artists keep their masters or revert ownership after a set period.
+
+The trade-off is that indie labels have smaller marketing budgets and less mainstream reach. But for artists whose audiences are in the tens of thousands rather than millions, the math often works out better. Earning 50% of a smaller number can beat 15% of a bigger one, especially when you factor in creative control and long-term ownership.
+
+Some indie labels have also adapted to the direct-sales model well. Plenty of indie label artists sell through [Bandcamp](https://bandcamp.com) and keep significantly more per sale than they would through streaming alone.
+
+## Going fully independent
+
+The infrastructure for independent music distribution has gotten dramatically better in the last decade. Services like [DistroKid](https://distrokid.com), [TuneCore](https://tunecore.com), [CD Baby](https://cdbaby.com), and [Amuse](https://amuse.io) let artists distribute to all major streaming platforms for a flat annual fee or a small percentage — and crucially, the artist keeps their masters and earns **80–100% of royalties** (minus the distributor's fee).
+
+Combine that with direct-sales platforms and the economics shift dramatically:
+
+| Model | Artist keeps per $10 album |
+|-------|---------------------------|
+| Major label (physical/digital) | $0–1.50 |
+| Indie label | $4–5.00 |
+| Independent via [Bandcamp](https://bandcamp.com) | $8.00–8.50 |
+| Independent via [Mirlo](https://mirlo.space) | $8.50–9.00 |
+| Independent via [Ampwall](https://ampwall.com) | $9.00–9.50 |
+| Independent via [Faircamp](https://simonrepp.com/faircamp/) | ~$9.70+ |
+
+That's not a marginal difference. An independent artist selling 1,000 albums on Bandcamp earns roughly the same as a major-label artist selling 5,000–8,000 copies. And the independent artist owns everything.
+
+## The real cost of a label: control
+
+Money is the obvious difference, but control matters just as much. Signed artists often can't:
+
+- Release music on their own schedule (labels control release timing)
+- Choose which songs become singles
+- Set their own prices or offer pay-what-you-want
+- Sell directly to fans without the label's involvement
+- Use their own recordings in other projects without permission
+
+Independence means deciding all of that yourself. Want to release an album next week? Do it. Want to offer a pay-what-you-want download? Go ahead. Want to put your music on platforms that pay artists fairly and skip the ones that don't? Your call.
+
+This is especially relevant as more artists realize that a smaller, engaged audience buying directly is worth more than a larger passive audience streaming. A thousand fans each buying a $10 album generates $8,000–9,500 on direct-sales platforms. Getting that same $8,000 from Spotify alone would require roughly **2 million streams**.
+
+## The discovery problem (and how it's changing)
+
+The biggest challenge for independent artists is still discovery. Labels have marketing machines. Independent artists have social media, word of mouth, and whatever organic growth they can generate.
+
+But this is changing. Tools like [Unstream](https://unstream.stream) help listeners find where their favorite artists sell directly across 15 platforms. Communities on [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), and music forums actively champion independent releases. Music blogs and independent publications still cover artists who aren't on major labels.
+
+And the artists who build direct relationships with fans — through email lists, community platforms like [Patreon](https://www.patreon.com) or [Ko-fi](https://ko-fi.com), and direct-sales storefronts — tend to have more durable careers than those who rely on algorithmic discovery. An algorithm can stop recommending you tomorrow. A fan who bought your last three albums on Bandcamp is going to buy the next one too.
+
+## What this means for listeners
+
+If you care about artists keeping more of what they earn:
+
+- **Buy directly** whenever you can. The difference between a streaming listen and a direct purchase is enormous for the artist.
+- **Check whether your favorite artists are independent** — if they are, your direct purchases matter even more because there's no label taking a cut.
+- **Search on [Unstream](https://unstream.stream)** to find where artists sell and compare what they keep on each platform.
+- **Support artists on [Patreon](https://www.patreon.com) or [Ko-fi](https://ko-fi.com)** if they have a presence there — recurring support is the closest thing to a sustainable income for independent musicians.
+
+The tools for artists to go independent have never been better. The missing piece is listeners knowing where to find them — and choosing to buy when they do.

--- a/data/guides/why-music-platforms-hide-artist-payout-rates.md
+++ b/data/guides/why-music-platforms-hide-artist-payout-rates.md
@@ -1,0 +1,94 @@
+---
+title: "Why music platforms hide what they pay artists"
+description: Most music platforms don't clearly disclose how much of your money reaches artists. Here's why that opacity exists, who it benefits, and why transparency matters.
+pillar: artist-economics
+published: 2026-03-29
+draft: true
+---
+
+
+Try to find out exactly how much [Spotify](https://spotify.com) pays per stream. Or what percentage of a sale [Apple Music](https://music.apple.com) passes to an independent artist. Or how [Amazon Music](https://music.amazon.com)'s royalty calculations actually work.
+
+You'll find estimates, leaked figures, third-party analyses, and a lot of hedging. What you won't find is a clear, public, standardized disclosure from the platforms themselves. That's not an accident.
+
+## What we know (and how we know it)
+
+The per-stream payout figures that get cited — $0.003–0.005 for Spotify, slightly more for Apple Music, less for YouTube — aren't published by the platforms. They come from artists sharing their royalty statements, aggregated data from distributors like [DistroKid](https://distrokid.com) and [CD Baby](https://cdbaby.com), and investigative journalism.
+
+These figures are also averages, which obscures a lot. Per-stream rates vary based on:
+
+- **Which country the listener is in** (a stream from a US premium subscriber is worth more than one from a free-tier listener in a lower-income country)
+- **Whether the listener is on a free or paid tier**
+- **The total number of streams on the platform that month** (the pool is fixed; more streams means each one is worth less)
+- **Negotiated rates** between the platform and different rights holders (major labels negotiate different deals than independent distributors)
+
+This complexity isn't inherently bad — music licensing is genuinely complicated. But the platforms use that complexity as a reason not to disclose simple, comparable numbers. "It depends on too many factors" becomes a justification for publishing nothing at all.
+
+## Why platforms benefit from opacity
+
+There are several reasons music platforms prefer not to publish clear payout data:
+
+### It prevents comparison shopping
+
+If every platform published a clear "artists receive X% of revenue" figure, listeners could compare them side by side and choose the one that pays artists best. That would create competitive pressure to increase payouts — which directly cuts into platform margins.
+
+Right now, most listeners have no idea that [Bandcamp](https://bandcamp.com) passes 80–85% to artists while Spotify's effective artist payout rate is a fraction of that. If that comparison were obvious and standardized, it would be much harder for low-paying platforms to retain users who care about artists.
+
+### It protects negotiated deals
+
+Major labels negotiate their own royalty rates with streaming platforms, and those rates are confidential. Spotify's deal with Universal Music Group is different from its deal with an independent distributor, which is different from its deal with Sony. Publishing clear payout rates would reveal these differences and create pressure to equalize them — which neither the platforms nor the major labels want.
+
+This also means that when Spotify says it has "paid $40 billion to rights holders," that number is technically true but misleading. A huge portion of that money went to three companies (Universal, Sony, Warner), not to the independent artists most people imagine when they hear "rights holders."
+
+### It shifts blame downstream
+
+When an artist complains about low payouts, the platform can point to the complexity of the system — labels take their cut, distributors take their cut, publishing rights are separate from recording rights, and so on. All true. But the opacity makes it impossible for artists or listeners to pinpoint exactly where value is being extracted, which means nobody is accountable for the final number.
+
+A signed artist earning $0.0007 per stream can't easily determine how much went to the platform, how much to their label, and how much to their distributor — because none of those parties publish clear breakdowns. Everyone points at everyone else.
+
+### It maintains the illusion of fairness
+
+Streaming platforms market themselves as democratizing music — anyone can upload, anyone can be discovered, the playing field is level. Publishing actual payout distributions would undermine that narrative pretty quickly.
+
+The reality is that the top 1% of artists capture the vast majority of streaming revenue. The median artist on Spotify earns almost nothing. But as long as the exact numbers stay fuzzy, platforms can keep telling the story that streaming works for everyone.
+
+## The platforms that do disclose
+
+Not every platform hides this. In fact, the ones that are most transparent tend to be the ones that pay artists the most:
+
+| Platform | Disclosed artist share | Source |
+|----------|----------------------|--------|
+| **[Ampwall](https://ampwall.com)** | ~92–95% | Published on site |
+| **[Ko-fi](https://ko-fi.com)** | ~92–97% | Published on site |
+| **[Mirlo](https://mirlo.space)** | ~86–90% | Published on site, co-op model |
+| **[Bandcamp](https://bandcamp.com)** | ~80–85% (97% on Fridays) | Published on site |
+| **[Faircamp](https://simonrepp.com/faircamp/)** | ~97%+ | Self-hosted, near-zero fees |
+| **[Qobuz](https://www.qobuz.com)** | ~70% for purchases | Published estimates |
+
+These platforms don't have anything to hide because their model is straightforward: you buy something, the artist gets most of the money, the platform takes a transparent cut. It's a selling point, not a liability.
+
+Contrast that with streaming platforms, where even the *concept* of "per-stream rate" is something the platforms avoid defining publicly.
+
+## Why transparency matters for listeners
+
+If you're spending money on music and part of your motivation is supporting artists, you deserve to know how much actually reaches them. Right now, the burden is on listeners to research this themselves — and most people don't, because the information is scattered, inconsistent, and deliberately hard to find.
+
+Transparency would change the market in a few ways:
+
+- **Informed choices.** Listeners could pick platforms based on artist payout rates the same way they consider price, catalog size, or audio quality.
+- **Competitive pressure.** If payout rates were visible and comparable, platforms that pay poorly would face real pressure to improve or lose users.
+- **Accountability.** Artists could see exactly where their money goes and make informed decisions about distribution.
+- **Trust.** Platforms that treat artists fairly could prove it instead of just claiming it.
+
+Some of this is starting to happen anyway. Artists share royalty screenshots on social media. Publications like [The Trichordist](https://thetrichordist.com) and others publish annual streaming rate analyses. But it's still piecemeal, and it still requires effort to find and interpret.
+
+## What you can do
+
+Until platforms are required or pressured to disclose payout rates standardly:
+
+- **Favor platforms that publish their rates.** [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), and others are upfront about what artists keep. That transparency is a feature, not a footnote.
+- **Use [Unstream](https://unstream.stream)** to search for artists across 15 platforms and see payout percentages for each one — we've done the research so you don't have to.
+- **Ask the question.** When a platform says it "supports artists," ask how much. If the answer is vague or unavailable, that tells you something.
+- **Buy directly when you can.** The simplest way to ensure your money reaches an artist is to pay them directly on a platform with transparent pricing. A $10 album on Bandcamp puts $8+ in the artist's pocket. No ambiguity, no opaque royalty pool, no six-month delay.
+
+The music industry has operated on opacity for decades — from label contracts to streaming royalties. The platforms that break with that pattern and show their work are the ones building real trust with artists and fans. Transparency isn't just a nice-to-have. It's how you know the system is actually working for the people making the music.


### PR DESCRIPTION
- "Labels vs. independence: what artists actually keep" — covers label deal structures, indie vs major payouts, and the economics of going fully independent
- "Why music platforms hide what they pay artists" — explores why streaming platforms obscure payout rates, who benefits from opacity, and the value of transparency

Both set as draft: true for review before publishing.

https://claude.ai/code/session_013QaSYENo9eTQJb36KgUBvS