### PR TITLE
Add Wikipedia artist bio summaries to search results

### DIFF
--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -27,6 +27,8 @@ interface MusicBrainzSearchResponse {
   socialLinks: SocialLink[];
   discoveredPlatforms: DiscoveredPlatformLink[];
   platformUrls: string[]; // Known platform URLs from MusicBrainz relations (bandcamp, mirlo, etc.)
+  wikipediaSummary: string | null;
+  wikipediaUrl: string | null;
 }
 
 // Known Mastodon/Fediverse instances (non-exhaustive, but covers popular ones)
@@ -114,6 +116,35 @@ function parseSocialUrl(url: string): SocialLink | null {
   }
 
   return null;
+}
+
+// Fetch a short bio summary from the Wikipedia REST API
+async function fetchWikipediaSummary(wikipediaUrl: string): Promise<{ extract: string; pageUrl: string } | null> {
+  try {
+    const match = wikipediaUrl.match(/\/wiki\/(.+)$/);
+    if (!match) return null;
+    const title = match[1];
+    const response = await globalThis.fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`,
+      {
+        headers: { 'User-Agent': 'Unstream/1.0 (https://unstream.stream)' },
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+    if (!response.ok) return null;
+    const data = await response.json() as {
+      type?: string;
+      extract?: string;
+      content_urls?: { desktop?: { page?: string } };
+    };
+    if (data.type === 'disambiguation') return null;
+    return {
+      extract: data.extract || '',
+      pageUrl: data.content_urls?.desktop?.page || wikipediaUrl,
+    };
+  } catch {
+    return null;
+  }
 }
 
 import { cacheGetOrFetch, artistCacheKey } from './cache';
@@ -432,6 +463,8 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     socialLinks: [],
     discoveredPlatforms: [],
     platformUrls: [],
+    wikipediaSummary: null,
+    wikipediaUrl: null,
   };
 
   try {
@@ -486,6 +519,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     let officialUrl: string | null = null;
     let discogsUrl: string | null = null;
     let linktreeUrl: string | null = null;
+    let wikipediaUrl: string | null = null;
     const socialLinks: SocialLink[] = [];
     const seenPlatforms = new Set<SocialPlatform>();
     const platformUrls: string[] = [];
@@ -512,6 +546,14 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       for (const rel of relations) {
         if (rel.type === 'discogs' && rel.url?.resource) {
           discogsUrl = rel.url.resource;
+          break;
+        }
+      }
+
+      // Look for English Wikipedia link
+      for (const rel of relations) {
+        if (rel.type === 'wikipedia' && rel.url?.resource && rel.url.resource.includes('en.wikipedia.org')) {
+          wikipediaUrl = rel.url.resource;
           break;
         }
       }
@@ -585,11 +627,12 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       }
     }
 
-    // Fetch additional social links from Discogs, official site, and PeerTube in parallel
-    const [discogsSocialLinks, officialSiteResult, peertubeLink] = await Promise.all([
+    // Fetch additional social links from Discogs, official site, PeerTube, and Wikipedia in parallel
+    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult] = await Promise.all([
       discogsUrl ? fetchDiscogsSocialLinks(discogsUrl) : Promise.resolve([]),
       officialUrl ? fetchOfficialSiteSocialLinks(officialUrl) : Promise.resolve({ socialLinks: [], linktreeUrl: null, discoveredPlatforms: [] }),
       searchPeerTubeChannels(artist.name),
+      wikipediaUrl ? fetchWikipediaSummary(wikipediaUrl) : Promise.resolve(null),
     ]);
 
     // If we found a Linktree URL from MusicBrainz or official site, scrape it for additional links
@@ -616,6 +659,8 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       socialLinks: allSocialLinks,
       discoveredPlatforms: officialSiteResult.discoveredPlatforms,
       platformUrls,
+      wikipediaSummary: wikipediaResult?.extract || null,
+      wikipediaUrl: wikipediaResult?.pageUrl || wikipediaUrl,
     };
   } catch (error: unknown) {
     const err = error as { name?: string; message?: string };
@@ -691,6 +736,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
         hasPre2005Release: false,
         socialLinks: [],
         discoveredPlatforms: [],
+        wikipediaSummary: null,
+        wikipediaUrl: null,
       }),
     };
   }

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -387,6 +387,27 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
               </span>
             </div>
           )}
+          {/* Wikipedia bio summary */}
+          {result.type === 'artist' && result.wikipediaSummary && (
+            <div className="space-y-1">
+              <p className="text-sm text-text-secondary leading-relaxed">
+                {result.wikipediaSummary.length > 200
+                  ? result.wikipediaSummary.substring(0, 200).replace(/\s+\S*$/, '') + '...'
+                  : result.wikipediaSummary}
+                {result.wikipediaUrl && (
+                  <>
+                    {' '}
+                    <a href={result.wikipediaUrl} target="_blank" rel="noopener noreferrer"
+                       className="text-accent-primary hover:underline text-xs"
+                       onClick={(e) => e.stopPropagation()}>
+                      Wikipedia
+                    </a>
+                  </>
+                )}
+              </p>
+            </div>
+          )}
+
           {/* Featured Release Section with Preview */}
           {latestRelease && platformsWithRelease.length > 0 && (
             <div className="space-y-2">

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -618,6 +618,11 @@ export function mergeWithMusicBrainzData(
       return 0;
     });
 
-    return { ...result, platforms: newPlatforms };
+    return {
+      ...result,
+      platforms: newPlatforms,
+      wikipediaSummary: mbData.wikipediaSummary || undefined,
+      wikipediaUrl: mbData.wikipediaUrl || undefined,
+    };
   });
 }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -68,6 +68,9 @@ export interface SearchResult {
   matchConfidence?: 'verified' | 'unverified' | 'claimed';
   // Slug for claimed artist page (/a/{slug})
   claimedSlug?: string;
+  // Wikipedia bio summary from MusicBrainz enrichment
+  wikipediaSummary?: string;
+  wikipediaUrl?: string;
 }
 
 // API response from /api/search/sources
@@ -92,6 +95,8 @@ export interface MusicBrainzData {
   hasPre2005Release: boolean;
   socialLinks: SocialLink[];
   platformUrls?: string[];
+  wikipediaSummary?: string | null;
+  wikipediaUrl?: string | null;
 }
 
 // Search state


### PR DESCRIPTION
## Summary
- Extracts Wikipedia URLs from MusicBrainz artist relations (`rel.type === 'wikipedia'`)
- Fetches summaries via Wikipedia REST API (`/api/rest_v1/page/summary/`) in parallel with existing Discogs/PeerTube enrichment
- Displays truncated bio (~200 chars) with "Wikipedia" attribution link in expanded ResultCard
- Graceful degradation — no bio appears for artists without Wikipedia pages

## Changes
- `api/functions/search-musicbrainz.ts` — Added `fetchWikipediaSummary()`, Wikipedia URL extraction from relations, parallel fetch
- `apps/web/src/types/index.ts` — Added `wikipediaSummary` + `wikipediaUrl` to `MusicBrainzData` and `SearchResult`
- `apps/web/src/services/sources.ts` — Pass Wikipedia fields through `mergeWithMusicBrainzData`
- `apps/web/src/components/ResultCard.tsx` — Bio display in expanded card section

## Test plan
- [x] Unit tests pass (165/165)
- [x] TypeScript typecheck clean
- [ ] Search for "Radiohead" — should show Wikipedia bio
- [ ] Search for "Kid Lightbulbs" — should show no bio (no Wikipedia page)
- [ ] Verify bio truncation at ~200 chars with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)