### PR TITLE
Only apply overrides relevant to the current search

### DIFF
--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -103,7 +103,14 @@ export function applyMergeOverrides(
       override.platform_urls.map(u => u.replace(/\/+$/, '').toLowerCase())
     );
 
-    // Step 1: Strip ALL override URLs from every existing result.
+    // Step 1: Check if this override is relevant to the current search.
+    // Only apply if at least one override URL appears in the search results.
+    const hasRelevantResult = aggregated.some(r =>
+      r.platforms.some(p => overrideUrls.has(p.url.replace(/\/+$/, '').toLowerCase()))
+    );
+    if (!hasRelevantResult) continue;
+
+    // Step 2: Strip ALL override URLs from every existing result.
     // The override result will be the sole owner of these URLs.
     for (const result of aggregated) {
       const before = result.platforms.length;


### PR DESCRIPTION
## Summary
This commit was part of #106 but didn't make it into the merge. Overrides were creating their result for every search regardless of query. Now skips overrides whose URLs don't appear in any search result.

## Test plan
- [ ] Search "kid lightbulbs" — no Radiohead/Gooseworx/Ben-G! results
- [ ] Search "ben g" — Ben-G! override appears (its Qobuz URL is in results)
- [ ] Search "radiohead" — Radiohead override applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)