### PR TITLE
Fix artist claim: verification_code null constraint

### DIFF
--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -413,6 +413,8 @@ export async function handler(event: {
     const email = (body.email || authUser.email || '').toLowerCase().trim();
 
     // Upsert the profile (allows retrying the claim flow)
+    // verification_code is a legacy NOT NULL column — populate it with a random value
+    // since the actual verification now uses link-back checking, not a code
     const { error: upsertError } = await client
       .from('artist_profiles')
       .upsert(
@@ -421,6 +423,7 @@ export async function handler(event: {
           user_id: userId,
           email,
           website_url: websiteUrl,
+          verification_code: crypto.randomUUID(),
           verified_at: null,
         },
         { onConflict: 'artist_id' }

--- a/supabase/migration-008-nullable-verification-code.sql
+++ b/supabase/migration-008-nullable-verification-code.sql
@@ -1,0 +1,8 @@
+-- Migration 008: Make verification_code nullable
+-- The claim flow was updated to use link-back verification (checking for an
+-- unstream.stream link on the artist's website) instead of a shared code.
+-- The verification_code column is no longer used, but was left as NOT NULL,
+-- which broke new artist profile creation.
+
+alter table artist_profiles
+  alter column verification_code drop not null;


### PR DESCRIPTION
## Bug

Artists trying to claim their profile get:

> Failed to start claim: null value in column "verification_code" of relation "artist_profiles" violates not-null constraint

## Root cause

`artist_profiles.verification_code` is `NOT NULL` (migration-002), but when the claim flow was updated to use link-back verification (checking for an `unstream.stream` link on the artist's website), the column was never populated or made nullable. New inserts fail because no value is provided.

## Fix

**Immediate (no migration needed):** Populate `verification_code` with `crypto.randomUUID()` in the upsert. The column isn't used anywhere in the current verification flow, so a random value satisfies the constraint without changing behaviour.

**Cleanup:** `migration-008` drops the `NOT NULL` constraint on the column so it can be properly retired.

## Deploy notes

Run `supabase/migration-008-nullable-verification-code.sql` in the Supabase SQL editor after deploying. The code fix works independently before the migration runs.

## Test plan

- [ ] Try claiming an artist profile — should no longer see the null constraint error
- [ ] Verify the full claim + link-back verification flow still works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)