### PR TITLE
Add changelog page and platform comparison guide

### DIFF
--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -2608,12 +2608,6 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://unstream.stream/artist/lenny-bruce</loc>
-    <lastmod>2026-03-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://unstream.stream/artist/les-rita-mitsouko</loc>
     <lastmod>2026-03-24</lastmod>
     <changefreq>monthly</changefreq>
@@ -4766,6 +4760,24 @@
     <lastmod>2026-03-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://unstream.stream/guides/every-platform-unstream-supports-compared</loc>
+    <lastmod>2026-04-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://unstream.stream/guides/labels-vs-independence-what-artists-actually-keep</loc>
+    <lastmod>2026-03-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://unstream.stream/guides/why-music-platforms-hide-artist-payout-rates</loc>
+    <lastmod>2026-03-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://unstream.stream/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing</loc>

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -10,6 +10,8 @@ export function Footer() {
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/guides" className="hover:text-text-primary transition-colors">Guides</Link>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
+          <Link to="/changelog" className="hover:text-text-primary transition-colors">Changelog</Link>
+          <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <a
             href="https://github.com/users/brandonlucasgreen/projects/4"
             target="_blank"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,6 +21,7 @@ const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage.tsx').the
 const GuidesIndexPage = lazy(() => import('./pages/GuidesIndexPage.tsx').then(m => ({ default: m.GuidesIndexPage })))
 const GuidePage = lazy(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
 const DevelopersPage = lazy(() => import('./pages/DevelopersPage.tsx').then(m => ({ default: m.DevelopersPage })))
+const ChangelogPage = lazy(() => import('./pages/ChangelogPage.tsx').then(m => ({ default: m.ChangelogPage })))
 
 function LoadingFallback() {
   return (
@@ -53,6 +54,7 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/admin/merge" element={<AdminMergePage />} />
             <Route path="/admin/verify" element={<AdminVerifyPage />} />
             <Route path="/developers" element={<DevelopersPage />} />
+            <Route path="/changelog" element={<ChangelogPage />} />
           </Routes>
         </Suspense>
       </BrowserRouter>

--- a/apps/web/src/pages/ChangelogPage.tsx
+++ b/apps/web/src/pages/ChangelogPage.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+interface ChangelogEntry {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  announced: boolean;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export function ChangelogPage() {
+  const [entries, setEntries] = useState<ChangelogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    document.title = 'Changelog - Unstream';
+    const descTag = document.querySelector('meta[name="description"]');
+    if (descTag) descTag.setAttribute('content', 'What\'s new in Unstream — a running log of shipped features and improvements.');
+
+    fetch('/data/shipped-features.json')
+      .then(res => res.json())
+      .then((data: ChangelogEntry[]) => {
+        const sorted = [...data].sort((a, b) => b.date.localeCompare(a.date));
+        setEntries(sorted);
+      })
+      .catch(() => setEntries([]))
+      .finally(() => setLoading(false));
+
+    return () => {
+      document.title = 'Unstream - Support Artists Directly';
+      const descTag = document.querySelector('meta[name="description"]');
+      if (descTag) descTag.setAttribute('content', 'Search any artist and find where to support them directly on alternative platforms like Bandcamp, Mirlo, and more.');
+    };
+  }, []);
+
+  // Group entries by date
+  const grouped = entries.reduce<Record<string, ChangelogEntry[]>>((acc, entry) => {
+    if (!acc[entry.date]) acc[entry.date] = [];
+    acc[entry.date].push(entry);
+    return acc;
+  }, {});
+
+  const dates = Object.keys(grouped).sort((a, b) => b.localeCompare(a));
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+
+      <div className="pt-6 pb-8 px-4">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="font-display text-3xl md:text-4xl font-semibold text-text-primary mb-2">Changelog</h1>
+          <p className="text-text-secondary text-lg">
+            What's new in Unstream.
+          </p>
+        </div>
+      </div>
+
+      <main className="px-4 pb-16">
+        <div className="max-w-2xl mx-auto">
+          {loading ? (
+            <p className="text-text-muted text-center">Loading...</p>
+          ) : entries.length === 0 ? (
+            <p className="text-text-muted text-center">Nothing here yet.</p>
+          ) : (
+            <div className="space-y-10">
+              {dates.map(date => (
+                <div key={date}>
+                  <p className="text-text-muted text-sm font-medium mb-4">{formatDate(date)}</p>
+                  <div className="space-y-4">
+                    {grouped[date].map(entry => (
+                      <div
+                        key={entry.id}
+                        className="bg-surface-secondary rounded-xl p-5 border border-border"
+                      >
+                        <h2 className="font-display text-base font-semibold text-text-primary mb-1">
+                          {entry.title}
+                        </h2>
+                        <p className="text-text-secondary text-sm">{entry.description}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/data/guides/every-platform-unstream-supports-compared.md
+++ b/data/guides/every-platform-unstream-supports-compared.md
@@ -1,0 +1,219 @@
+---
+title: "Every platform Unstream supports: compared"
+description: A complete comparison of all 15 music platforms Unstream searches — payout rates, what they're best for, and who should use them.
+pillar: platform-discovery
+published: 2026-04-11
+draft: false
+---
+
+Unstream searches 15 music platforms at once so you can see everywhere an artist sells their music — and how much of your money actually reaches them. But what's the difference between all of these? Here's a full breakdown.
+
+## Quick comparison
+
+| Platform | Category | Artist payout | Best for |
+|---|---|---|---|
+| Bandcamp | Marketplace | 80–85% (up to ~97% on Fridays) | Everything — the default for indie music |
+| Mirlo | Marketplace | 86–90% | Artists who care about cooperative ownership |
+| Ampwall | Marketplace | 92–95% | Simple, high-payout storefronts |
+| Qobuz | Marketplace | ~70% | Hi-res audio purchases |
+| Beatport | Marketplace | 55–70% | Electronic and DJ music |
+| EVEN | Marketplace | ~80% | Direct-to-fan marketplace |
+| Jam.coop | Marketplace | Co-op model | Listener-owned cooperative |
+| Discogs | Marketplace | Varies | Physical records (used and new) |
+| Ko-fi | Patronage | 92–97% | Tips and small purchases |
+| Buy Me a Coffee | Patronage | ~92% | Simple one-time support |
+| Patreon | Patronage | 86–90% | Memberships and ongoing support |
+| Faircamp | Decentralized | 90–97% | Self-hosted storefronts |
+| Bandwagon | Decentralized | — | ActivityPub-based music community |
+| Hoopla | Library | — | Free listening with a library card |
+| Freegal | Library | — | Free listening with a library card |
+
+Payout percentages represent what artists keep after platform fees, before payment processing costs. "~97% on Fridays" for Bandcamp reflects the Bandcamp Friday promotion when their fee is waived.
+
+---
+
+## Music marketplaces
+
+These are platforms where you buy music directly and the artist keeps a cut of the sale.
+
+### Bandcamp
+
+**Payout: 80–85%, up to ~97% on Bandcamp Fridays**
+
+The biggest and most established artist-friendly marketplace. Over a million artists have pages here — if you're looking for an indie artist, they're almost certainly on Bandcamp. You can buy digital downloads in any format (MP3, FLAC, WAV, and more) plus physical releases like vinyl, CDs, and cassettes. Artists can also run fan subscriptions.
+
+On the first Friday of each month ([Bandcamp Friday](https://unstream.stream/guides/bandcamp-friday-explained)), Bandcamp waives their revenue share, so artists keep nearly everything. If you're going to buy music, those days are worth timing your purchases around.
+
+Bandcamp went through a rough patch in 2023–2024 (sold twice, some layoffs), but the platform stabilized. The catalog and community remain strong. It's still the best default for independent music.
+
+**Best for:** Fans who want to buy music digitally or physically and support artists as directly as possible.
+
+---
+
+### Mirlo
+
+**Payout: 86–90%**
+
+Mirlo is a platform cooperative — meaning it's collectively owned by its community rather than investors. That ownership model is what distinguishes it: artists here are investing in a platform that has structural reasons to prioritize them. The interface is clean, focused, and still developing; they're actively building features like community playlists and listener profiles.
+
+Smaller catalog than Bandcamp, but growing steadily and attracting artists who think carefully about where they sell.
+
+**Best for:** Fans who want to support artists on a platform that won't be sold to a private equity firm.
+
+---
+
+### Ampwall
+
+**Payout: 92–95%**
+
+One of the highest payout rates out there. Ampwall is intentionally minimal — a clean storefront for buying music, without the social features and community mechanics of Bandcamp. You get in, find the music, buy it, get the files. For artists who want a straightforward way to sell without overhead, it works well.
+
+Still a growing catalog, but worth checking for newer indie and experimental artists.
+
+**Best for:** Fans who want to maximize the percentage going to the artist on a direct purchase.
+
+---
+
+### Qobuz
+
+**Payout: ~70%**
+
+Qobuz sits in a different category: hi-res audio. You can buy albums in lossless formats up to 24-bit/192kHz — meaningfully better than CD quality and far above streaming. The catalog leans toward jazz, classical, and established indie. They also have a streaming subscription tier, but the purchase side is where Qobuz stands out from everything else.
+
+If you care about sound quality and want to own music in the best possible format, this is the place.
+
+**Best for:** Audiophiles who want to actually own music in the highest-quality format available.
+
+---
+
+### Beatport
+
+**Payout: 55–70%**
+
+The dominant marketplace for electronic music and DJs. Beatport specializes in dance, techno, house, and related genres — it's where DJs go to buy tracks to play out, and it's the place most electronic artists use for their official releases. DRM-free downloads, so you actually own what you buy.
+
+The payout rate is lower than the other marketplaces here, which matters — but for electronic music, Beatport is often the only option for a proper release outside streaming.
+
+**Best for:** Fans of electronic, DJ, and dance music who want to buy tracks legally and DRM-free.
+
+---
+
+### EVEN
+
+**Payout: ~80%**
+
+EVEN is a direct-to-fan marketplace focused on giving artists more control over how they sell. Artist keeps roughly 80% of each sale. Smaller platform, but worth checking if you're looking for artists who prioritize ownership and direct relationships with fans.
+
+**Best for:** Fans interested in supporting artists on emerging direct-sales platforms.
+
+---
+
+### Jam.coop
+
+**Payout: Co-op model**
+
+Jam.coop is building a listener-owned cooperative music service. The goal: instead of the pro-rata streaming model (where your subscription gets pooled across millions of streams), your money goes to the artists you actually listen to. Still developing, but the concept is genuinely different from anything else in this list.
+
+**Best for:** Fans who want a streaming experience that's structured around direct support rather than market share.
+
+---
+
+### Discogs
+
+**Payout: Varies (marketplace)**
+
+Discogs is the world's largest physical music marketplace and database. It's primarily a secondary market — used vinyl, CDs, cassettes — but many artists and labels also sell new releases through their Discogs shops. The database is comprehensive to an almost absurd degree, covering millions of releases across every genre.
+
+Payout varies because it's a marketplace: sellers (often independent record dealers or collectors) set prices, and Discogs takes a fee. When you buy direct from a label or artist's Discogs shop, more goes to them.
+
+**Best for:** Collectors, crate-diggers, and anyone who wants to buy physical music.
+
+---
+
+## Patronage platforms
+
+These let fans support artists with tips or recurring subscriptions, separate from buying specific releases.
+
+### Ko-fi
+
+**Payout: 92–97%**
+
+Ko-fi started as a simple tipping tool ("buy me a coffee") and has grown into a lightweight shop and membership platform. Artists keep an exceptional percentage — 97% of tips, 92% of sales. Many musicians use it as a low-pressure way to accept support alongside their main sales platform. Also good for selling individual tracks, digital zines, or other small-format goods.
+
+**Best for:** Fans who want to give artists a direct tip or buy small digital goods with minimal platform overhead.
+
+---
+
+### Buy Me a Coffee
+
+**Payout: ~92%**
+
+Similar to Ko-fi in concept — one-time tips and monthly memberships. Slightly simpler interface, slightly fewer features. Artists keep about 92%. A good option for artists who want something minimal that just works.
+
+**Best for:** Quick, direct support for artists who don't need complex membership tiers.
+
+---
+
+### Patreon
+
+**Payout: 86–90%**
+
+The original creator membership platform. Artists keep 86–90% of subscription revenue. Works best for artists who put out content consistently — new music, demos, behind-the-scenes content, early access, livestreams. A dedicated Patreon community can give an artist genuinely stable, predictable income.
+
+The tradeoff: Patreon rewards consistency. It takes real effort to keep members engaged, and fans who don't see regular updates tend to cancel.
+
+**Best for:** Fans who want to support artists they follow closely and get ongoing access to their work.
+
+---
+
+## Decentralized platforms
+
+These push further — artists control their own infrastructure or use open protocols, with no central platform in the middle.
+
+### Faircamp
+
+**Payout: 90–97%**
+
+Faircamp is an open-source tool that generates a beautiful static website for selling music — think self-hosted Bandcamp. Because there's no platform fee, artists keep 90–97% of sales (just payment processor costs). The tradeoff is that it takes some technical comfort to set up. But the result is a fast, fully artist-controlled storefront.
+
+The [Faircamp Webring](https://faircamp.webr.ing) connects Faircamp sites together and helps solve the discovery problem.
+
+**Best for:** Fans who want to buy direct from artists running their own store, with nothing in between.
+
+---
+
+### Bandwagon
+
+**Payout: —**
+
+Bandwagon is built on ActivityPub — the open protocol behind Mastodon and the fediverse — applied to music. The idea is a decentralized marketplace where artists aren't locked into any single company's decisions or survival. It's still early, but it's the most direct attempt to do for music commerce what Mastodon did for social.
+
+**Best for:** Fans interested in the future of decentralized music platforms.
+
+---
+
+## Library services
+
+These aren't about buying — they're about accessing music for free through your local public library.
+
+### Hoopla
+
+Free with a library card. Hoopla has a surprisingly large catalog of music alongside ebooks, audiobooks, and films. Artists don't get paid per stream the way they do on commercial platforms — the library licenses content through distribution deals — but you're not paying a streaming giant, either. Great for discovery and exploration.
+
+**Best for:** Fans who want to explore music at no cost while supporting their local library system.
+
+---
+
+### Freegal
+
+Also free with a library card. Freegal partners with Sony Music Distribution and offers streaming and even permanent downloads (you typically get a set number per week). Catalog skews toward major labels and some indie. Less discovery-oriented than Hoopla, but the download option is genuinely useful.
+
+**Best for:** Fans who want to legally download some music for free each month.
+
+---
+
+## Finding artists across all of these
+
+The biggest friction with this whole ecosystem is fragmentation. An artist might sell on Bandcamp, accept tips on Ko-fi, and have a Faircamp site — but you'd have to check each one separately.
+
+[Unstream](https://unstream.stream) searches all 15 of these platforms at once. Search for any artist and see everywhere they sell, how much they keep on each platform, and where you can support them most directly.

--- a/data/shipped-features.json
+++ b/data/shipped-features.json
@@ -33,5 +33,26 @@
     "description": "Save artists in the Mac app or browser extension and get notified when they drop something new. No more missing releases from the artists you care about.",
     "date": "2026-03-22",
     "announced": false
+  },
+  {
+    "id": "public-api",
+    "title": "Public API v1",
+    "description": "Developers can now build on top of Unstream. The public API supports artist search, artist lookup, URL resolution, and a full platform list — with API key auth and tiered rate limiting.",
+    "date": "2026-04-11",
+    "announced": false
+  },
+  {
+    "id": "noscript-search",
+    "title": "No-JavaScript search",
+    "description": "Unstream now works without JavaScript. The search experience is fully server-rendered for accessibility, crawlers, and anyone who prefers a leaner web.",
+    "date": "2026-04-11",
+    "announced": false
+  },
+  {
+    "id": "ios-app",
+    "title": "Universal Apple app (iOS + macOS)",
+    "description": "The Mac app is now a universal Apple app. Download it on iPhone and iPad too — search for artists, save your favorites, and get release alerts on the go.",
+    "date": "2026-04-11",
+    "announced": false
   }
 ]


### PR DESCRIPTION
## Summary

- **New `/changelog` page** — reads from `data/shipped-features.json`, grouped by date, newest first. Linked in the footer. Easy to update by adding entries to the JSON.
- **Updated `data/shipped-features.json`** — added 3 new entries for recent ships: Public API v1, no-JS search, and universal Apple app.
- **New guide: "Every platform Unstream supports: compared"** — covers all 15 platforms with a comparison table (payout %, category, best for) plus a write-up of each one. Good SEO surface for "bandcamp alternatives" and "how much do artists make on X" queries.
- **Sitemap updated** with new guide URL.

## Test plan

- [ ] Visit `/changelog` — should show all entries grouped by date, newest first
- [ ] Visit `/guides/every-platform-unstream-supports-compared` — should render the full guide with comparison table
- [ ] Check footer — "Changelog" link should appear between Guides and Roadmap
- [ ] Verify Netlify preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)