### PR TITLE
Add product analytics dashboard

### DIFF
--- a/api/functions/analytics-app-event.ts
+++ b/api/functions/analytics-app-event.ts
@@ -1,0 +1,100 @@
+// POST /api/analytics/app-event
+// Records anonymous product usage events from web, extension, and Mac app.
+// No PII stored: session_hash is a one-way SHA-256 of (ip + user_agent + date).
+
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const VALID_EVENT_TYPES = new Set([
+  'search',
+  'platform_click',
+  'extension_activated',
+  'page_view',
+  'release_alert',
+]);
+
+const VALID_APPS = new Set(['web', 'extension', 'mac']);
+
+async function hashSessionId(ip: string, userAgent: string): Promise<string> {
+  const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  const raw = `${ip}:${userAgent}:${date}`;
+  const encoded = new TextEncoder().encode(raw);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body?: string;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: CORS_HEADERS, body: '' };
+  }
+
+  // Lenient rate limit — fire-and-forget from clients
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  let body: { event_type?: string; app?: string; context?: Record<string, unknown> };
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const { event_type, app, context = {} } = body;
+
+  if (!event_type || !VALID_EVENT_TYPES.has(event_type)) {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  if (!app || !VALID_APPS.has(app)) {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  // Sanitize context: only allow primitive values, strip any PII fields
+  const safeContext: Record<string, unknown> = {};
+  const ALLOWED_CONTEXT_KEYS = new Set([
+    'has_results', 'result_count', 'platform', 'streaming_service', 'page',
+  ]);
+  for (const [k, v] of Object.entries(context)) {
+    if (ALLOWED_CONTEXT_KEYS.has(k) && (typeof v === 'string' || typeof v === 'boolean' || typeof v === 'number')) {
+      safeContext[k] = v;
+    }
+  }
+
+  const userAgent = event.headers['user-agent'] || '';
+  const sessionHash = await hashSessionId(ip, userAgent);
+
+  try {
+    await client.from('app_events').insert({
+      event_type,
+      app,
+      context: safeContext,
+      session_hash: sessionHash,
+    });
+  } catch {
+    // Silent fail — never break the caller for analytics
+  }
+
+  return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+}

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -1,0 +1,211 @@
+// GET /api/analytics/dashboard
+// Admin-only endpoint returning aggregated product analytics for the dashboard.
+
+import { getClient } from './db';
+import { authenticateAdmin } from './middleware';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const admin = await authenticateAdmin(event.headers['authorization'] || event.headers['Authorization']);
+  if (!admin) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const now = new Date();
+  const today = now.toISOString().split('T')[0];
+  const ago7 = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const ago30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const todayStart = `${today}T00:00:00.000Z`;
+
+  try {
+    // Run all queries in parallel
+    const [
+      searchesToday,
+      searches7d,
+      searches30d,
+      successfulSearches7d,
+      daily30d,
+      byApp30d,
+      platforms30d,
+      streamingServices30d,
+      recentEvents,
+    ] = await Promise.all([
+      // Searches today
+      client
+        .from('app_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('event_type', 'search')
+        .gte('created_at', todayStart),
+
+      // Searches last 7 days
+      client
+        .from('app_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('event_type', 'search')
+        .gte('created_at', ago7),
+
+      // Searches last 30 days
+      client
+        .from('app_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('event_type', 'search')
+        .gte('created_at', ago30),
+
+      // Successful searches (has_results=true) last 7 days
+      client
+        .from('app_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('event_type', 'search')
+        .eq('context->>has_results', 'true')
+        .gte('created_at', ago7),
+
+      // Daily event counts for last 30 days (searches + clicks)
+      client
+        .from('app_events')
+        .select('created_at, event_type')
+        .in('event_type', ['search', 'platform_click', 'extension_activated'])
+        .gte('created_at', ago30)
+        .order('created_at', { ascending: true }),
+
+      // Breakdown by app (last 30 days)
+      client
+        .from('app_events')
+        .select('app, event_type')
+        .in('event_type', ['search', 'platform_click'])
+        .gte('created_at', ago30),
+
+      // Platform click breakdown (last 30 days)
+      client
+        .from('app_events')
+        .select('context')
+        .eq('event_type', 'platform_click')
+        .gte('created_at', ago30),
+
+      // Extension streaming service breakdown (last 30 days)
+      client
+        .from('app_events')
+        .select('context')
+        .eq('event_type', 'extension_activated')
+        .gte('created_at', ago30),
+
+      // Recent 20 events
+      client
+        .from('app_events')
+        .select('event_type, app, context, created_at')
+        .order('created_at', { ascending: false })
+        .limit(20),
+    ]);
+
+    // --- Build daily chart data (last 30 days) ---
+    const dailyMap: Record<string, { searches: number; clicks: number; activations: number }> = {};
+
+    // Pre-fill all 30 days
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+      const dateStr = d.toISOString().split('T')[0];
+      dailyMap[dateStr] = { searches: 0, clicks: 0, activations: 0 };
+    }
+
+    for (const row of (daily30d.data || [])) {
+      const dateStr = row.created_at.split('T')[0];
+      if (!dailyMap[dateStr]) continue;
+      if (row.event_type === 'search') dailyMap[dateStr].searches++;
+      else if (row.event_type === 'platform_click') dailyMap[dateStr].clicks++;
+      else if (row.event_type === 'extension_activated') dailyMap[dateStr].activations++;
+    }
+
+    const daily = Object.entries(dailyMap).map(([date, counts]) => ({ date, ...counts }));
+
+    // --- By app breakdown ---
+    const appMap: Record<string, { searches: number; clicks: number }> = {
+      web: { searches: 0, clicks: 0 },
+      extension: { searches: 0, clicks: 0 },
+      mac: { searches: 0, clicks: 0 },
+    };
+    for (const row of (byApp30d.data || [])) {
+      if (!appMap[row.app]) appMap[row.app] = { searches: 0, clicks: 0 };
+      if (row.event_type === 'search') appMap[row.app].searches++;
+      else if (row.event_type === 'platform_click') appMap[row.app].clicks++;
+    }
+    const byApp = Object.entries(appMap)
+      .map(([app, counts]) => ({ app, ...counts }))
+      .sort((a, b) => (b.searches + b.clicks) - (a.searches + a.clicks));
+
+    // --- Platform breakdown ---
+    const platformMap: Record<string, number> = {};
+    for (const row of (platforms30d.data || [])) {
+      const platform = (row.context as Record<string, string>)?.platform;
+      if (platform) platformMap[platform] = (platformMap[platform] || 0) + 1;
+    }
+    const platforms = Object.entries(platformMap)
+      .map(([platform, clicks]) => ({ platform, clicks }))
+      .sort((a, b) => b.clicks - a.clicks)
+      .slice(0, 10);
+
+    // --- Streaming service breakdown ---
+    const serviceMap: Record<string, number> = {};
+    for (const row of (streamingServices30d.data || [])) {
+      const service = (row.context as Record<string, string>)?.streaming_service;
+      if (service) serviceMap[service] = (serviceMap[service] || 0) + 1;
+    }
+    const streamingServices = Object.entries(serviceMap)
+      .map(([service, activations]) => ({ service, activations }))
+      .sort((a, b) => b.activations - a.activations);
+
+    // --- Success rate ---
+    const totalSearches7d = searches7d.count || 0;
+    const successRate7d = totalSearches7d > 0
+      ? Math.round(((successfulSearches7d.count || 0) / totalSearches7d) * 100)
+      : null;
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        summary: {
+          searches_today: searchesToday.count || 0,
+          searches_7d: totalSearches7d,
+          searches_30d: searches30d.count || 0,
+          success_rate_7d: successRate7d,
+          top_platform: platforms[0]?.platform || null,
+          top_streaming_service: streamingServices[0]?.service || null,
+        },
+        daily,
+        by_app: byApp,
+        platforms,
+        streaming_services: streamingServices,
+        recent: (recentEvents.data || []).map(e => ({
+          event_type: e.event_type,
+          app: e.app,
+          context: e.context,
+          created_at: e.created_at,
+        })),
+      }),
+    };
+  } catch (err) {
+    console.error('[Analytics Dashboard] Error:', err);
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to fetch analytics' }) };
+  }
+}

--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -61,6 +61,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   } else if (message.type === 'TRACK_ANALYTICS') {
     trackAnalyticsEvent(message.slug, message.metric);
+  } else if (message.type === 'TRACK_APP_EVENT') {
+    trackAppEvent(message.event_type, message.context || {});
   } else if (message.type === 'MUSIC_STOPPED') {
     handleMusicStopped();
   } else if (message.type === 'CHECK_RELEASES_NOW') {
@@ -95,6 +97,19 @@ async function trackAnalyticsEvent(slug, metric) {
   }
 }
 
+// Fire-and-forget product analytics event
+async function trackAppEvent(event_type, context = {}) {
+  try {
+    await fetch(`${API_BASE}/analytics/app-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event_type, app: 'extension', context }),
+    });
+  } catch {
+    // silent fail
+  }
+}
+
 // Handle music detection from content scripts
 async function handleMusicDetection(data) {
   const { artist, title, source } = data;
@@ -118,6 +133,9 @@ async function handleMusicDetection(data) {
     currentTrack: { artist, title, source, timestamp: now }
   });
 
+  // Track extension activation with streaming service
+  trackAppEvent('extension_activated', { streaming_service: source || 'unknown' });
+
   // Fetch results
   try {
     const data = await searchArtist(artist);
@@ -127,6 +145,9 @@ async function handleMusicDetection(data) {
     await chrome.storage.local.set({
       [`cache:${artist}`]: { results, timestamp: now }
     });
+
+    // Track search (product analytics)
+    trackAppEvent('search', { has_results: results.length > 0, result_count: results.length });
 
     // Track search appearances for claimed artists
     for (const result of results) {

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -223,11 +223,12 @@ function renderResults(results) {
     link.target = '_blank';
     link.className = 'result-item';
     link.title = config.name;
-    if (claimedSlug) {
-      link.addEventListener('click', () => {
+    link.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'TRACK_APP_EVENT', event_type: 'platform_click', context: { platform: platform.sourceId } });
+      if (claimedSlug) {
         chrome.runtime.sendMessage({ type: 'TRACK_ANALYTICS', slug: claimedSlug, metric: `click:${platform.sourceId}` });
-      });
-    }
+      }
+    });
 
     const iconSpan = document.createElement('span');
     iconSpan.className = 'result-icon';

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -164,6 +164,7 @@ function App() {
 
       setResults(response.results);
       setIsLoading(false);
+      analytics.trackSearchResults(response.results.length > 0, response.results.length);
 
       // Phase 2: MusicBrainz enrichment (runs in background)
       if (response.hasPendingEnrichment && response.results.length > 0) {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -22,6 +22,7 @@ const GuidesIndexPage = lazy(() => import('./pages/GuidesIndexPage.tsx').then(m 
 const GuidePage = lazy(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
 const DevelopersPage = lazy(() => import('./pages/DevelopersPage.tsx').then(m => ({ default: m.DevelopersPage })))
 const ChangelogPage = lazy(() => import('./pages/ChangelogPage.tsx').then(m => ({ default: m.ChangelogPage })))
+const AdminAnalyticsPage = lazy(() => import('./pages/AdminAnalyticsPage.tsx').then(m => ({ default: m.AdminAnalyticsPage })))
 
 function LoadingFallback() {
   return (
@@ -53,6 +54,7 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/guides/:slug" element={<GuidePage />} />
             <Route path="/admin/merge" element={<AdminMergePage />} />
             <Route path="/admin/verify" element={<AdminVerifyPage />} />
+            <Route path="/admin/analytics" element={<AdminAnalyticsPage />} />
             <Route path="/developers" element={<DevelopersPage />} />
             <Route path="/changelog" element={<ChangelogPage />} />
           </Routes>

--- a/apps/web/src/pages/AdminAnalyticsPage.tsx
+++ b/apps/web/src/pages/AdminAnalyticsPage.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface DailyStat {
+  date: string;
+  searches: number;
+  clicks: number;
+  activations: number;
+}
+
+interface AppStat {
+  app: string;
+  searches: number;
+  clicks: number;
+}
+
+interface PlatformStat {
+  platform: string;
+  clicks: number;
+}
+
+interface StreamingStat {
+  service: string;
+  activations: number;
+}
+
+interface RecentEvent {
+  event_type: string;
+  app: string;
+  context: Record<string, unknown>;
+  created_at: string;
+}
+
+interface DashboardData {
+  summary: {
+    searches_today: number;
+    searches_7d: number;
+    searches_30d: number;
+    success_rate_7d: number | null;
+    top_platform: string | null;
+    top_streaming_service: string | null;
+  };
+  daily: DailyStat[];
+  by_app: AppStat[];
+  platforms: PlatformStat[];
+  streaming_services: StreamingStat[];
+  recent: RecentEvent[];
+}
+
+// ─── Bar chart ───────────────────────────────────────────────────────────────
+
+function BarChart({ data }: { data: DailyStat[] }) {
+  const maxVal = Math.max(...data.map(d => d.searches + d.clicks), 1);
+  const width = 780;
+  const height = 160;
+  const padLeft = 36;
+  const padBottom = 28;
+  const chartW = width - padLeft - 8;
+  const chartH = height - padBottom - 8;
+  const barW = Math.floor(chartW / data.length) - 2;
+
+  // Y-axis ticks
+  const ticks = [0, Math.round(maxVal / 2), maxVal];
+
+  // Format date labels: show day-of-month, highlight first of month
+  const formatLabel = (dateStr: string) => {
+    const d = new Date(dateStr + 'T00:00:00');
+    return d.getDate() === 1
+      ? d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      : String(d.getDate());
+  };
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full"
+      style={{ height: `${height}px` }}
+      aria-label="30-day event chart"
+    >
+      {/* Y-axis grid lines */}
+      {ticks.map(tick => {
+        const y = 8 + chartH - (tick / maxVal) * chartH;
+        return (
+          <g key={tick}>
+            <line
+              x1={padLeft}
+              x2={width - 8}
+              y1={y}
+              y2={y}
+              stroke="currentColor"
+              strokeOpacity={0.1}
+              strokeWidth={1}
+            />
+            <text
+              x={padLeft - 4}
+              y={y + 4}
+              textAnchor="end"
+              fontSize={10}
+              fill="currentColor"
+              opacity={0.4}
+            >
+              {tick}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Bars */}
+      {data.map((d, i) => {
+        const x = padLeft + i * (chartW / data.length) + 1;
+        const searchH = (d.searches / maxVal) * chartH;
+        const clickH = (d.clicks / maxVal) * chartH;
+        const activationH = (d.activations / maxVal) * chartH;
+        const totalH = searchH + clickH + activationH;
+        const barY = 8 + chartH - totalH;
+
+        // Show date label every ~5 days or first of month
+        const date = new Date(d.date + 'T00:00:00');
+        const showLabel = i === 0 || i === data.length - 1 || date.getDate() === 1 || i % 5 === 0;
+
+        return (
+          <g key={d.date}>
+            {/* Activation segment (bottom) */}
+            {activationH > 0 && (
+              <rect
+                x={x}
+                y={8 + chartH - activationH}
+                width={barW}
+                height={activationH}
+                rx={1}
+                fill="var(--color-accent-secondary, #8b5cf6)"
+                opacity={0.5}
+              />
+            )}
+            {/* Click segment */}
+            {clickH > 0 && (
+              <rect
+                x={x}
+                y={8 + chartH - activationH - clickH}
+                width={barW}
+                height={clickH}
+                fill="var(--color-accent-primary, #22d3ee)"
+                opacity={0.6}
+              />
+            )}
+            {/* Search segment (top) */}
+            {searchH > 0 && (
+              <rect
+                x={x}
+                y={barY}
+                width={barW}
+                height={searchH}
+                rx={1}
+                fill="var(--color-accent-primary, #22d3ee)"
+                opacity={0.9}
+              />
+            )}
+            {/* X-axis label */}
+            {showLabel && (
+              <text
+                x={x + barW / 2}
+                y={height - 4}
+                textAnchor="middle"
+                fontSize={9}
+                fill="currentColor"
+                opacity={0.4}
+              >
+                {formatLabel(d.date)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ─── Metric card ─────────────────────────────────────────────────────────────
+
+function MetricCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+  return (
+    <div className="bg-surface-secondary rounded-xl p-4 border border-border">
+      <p className="text-text-muted text-xs font-medium uppercase tracking-wide mb-1">{label}</p>
+      <p className="text-text-primary text-2xl font-semibold font-display">{value}</p>
+      {sub && <p className="text-text-muted text-xs mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+// ─── Table ───────────────────────────────────────────────────────────────────
+
+function DataTable<T extends Record<string, unknown>>({
+  rows,
+  columns,
+  emptyLabel = 'No data yet',
+}: {
+  rows: T[];
+  columns: { key: keyof T; label: string; align?: 'left' | 'right' }[];
+  emptyLabel?: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="text-text-muted text-sm py-4 text-center">{emptyLabel}</p>;
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-border">
+          {columns.map(col => (
+            <th
+              key={String(col.key)}
+              className={`pb-2 text-text-muted font-medium text-xs uppercase tracking-wide ${col.align === 'right' ? 'text-right' : 'text-left'}`}
+            >
+              {col.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i} className="border-b border-border/40 last:border-0">
+            {columns.map(col => (
+              <td
+                key={String(col.key)}
+                className={`py-2 text-text-secondary ${col.align === 'right' ? 'text-right tabular-nums' : ''}`}
+              >
+                {String(row[col.key] ?? '—')}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+function formatEventType(t: string) {
+  return t.replace(/_/g, ' ');
+}
+
+function formatRelativeTime(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export function AdminAnalyticsPage() {
+  const { isAdmin, isLoading: authLoading, session } = useAuth();
+  const navigate = useNavigate();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = 'Analytics - Unstream Admin';
+    return () => { document.title = 'Unstream - Support Artists Directly'; };
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAdmin) {
+      navigate('/');
+      return;
+    }
+
+    fetch('/api/analytics/dashboard', {
+      headers: { Authorization: `Bearer ${session?.access_token}` },
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((d: DashboardData) => setData(d))
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [authLoading, isAdmin, session, navigate]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-text-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-red-500 text-sm">Failed to load analytics: {error}</p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, daily, by_app, platforms, streaming_services, recent } = data;
+
+  const appRows = by_app.map(a => ({
+    app: a.app,
+    searches: a.searches,
+    clicks: a.clicks,
+    total: a.searches + a.clicks,
+  }));
+
+  const recentRows = recent.map(e => ({
+    type: formatEventType(e.event_type),
+    app: e.app,
+    detail: Object.entries(e.context)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ') || '—',
+    when: formatRelativeTime(e.created_at),
+  }));
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+
+      <div className="pt-6 pb-4 px-4">
+        <div className="max-w-5xl mx-auto">
+          <h1 className="font-display text-2xl font-semibold text-text-primary">Analytics</h1>
+          <p className="text-text-muted text-sm mt-1">Last 30 days · anonymized · no PII stored</p>
+        </div>
+      </div>
+
+      <main className="px-4 pb-16">
+        <div className="max-w-5xl mx-auto space-y-8">
+
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+            <MetricCard label="Searches today" value={summary.searches_today.toLocaleString()} />
+            <MetricCard label="Searches 7d" value={summary.searches_7d.toLocaleString()} />
+            <MetricCard label="Searches 30d" value={summary.searches_30d.toLocaleString()} />
+            <MetricCard
+              label="Success rate 7d"
+              value={summary.success_rate_7d !== null ? `${summary.success_rate_7d}%` : '—'}
+              sub="searches with results"
+            />
+            <MetricCard
+              label="Top platform"
+              value={summary.top_platform ?? '—'}
+            />
+            <MetricCard
+              label="Top streaming"
+              value={summary.top_streaming_service ?? '—'}
+            />
+          </div>
+
+          {/* 30-day chart */}
+          <div className="bg-surface-secondary rounded-xl border border-border p-5">
+            <div className="flex items-center gap-4 mb-4">
+              <h2 className="font-display text-sm font-semibold text-text-primary">30-day volume</h2>
+              <div className="flex items-center gap-3 text-xs text-text-muted ml-auto">
+                <span className="flex items-center gap-1.5">
+                  <span className="w-2.5 h-2.5 rounded-sm inline-block" style={{ background: 'var(--color-accent-primary, #22d3ee)', opacity: 0.9 }} />
+                  Searches
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="w-2.5 h-2.5 rounded-sm inline-block" style={{ background: 'var(--color-accent-primary, #22d3ee)', opacity: 0.6 }} />
+                  Clicks
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="w-2.5 h-2.5 rounded-sm inline-block" style={{ background: 'var(--color-accent-secondary, #8b5cf6)', opacity: 0.5 }} />
+                  Extension activations
+                </span>
+              </div>
+            </div>
+            <div className="text-text-primary">
+              {daily.length > 0
+                ? <BarChart data={daily} />
+                : <p className="text-text-muted text-sm py-8 text-center">No data yet — events will appear once users start using the app.</p>
+              }
+            </div>
+          </div>
+
+          {/* Bottom tables */}
+          <div className="grid md:grid-cols-2 gap-6">
+
+            {/* Platform breakdown */}
+            <div className="bg-surface-secondary rounded-xl border border-border p-5">
+              <h2 className="font-display text-sm font-semibold text-text-primary mb-4">Platform clicks (30d)</h2>
+              <DataTable
+                rows={platforms as unknown as Record<string, unknown>[]}
+                columns={[
+                  { key: 'platform', label: 'Platform' },
+                  { key: 'clicks', label: 'Clicks', align: 'right' },
+                ]}
+                emptyLabel="No click data yet"
+              />
+            </div>
+
+            {/* By app */}
+            <div className="bg-surface-secondary rounded-xl border border-border p-5">
+              <h2 className="font-display text-sm font-semibold text-text-primary mb-4">By app (30d)</h2>
+              <DataTable
+                rows={appRows as unknown as Record<string, unknown>[]}
+                columns={[
+                  { key: 'app', label: 'App' },
+                  { key: 'searches', label: 'Searches', align: 'right' },
+                  { key: 'clicks', label: 'Clicks', align: 'right' },
+                ]}
+                emptyLabel="No app data yet"
+              />
+            </div>
+
+            {/* Streaming services */}
+            <div className="bg-surface-secondary rounded-xl border border-border p-5">
+              <h2 className="font-display text-sm font-semibold text-text-primary mb-4">Extension: streaming services (30d)</h2>
+              <DataTable
+                rows={streaming_services as unknown as Record<string, unknown>[]}
+                columns={[
+                  { key: 'service', label: 'Service' },
+                  { key: 'activations', label: 'Activations', align: 'right' },
+                ]}
+                emptyLabel="No extension activations yet"
+              />
+            </div>
+
+            {/* Recent events */}
+            <div className="bg-surface-secondary rounded-xl border border-border p-5">
+              <h2 className="font-display text-sm font-semibold text-text-primary mb-4">Recent events</h2>
+              <DataTable
+                rows={recentRows as unknown as Record<string, unknown>[]}
+                columns={[
+                  { key: 'type', label: 'Event' },
+                  { key: 'app', label: 'App' },
+                  { key: 'detail', label: 'Detail' },
+                  { key: 'when', label: 'When', align: 'right' },
+                ]}
+                emptyLabel="No events yet"
+              />
+            </div>
+          </div>
+
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/services/analytics.ts
+++ b/apps/web/src/services/analytics.ts
@@ -1,10 +1,14 @@
 /**
- * Analytics tracking using GoatCounter + Unstream artist analytics API.
+ * Analytics tracking using GoatCounter + Unstream artist analytics API
+ * + product analytics (app_events).
  *
  * General events (search, download, etc.) go to GoatCounter only.
  * Artist-specific events (search appearances, page views, link clicks)
  * go to BOTH GoatCounter and our Supabase-backed analytics API so
  * verified artists can see their stats on the dashboard.
+ * Product events (all user actions) go to the app_events endpoint for
+ * the admin analytics dashboard. All product events are anonymized —
+ * no user IDs, no PII, just hashed session tokens.
  */
 
 declare global {
@@ -27,20 +31,53 @@ function trackArtistEvent(slug: string, metric: string): void {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ slug, metric }),
-  }).catch(() => {}); // silently ignore errors
+  }).catch(() => {});
+}
+
+/** Fire-and-forget POST to the product analytics endpoint. */
+function trackAppEvent(
+  event_type: string,
+  context: Record<string, string | number | boolean> = {},
+): void {
+  fetch('/api/analytics/app-event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ event_type, app: 'web', context }),
+  }).catch(() => {});
 }
 
 export const analytics = {
   // General events (GoatCounter only)
   trackDownload: () => trackEvent('/download'),
-  trackSearch: () => trackEvent('/search'),
-  trackPlatformClick: (platformName: string) => trackEvent(`/go/${platformName.toLowerCase()}`),
   trackReportIssue: () => trackEvent('/report-issue'),
 
-  // Artist-specific events (GoatCounter + Supabase analytics API)
+  // Search initiated (GoatCounter + product analytics — fires before results arrive)
+  trackSearch: () => {
+    trackEvent('/search');
+    trackAppEvent('search', {});
+  },
+
+  // Search results received (product analytics — fires once results are known)
+  trackSearchResults: (hasResults: boolean, resultCount: number) => {
+    trackAppEvent('search', { has_results: hasResults, result_count: resultCount });
+  },
+
+  // Platform click (GoatCounter + product analytics)
+  trackPlatformClick: (platformName: string) => {
+    trackEvent(`/go/${platformName.toLowerCase()}`);
+    trackAppEvent('platform_click', { platform: platformName.toLowerCase() });
+  },
+
+  // Page views (product analytics only — GoatCounter handles page views automatically)
+  trackPageView: (page: string) => {
+    trackAppEvent('page_view', { page });
+  },
+
+  // Artist-specific events (GoatCounter + Supabase artist analytics + product analytics)
   trackArtistPageView: (slug: string) => {
     trackEvent(`/artist/${slug}/view`);
     trackArtistEvent(slug, 'view');
+    trackAppEvent('page_view', { page: 'artist' });
   },
   trackArtistSearchAppearance: (slug: string) => {
     trackEvent(`/artist/${slug}/search`);
@@ -49,5 +86,6 @@ export const analytics = {
   trackArtistLinkClick: (slug: string, platform: string) => {
     trackEvent(`/artist/${slug}/click/${platform.toLowerCase()}`);
     trackArtistEvent(slug, `click:${platform.toLowerCase()}`);
+    trackAppEvent('platform_click', { platform: platform.toLowerCase() });
   },
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -94,6 +94,16 @@
   status = 200
 
 [[redirects]]
+  from = "/api/analytics/app-event"
+  to = "/.netlify/functions/analytics-app-event"
+  status = 200
+
+[[redirects]]
+  from = "/api/analytics/dashboard"
+  to = "/.netlify/functions/analytics-dashboard"
+  status = 200
+
+[[redirects]]
   from = "/api/admin/merge-override"
   to = "/.netlify/functions/admin-merge-override"
   status = 200

--- a/supabase/migration-009-app-events.sql
+++ b/supabase/migration-009-app-events.sql
@@ -1,0 +1,31 @@
+-- Migration 009: App events table for product analytics
+-- Stores anonymized product usage events from web, extension, and Mac app.
+-- No PII stored: IP addresses are never saved; session_hash is a one-way
+-- SHA-256 of (ip + user_agent + date) for same-session deduplication only.
+
+create table app_events (
+  id bigserial primary key,
+  event_type text not null,   -- 'search', 'platform_click', 'extension_activated', 'page_view', 'release_alert'
+  app text not null,          -- 'web', 'extension', 'mac'
+  context jsonb not null default '{}',
+  -- context fields (by event type):
+  --   search:              { has_results: bool, result_count: int }
+  --   platform_click:      { platform: text }
+  --   extension_activated: { streaming_service: text }
+  --   page_view:           { page: text }
+  --   release_alert:       { platform: text }
+  session_hash text,          -- anonymous daily session ID (never raw IP/UA)
+  created_at timestamptz not null default now()
+);
+
+-- Efficient queries for dashboard (time range + type filters)
+create index idx_app_events_created_at on app_events(created_at desc);
+create index idx_app_events_type_app on app_events(event_type, app, created_at desc);
+
+-- RLS: public can insert (event recording), only service role can read (dashboard)
+alter table app_events enable row level security;
+
+create policy "Public insert app events" on app_events
+  for insert with check (true);
+
+-- Dashboard reads go through the service role client, which bypasses RLS


### PR DESCRIPTION
## Summary

- **`app_events` table** (migration-009): anonymized product event storage. Stores event type, app, a context JSON blob, and a SHA-256 session hash (IP + user-agent + date, never stored raw). No user IDs, no PII.
- **`/api/analytics/app-event`**: public POST endpoint for recording events from web, extension, and Mac app
- **`/api/analytics/dashboard`**: admin-only GET endpoint — returns 30-day daily stats, platform click leaderboard, by-app breakdown, extension streaming service breakdown, recent events
- **`/admin/analytics`**: admin analytics dashboard — metric cards, SVG bar chart (no chart lib dependency), breakdown tables
- **Web instrumentation**: `trackSearch` + `trackSearchResults` (captures success rate), `trackPlatformClick`
- **Extension instrumentation**: `extension_activated` (with streaming service), search results, platform clicks

## What you can now see

- Searches per day / 7d / 30d
- Search success rate (% that returned results)
- Which platforms get clicked most
- Which app drives most usage (web vs extension vs Mac)
- Which streaming service the extension activates on most (Spotify vs Apple Music)
- Live recent event feed

## Deploy notes

Run `supabase/migration-009-app-events.sql` in Supabase SQL editor after merging. The app will send events immediately on deploy but the dashboard will start empty until data accumulates.

## Test plan

- [ ] Visit `/admin/analytics` while logged in as admin — should load the dashboard
- [ ] Visit `/admin/analytics` while not logged in — should redirect to `/`
- [ ] Run a search on the web app — check recent events feed shows a `search` event
- [ ] Click a platform link — check `platform_click` appears in feed
- [ ] Verify bar chart renders once data is present
- [ ] Verify all 165 unit tests still pass (they do — build is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)