### PR TITLE
Reserve override URLs to prevent wrong Qobuz attachment

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1244,12 +1244,17 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
 
   const aggregated = aggregateResults(allResults, query);
 
+  // Fetch overrides early so we can reserve their URLs during Phase 2
+  const overrides = await getMergeOverrides();
+  const reservedOverrideUrls = new Set(
+    overrides.flatMap(o => o.platform_urls.map(u => u.replace(/\/+$/, '').toLowerCase()))
+  );
+
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
-  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches);
+  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, reservedOverrideUrls);
   createQobuzOnlyResults(aggregated, qobuzMatches);
 
   // Phase 2.5: Apply manual merge overrides before release-based disambiguation
-  const overrides = await getMergeOverrides();
   if (overrides.length > 0) {
     applyMergeOverrides(aggregated, overrides);
   }

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -447,6 +447,7 @@ export function attachQobuzAndSearchLinks(
   aggregated: AggregatedResult[],
   qobuzMatches: Map<string, string>,
   ampwallMatches: Map<string, string>,
+  reservedOverrideUrls?: Set<string>,
 ): void {
   const usedPlatformUrls = new Set<string>();
 
@@ -477,9 +478,11 @@ export function attachQobuzAndSearchLinks(
     }
 
     // Qobuz: attach ALL name variations (e.g. "morice", "morice1", "morice2")
-    // Disambiguation will sort out which actually match based on releases
+    // Disambiguation will sort out which actually match based on releases.
+    // Skip URLs reserved by merge overrides — the override will handle them.
     for (const [qobuzName, qobuzUrl] of qobuzMatches) {
       if (isQobuzVariation(qobuzName, normalizedName)) {
+        if (reservedOverrideUrls?.has(qobuzUrl.replace(/\/+$/, '').toLowerCase())) continue;
         result.platforms.push({ sourceId: 'qobuz', url: qobuzUrl });
       }
     }


### PR DESCRIPTION
## Summary
Follow-up to #101. Override Qobuz URLs were being attached to unrelated Bandcamp results by `attachQobuzAndSearchLinks` (name-based matching) *before* the override had a chance to claim them. This caused searching "ben g" to merge the override's Qobuz link onto a different Bandcamp "BenG" artist, combining them into one wrong result.

## Fix
- Fetch overrides before Phase 2 and collect all their URLs into a reserved set
- `attachQobuzAndSearchLinks` skips attaching any Qobuz URL that's in the reserved set
- The override then claims its URLs as normal during Phase 2.5

## Test plan
- [ ] Search "ben-g!" — shows Ben-G! with correct photo and Qobuz link
- [ ] Search "ben g" — shows Ben-G! as a separate result from Bandcamp "BenG"
- [ ] Other overrides still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)