### PR TITLE
Update platform count to 15+ across all copy

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,9 +6,9 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unstream - Support Artists Directly</title>
-    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 17 platforms. Free and open source." />
+    <meta name="description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 15+ platforms. Free and open source." />
     <meta property="og:title" content="Unstream - Support Artists Directly" />
-    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 17 platforms. Free and open source." />
+    <meta property="og:description" content="Search any artist. See where your money actually goes. Unstream shows artist payout percentages across 15+ platforms. Free and open source." />
     <meta property="og:image" content="https://unstream.stream/og-image.png" />
     <meta property="og:url" content="https://unstream.stream" />
     <meta property="og:type" content="website" />

--- a/apps/web/public/docs/openapi.yaml
+++ b/apps/web/public/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Unstream API
   description: |
-    Find your favorite artists on alternative music platforms. Search across 17+ platforms
+    Find your favorite artists on alternative music platforms. Search across 15+ platforms
     including Bandcamp, Mirlo, Qobuz, Beatport, Faircamp, Patreon, and more.
 
     ## Authentication

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -296,7 +296,7 @@ function App() {
             Find where to buy music directly from artists you love
           </h1>
           <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
-            Search with Unstream across 17+ platforms where artists keep up to 97% of every sale — not fractions of a penny from streams.
+            Search with Unstream across 15+ platforms where artists keep up to 97% of every sale — not fractions of a penny from streams.
           </p>
         </div>
       </div>

--- a/apps/web/src/pages/DevelopersPage.tsx
+++ b/apps/web/src/pages/DevelopersPage.tsx
@@ -9,7 +9,7 @@ export function DevelopersPage() {
         <div className="prose prose-gray dark:prose-invert max-w-none">
           <h1>Unstream API</h1>
           <p className="text-lg text-gray-600 dark:text-gray-400">
-            Find your favorite artists on alternative music platforms. Search across 17+ platforms
+            Find your favorite artists on alternative music platforms. Search across 15+ platforms
             including Bandcamp, Mirlo, Qobuz, Beatport, Faircamp, Patreon, and more.
           </p>
           <p>

--- a/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
+++ b/data/guides/bandcamp-and-beyond-alternative-music-platforms-worth-knowing.md
@@ -57,4 +57,4 @@ Don't sleep on your local library. **[Hoopla](https://www.hoopladigital.com)** a
 
 The biggest pain point with this whole ecosystem is fragmentation. Your favorite artist might be on Bandcamp, Mirlo, *and* Ko-fi — but you'd have no idea unless you checked each platform separately.
 
-That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 17 platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.
+That's what [Unstream](https://unstream.stream) does. Search for any artist and it checks 15+ platforms at once, showing you everywhere they sell and how much of your money actually reaches them on each one.

--- a/data/guides/how-to-build-a-music-library-without-streaming.md
+++ b/data/guides/how-to-build-a-music-library-without-streaming.md
@@ -29,7 +29,7 @@ Over a year that's 12–24 albums you permanently own, with $100+ going directly
 
 This used to be the annoying part. Artists sell across tons of platforms — [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), their own websites, [Ko-fi](https://ko-fi.com) — and checking each one individually is tedious enough that most people just don't bother.
 
-[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 17 platforms, with how much of your money reaches them on each one. Free, no account needed.
+[Unstream](https://unstream.stream) does this in one search. Type in an artist and it shows everywhere they sell across 15+ platforms, with how much of your money reaches them on each one. Free, no account needed.
 
 ## Pick a music player
 

--- a/data/guides/labels-vs-independence-what-artists-actually-keep.md
+++ b/data/guides/labels-vs-independence-what-artists-actually-keep.md
@@ -87,7 +87,7 @@ This is where the "1,000 true fans" math gets real. A thousand fans each buying 
 
 The biggest challenge for independent artists is still discovery. Labels have marketing machines. Independent artists have social media, word of mouth, and whatever organic growth they can build.
 
-But this is shifting. Tools like [Unstream](https://unstream.stream) help listeners find where their favorite artists sell directly across 17 platforms. Communities on [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), and music forums actively champion independent releases. Music blogs and independent publications still cover artists who aren't on major labels.
+But this is shifting. Tools like [Unstream](https://unstream.stream) help listeners find where their favorite artists sell directly across 15+ platforms. Communities on [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), and music forums actively champion independent releases. Music blogs and independent publications still cover artists who aren't on major labels.
 
 And the artists who build direct relationships with fans — through email lists, community platforms like [Patreon](https://www.patreon.com) or [Ko-fi](https://ko-fi.com), and direct-sales storefronts — tend to have more durable careers than those who rely on algorithmic discovery. An algorithm can stop recommending you tomorrow. A fan who bought your last three albums on Bandcamp is going to buy the next one too.
 

--- a/data/guides/the-real-cost-of-free-music.md
+++ b/data/guides/the-real-cost-of-free-music.md
@@ -53,6 +53,6 @@ This isn't theoretical. Bandcamp alone has paid artists over a billion dollars. 
 You don't have to quit streaming. But a few things go a long way:
 
 1. **Pick the artists you care about most** and buy their music directly. One $10 album purchase on Bandcamp gives an artist more than thousands of streams.
-2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 17 platforms and see how much of your money reaches them on each one.
+2. **Use [Unstream](https://unstream.stream)** to find where artists sell across 15+ platforms and see how much of your money reaches them on each one.
 3. **Buy on Bandcamp Fridays** (first Friday of every month) when artists keep ~97%.
 4. **Tell people.** Most listeners have no idea how any of this works. The streaming experience is so smooth that it's easy to assume the artists behind it are being taken care of. They're mostly not.

--- a/data/guides/where-your-money-goes-streaming-vs-buying.md
+++ b/data/guides/where-your-money-goes-streaming-vs-buying.md
@@ -50,7 +50,7 @@ And it compounds in a way streaming doesn't. After three years of streaming you 
 You don't need to cancel streaming — plenty of people keep it for casual listening and convenience while also buying from artists they care about. That's fine. Even small shifts matter:
 
 - **Buy from one or two artists a month** instead of just streaming them. Prioritize the ones who seem like they need it most — independent, unsigned, small following.
-- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 17 platforms and see exactly how much reaches them on each one.
+- **Search on [Unstream](https://unstream.stream)** to find where your favorite artists sell across 15+ platforms and see exactly how much reaches them on each one.
 - **Buy on Bandcamp Fridays** to maximize what goes to the artist.
 - **Check your library's music services** — [Hoopla](https://www.hoopladigital.com) and [Freegal](https://www.freegalmusic.com) are free with a library card and good for exploring new stuff without spending.
 

--- a/data/guides/why-music-platforms-hide-artist-payout-rates.md
+++ b/data/guides/why-music-platforms-hide-artist-payout-rates.md
@@ -89,7 +89,7 @@ Some of this is starting to happen anyway. Artists share royalty screenshots on 
 Until platforms are required or pressured to disclose payout rates in a standardized way:
 
 - **Favor platforms that publish their rates.** [Bandcamp](https://bandcamp.com), [Mirlo](https://mirlo.space), [Ampwall](https://ampwall.com), and others are upfront about what artists keep. That transparency is a feature.
-- **Use [Unstream](https://unstream.stream)** to search for artists across 17 platforms and see payout percentages for each one.
+- **Use [Unstream](https://unstream.stream)** to search for artists across 15+ platforms and see payout percentages for each one.
 - **Ask the question.** When a platform says it "supports artists," ask how much. If the answer is vague or unavailable, that tells you something.
 - **Buy directly when you can.** A $10 album on Bandcamp puts [about $8.20 in the artist's pocket](https://bandcamp.com/fair_trade_music_policy). No ambiguity, no opaque royalty pool, no six-month delay.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Unstream API
   description: |
-    Find your favorite artists on alternative music platforms. Search across 17+ platforms
+    Find your favorite artists on alternative music platforms. Search across 15+ platforms
     including Bandcamp, Mirlo, Qobuz, Beatport, Faircamp, Patreon, and more.
 
     ## Authentication


### PR DESCRIPTION
## Summary

- Updates all references to "17 platforms" / "17+ platforms" → "15+ platforms"
- Covers homepage meta tags, hero copy, developers page, OpenAPI docs (both copies), and 6 guide articles

## Files changed

- `apps/web/index.html` — meta description and OG description
- `apps/web/src/App.tsx` — hero tagline
- `apps/web/src/pages/DevelopersPage.tsx` — API intro copy
- `apps/web/public/docs/openapi.yaml` + `docs/openapi.yaml` — API description
- 6 guide markdown files in `data/guides/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)