### PR TITLE
Address code review notes from analytics crypto fix (#140)

### DIFF
--- a/api/functions/analytics-app-event.ts
+++ b/api/functions/analytics-app-event.ts
@@ -90,7 +90,7 @@ export async function handler(event: {
     session_hash: sessionHash,
   });
   if (insertError) {
-    console.error('[Analytics] Failed to insert app_event:', insertError.message);
+    console.error('[Analytics] Failed to insert app_event:', insertError);
   }
 
   return { statusCode: 204, headers: CORS_HEADERS, body: '' };

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -126,7 +126,7 @@ export async function handler(event: {
     if (queryErrors.length > 0) {
       console.error('[Analytics Dashboard] Query errors:', queryErrors.map(e => e?.message));
       // If the core count queries all errored (e.g. app_events table missing), surface it
-      if (searchesToday.error && searches7d.error && searches30d.error) {
+      if (queryErrors.length >= 3) {
         return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Analytics table unavailable — migration may not have been applied' }) };
       }
     }

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -1,6 +1,7 @@
 // Centralized middleware for API functions.
 // Provides CORS, authentication, query validation, and SSRF protection.
 
+import { createHash, randomUUID, timingSafeEqual } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
 
@@ -123,11 +124,7 @@ export async function authenticateApiKey(
   if (prefix.length < 12) return null;
 
   // Hash the full key with SHA-256
-  const encoder = new TextEncoder();
-  const encoded = encoder.encode(apiKeyHeader);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const keyHash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  const keyHash = createHash('sha256').update(apiKeyHeader).digest('hex');
 
   // Look up by prefix and compare hash
   const { data: keyRow, error } = await client
@@ -140,7 +137,6 @@ export async function authenticateApiKey(
   if (error || !keyRow) return null;
 
   // Timing-safe hash comparison to prevent timing attacks
-  const { timingSafeEqual } = await import('crypto');
   const hashA = Buffer.from(keyRow.key_hash, 'hex');
   const hashB = Buffer.from(keyHash, 'hex');
   if (hashA.length !== hashB.length || !timingSafeEqual(hashA, hashB)) return null;
@@ -321,7 +317,7 @@ export function isUrlHostnameAllowed(urlString: string): boolean {
  * Generate a unique request ID for tracing.
  */
 export function generateRequestId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #140 based on post-merge review from Tyson (security) and McMurray (backend). Four items, all small:

- **`middleware.ts` — two more `crypto` global usages fixed**: `authenticateApiKey` was using `crypto.subtle.digest` (same Node 18 instability that broke analytics), and `generateRequestId` was using `crypto.randomUUID()`. Both replaced with imports from Node's built-in `crypto` module (`createHash`, `randomUUID`, `timingSafeEqual`). Also cleans up the existing dynamic `import('crypto')` for `timingSafeEqual` since it's now a static import.
- **`analytics-dashboard.ts` — error guard broadened**: The condition for returning 500 was `searchesToday.error && searches7d.error && searches30d.error` — too narrow. Partial failures in `successfulSearches7d` or `daily30d` would log an error but silently return wrong data (0% success rate, empty chart). Changed to `queryErrors.length >= 3`.
- **`analytics-app-event.ts` — log full error object**: Was logging `insertError.message`; changed to `insertError` to include the Postgres error code in Netlify logs, consistent with how other functions in the codebase log Supabase errors.

## Not included

Tyson flagged the `session_hash` as technically reversible (SHA-256 of IP+UA+date is precomputable). Hardening to HMAC would require adding a `SESSION_HASH_SECRET` env var to Netlify — leaving that for a separate PR when there's time to do the env var change alongside the code.

## Test plan

- [ ] Merge and verify Netlify deploy succeeds
- [ ] Confirm API key auth still works (the `authenticateApiKey` path changed)
- [ ] Confirm admin analytics dashboard still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)