### PR TITLE
Add no-JS fallback search experience

### DIFF
--- a/api/edge/noscript-search.ts
+++ b/api/edge/noscript-search.ts
@@ -1,0 +1,332 @@
+import { Context } from "https://edge.netlify.com";
+
+interface PlatformLink {
+  sourceId: string;
+  url: string;
+  latestRelease?: {
+    title: string;
+    type: string;
+    url: string;
+    imageUrl?: string;
+    releaseDate?: string;
+  };
+}
+
+interface SearchResult {
+  id: string;
+  name: string;
+  artist?: string;
+  type: 'artist' | 'album' | 'track';
+  imageUrl?: string;
+  platforms: PlatformLink[];
+  matchConfidence?: 'verified' | 'unverified';
+}
+
+const PLATFORM_INFO: Record<string, { name: string; icon: string; category: string; searchOnly?: boolean; payoutPercent?: string }> = {
+  bandcamp: { name: 'Bandcamp', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
+  mirlo: { name: 'Mirlo', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
+  ampwall: { name: 'Ampwall', icon: '🔊', category: 'marketplace', searchOnly: true, payoutPercent: '92-95%' },
+  bandwagon: { name: 'Bandwagon', icon: '🚐', category: 'decentralized' },
+  faircamp: { name: 'Faircamp', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
+  patreon: { name: 'Patreon', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },
+  buymeacoffee: { name: 'Buy Me a Coffee', icon: '☕', category: 'patronage', searchOnly: true, payoutPercent: '~92%' },
+  kofi: { name: 'Ko-fi', icon: '🍵', category: 'patronage', searchOnly: true, payoutPercent: '92-97%' },
+  hoopla: { name: 'Hoopla', icon: '🎧', category: 'library' },
+  freegal: { name: 'Freegal', icon: '🎵', category: 'library' },
+  qobuz: { name: 'Qobuz', icon: '💿', category: 'marketplace', payoutPercent: '~70%' },
+  jamcoop: { name: 'Jam.coop', icon: '🎸', category: 'marketplace' },
+  officialsite: { name: 'Official Site', icon: '🌐', category: 'official' },
+  discogs: { name: 'Discogs', icon: '💿', category: 'marketplace' },
+  instagram: { name: 'Instagram', icon: '📷', category: 'social' },
+  facebook: { name: 'Facebook', icon: '👤', category: 'social' },
+  tiktok: { name: 'TikTok', icon: '🎬', category: 'social' },
+  youtube: { name: 'YouTube', icon: '▶️', category: 'social' },
+  threads: { name: 'Threads', icon: '🧵', category: 'social' },
+  bluesky: { name: 'Bluesky', icon: '🦋', category: 'social' },
+  mastodon: { name: 'Mastodon', icon: '🐘', category: 'social' },
+  peertube: { name: 'PeerTube', icon: '🎥', category: 'social' },
+};
+
+const CATEGORY_ORDER = ['marketplace', 'patronage', 'library', 'decentralized', 'official'];
+const CATEGORY_LABELS: Record<string, string> = {
+  marketplace: 'Support directly',
+  patronage: 'Patronage',
+  library: 'Libraries',
+  decentralized: 'Decentralized',
+  official: 'Official',
+  social: 'Social',
+};
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderResultCard(result: SearchResult): string {
+  const name = escapeHtml(result.name);
+  const platforms = result.platforms.filter(p => {
+    const u = p.url.toLowerCase();
+    return !u.includes('duckduckgo.com') && !u.includes('google.com/search') && !u.includes('searchstyle=search');
+  });
+
+  const mainPlatforms = platforms.filter(p => PLATFORM_INFO[p.sourceId]?.category !== 'social');
+  const socialPlatforms = platforms.filter(p => PLATFORM_INFO[p.sourceId]?.category === 'social');
+
+  // Group by category
+  const grouped: Record<string, PlatformLink[]> = {};
+  for (const p of mainPlatforms) {
+    const cat = PLATFORM_INFO[p.sourceId]?.category || 'other';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(p);
+  }
+
+  let platformsHtml = '';
+  for (const cat of CATEGORY_ORDER) {
+    if (!grouped[cat] || grouped[cat].length === 0) continue;
+    const links = grouped[cat].map(p => {
+      const info = PLATFORM_INFO[p.sourceId];
+      if (!info) return '';
+      const label = info.searchOnly ? `Search ${info.name}` : info.name;
+      return `<a href="${escapeHtml(p.url)}" target="_blank" rel="noopener noreferrer" class="platform-link">
+        <span class="platform-icon">${info.icon}</span>
+        <span class="platform-name">${escapeHtml(label)}</span>
+        ${info.payoutPercent ? `<span class="payout">${info.payoutPercent} to artist</span>` : ''}
+        <span class="external-icon">↗</span>
+      </a>`;
+    }).join('');
+
+    platformsHtml += `
+      <div class="category-label">${CATEGORY_LABELS[cat] || cat}</div>
+      <div class="platform-list">${links}</div>`;
+  }
+
+  // Social links
+  if (socialPlatforms.length > 0) {
+    const socialLinks = socialPlatforms.map(p => {
+      const info = PLATFORM_INFO[p.sourceId];
+      if (!info) return '';
+      return `<a href="${escapeHtml(p.url)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(info.name)}" class="social-link">${info.icon}</a>`;
+    }).join('');
+    platformsHtml += `
+      <div class="category-label" style="margin-top:16px">Social</div>
+      <div class="social-list">${socialLinks}</div>`;
+  }
+
+  const badge = result.matchConfidence === 'verified'
+    ? '<span class="badge verified">Verified</span>'
+    : '';
+
+  return `<div class="result-card">
+    <div class="result-header">
+      ${result.imageUrl ? `<img src="${escapeHtml(result.imageUrl)}" alt="${name}" class="result-image" loading="lazy">` : ''}
+      <div>
+        <h2 class="result-name">${name} ${badge}</h2>
+        <span class="result-type">${result.type}</span>
+      </div>
+    </div>
+    ${platformsHtml}
+  </div>`;
+}
+
+function renderPage(query: string, results: SearchResult[], error?: string): string {
+  const escapedQuery = escapeHtml(query);
+
+  let bodyContent = '';
+  if (error) {
+    bodyContent = `<p class="error-msg">${escapeHtml(error)}</p>`;
+  } else if (query && results.length === 0) {
+    bodyContent = `<p class="no-results">No results found for "${escapedQuery}". Try a different spelling or search for another artist.</p>`;
+  } else if (results.length > 0) {
+    // Only show artist-type results in noscript mode for clarity
+    const artistResults = results.filter(r => r.type === 'artist');
+    const displayResults = artistResults.length > 0 ? artistResults : results.slice(0, 5);
+    bodyContent = displayResults.map(renderResultCard).join('');
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${query ? `${escapedQuery} - Unstream Search` : 'Search - Unstream'}</title>
+  <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 17 platforms.">
+  <meta name="robots" content="noindex">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root { --bg: #0d0d0d; --bg2: #1a1a1a; --text: #f0f0f0; --muted: #999; --border: #2a2a2a; --accent: #ff6b35; --footer-border: #1a1a1a; }
+    @media (prefers-color-scheme: light) {
+      :root { --bg: #ffffff; --bg2: #f5f5f5; --text: #1a1a1a; --muted: #555; --border: #e0e0e0; --accent: #e55a2b; --footer-border: #e0e0e0; }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Golos Text', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; -webkit-font-smoothing: antialiased; }
+    a { color: inherit; }
+    .container { max-width: 640px; margin: 0 auto; padding: 0 24px; width: 100%; }
+
+    /* Header */
+    .header { padding: 32px 0 24px; text-align: center; }
+    .header h1 { font-size: 24px; font-weight: 700; }
+    .header h1 a { text-decoration: none; color: var(--text); }
+    .header p { font-size: 14px; color: var(--muted); margin-top: 4px; }
+
+    /* Search form */
+    .search-form { display: flex; gap: 8px; margin-bottom: 32px; }
+    .search-input {
+      flex: 1; padding: 12px 16px; border-radius: 12px;
+      border: 1px solid var(--border); background: var(--bg2);
+      color: var(--text); font-size: 16px; font-family: inherit;
+      outline: none;
+    }
+    .search-input:focus { border-color: var(--accent); }
+    .search-input::placeholder { color: var(--muted); }
+    .search-btn {
+      padding: 12px 24px; border-radius: 12px; border: none;
+      background: var(--accent); color: #fff; font-size: 16px;
+      font-family: inherit; font-weight: 600; cursor: pointer;
+    }
+    .search-btn:hover { opacity: 0.9; }
+
+    /* Results */
+    .result-card {
+      border: 1px solid var(--border); border-radius: 16px;
+      padding: 24px; margin-bottom: 20px; background: var(--bg2);
+    }
+    .result-header { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; }
+    .result-image { width: 64px; height: 64px; border-radius: 50%; object-fit: cover; border: 2px solid var(--border); }
+    .result-name { font-size: 20px; font-weight: 700; }
+    .result-type { font-size: 12px; color: var(--muted); text-transform: capitalize; }
+    .badge { font-size: 11px; padding: 2px 8px; border-radius: 999px; font-weight: 600; vertical-align: middle; }
+    .badge.verified { background: #22c55e20; color: #22c55e; }
+
+    .category-label {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--muted); margin-bottom: 8px; margin-top: 16px;
+    }
+    .category-label:first-child { margin-top: 0; }
+    .platform-list { display: grid; gap: 8px; }
+    .platform-link {
+      display: flex; align-items: center; gap: 12px;
+      padding: 10px 14px; border-radius: 10px;
+      background: var(--bg); border: 1px solid var(--border);
+      text-decoration: none; color: var(--text); font-size: 14px;
+    }
+    .platform-link:hover { border-color: var(--accent); }
+    .platform-icon { font-size: 18px; }
+    .platform-name { flex: 1; font-weight: 500; }
+    .payout { font-size: 11px; color: var(--muted); }
+    .external-icon { color: var(--muted); font-size: 14px; }
+
+    .social-list { display: flex; flex-wrap: wrap; gap: 8px; }
+    .social-link {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 40px; height: 40px; border-radius: 50%;
+      background: var(--bg); border: 1px solid var(--border);
+      text-decoration: none; font-size: 18px;
+    }
+    .social-link:hover { border-color: var(--accent); }
+
+    .no-results, .error-msg { color: var(--muted); font-size: 16px; text-align: center; padding: 48px 0; }
+    .error-msg { color: #ef4444; }
+    .noscript-note { font-size: 13px; color: var(--muted); text-align: center; margin-bottom: 24px; }
+
+    /* Footer */
+    footer { margin-top: auto; padding: 24px 16px; border-top: 1px solid var(--footer-border); }
+    .footer-inner {
+      max-width: 640px; margin: 0 auto; display: flex; flex-direction: column;
+      align-items: center; gap: 12px; font-size: 14px; color: var(--muted);
+    }
+    .footer-inner a { color: var(--muted); text-decoration: none; }
+    .footer-inner a:hover { color: var(--text); }
+    .footer-nav { display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; }
+    .footer-dot { opacity: 0.4; font-size: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1><a href="/search">Unstream</a></h1>
+      <p>Find music on platforms that pay artists fairly.</p>
+    </div>
+
+    <form class="search-form" action="/search" method="get">
+      <input type="text" name="q" class="search-input" placeholder="Search for an artist..." value="${escapedQuery}" autofocus>
+      <button type="submit" class="search-btn">Search</button>
+    </form>
+
+    <p class="noscript-note">You're viewing Unstream without JavaScript. Some features are unavailable, but search works fine.</p>
+
+    ${bodyContent}
+  </div>
+
+  <footer>
+    <div class="footer-inner">
+      <a href="https://bgreen.lol" target="_blank" rel="noopener noreferrer">Made with love in Massachusetts, USA</a>
+      <nav class="footer-nav">
+        <a href="/artists">Artist index</a>
+        <span class="footer-dot">&#x2022;</span>
+        <a href="https://unstream.featurebase.app/roadmap" target="_blank" rel="noopener noreferrer">Roadmap</a>
+        <span class="footer-dot">&#x2022;</span>
+        <a href="mailto:support@unstream.stream">Support</a>
+        <span class="footer-dot">&#x2022;</span>
+        <a href="https://liberapay.com/brandonlucasgreen/donate" target="_blank" rel="noopener noreferrer">Donate</a>
+        <span class="footer-dot">&#x2022;</span>
+        <a href="/privacy-policy">Privacy</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>`;
+}
+
+export default async function handler(request: Request, context: Context) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q')?.trim() || '';
+
+  // No query — render empty search page
+  if (!query) {
+    return new Response(renderPage('', []), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  // Fetch search results from the internal API
+  const baseUrl = `${url.protocol}//${url.host}`;
+  try {
+    const searchUrl = new URL('/api/search/sources', baseUrl);
+    searchUrl.searchParams.set('query', query);
+
+    const response = await fetch(searchUrl.toString(), {
+      headers: { 'User-Agent': 'Unstream NoScript Search' },
+    });
+
+    if (!response.ok) {
+      return new Response(renderPage(query, [], 'Search is temporarily unavailable. Please try again.'), {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    const data = await response.json();
+    const results: SearchResult[] = data.results || [];
+
+    return new Response(renderPage(query, results), {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+  } catch {
+    return new Response(renderPage(query, [], 'Something went wrong. Please try again.'), {
+      status: 500,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+}
+
+export const config = {
+  path: "/search",
+};

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -23,6 +23,46 @@
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <style>
+        :root { --ns-bg: #0d0d0d; --ns-bg2: #1a1a1a; --ns-text: #f0f0f0; --ns-muted: #999; --ns-border: #2a2a2a; --ns-accent: #ff6b35; }
+        @media (prefers-color-scheme: light) {
+          :root { --ns-bg: #ffffff; --ns-bg2: #f5f5f5; --ns-text: #1a1a1a; --ns-muted: #555; --ns-border: #e0e0e0; --ns-accent: #e55a2b; }
+        }
+        .noscript-fallback {
+          position: fixed; inset: 0; z-index: 9999;
+          background: var(--ns-bg); color: var(--ns-text);
+          font-family: 'Golos Text', system-ui, sans-serif;
+          display: flex; flex-direction: column; align-items: center;
+          justify-content: center; padding: 24px; text-align: center;
+        }
+        .noscript-fallback h1 { font-size: 28px; font-weight: 700; margin-bottom: 8px; }
+        .noscript-fallback p { font-size: 16px; color: var(--ns-muted); margin-bottom: 32px; max-width: 480px; }
+        .noscript-form { display: flex; gap: 8px; width: 100%; max-width: 480px; }
+        .noscript-form input {
+          flex: 1; padding: 14px 18px; border-radius: 12px;
+          border: 1px solid var(--ns-border); background: var(--ns-bg2);
+          color: var(--ns-text); font-size: 16px; font-family: inherit;
+        }
+        .noscript-form button {
+          padding: 14px 28px; border-radius: 12px; border: none;
+          background: var(--ns-accent); color: #fff;
+          font-size: 16px; font-family: inherit; font-weight: 600; cursor: pointer;
+        }
+        .noscript-form button:hover { opacity: 0.9; }
+        .noscript-note { font-size: 13px; color: var(--ns-muted); margin-top: 24px; }
+        .noscript-note a { color: var(--ns-accent); }
+      </style>
+      <div class="noscript-fallback">
+        <h1>Unstream</h1>
+        <p>Find music on platforms that pay artists fairly. Search any artist to see where your money actually goes.</p>
+        <form class="noscript-form" action="/search" method="get">
+          <input type="text" name="q" placeholder="Search for an artist..." autofocus>
+          <button type="submit">Search</button>
+        </form>
+        <p class="noscript-note">You're viewing Unstream without JavaScript. Core search works, but some features require JS. <a href="/artists">Browse the artist index</a></p>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
     <script data-goatcounter="https://unstream.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,10 @@
   function = "claimed-artist-page"
 
 [[edge_functions]]
+  path = "/search"
+  function = "noscript-search"
+
+[[edge_functions]]
   path = "/artists"
   function = "artist-directory-page"
 


### PR DESCRIPTION
## Summary
- Adds a `<noscript>` overlay on the homepage with a search form, so users without JavaScript see Unstream branding and can search immediately
- New `/search` edge function that calls the existing search API and renders full server-side HTML with platform links, payout percentages, and category grouping
- Respects `prefers-color-scheme` for light/dark theming (since localStorage-based theme needs JS)

Closes #131

## What works without JS
- Search for any artist
- View results grouped by category (marketplace, patronage, library, etc.)
- Click through to Bandcamp, Mirlo, Qobuz, and all other platforms
- Browse the artist index

## What still requires JS
- Auth flows (artist claim, dashboard, edit)
- Admin tools
- Real-time search enrichment (MusicBrainz phase 2)
- Analytics

## Test plan
- [ ] Deploy preview: disable JS in browser, visit homepage — should see search form
- [ ] Search for an artist (e.g. "Radiohead") — should see server-rendered results with platform links
- [ ] Verify platform links open correctly
- [ ] Search with no results — should show friendly empty state
- [ ] Verify normal JS experience is unaffected (noscript block is invisible)
- [ ] Test light/dark mode via OS preference toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)