### PR TITLE
Add EVEN as 17th search platform via Algolia

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Unstream helps music listeners find their favorite artists on alternative platforms outside streaming, so they can support artists directly. It searches 16 platforms (Bandcamp, Mirlo, Ampwall, Qobuz, Beatport, Faircamp, Patreon, etc.) and shows verified links grouped by category with artist payout percentages.
+Unstream helps music listeners find their favorite artists on alternative platforms outside streaming, so they can support artists directly. It searches 17 platforms (Bandcamp, Mirlo, Ampwall, Qobuz, Beatport, Faircamp, Patreon, etc.) and shows verified links grouped by category with artist payout percentages.
 
 The product runs at [unstream.stream](https://unstream.stream).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [unstream.stream](https://unstream.stream)
 
-Unstream searches 16 platforms to find where your favorite artists sell music, accept patronage, or share music for free outside the streaming ecosystem. It shows artist payout percentages so you can make informed choices about where your money goes.
+Unstream searches 17 platforms to find where your favorite artists sell music, accept patronage, or share music for free outside the streaming ecosystem. It shows artist payout percentages so you can make informed choices about where your money goes.
 
 ## How it works
 

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1094,6 +1094,64 @@ async function searchBeatport(query: string): Promise<Map<string, string>> {
   return new Map(data);
 }
 
+// Search EVEN via Algolia API (direct-to-fan marketplace)
+async function searchEven(query: string): Promise<Map<string, string>> {
+  const cacheKey = artistCacheKey('even', query);
+
+  const { data } = await cacheGetOrFetch<[string, string][]>(
+    cacheKey,
+    async () => {
+      const results: [string, string][] = [];
+
+      try {
+        const response = await fetchWithTimeout('https://S64VD9CU46-dsn.algolia.net/1/indexes/Artist/query', {
+          method: 'POST',
+          headers: {
+            'X-Algolia-Application-Id': 'S64VD9CU46',
+            'X-Algolia-API-Key': 'eea52fd4a67d03678477ffdfbad362e2',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ query, hitsPerPage: 10 }),
+        }, 5000);
+
+        if (!response.ok) return results;
+
+        const json = await response.json();
+        const queryNormalized = normalizeForComparison(query);
+        const seen = new Set<string>();
+
+        for (const hit of json.hits || []) {
+          const name = hit.name;
+          const slug = hit.slug || hit.username;
+          if (!name || !slug) continue;
+
+          const normalizedName = normalizeForComparison(name);
+
+          // Strict matching: exact, query prefix, or numeric suffix variation
+          const isMatch = normalizedName === queryNormalized ||
+            queryNormalized.startsWith(normalizedName) ||
+            (normalizedName.startsWith(queryNormalized) && /^\d*$/.test(normalizedName.slice(queryNormalized.length)));
+
+          if (isMatch && !seen.has(normalizedName)) {
+            seen.add(normalizedName);
+            results.push([normalizedName, `https://even.biz/artists/${slug}`]);
+          }
+        }
+      } catch (error: unknown) {
+        const err = error as { name?: string; message?: string };
+        if (err.name !== 'AbortError') {
+          console.error('EVEN search error:', err.message);
+        }
+      }
+
+      return results;
+    },
+    PLATFORM_CACHE_TTL
+  );
+
+  return new Map(data);
+}
+
 // ---------------------------------------------------------------------------
 // Phase 3: Fetch releases & disambiguate
 // ---------------------------------------------------------------------------
@@ -1290,7 +1348,7 @@ async function attachNameOnlyPlatforms(
 
 async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
-  const [bandcampResults, bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults] = await Promise.allSettled([
+  const [bandcampResults, bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults] = await Promise.allSettled([
     searchBandcamp(query),
     searchBandwagon(query),
     searchMirlo(query),
@@ -1300,6 +1358,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
     searchQobuz(query),
     searchAmpwall(query),
     searchBeatport(query),
+    searchEven(query),
   ]);
 
   const allResults: PlatformResult[] = [];
@@ -1312,6 +1371,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
     ['jamcoop', jamcoopResults.status === 'fulfilled' ? jamcoopResults.value : new Map()],
     ['patreon', patreonResults.status === 'fulfilled' ? patreonResults.value : new Map()],
     ['beatport', beatportResults.status === 'fulfilled' ? beatportResults.value : new Map()],
+    ['even', evenResults.status === 'fulfilled' ? evenResults.value : new Map()],
   ];
   const qobuzMatches = qobuzResults.status === 'fulfilled' ? qobuzResults.value : new Map<string, string>();
   const ampwallMatches = ampwallResults.status === 'fulfilled' ? ampwallResults.value : new Map<string, string>();

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -15,6 +15,7 @@ export type SourceId =
   | 'kofi'
   | 'qobuz'
   | 'beatport'
+  | 'even'
   | 'officialsite'
   | 'discogs';
 
@@ -86,6 +87,7 @@ export function sourceIdFromUrl(url: string): SourceId | null {
     if (host.endsWith('buymeacoffee.com')) return 'buymeacoffee';
     if (host.endsWith('ko-fi.com')) return 'kofi';
     if (host.endsWith('beatport.com')) return 'beatport';
+    if (host.endsWith('even.biz')) return 'even';
     return null;
   } catch {
     return null;

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -13,7 +13,7 @@
       "strict_min_version": "120.0"
     }
   },
-  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 16 platforms. Free, open source, no tracking.",
+  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free, open source, no tracking.",
   "version": "2.1.0",
   "icons": {
     "16": "icons/icon16.png",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Unstream - Support Music Directly",
-  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 16 platforms. Free and open source.",
+  "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free and open source.",
   "version": "2.1.0",
   "icons": {
     "16": "icons/icon16.png",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,9 +6,9 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unstream - Support Artists Directly</title>
-    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 16 platforms. Free and open source." />
+    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 17 platforms. Free and open source." />
     <meta property="og:title" content="Unstream - Support Artists Directly" />
-    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 16 platforms. Free and open source." />
+    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 17 platforms. Free and open source." />
     <meta property="og:image" content="https://unstream.stream/og-image.png" />
     <meta property="og:url" content="https://unstream.stream" />
     <meta property="og:type" content="website" />

--- a/apps/web/server/api.ts
+++ b/apps/web/server/api.ts
@@ -13,7 +13,8 @@ type SourceId =
   | 'hoopla'
   | 'freegal'
   | 'qobuz'
-  | 'beatport';
+  | 'beatport'
+  | 'even';
 
 // Social platform types for MusicBrainz enrichment
 type SocialPlatform = 'instagram' | 'facebook' | 'tiktok' | 'youtube' | 'threads' | 'bluesky' | 'twitter';
@@ -973,6 +974,50 @@ async function searchBeatport(query: string): Promise<Map<string, string>> {
   return results;
 }
 
+// Search EVEN via Algolia API (direct-to-fan marketplace)
+async function searchEven(query: string): Promise<Map<string, string>> {
+  const results = new Map<string, string>();
+
+  try {
+    const response = await fetchWithTimeout('https://S64VD9CU46-dsn.algolia.net/1/indexes/Artist/query', {
+      method: 'POST',
+      headers: {
+        'X-Algolia-Application-Id': 'S64VD9CU46',
+        'X-Algolia-API-Key': 'eea52fd4a67d03678477ffdfbad362e2',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, hitsPerPage: 10 }),
+    }, 5000);
+
+    if (!response.ok) return results;
+
+    const json = await response.json();
+    const queryNormalized = normalizeForComparison(query);
+
+    for (const hit of (json as { hits?: { name?: string; slug?: string; username?: string }[] }).hits || []) {
+      const name = hit.name;
+      const slug = hit.slug || hit.username;
+      if (!name || !slug) continue;
+
+      const normalizedName = normalizeForComparison(name);
+
+      const isMatch = normalizedName === queryNormalized ||
+        queryNormalized.startsWith(normalizedName) ||
+        (normalizedName.startsWith(queryNormalized) && /^\d*$/.test(normalizedName.slice(queryNormalized.length)));
+
+      if (isMatch && !results.has(normalizedName)) {
+        results.set(normalizedName, `https://even.biz/artists/${slug}`);
+      }
+    }
+  } catch (error: any) {
+    if (error.name !== 'AbortError') {
+      console.error('EVEN search error:', error.message);
+    }
+  }
+
+  return results;
+}
+
 function generateResultId(name: string, artist?: string): string {
   const normalized = normalizeForComparison(artist ? `${artist}-${name}` : name);
   return normalized || Math.random().toString(36).substring(2);
@@ -1031,7 +1076,7 @@ function aggregateResults(allResults: PlatformResult[], query?: string): Aggrega
 }
 
 async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
-  const [bandcampResults, bandwagonResults, mirloResults, faircampResults, patreonResults, qobuzResults, musicbrainzResults, beatportResults] = await Promise.allSettled([
+  const [bandcampResults, bandwagonResults, mirloResults, faircampResults, patreonResults, qobuzResults, musicbrainzResults, beatportResults, evenResults] = await Promise.allSettled([
     searchBandcamp(query),
     searchBandwagon(query),
     searchMirlo(query),
@@ -1040,6 +1085,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
     searchQobuz(query),
     searchMusicBrainz(query),
     searchBeatport(query),
+    searchEven(query),
   ]);
 
   const allResults: PlatformResult[] = [];
@@ -1069,6 +1115,9 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
 
   // Get Beatport matches (returns Map of normalized artist name -> URL)
   const beatportMatches = beatportResults.status === 'fulfilled' ? beatportResults.value : new Map<string, string>();
+
+  // Get EVEN matches (returns Map of normalized artist name -> URL)
+  const evenMatches = evenResults.status === 'fulfilled' ? evenResults.value : new Map<string, string>();
 
   // Get aggregated results
   const aggregated = aggregateResults(allResults, query);
@@ -1134,6 +1183,14 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
         result.platforms.push({
           sourceId: 'beatport',
           url: beatportMatches.get(normalizedName)!,
+        });
+      }
+
+      // Add EVEN link if artist matches
+      if (evenMatches.has(normalizedName)) {
+        result.platforms.push({
+          sourceId: 'even',
+          url: evenMatches.get(normalizedName)!,
         });
       }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -295,7 +295,7 @@ function App() {
             Find where to buy music directly from artists you love
           </h1>
           <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
-            Search with Unstream across 16+ platforms where artists keep up to 97% of every sale — not fractions of a penny from streams.
+            Search with Unstream across 17+ platforms where artists keep up to 97% of every sale — not fractions of a penny from streams.
           </p>
         </div>
       </div>

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -145,6 +145,18 @@ export const sources: Record<SourceId, Source> = {
     homepageUrl: 'https://www.beatport.com',
     artistPayoutPercent: '55-70%',
   },
+  even: {
+    id: 'even',
+    name: 'EVEN',
+    description: 'Direct-to-fan music marketplace',
+    color: '#000000',
+    icon: '🎤',
+    category: 'marketplace',
+    hasEmbed: false,
+    searchUrlTemplate: 'https://even.biz/search?q={query}',
+    homepageUrl: 'https://even.biz',
+    artistPayoutPercent: '~80%',
+  },
   jamcoop: {
     id: 'jamcoop',
     name: 'Jam.coop',
@@ -273,7 +285,7 @@ export const sourceCategories = {
   marketplace: {
     name: 'Music Marketplaces',
     description: 'Buy music directly from artists',
-    sources: ['bandcamp', 'mirlo', 'ampwall', 'qobuz', 'beatport', 'jamcoop', 'discogs'] as SourceId[],
+    sources: ['bandcamp', 'mirlo', 'ampwall', 'qobuz', 'beatport', 'even', 'jamcoop', 'discogs'] as SourceId[],
   },
   patronage: {
     name: 'Patronage Platforms',

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -12,6 +12,7 @@ export type SourceId =
   | 'freegal'
   | 'qobuz'
   | 'beatport'
+  | 'even'
   | 'jamcoop'
   | 'officialsite'
   | 'discogs'

--- a/apps/web/tests/fixtures/expected-results.json
+++ b/apps/web/tests/fixtures/expected-results.json
@@ -94,6 +94,19 @@
     }
   },
   {
+    "query": "French Montana",
+    "assertions": {
+      "minResults": 1,
+      "results": [
+        {
+          "name": "French Montana",
+          "requiredPlatforms": ["even"],
+          "urlPatterns": { "even": "even.biz/artists/" }
+        }
+      ]
+    }
+  },
+  {
     "query": "",
     "assertions": {
       "expectError": true,

--- a/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
+++ b/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
@@ -57,4 +57,4 @@ Don't sleep on your local library. **[Hoopla](https://www.hoopladigital.com)** a
 
 The biggest pain point with this whole ecosystem is fragmentation. Your favorite artist might be on Bandcamp, Mirlo, *and* Ko-fi — but you'd have no idea unless you checked each platform separately.
 
-That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 16 platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.
+That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 17 platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.

--- a/data/guides/how-to-build-a-music-library-without-streaming.md
+++ b/data/guides/how-to-build-a-music-library-without-streaming.md
@@ -29,7 +29,7 @@ Over a year that's 12–24 albums you permanently own, with $100+ going directly
 
 This used to be the annoying part. Artists sell across tons of platforms — [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), their own websites, [Ko-fi](https://ko-fi.com) — and checking each one individually is tedious enough that most people just don't bother.
 
-[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 16 platforms, with how much of your money reaches them on each one. Free, no account needed.
+[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 17 platforms, with how much of your money reaches them on each one. Free, no account needed.
 
 ## Pick a music player
 

--- a/data/guides/labels-vs-independence-what-artists-actually-keep.md
+++ b/data/guides/labels-vs-independence-what-artists-actually-keep.md
@@ -87,7 +87,7 @@ This is where the "1,000 true fans" math gets real. A thousand fans each buying 
 
 The biggest challenge for independent artists is still discovery. Labels have marketing machines. Independent artists have social media, word of mouth, and whatever organic growth they can build.
 
-But this is shifting. Tools like [Unstream](https://unstream.stream) help listeners find where their favorite artists sell directly across 15 platforms. Communities on [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), and music forums actively champion independent releases. Music blogs and independent publications still cover artists who aren't on major labels.
+But this is shifting. Tools like [Unstream](https://unstream.stream) help listeners find where their favorite artists sell directly across 17 platforms. Communities on [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), and music forums actively champion independent releases. Music blogs and independent publications still cover artists who aren't on major labels.
 
 And the artists who build direct relationships with fans — through email lists, community platforms like [Patreon](https://www.patreon.com) or [Ko-fi](https://ko-fi.com), and direct-sales storefronts — tend to have more durable careers than those who rely on algorithmic discovery. An algorithm can stop recommending you tomorrow. A fan who bought your last three albums on Bandcamp is going to buy the next one too.
 

--- a/data/guides/the-real-cost-of-free-music.md
+++ b/data/guides/the-real-cost-of-free-music.md
@@ -53,6 +53,6 @@ This isn't theoretical. Bandcamp alone has paid artists over a billion dollars. 
 You don't have to quit streaming. But a few things go a long way:
 
 1. **Pick the artists you care about most** and buy their music directly. One $10 album purchase on Bandcamp gives an artist more than thousands of streams.
-2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 16 platforms and see how much of your money reaches them on each one.
+2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 17 platforms and see how much of your money reaches them on each one.
 3. **Buy on Bandcamp Fridays** (first Friday of every month) when artists keep ~97%.
 4. **Tell people.** Most listeners have no idea how any of this works. The streaming experience is so smooth that it's easy to assume the artists behind it are being taken care of. They're mostly not.

--- a/data/guides/where-your-money-goes-streaming-vs-buying.md
+++ b/data/guides/where-your-money-goes-streaming-vs-buying.md
@@ -50,7 +50,7 @@ And it compounds in a way streaming doesn't. After three years of streaming you 
 You don't need to cancel streaming — plenty of people keep it for casual listening and convenience while also buying from artists they care about. That's fine. Even small shifts matter:
 
 - **Buy from one or two artists a month** instead of just streaming them. Prioritize the ones who seem like they need it most — independent, unsigned, small following.
-- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 16 platforms and see exactly how much reaches them on each one.
+- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 17 platforms and see exactly how much reaches them on each one.
 - **Buy on Bandcamp Fridays** to maximize what goes to the artist.
 - **Check your library's music services** — [Hoopla](https://www.hoopladigital.com) and [Freegal](https://www.freegalmusic.com) are free with a library card and good for exploring new stuff without spending.
 

--- a/data/guides/why-music-platforms-hide-artist-payout-rates.md
+++ b/data/guides/why-music-platforms-hide-artist-payout-rates.md
@@ -89,7 +89,7 @@ Some of this is starting to happen anyway. Artists share royalty screenshots on 
 Until platforms are required or pressured to disclose payout rates in a standardized way:
 
 - **Favor platforms that publish their rates.** [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), and others are upfront about what artists keep. That transparency is a feature.
-- **Use [Unstream](https://unstream.stream)** to search for artists across 15 platforms and see payout percentages for each one.
+- **Use [Unstream](https://unstream.stream)** to search for artists across 17 platforms and see payout percentages for each one.
 - **Ask the question.** When a platform says it "supports artists," ask how much. If the answer is vague or unavailable, that tells you something.
 - **Buy directly when you can.** A $10 album on Bandcamp puts [about $8.20 in the artist's pocket](https://bandcamp.com/fair_trade_music_policy). No ambiguity, no opaque royalty pool, no six-month delay.
 

--- a/scripts/generate-social-posts.ts
+++ b/scripts/generate-social-posts.ts
@@ -525,9 +525,9 @@ function generatePromoPost(weekNumber: number): { posts: PostDraft['posts']; fea
 
   switch (angle) {
     case 0: // what it does
-      threads = `i built a free tool that searches 16 platforms to help you find where to buy music directly from artists. no account, no tracking, no paywall.\n\n${url}`;
-      bluesky = `Free tool that searches 16 platforms to find where to buy music directly from artists. No account needed.\n\n${url}`;
-      instagram = `Unstream searches 15 alternative music platforms to help you find where to buy music directly from artists.\n\nNo account. No tracking. No paywall. Just a way to get more money to the people who make the music.\n\n${url}`;
+      threads = `i built a free tool that searches 17 platforms to help you find where to buy music directly from artists. no account, no tracking, no paywall.\n\n${url}`;
+      bluesky = `Free tool that searches 17 platforms to find where to buy music directly from artists. No account needed.\n\n${url}`;
+      instagram = `Unstream searches 17 alternative music platforms to help you find where to buy music directly from artists.\n\nNo account. No tracking. No paywall. Just a way to get more money to the people who make the music.\n\n${url}`;
       break;
 
     case 1: // the why
@@ -549,9 +549,9 @@ function generatePromoPost(weekNumber: number): { posts: PostDraft['posts']; fea
       break;
 
     case 4: // how it works
-      threads = `search for any artist on Unstream and it checks 16 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in a few seconds. shows you where to buy their music directly — with payout percentages so you know where your money goes.\n\n${url}`;
-      bluesky = `Search any artist on Unstream → it checks 16 platforms and shows where to buy their music directly, with payout percentages.\n\n${url}`;
-      instagram = `Search for any artist on Unstream.\n\nIt checks 16 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in seconds — and shows you where to buy their music directly, with transparent payout percentages.\n\n${url}`;
+      threads = `search for any artist on Unstream and it checks 17 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in a few seconds. shows you where to buy their music directly — with payout percentages so you know where your money goes.\n\n${url}`;
+      bluesky = `Search any artist on Unstream → it checks 17 platforms and shows where to buy their music directly, with payout percentages.\n\n${url}`;
+      instagram = `Search for any artist on Unstream.\n\nIt checks 17 platforms — Bandcamp, Faircamp, Mirlo, Qobuz, and more — in seconds — and shows you where to buy their music directly, with transparent payout percentages.\n\n${url}`;
       break;
 
     default: // the pitch, earnest


### PR DESCRIPTION
## Summary
Integrates EVEN (even.biz), a direct-to-fan music marketplace where artists keep 80%, as Unstream's 17th platform.

**Technical approach:** Unlike Beatport (HTML scraping) or Bandcamp (HTML parsing), EVEN uses Algolia for search with publicly exposed search-only credentials (standard client-side pattern). This gives us structured JSON responses with ~4ms latency — the cleanest integration yet.

- Registered EVEN as a marketplace platform (80% payout, black branding)
- `searchEven()` hits Algolia's `Artist` index directly with name matching
- Wired into `searchAllPlatforms()` as a name-only platform
- Added French Montana test fixture
- Updated platform count 16 → 17 across all references
- Local dev server also updated

## Test plan
- [x] Unit tests pass (165/165)
- [x] TypeScript typecheck clean
- [ ] Search for "French Montana" — should show EVEN result
- [ ] Search for "LaRussell" — should show EVEN result
- [ ] Verify EVEN badge renders with correct color
- [ ] Verify artist edit page shows EVEN in platform dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)