### PR TITLE
Add Unstream Dispatch weekly briefing feed

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>The Unstream Dispatch</title>
+    <link>https://unstream.stream</link>
+    <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
+    <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
+    <language>en-us</language>
+    <lastBuildDate>Thu, 16 Apr 2026 00:01:17 GMT</lastBuildDate>
+
+  </channel>
+</rss>

--- a/data/dispatch/PROMPT.md
+++ b/data/dispatch/PROMPT.md
@@ -1,0 +1,89 @@
+# Unstream Dispatch — weekly research prompt
+
+You are **Gail**, Unstream's music industry researcher. Before doing anything else, read your agent definition at `.claude/agents/gail.md` — it defines your voice, what you track, and what you should never do.
+
+## Your task
+
+Produce this week's **Unstream Dispatch**: a short, opinionated briefing of what's happening in the music platform ecosystem, written for Brandon (Unstream's founder) and a public RSS audience of music industry observers.
+
+## Research scope
+
+Use `web_search` and `web_fetch` to gather news from the **past 7 days** across these five areas:
+
+1. **Platform updates** — Bandcamp, Mirlo, Ampwall, Faircamp, Qobuz, Beatport, Jam.coop, Bandwagon, Patreon, Discogs. Pricing, policy, ownership, features, sentiment.
+2. **Emerging platforms** — EVEN, Ampled, Resonate, Audius, Sound.xyz, Catalog, Nina Protocol, Subvert.fm, and anything new that's launched. Launches, pivots, funding, artist adoption signals.
+3. **Fediverse / decentralized music** — Funkwhale, PeerTube music channels, ActivityPub music projects.
+4. **Streaming economics** — Spotify, Apple Music, YouTube Music, Tidal, Amazon Music. Payout changes, policy shifts, licensing disputes, regulatory developments.
+5. **Industry-wide** — RIAA data, legislative/regulatory changes, union/guild activity, label deals, music AI developments affecting artists.
+
+Search queries to consider: `music streaming news`, `bandcamp news`, `indie music platform news`, `spotify policy change`, `artist payout news`, `new music platform launch`, `music industry {current month year}`.
+
+## Output format
+
+Write a markdown file at `data/dispatch/YYYY-Www.md` (ISO week number — look up the current date and compute the correct week).
+
+Required frontmatter (replace placeholders with real values):
+
+```yaml
+---
+title: "Week of {Month D, YYYY}"
+week: YYYY-Www
+published: YYYY-MM-DD
+summary: "One-line teaser — the single most important thread of the week, in under 140 characters"
+---
+```
+
+Body structure (use these H2 headings verbatim; omit a section entirely if there's nothing newsworthy rather than padding):
+
+```
+## Platform watch
+
+- **[Platform]**: What happened. Why it matters for Unstream or for artists. Link to source.
+
+## Emerging & alternative
+
+- **[Platform]**: Same structure.
+
+## Fediverse & decentralized
+
+- **[Project]**: Same structure.
+
+## Streaming economics
+
+- **[Platform/Topic]**: Same structure.
+
+## Industry pulse
+
+- **[Topic]**: Same structure.
+
+## Unstream implications
+
+Concrete takeaways. What should Unstream build, ship, integrate, or stop doing based on this week's news? Be specific. If nothing actionable, say so — don't fabricate.
+
+## Confidence
+
+Brief note: what's confirmed, what's speculation, what's rumor. Readers should be able to trust your calibration.
+```
+
+## Voice reminders
+
+- Direct, unfiltered, opinionated. If a hyped platform is vaporware, say so.
+- Link to sources. Distinguish reporting from analysis.
+- Never sound AI-written. No "in an ever-evolving landscape" or "let's dive in" phrases.
+- Never suggest Twitter/X. Unstream dropped it as an ethical decision.
+- Concise. A reader should finish the whole thing in 3 minutes.
+
+## Publishing workflow
+
+After writing the markdown file:
+
+1. Create a new branch: `claude/dispatch-YYYY-Www`
+2. Commit the file with message: `Add dispatch for YYYY-Www`
+3. Push the branch
+4. Open a pull request titled `Dispatch: Week of {Month D, YYYY}` with a short PR description summarizing the top 2–3 items.
+
+Brandon will review, refine, and merge. Do **not** merge the PR yourself.
+
+## If a week is genuinely slow
+
+If there's not enough news to fill 3+ sections, write a shorter dispatch. Don't pad. A 200-word "quiet week" dispatch is better than a 1000-word filler.

--- a/data/dispatch/README.md
+++ b/data/dispatch/README.md
@@ -1,0 +1,36 @@
+# The Unstream Dispatch
+
+A weekly briefing of music industry news, written by Gail (Unstream's music industry researcher) and published as an RSS feed at `/dispatch.xml`.
+
+## How it works
+
+1. A scheduled Claude Code **routine** (created via `/schedule`) runs every Friday.
+2. The routine reads `PROMPT.md` in this directory, does the research using web search, and writes a new markdown file at `data/dispatch/YYYY-Www.md`.
+3. The routine commits to a `claude/dispatch-YYYY-Www` branch and opens a pull request.
+4. Brandon reviews, refines, and merges the PR.
+5. On merge, Netlify rebuilds. `scripts/generate-dispatch-feed.ts` regenerates `apps/web/public/dispatch.xml` from all entries in this directory.
+
+## Dispatch format
+
+Each dispatch is a markdown file named `YYYY-Www.md` (ISO week number — e.g. `2026-W16.md`).
+
+Required frontmatter:
+
+```yaml
+---
+title: "Week of April 17, 2026"
+week: 2026-W16
+published: 2026-04-17
+summary: "One-line teaser for the feed"
+---
+```
+
+Body is markdown. The body becomes the `<content:encoded>` of the RSS item.
+
+Set `draft: true` in frontmatter to exclude a dispatch from the feed (useful when a routine opens a PR and you want to hold it back from publishing while refining).
+
+## Publishing pipeline
+
+- Markdown in → RSS out. No web UI in v1 — entries are read in RSS readers.
+- Web UI at `/dispatch/:week` is planned for a future version. The frontmatter and file structure here are designed to plug into it without migration.
+- The feed URL is public at `https://unstream.stream/dispatch.xml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "marked": "^18.0.0",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
@@ -4185,6 +4186,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-find-and-replace": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cd apps/web && npx vite",
-    "build": "npx tsx scripts/generate-guides-manifest.ts && cd apps/web && npx tsc -b && npx vitest run tests/unit && npx vite build && npx tsx ../../scripts/generate-sitemap.ts",
+    "build": "npx tsx scripts/generate-guides-manifest.ts && npx tsx scripts/generate-dispatch-feed.ts && cd apps/web && npx tsc -b && npx vitest run tests/unit && npx vite build && npx tsx ../../scripts/generate-sitemap.ts",
     "generate:artists": "tsx scripts/generate-artist-list.ts",
     "generate:data": "tsx scripts/generate-artist-data.ts",
     "generate:social": "tsx scripts/generate-social-posts.ts",
@@ -41,6 +41,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "marked": "^18.0.0",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",

--- a/scripts/generate-dispatch-feed.ts
+++ b/scripts/generate-dispatch-feed.ts
@@ -73,6 +73,9 @@ function toRfc822(isoDate: string): string {
   // Interpret the date as 10:00 ET on that day (the publish time).
   // Using UTC -04:00 as a stable offset avoids DST surprises in the feed — RSS readers only care about ordering.
   const date = new Date(`${isoDate}T14:00:00Z`);
+  if (isNaN(date.getTime())) {
+    throw new Error(`Invalid published date: "${isoDate}" — use YYYY-MM-DD format`);
+  }
   return date.toUTCString();
 }
 
@@ -123,13 +126,15 @@ function main() {
   const itemsXml = entries
     .map((entry) => {
       const html = marked.parse(entry.bodyMarkdown, { async: false }) as string;
+      // Escape the CDATA terminator so body content can never break the XML structure.
+      const cdataSafe = html.replace(/]]>/g, ']]]]><![CDATA[>');
       return `    <item>
       <title>${escapeXml(entry.title)}</title>
       <link>${escapeXml(`${SITE_URL}/dispatch/${entry.slug}`)}</link>
       <guid isPermaLink="false">unstream-dispatch-${escapeXml(entry.slug)}</guid>
       <pubDate>${toRfc822(entry.published)}</pubDate>
       <description>${escapeXml(entry.summary)}</description>
-      <content:encoded><![CDATA[${html}]]></content:encoded>
+      <content:encoded><![CDATA[${cdataSafe}]]></content:encoded>
     </item>`;
     })
     .join('\n');

--- a/scripts/generate-dispatch-feed.ts
+++ b/scripts/generate-dispatch-feed.ts
@@ -1,0 +1,155 @@
+/**
+ * Generate dispatch.xml (RSS 2.0 feed) from data/dispatch/*.md
+ *
+ * Each dispatch markdown file has YAML frontmatter:
+ *   ---
+ *   title: "Week of April 17, 2026"
+ *   week: 2026-W16
+ *   published: 2026-04-17
+ *   summary: "One-line teaser"
+ *   draft: true          (optional — excluded from feed)
+ *   ---
+ *
+ * README.md and PROMPT.md in the dispatch directory are ignored.
+ *
+ * Output: apps/web/public/dispatch.xml
+ * Usage: npx tsx scripts/generate-dispatch-feed.ts
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { marked } from 'marked';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DISPATCH_DIR = join(__dirname, '..', 'data', 'dispatch');
+const OUTPUT_PATH = join(__dirname, '..', 'apps', 'web', 'public', 'dispatch.xml');
+
+const SITE_URL = 'https://unstream.stream';
+const FEED_URL = `${SITE_URL}/dispatch.xml`;
+const FEED_TITLE = 'The Unstream Dispatch';
+const FEED_DESCRIPTION = 'Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.';
+
+const IGNORED_FILES = new Set(['README.md', 'PROMPT.md']);
+
+interface DispatchEntry {
+  slug: string;
+  title: string;
+  week: string;
+  published: string;
+  summary: string;
+  bodyMarkdown: string;
+}
+
+function parseFrontmatter(content: string): { fields: Record<string, string>; body: string } | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return null;
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    value = value.replace(/\\"/g, '"').replace(/\\'/g, "'");
+    fields[key] = value;
+  }
+  return { fields, body: match[2].trim() };
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toRfc822(isoDate: string): string {
+  // Interpret the date as 10:00 ET on that day (the publish time).
+  // Using UTC -04:00 as a stable offset avoids DST surprises in the feed — RSS readers only care about ordering.
+  const date = new Date(`${isoDate}T14:00:00Z`);
+  return date.toUTCString();
+}
+
+function main() {
+  const files = readdirSync(DISPATCH_DIR).filter(
+    (f) => f.endsWith('.md') && !IGNORED_FILES.has(f)
+  );
+
+  const entries: DispatchEntry[] = [];
+
+  for (const file of files) {
+    const content = readFileSync(join(DISPATCH_DIR, file), 'utf-8');
+    const parsed = parseFrontmatter(content);
+
+    if (!parsed) {
+      console.warn(`Skipping ${file}: no frontmatter found`);
+      continue;
+    }
+
+    const { fields, body } = parsed;
+
+    if (fields.draft === 'true') {
+      console.log(`Skipping ${file}: draft`);
+      continue;
+    }
+
+    const missing = ['title', 'week', 'published', 'summary'].filter((k) => !fields[k]);
+    if (missing.length > 0) {
+      console.warn(`Skipping ${file}: missing frontmatter fields: ${missing.join(', ')}`);
+      continue;
+    }
+
+    entries.push({
+      slug: basename(file, '.md'),
+      title: fields.title,
+      week: fields.week,
+      published: fields.published,
+      summary: fields.summary,
+      bodyMarkdown: body,
+    });
+  }
+
+  // Sort newest first
+  entries.sort((a, b) => b.published.localeCompare(a.published));
+
+  const now = new Date().toUTCString();
+
+  const itemsXml = entries
+    .map((entry) => {
+      const html = marked.parse(entry.bodyMarkdown, { async: false }) as string;
+      return `    <item>
+      <title>${escapeXml(entry.title)}</title>
+      <link>${escapeXml(`${SITE_URL}/dispatch/${entry.slug}`)}</link>
+      <guid isPermaLink="false">unstream-dispatch-${escapeXml(entry.slug)}</guid>
+      <pubDate>${toRfc822(entry.published)}</pubDate>
+      <description>${escapeXml(entry.summary)}</description>
+      <content:encoded><![CDATA[${html}]]></content:encoded>
+    </item>`;
+    })
+    .join('\n');
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(FEED_TITLE)}</title>
+    <link>${escapeXml(SITE_URL)}</link>
+    <atom:link href="${escapeXml(FEED_URL)}" rel="self" type="application/rss+xml" />
+    <description>${escapeXml(FEED_DESCRIPTION)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${now}</lastBuildDate>
+${itemsXml}
+  </channel>
+</rss>
+`;
+
+  writeFileSync(OUTPUT_PATH, feed);
+  console.log(`Wrote ${entries.length} dispatch${entries.length === 1 ? '' : 'es'} to ${OUTPUT_PATH}`);
+}
+
+main();


### PR DESCRIPTION
Scaffolds a weekly music industry briefing published as an RSS feed at /dispatch.xml. Dispatches live as markdown files in data/dispatch/ with frontmatter; the build generates dispatch.xml from them via scripts/generate-dispatch-feed.ts. Designed to be fed by a Claude Code scheduled routine that opens a PR each Friday with the week's dispatch.

Includes the prompt the routine runs (data/dispatch/PROMPT.md), pulling its voice and research scope from the Gail agent definition.