### PR TITLE
Fix analytics events never recording (crypto.subtle on Node 18)

### DIFF
--- a/api/functions/analytics-app-event.ts
+++ b/api/functions/analytics-app-event.ts
@@ -2,6 +2,7 @@
 // Records anonymous product usage events from web, extension, and Mac app.
 // No PII stored: session_hash is a one-way SHA-256 of (ip + user_agent + date).
 
+import { createHash } from 'crypto';
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
@@ -22,13 +23,9 @@ const VALID_EVENT_TYPES = new Set([
 
 const VALID_APPS = new Set(['web', 'extension', 'mac']);
 
-async function hashSessionId(ip: string, userAgent: string): Promise<string> {
+function hashSessionId(ip: string, userAgent: string): string {
   const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
-  const raw = `${ip}:${userAgent}:${date}`;
-  const encoded = new TextEncoder().encode(raw);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  return createHash('sha256').update(`${ip}:${userAgent}:${date}`).digest('hex');
 }
 
 export async function handler(event: {
@@ -83,17 +80,17 @@ export async function handler(event: {
   }
 
   const userAgent = event.headers['user-agent'] || '';
-  const sessionHash = await hashSessionId(ip, userAgent);
+  const sessionHash = hashSessionId(ip, userAgent);
 
-  try {
-    await client.from('app_events').insert({
-      event_type,
-      app,
-      context: safeContext,
-      session_hash: sessionHash,
-    });
-  } catch {
-    // Silent fail — never break the caller for analytics
+  // Supabase JS client returns { error } rather than throwing — check it explicitly
+  const { error: insertError } = await client.from('app_events').insert({
+    event_type,
+    app,
+    context: safeContext,
+    session_hash: sessionHash,
+  });
+  if (insertError) {
+    console.error('[Analytics] Failed to insert app_event:', insertError.message);
   }
 
   return { statusCode: 204, headers: CORS_HEADERS, body: '' };

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -118,6 +118,19 @@ export async function handler(event: {
         .limit(20),
     ]);
 
+    // Surface query errors early — Supabase returns { error } rather than throwing
+    const queryErrors = [
+      searchesToday.error, searches7d.error, searches30d.error,
+      successfulSearches7d.error, daily30d.error,
+    ].filter(Boolean);
+    if (queryErrors.length > 0) {
+      console.error('[Analytics Dashboard] Query errors:', queryErrors.map(e => e?.message));
+      // If the core count queries all errored (e.g. app_events table missing), surface it
+      if (searchesToday.error && searches7d.error && searches30d.error) {
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Analytics table unavailable — migration may not have been applied' }) };
+      }
+    }
+
     // --- Build daily chart data (last 30 days) ---
     const dailyMap: Record<string, { searches: number; clicks: number; activations: number }> = {};
 


### PR DESCRIPTION
## Summary

- **Root cause:** `analytics-app-event.ts` used `crypto.subtle` (the browser-style Web Crypto API), which is not a stable global on Node.js 18 — Netlify's Lambda runtime. Every analytics POST was crashing with `TypeError: Cannot read properties of undefined (reading 'digest')` before it could write to the DB. The frontend's fire-and-forget `.catch(() => {})` silently swallowed every 500 response, so no events were ever recorded and the admin analytics page showed all zeros.
- Replace `crypto.subtle.digest` with `import { createHash } from 'crypto'` — Node's built-in synchronous hash, reliable on all Node versions
- Fix Supabase insert error handling: the JS client returns `{ error }` rather than throwing, so the previous `try/catch` never caught DB failures; now logs via `console.error`
- `analytics-dashboard.ts`: return a real 500 with a descriptive message when all core count queries fail, instead of silently showing zeros

## Test plan

- [ ] Deploy to Netlify and perform a search — verify a row appears in `app_events` in Supabase
- [ ] Check admin analytics page shows non-zero searches after a few test searches
- [ ] Verify Netlify function logs show no errors from `analytics-app-event`

🤖 Generated with [Claude Code](https://claude.com/claude-code)