### PR TITLE
Reserve all Qobuz variants for override artists by name

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1244,14 +1244,17 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
 
   const aggregated = aggregateResults(allResults, query);
 
-  // Fetch overrides early so we can reserve their URLs during Phase 2
+  // Fetch overrides early so we can reserve their URLs and names during Phase 2
   const overrides = await getMergeOverrides();
   const reservedOverrideUrls = new Set(
     overrides.flatMap(o => o.platform_urls.map(u => u.replace(/\/+$/, '').toLowerCase()))
   );
+  const reservedOverrideNames = new Set(
+    overrides.map(o => normalizeForComparison(o.group_name))
+  );
 
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
-  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, reservedOverrideUrls);
+  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, reservedOverrideUrls, reservedOverrideNames);
   createQobuzOnlyResults(aggregated, qobuzMatches);
 
   // Phase 2.5: Apply manual merge overrides before release-based disambiguation

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -448,6 +448,7 @@ export function attachQobuzAndSearchLinks(
   qobuzMatches: Map<string, string>,
   ampwallMatches: Map<string, string>,
   reservedOverrideUrls?: Set<string>,
+  reservedOverrideNames?: Set<string>,
 ): void {
   const usedPlatformUrls = new Set<string>();
 
@@ -479,10 +480,12 @@ export function attachQobuzAndSearchLinks(
 
     // Qobuz: attach ALL name variations (e.g. "morice", "morice1", "morice2")
     // Disambiguation will sort out which actually match based on releases.
-    // Skip URLs reserved by merge overrides — the override will handle them.
+    // Skip Qobuz matches whose name matches an override — the override owns
+    // all Qobuz variants for that artist, not just the exact URL in its list.
     for (const [qobuzName, qobuzUrl] of qobuzMatches) {
       if (isQobuzVariation(qobuzName, normalizedName)) {
         if (reservedOverrideUrls?.has(qobuzUrl.replace(/\/+$/, '').toLowerCase())) continue;
+        if (reservedOverrideNames?.has(qobuzName.replace(/\d+$/, ''))) continue;
         result.platforms.push({ sourceId: 'qobuz', url: qobuzUrl });
       }
     }


### PR DESCRIPTION
## Summary
Follow-up to #103. The URL reservation only blocked the override's exact Qobuz URL, but Qobuz returns multiple URL variants for the same artist (e.g. `ben-g`, `ben-g-1`, `ben-g-5`). Unreserved variants were still getting attached to the wrong Bandcamp result.

Now also checks the Qobuz match's base name (stripping trailing digits) against override names. If it matches, the Qobuz link is skipped — the override will handle it.

## Test plan
- [ ] Search "ben g" — Bandcamp "BenG" result should NOT have any Qobuz link or featured release
- [ ] Search "ben-g!" — Ben-G! override result works correctly with Qobuz link
- [ ] Other artists with Qobuz links unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)