### PR TITLE
Block orphaned Qobuz standalones for override-reserved artists

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1244,14 +1244,17 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
 
   const aggregated = aggregateResults(allResults, query);
 
-  // Fetch overrides early so we can reserve their URLs during Phase 2
+  // Fetch overrides early so we can reserve their URLs and names during Phase 2
   const overrides = await getMergeOverrides();
   const reservedOverrideUrls = new Set(
     overrides.flatMap(o => o.platform_urls.map(u => u.replace(/\/+$/, '').toLowerCase()))
   );
+  const reservedOverrideNames = new Set(
+    overrides.map(o => normalizeForComparison(o.group_name))
+  );
 
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
-  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, reservedOverrideUrls);
+  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, reservedOverrideUrls, reservedOverrideNames);
   createQobuzOnlyResults(aggregated, qobuzMatches);
 
   // Phase 2.5: Apply manual merge overrides before release-based disambiguation

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1268,7 +1268,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   removeDeadQobuzLinks(aggregated);
   crossPlatformReleaseComparison(aggregated);
   deduplicateQobuzUrls(aggregated);
-  createOrphanedQobuzStandalones(aggregated, qobuzMatches);
+  createOrphanedQobuzStandalones(aggregated, qobuzMatches, reservedOverrideUrls, reservedOverrideNames);
   const disambiguated = splitSuspiciousPlatforms(aggregated);
   const merged = mergeByReleaseOverlap(disambiguated);
 

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -630,6 +630,8 @@ export function deduplicateQobuzUrls(aggregated: AggregatedResult[]): void {
 export function createOrphanedQobuzStandalones(
   aggregated: AggregatedResult[],
   qobuzMatches: Map<string, string>,
+  reservedOverrideUrls?: Set<string>,
+  reservedOverrideNames?: Set<string>,
 ): void {
   const attachedUrls = new Set<string>();
   for (const r of aggregated) {
@@ -640,6 +642,9 @@ export function createOrphanedQobuzStandalones(
 
   for (const [qobuzName, qobuzUrl] of qobuzMatches) {
     if (attachedUrls.has(qobuzUrl)) continue;
+    // Skip URLs/names reserved by overrides — the override handles them
+    if (reservedOverrideUrls?.has(qobuzUrl.replace(/\/+$/, '').toLowerCase())) continue;
+    if (reservedOverrideNames?.has(qobuzName.replace(/\d+$/, ''))) continue;
 
     const displayName = qobuzDisplayName(qobuzUrl, qobuzName);
     const standaloneId = `qobuz-standalone-${qobuzName}`;

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -448,6 +448,7 @@ export function attachQobuzAndSearchLinks(
   qobuzMatches: Map<string, string>,
   ampwallMatches: Map<string, string>,
   reservedOverrideUrls?: Set<string>,
+  reservedOverrideNames?: Set<string>,
 ): void {
   const usedPlatformUrls = new Set<string>();
 
@@ -479,10 +480,12 @@ export function attachQobuzAndSearchLinks(
 
     // Qobuz: attach ALL name variations (e.g. "morice", "morice1", "morice2")
     // Disambiguation will sort out which actually match based on releases.
-    // Skip URLs reserved by merge overrides — the override will handle them.
+    // Skip Qobuz matches whose name matches an override — the override owns
+    // all Qobuz variants for that artist, not just the exact URL in its list.
     for (const [qobuzName, qobuzUrl] of qobuzMatches) {
       if (isQobuzVariation(qobuzName, normalizedName)) {
         if (reservedOverrideUrls?.has(qobuzUrl.replace(/\/+$/, '').toLowerCase())) continue;
+        if (reservedOverrideNames?.has(qobuzName.replace(/\d+$/, ''))) continue;
         result.platforms.push({ sourceId: 'qobuz', url: qobuzUrl });
       }
     }


### PR DESCRIPTION
## Summary
Follow-up to #103 and #104. Reserved Qobuz URLs were still leaking through `createOrphanedQobuzStandalones` — a second standalone creation function that runs after disambiguation. Since the URL wasn't attached to any result (blocked by reservation), it was treated as "orphaned" and a standalone was created, which then got merged with the wrong artist by name during disambiguation.

## Fix
Pass `reservedOverrideUrls` and `reservedOverrideNames` to `createOrphanedQobuzStandalones` so it also skips creating standalones for override-owned Qobuz matches.

## Test plan
- [ ] Search "ben g" — Bandcamp "BenG" should have NO Qobuz link or featured release
- [ ] Search "ben-g!" — Ben-G! override result shows correctly with its own Qobuz link
- [ ] Both results appear separately, not merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)