### PR TITLE
Remove hardcoded Algolia credentials from web server

### DIFF
--- a/apps/web/server/api.ts
+++ b/apps/web/server/api.ts
@@ -978,12 +978,19 @@ async function searchBeatport(query: string): Promise<Map<string, string>> {
 async function searchEven(query: string): Promise<Map<string, string>> {
   const results = new Map<string, string>();
 
+  const algoliaAppId = process.env.ALGOLIA_APP_ID || 'S64VD9CU46';
+  const algoliaApiKey = process.env.ALGOLIA_API_KEY;
+  if (!algoliaApiKey) {
+    console.warn('[EVEN] Missing ALGOLIA_API_KEY env var, skipping Even search');
+    return results;
+  }
+
   try {
-    const response = await fetchWithTimeout('https://S64VD9CU46-dsn.algolia.net/1/indexes/Artist/query', {
+    const response = await fetchWithTimeout(`https://${algoliaAppId}-dsn.algolia.net/1/indexes/Artist/query`, {
       method: 'POST',
       headers: {
-        'X-Algolia-Application-Id': 'S64VD9CU46',
-        'X-Algolia-API-Key': 'eea52fd4a67d03678477ffdfbad362e2',
+        'X-Algolia-Application-Id': algoliaAppId,
+        'X-Algolia-API-Key': algoliaApiKey,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ query, hitsPerPage: 10 }),


### PR DESCRIPTION
Replace hardcoded Algolia app ID and API key in searchEven() with
ALGOLIA_APP_ID and ALGOLIA_API_KEY env vars, matching the pattern
already used in api/functions/search-sources.ts. Even search is
skipped gracefully if the key is missing.

https://claude.ai/code/session_01CAZAsddAMbuZTwgTFZN69Y