### PR TITLE
Fix analytics dashboard 500: undefined totalSearches7d

### DIFF
--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -205,7 +205,7 @@ export async function handler(event: {
       body: JSON.stringify({
         summary: {
           searches_today: searchesToday.count || 0,
-          searches_7d: totalSearches7d,
+          searches_7d: searches7d.count || 0,
           searches_30d: searches30d.count || 0,
           success_rate_7d: successRate7d,
           top_platform: platforms[0]?.platform || null,


### PR DESCRIPTION
## Summary

Root cause of the persistent 500 on `/admin/analytics`.

PR #144 rewrote the success rate calculation block but left `totalSearches7d` in the JSON response body where it was no longer defined. This caused a `ReferenceError` at the `JSON.stringify` call, which the catch block turned into a 500.

**Fix:** replace `totalSearches7d` with `searches7d.count || 0` directly.

PR #145 fixed a separate but related issue (bad JSONB filter) — this fixes the actual crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)