### PR TITLE
Swap GoatCounter for Umami analytics

### DIFF
--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -308,7 +308,7 @@ function generateArtistPageHtml(
   ${jsHref ? `<script type="module" src="${jsHref}"></script>` : '<script type="module" src="/src/main.tsx"></script>'}
 
   <!-- Analytics -->
-  <script data-goatcounter="https://unstream.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="0b2ee6ec-0b7a-4ea6-9b79-8ebc3b280874"></script>
 </body>
 </html>`;
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -64,7 +64,6 @@
       </div>
     </noscript>
     <script type="module" src="/src/main.tsx"></script>
-    <script data-goatcounter="https://unstream.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="0b2ee6ec-0b7a-4ea6-9b79-8ebc3b280874"></script>
   </body>
 </html>

--- a/apps/web/src/services/analytics.ts
+++ b/apps/web/src/services/analytics.ts
@@ -1,10 +1,10 @@
 /**
- * Analytics tracking using GoatCounter + Unstream artist analytics API
+ * Analytics tracking using Umami + Unstream artist analytics API
  * + product analytics (app_events).
  *
- * General events (search, download, etc.) go to GoatCounter only.
+ * General events (search, download, etc.) go to Umami only.
  * Artist-specific events (search appearances, page views, link clicks)
- * go to BOTH GoatCounter and our Supabase-backed analytics API so
+ * go to BOTH Umami and our Supabase-backed analytics API so
  * verified artists can see their stats on the dashboard.
  * Product events (all user actions) go to the app_events endpoint for
  * the admin analytics dashboard. All product events are anonymized —
@@ -13,16 +13,14 @@
 
 declare global {
   interface Window {
-    goatcounter?: {
-      count: (vars: { path: string; event: boolean }) => void;
+    umami?: {
+      track: (eventName: string, data?: Record<string, string | number | boolean>) => void;
     };
   }
 }
 
-function trackEvent(path: string): void {
-  if (window.goatcounter?.count) {
-    window.goatcounter.count({ path, event: true });
-  }
+function trackEvent(eventName: string): void {
+  window.umami?.track(eventName);
 }
 
 /** Fire-and-forget POST to our analytics API for artist-level metrics. */
@@ -47,13 +45,13 @@ function trackAppEvent(
 }
 
 export const analytics = {
-  // General events (GoatCounter only)
-  trackDownload: () => trackEvent('/download'),
-  trackReportIssue: () => trackEvent('/report-issue'),
+  // General events (Umami only)
+  trackDownload: () => trackEvent('download'),
+  trackReportIssue: () => trackEvent('report-issue'),
 
-  // Search initiated (GoatCounter + product analytics — fires before results arrive)
+  // Search initiated (Umami + product analytics — fires before results arrive)
   trackSearch: () => {
-    trackEvent('/search');
+    trackEvent('search');
     trackAppEvent('search', {});
   },
 
@@ -62,29 +60,29 @@ export const analytics = {
     trackAppEvent('search', { has_results: hasResults, result_count: resultCount });
   },
 
-  // Platform click (GoatCounter + product analytics)
+  // Platform click (Umami + product analytics)
   trackPlatformClick: (platformName: string) => {
-    trackEvent(`/go/${platformName.toLowerCase()}`);
+    trackEvent(`go-${platformName.toLowerCase()}`);
     trackAppEvent('platform_click', { platform: platformName.toLowerCase() });
   },
 
-  // Page views (product analytics only — GoatCounter handles page views automatically)
+  // Page views (product analytics only — Umami handles page views automatically)
   trackPageView: (page: string) => {
     trackAppEvent('page_view', { page });
   },
 
-  // Artist-specific events (GoatCounter + Supabase artist analytics + product analytics)
+  // Artist-specific events (Umami + Supabase artist analytics + product analytics)
   trackArtistPageView: (slug: string) => {
-    trackEvent(`/artist/${slug}/view`);
+    trackEvent(`artist-view`);
     trackArtistEvent(slug, 'view');
     trackAppEvent('page_view', { page: 'artist' });
   },
   trackArtistSearchAppearance: (slug: string) => {
-    trackEvent(`/artist/${slug}/search`);
+    trackEvent(`artist-search`);
     trackArtistEvent(slug, 'search');
   },
   trackArtistLinkClick: (slug: string, platform: string) => {
-    trackEvent(`/artist/${slug}/click/${platform.toLowerCase()}`);
+    trackEvent(`artist-click-${platform.toLowerCase()}`);
     trackArtistEvent(slug, `click:${platform.toLowerCase()}`);
     trackAppEvent('platform_click', { platform: platform.toLowerCase() });
   },

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' gc.zgo.at letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://unstream.goatcounter.com https://letterbird.co; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' cloud.umami.is letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://cloud.umami.is https://letterbird.co; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
 
 [[edge_functions]]
   path = "/"


### PR DESCRIPTION
Replace GoatCounter with Umami Cloud across the entire web app:
- Update script tags in index.html and artist-page edge function
- Replace window.goatcounter.count() with window.umami.track() in analytics.ts
- Update CSP in netlify.toml (gc.zgo.at → cloud.umami.is for script-src;
  unstream.goatcounter.com → cloud.umami.is for connect-src)
- Rename event paths to Umami-friendly strings (e.g. /go/bandcamp → go-bandcamp)

https://claude.ai/code/session_011WpmM9g13ZZbxVPekyDDzm