### PR TITLE
Improve artist page SEO, share CTA, and search result save redesign

### DIFF
--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -102,6 +102,17 @@ function generateArtistPageHtml(
       return info && info.category !== 'social';
     });
   const platformNames = allPlatforms.map(p => PLATFORM_INFO[p.sourceId]?.name).filter(Boolean);
+
+  // Build title suffix from actual platforms (keep it short for SERPs)
+  let titlePlatforms: string;
+  if (platformNames.length === 0) {
+    titlePlatforms = 'alternative platforms';
+  } else if (platformNames.length <= 2) {
+    titlePlatforms = platformNames.join(' &amp; ');
+  } else {
+    titlePlatforms = `${platformNames[0]} &amp; more`;
+  }
+
   let description: string;
   if (platformNames.length === 0) {
     description = `Find ${artistName} on alternative music platforms. Support artists directly outside streaming.`;
@@ -199,18 +210,18 @@ function generateArtistPageHtml(
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapedName} on Bandcamp &amp; alternative platforms | Unstream</title>
+  <title>${escapedName} on ${titlePlatforms} | Unstream</title>
   <meta name="description" content="${escapeHtml(description)}">
   <link rel="canonical" href="${canonicalUrl}">
   <meta property="og:type" content="profile">
   <meta property="og:url" content="${canonicalUrl}">
-  <meta property="og:title" content="${escapedName} on Bandcamp &amp; alternative platforms | Unstream">
+  <meta property="og:title" content="${escapedName} on ${titlePlatforms} | Unstream">
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:site_name" content="Unstream">
   ${imageUrl ? `<meta property="og:image" content="${escapeHtml(imageUrl)}">
   <meta property="og:image:alt" content="${escapedName}">` : ''}
   <meta name="twitter:card" content="${imageUrl ? 'summary_large_image' : 'summary'}">
-  <meta name="twitter:title" content="${escapedName} on Bandcamp &amp; alternative platforms | Unstream">
+  <meta name="twitter:title" content="${escapedName} on ${titlePlatforms} | Unstream">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   ${imageUrl ? `<meta name="twitter:image" content="${escapeHtml(imageUrl)}">` : ''}
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>

--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -90,7 +90,28 @@ function generateArtistPageHtml(
   const canonicalUrl = `https://unstream.stream/artist/${slug}`;
   const firstArtist = results.find(r => r.type === 'artist');
   const imageUrl = firstArtist?.imageUrl || '';
-  const description = `Find ${artistName} on Bandcamp, Qobuz, and other ethical music platforms. Support artists directly.`;
+
+  // Build SEO description dynamically from actual platforms found
+  const allPlatforms = (firstArtist?.platforms || [])
+    .filter(p => {
+      const u = p.url.toLowerCase();
+      return !u.includes('duckduckgo.com') && !u.includes('google.com/search') && !u.includes('searchstyle=search');
+    })
+    .filter(p => {
+      const info = PLATFORM_INFO[p.sourceId];
+      return info && info.category !== 'social';
+    });
+  const platformNames = allPlatforms.map(p => PLATFORM_INFO[p.sourceId]?.name).filter(Boolean);
+  let description: string;
+  if (platformNames.length === 0) {
+    description = `Find ${artistName} on alternative music platforms. Support artists directly outside streaming.`;
+  } else if (platformNames.length <= 3) {
+    description = `${artistName} is on ${platformNames.join(', ')}. Find direct links and support them outside streaming.`;
+  } else {
+    const featured = platformNames.slice(0, 2).join(', ');
+    const remaining = platformNames.length - 2;
+    description = `${artistName} is on ${featured}, and ${remaining} other platform${remaining > 1 ? 's' : ''}. Find direct links and support them outside streaming.`;
+  }
 
   // Gather all platforms from the first artist result
   const platforms = firstArtist?.platforms || [];
@@ -178,18 +199,18 @@ function generateArtistPageHtml(
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapedName} - Unstream | Listen on platforms that pay artists fairly</title>
+  <title>${escapedName} on Bandcamp &amp; alternative platforms | Unstream</title>
   <meta name="description" content="${escapeHtml(description)}">
   <link rel="canonical" href="${canonicalUrl}">
   <meta property="og:type" content="profile">
   <meta property="og:url" content="${canonicalUrl}">
-  <meta property="og:title" content="${escapedName} - Unstream">
+  <meta property="og:title" content="${escapedName} on Bandcamp &amp; alternative platforms | Unstream">
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:site_name" content="Unstream">
   ${imageUrl ? `<meta property="og:image" content="${escapeHtml(imageUrl)}">
   <meta property="og:image:alt" content="${escapedName}">` : ''}
   <meta name="twitter:card" content="${imageUrl ? 'summary_large_image' : 'summary'}">
-  <meta name="twitter:title" content="${escapedName} - Unstream">
+  <meta name="twitter:title" content="${escapedName} on Bandcamp &amp; alternative platforms | Unstream">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   ${imageUrl ? `<meta name="twitter:image" content="${escapeHtml(imageUrl)}">` : ''}
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -238,7 +238,7 @@ function App() {
           </p>
           <div className="flex flex-col items-center gap-3 mb-2">
             <a
-              href="https://github.com/brandonlucasgreen/unstream/releases/latest/download/Unstream.dmg"
+              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
               className="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-accent-primary text-white hover:bg-accent-primary/90 transition-colors font-medium shadow-lg shadow-accent-primary/20"
               onClick={() => analytics.trackDownload()}
             >

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -38,7 +38,6 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
   const [showPlayer, setShowPlayer] = useState(false);
   const [showReportForm, setShowReportForm] = useState(false);
   const [reportText, setReportText] = useState('');
-  const [showSavePromo, setShowSavePromo] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
 
   // Helper to check if a URL is a direct link vs a search URL
@@ -276,16 +275,6 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
 
         {/* Action buttons + expand arrow */}
         <div className="flex-shrink-0 flex items-center gap-1">
-          {/* Save button */}
-          <button
-            onClick={(e) => { e.stopPropagation(); setShowSavePromo(!showSavePromo); }}
-            className={`p-1.5 rounded-lg transition-colors ${showSavePromo ? 'text-accent-primary bg-accent-primary/10' : 'text-text-muted hover:text-text-primary hover:bg-bg-secondary'}`}
-            title="Save this artist"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-          </button>
           {/* Share button */}
           <button
             onClick={handleShare}
@@ -313,64 +302,6 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
           </svg>
         </div>
       </div>
-
-      {/* Save artist promo banner */}
-      {showSavePromo && (
-        <div className="px-4 pb-3 animate-in slide-in-from-top-2 duration-200" onClick={(e) => e.stopPropagation()}>
-          <div className="p-3 rounded-lg bg-accent-primary/5 border border-accent-primary/20">
-            <div className="flex items-start gap-3">
-              <svg className="w-5 h-5 text-accent-primary flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-              </svg>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-text-primary mb-1">Save artists with the Unstream app</p>
-                <p className="text-xs text-text-muted mb-3">
-                  The free Unstream app and browser extensions detect what's playing automatically, so you keep track of artists you want to support &amp; get notified when they release new music.
-                </p>
-                <div className="flex flex-wrap items-center gap-2">
-                  <a
-                    href="https://github.com/brandonlucasgreen/unstream/releases/latest/download/Unstream.dmg"
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-                    </svg>
-                    Mac app
-                  </a>
-                  <a
-                    href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
-                    </svg>
-                    Chrome
-                  </a>
-                  <a
-                    href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
-                    </svg>
-                    Firefox
-                  </a>
-                  <button
-                    onClick={() => setShowSavePromo(false)}
-                    className="px-3 py-1.5 rounded-lg text-xs text-text-muted hover:text-text-primary transition-colors"
-                  >
-                    Dismiss
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Expanded platform list */}
       {expanded && (
@@ -669,6 +600,48 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                   url={platform.url}
                 />
               ))}
+            </div>
+          )}
+
+          {/* Save / app promo - always visible */}
+          {result.type === 'artist' && (
+            <div className="flex items-center gap-3 p-3 rounded-lg bg-accent-primary/5 border border-accent-primary/10">
+              <svg className="w-4 h-4 text-accent-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-text-secondary">
+                  <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
+                  {' '}with the free{' '}
+                  <a
+                    href="https://github.com/brandonlucasgreen/unstream/releases/latest/download/Unstream.dmg"
+                    className="text-accent-primary hover:underline"
+                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
+                  >
+                    Mac app
+                  </a>
+                  {' '}or browser extension for{' '}
+                  <a
+                    href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-primary hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Chrome
+                  </a>
+                  {' / '}
+                  <a
+                    href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-primary hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Firefox
+                  </a>
+                </p>
+              </div>
             </div>
           )}
 

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -626,7 +626,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-accent-primary hover:underline"
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
                   >
                     Chrome
                   </a>
@@ -636,7 +636,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-accent-primary hover:underline"
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
                   >
                     Firefox
                   </a>

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -614,7 +614,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                   <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
                   {' '}with the free{' '}
                   <a
-                    href="https://github.com/brandonlucasgreen/unstream/releases/latest/download/Unstream.dmg"
+                    href="https://github.com/brandonlucasgreen/unstream/releases/latest"
                     className="text-accent-primary hover:underline"
                     onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
                   >

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -605,42 +605,51 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
 
           {/* Save / app promo - always visible */}
           {result.type === 'artist' && (
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-accent-primary/5 border border-accent-primary/10">
-              <svg className="w-4 h-4 text-accent-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-              </svg>
-              <div className="flex-1 min-w-0">
+            <div className="p-3 rounded-lg bg-accent-primary/5 border border-accent-primary/10">
+              <div className="flex items-center gap-2 mb-2.5">
+                <svg className="w-4 h-4 text-accent-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                </svg>
                 <p className="text-xs text-text-secondary">
                   <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
-                  {' '}with the free{' '}
-                  <a
-                    href="https://github.com/brandonlucasgreen/unstream/releases/latest"
-                    className="text-accent-primary hover:underline"
-                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
-                  >
-                    Mac app
-                  </a>
-                  {' '}or browser extension for{' '}
-                  <a
-                    href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-accent-primary hover:underline"
-                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
-                  >
-                    Chrome
-                  </a>
-                  {' / '}
-                  <a
-                    href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-accent-primary hover:underline"
-                    onClick={(e) => { e.stopPropagation(); analytics.trackDownload(); }}
-                  >
-                    Firefox
-                  </a>
+                  {' '}with the free app or browser extension
                 </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                <a
+                  href="https://github.com/brandonlucasgreen/unstream/releases/latest"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
+                  onClick={() => analytics.trackDownload()}
+                >
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+                  </svg>
+                  Mac app
+                </a>
+                <a
+                  href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
+                  onClick={() => analytics.trackDownload()}
+                >
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
+                  </svg>
+                  Chrome
+                </a>
+                <a
+                  href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
+                  onClick={() => analytics.trackDownload()}
+                >
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
+                  </svg>
+                  Firefox
+                </a>
               </div>
             </div>
           )}

--- a/apps/web/src/pages/ArtistDashboardPage.tsx
+++ b/apps/web/src/pages/ArtistDashboardPage.tsx
@@ -24,6 +24,21 @@ export function ArtistDashboardPage() {
   const [profiles, setProfiles] = useState<ClaimedProfile[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [copiedSlug, setCopiedSlug] = useState<string | null>(null);
+
+  const handleShareProfile = async (slug: string) => {
+    const url = `https://unstream.stream/a/${slug}`;
+    const text = `Find my music on alternative platforms with Unstream`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'My Unstream page', text, url });
+      } catch { /* cancelled */ }
+    } else {
+      await navigator.clipboard.writeText(url);
+      setCopiedSlug(slug);
+      setTimeout(() => setCopiedSlug(null), 2000);
+    }
+  };
 
   useEffect(() => {
     if (authLoading) return; // Wait for auth context to resolve
@@ -130,6 +145,27 @@ export function ArtistDashboardPage() {
                       >
                         View
                       </Link>
+                      <button
+                        onClick={() => handleShareProfile(profile.slug)}
+                        className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors flex items-center gap-1.5"
+                        title="Share your artist page"
+                      >
+                        {copiedSlug === profile.slug ? (
+                          <>
+                            <svg className="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                            Copied!
+                          </>
+                        ) : (
+                          <>
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                            </svg>
+                            Share
+                          </>
+                        )}
+                      </button>
                     </div>
                   </div>
                   <ArtistAnalytics slug={profile.slug} />

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { SearchBar } from '../components/SearchBar';
 import { ResultCard } from '../components/ResultCard';
 
@@ -12,11 +12,29 @@ import { analytics } from '../services/analytics';
 export function ArtistPage() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const justClaimed = searchParams.get('claimed') !== null;
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isEnriching, setIsEnriching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [artistName, setArtistName] = useState('');
+  const [claimBannerDismissed, setClaimBannerDismissed] = useState(false);
+  const [claimShareCopied, setClaimShareCopied] = useState(false);
+
+  const handleClaimShare = async () => {
+    const url = `https://unstream.stream/a/${slug}`;
+    const text = `Find my music on alternative platforms with Unstream`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: `${displayName} on Unstream`, text, url });
+      } catch { /* cancelled */ }
+    } else {
+      await navigator.clipboard.writeText(url);
+      setClaimShareCopied(true);
+      setTimeout(() => setClaimShareCopied(false), 2000);
+    }
+  };
 
   // Derive display name from slug as initial value
   const displayName = artistName || (slug?.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()) || '');
@@ -24,10 +42,10 @@ export function ArtistPage() {
   // Update page title and meta tags
   useEffect(() => {
     if (displayName) {
-      document.title = `${displayName} on Unstream - Support artists directly`;
+      document.title = `${displayName} on Bandcamp & alternative platforms | Unstream`;
       const metaDesc = document.querySelector('meta[name="description"]');
       if (metaDesc) {
-        metaDesc.setAttribute('content', `Find ${displayName} on Bandcamp, Qobuz, and other ethical music platforms. Support artists directly.`);
+        metaDesc.setAttribute('content', `${displayName} is on Bandcamp and other alternative platforms. Find direct links and support them outside streaming.`);
       }
     }
     return () => {
@@ -189,6 +207,53 @@ export function ArtistPage() {
             isLoading={isLoading}
             initialQuery={displayName}
           />
+
+          {/* Post-claim success banner */}
+          {justClaimed && !claimBannerDismissed && (
+            <div className="mt-6 p-4 rounded-xl bg-green-500/10 border border-green-500/20">
+              <div className="flex items-start gap-3">
+                <svg className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-text-primary mb-1">
+                    Your page is live! Share it with your fans.
+                  </p>
+                  <p className="text-xs text-text-muted mb-3">
+                    Let your audience know they can find all your alternative platform links in one place.
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleClaimShare}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
+                    >
+                      {claimShareCopied ? (
+                        <>
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                          </svg>
+                          Link copied!
+                        </>
+                      ) : (
+                        <>
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                          </svg>
+                          Share your page
+                        </>
+                      )}
+                    </button>
+                    <button
+                      onClick={() => setClaimBannerDismissed(true)}
+                      className="px-3 py-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
 
           {/* Error state */}
           {error && (

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -147,7 +147,7 @@ export function ArtistPage() {
           </p>
           <div className="flex flex-col items-center gap-3 mb-2">
             <a
-              href="https://github.com/brandonlucasgreen/unstream/releases/latest/download/Unstream.dmg"
+              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
               className="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-accent-primary text-white hover:bg-accent-primary/90 transition-colors font-medium shadow-lg shadow-accent-primary/20"
               onClick={() => analytics.trackDownload()}
             >


### PR DESCRIPTION
## Summary
- **Artist page SEO**: Dynamic OG descriptions listing actual platforms found per artist (e.g. "Aphex Twin is on Bandcamp, Mirlo, and 9 other platforms"). Title tags also dynamic based on platforms present instead of hardcoding "Bandcamp".
- **Share CTA for verified artists**: Share button on artist dashboard + post-claim success banner ("Your page is live! Share it with your fans") with native share / clipboard copy.
- **Search result save redesign**: Replaced hidden bookmark-button-to-modal flow with persistent inline "Save artists & get release alerts" blurb with Mac app/Chrome/Firefox links always visible in expanded result cards. Consistent download tracking on all install links.

## Test plan
- [ ] Search for an artist with Bandcamp presence — verify title reads "{Artist} on Bandcamp & more | Unstream"
- [ ] Search for an artist with only 1-2 platforms — verify title lists them specifically
- [ ] Check OG tags with a social card previewer (e.g. opengraph.xyz)
- [ ] Visit /artist-dashboard as a verified artist — confirm Share button copies URL with "Copied!" feedback
- [ ] Visit /a/{slug}?claimed — confirm green success banner with share CTA appears and is dismissable
- [ ] Expand a search result — confirm inline save/app promo blurb is visible without clicking anything
- [ ] Click Mac app, Chrome, and Firefox links in the blurb — confirm all three fire analytics events

🤖 Generated with [Claude Code](https://claude.com/claude-code)