### PR TITLE
Add dispatch for 2026-W16

### DIFF
--- a/data/dispatch/2026-W16.md
+++ b/data/dispatch/2026-W16.md
@@ -1,0 +1,65 @@
+---
+title: "Week of April 14, 2026"
+week: 2026-W16
+published: 2026-04-16
+draft: true
+summary: "Record industry revenue, record artist dissatisfaction — the streaming paradox hits new extremes"
+---
+
+## Platform watch
+
+- **Beatport**: Completed its absorption of Beatsource in March. All Beatsource subscribers are now on Beatport — playlists, history, login, everything migrated. The DJ download/streaming market is now effectively a Beatport monopoly for the professional tier. Worth updating the platform entry to reflect the consolidation; Beatsource as a separate listing is dead. ([DJ Life Magazine](https://djlifemag.com/2026/03/beatport-beatsource-unite-into-one-premium-dj-platform/))
+
+- **Bandcamp**: No new policy news this week — the January AI ban is settled policy now. The next Bandcamp Friday is May 1 (April had none). Still under Songtradr. Still the best per-artist payout of any marketplace. The absence of news is fine; stability here matters more than activity. ([Bandcamp Daily](https://daily.bandcamp.com/essential-releases/essential-releases-april-10-2026))
+
+- **Qobuz**: At the Brick Lane Jazz Festival in London this week, continuing its live-capture and curation strategy. Nothing structural to report — the CarPlay + Siri launch in February was their most recent product move. ([Qobuz Magazine](https://www.qobuz.com/us-en/magazine/story/2026/04/08/qobuz-at-brick-lane-jazz-festival/))
+
+- **Patreon**: Podcasters earned $629M on the platform in 2025, up 33% YoY — but that's podcasters, not musicians. No music-specific update this week. The number is a reminder that Patreon's growth story is increasingly a podcast story, not a music story. ([Digital Music News](https://www.digitalmusicnews.com/2026/04/08/patreon-podcast-earnings-2025/))
+
+- **Mirlo / Ampwall / Faircamp**: Nothing this week from any of them. Faircamp's core maintainer flagged the main branch may be unstable through summer during a restructuring push. Not alarming — solo open-source project, normal development reality.
+
+## Emerging & alternative
+
+- **Warner Music Group acquires Revelator** (April 1): WMG agreed to buy Revelator, a B2B platform that handles royalty accounting, distribution infrastructure, and analytics for independent labels and distributors. This is significant: Revelator quietly underpins a chunk of the independent sector's financial plumbing. A major now owns it. Watch whether terms of service or pricing shift for indie clients. ([PRNewswire](https://www.prnewswire.com/news-releases/warner-music-group-agrees-to-acquire-revelator-state-of-the-art-independent-music-platform-302731480.html))
+
+- **UMG x Udio**: The licensed AI music creation platform that came out of UMG's settlement with Udio is still in the "launching in 2026" phase with no hard date. The premise — use the UMG catalog as training data, split revenue with rights holders — is the template the industry appears to be building toward. No news this week; just worth tracking. ([Hypebeast](https://hypebeast.com/2025/10/umg-x-udio-settle-launch-licensed-ai-music-platform-in-2026))
+
+## Streaming economics
+
+- **The paradox study** (April 14): A study out this week found 55% of artists earned less than €1,000 from music in 2025. 26% earned nothing. 83% described themselves as dissatisfied or very dissatisfied with streaming royalty rates. This is running parallel to Spotify reporting its largest-ever annual payout ($11B to the industry in 2025). The money is real. It just concentrates at the top: over 1,500 artists cleared $1M+ from Spotify alone, while the median artist sees fractions of a cent per stream. ([Digital Music News](https://www.digitalmusicnews.com/2026/04/14/music-streaming-royalties-paradox-study/))
+
+- **Spotify video opt-out** (April 9): Spotify rolled out a toggle for all users to disable video entirely in the app. Previously limited to some users. Functionally minor — this is Spotify responding to the loud user complaints about video autoplay — but it signals they're not fully committed to the video pivot. ([TechCrunch](https://techcrunch.com/2026/04/09/spotify-now-lets-everyone-turn-off-all-videos-in-its-app/))
+
+- **Deezer's AI detection tool, now licensed** (March 27): Deezer licensed its AI music detection tool (99.8% accuracy) to Hungarian collecting society EJI — the first PRO to deploy it. The number that matters: 39% of all new daily uploads to Deezer are now AI-generated, up from 28% in September. That's not a slow creep, that's a flood. EJI doesn't pay royalties for AI tracks, which is the policy purpose. Deezer is selling the tool to other rights orgs. ([Digital Music News](https://www.digitalmusicnews.com/2026/03/27/deezer-ai-detection-tech-license-eji/) | [Deezer Newsroom](https://newsroom-deezer.com/2026/03/deezer-and-eji-partnership-to-filter-out-recordings-created-by-ai/))
+
+## Industry pulse
+
+- **SAG-AFTRA / AMPTP talks**: Resuming April 27 with AI protections as a central sticking point. The sound recordings deal already ratified by WMG, Sony, UMG, and Disney Music sets the template: AI vocal replicas of artists require explicit consent, minimum compensation, and disclosure. The April 27 talks extend those protections to the broader performer contract. ([Deadline](https://deadline.com/2026/04/sag-aftra-resumes-2026-talks-with-amptp-date-1236782965/))
+
+- **AI litigation**: Still messy. WMG settled with both Suno and Udio. UMG settled with Udio. But UMG and Sony's talks with Suno are stalled — described as a "deeper divide over control and monetization." GEMA's German case against Suno has a ruling scheduled June 12. A major US fair use ruling on AI training data is expected sometime this summer. The legal framework for AI music is still being written. ([Bloomberg Law](https://news.bloomberglaw.com/ip-law/music-piracy-ai-lawsuits-top-2026-copyright-litigation-calendar))
+
+- **87% of artists use AI tools**: A Symphonic Distribution survey (April 8) found nearly 9 in 10 independent artists already use AI somewhere in their workflow — most commonly mastering/stem separation (79%), then songwriting (66%). The AI-as-tool vs. AI-as-replacement distinction is increasingly the relevant frame, not AI vs. no-AI. ([Symphonic Blog](https://blog.symphonic.com/2026/04/08/ai-tools-independent-musicians-2026/))
+
+- **RIAA 2025**: US recorded music hit $11.5B wholesale — another record. Latin music crossed $1B in the US for the first time. Vinyl still 75%+ of physical revenue. ([RIAA](https://www.riaa.com/riaa-reports-us-recorded-music-annual-revenue-achieves-new-high-of-11-5-billion-in-2025/))
+
+## Unstream implications
+
+**Lead with the paradox.** The April 14 artist satisfaction data is the clearest empirical case for Unstream's existence: record industry revenue, majority of artists earning almost nothing from it. That's the elevator pitch. Consider surfacing it on the homepage or in the "Why Unstream?" copy — "In 2025, 55% of artists earned less than €1,000 from streaming" is a more powerful hook than anything generic about supporting artists.
+
+**Update the Beatport entry**: Beatsource is gone. The platform listing should reflect Beatport as the unified platform. Low effort, keeps the data accurate.
+
+**AI music flood on platforms** (39% of Deezer uploads): This will hit Bandcamp eventually, even with the ban. Worth thinking about whether Unstream should surface a platform's AI policy as a filter or badge — Bandcamp's ban vs. platforms with no policy is a differentiator that matters to the listeners Unstream is trying to reach.
+
+**WMG / Revelator**: Not immediately actionable, but track it. If Revelator's terms tighten for indie clients, some distributors built on top of it may need to find alternatives. Could affect platform stability for some sources Unstream links to.
+
+**Nothing to stop doing this week.** The decentralized/fediverse space (Mirlo, Funkwhale, Faircamp) had no news — normal for a slow week. Don't manufacture urgency there.
+
+## Confidence
+
+**High confidence**: Artist satisfaction study (multiple outlets), Spotify video opt-out (TechCrunch direct), Deezer/EJI deal (Deezer newsroom + third-party corroboration), RIAA year-end (RIAA direct), Beatport/Beatsource merger (multiple trade outlets), SAG-AFTRA talks (Deadline + Hollywood Reporter).
+
+**Moderate confidence**: WMG/Revelator acquisition — announced via press release, no independent reporting found yet on terms or implications.
+
+**Low / speculative**: UMG x Udio licensed platform launch timing — "2026" is the only commitment and no product has shipped. The AI litigation "stalemate" characterization is from secondary reporting, not a primary statement from UMG or Sony.
+
+**Not found**: Mirlo, Ampwall, Faircamp (active), Jam.coop, Bandwagon, Resonate, Sound.xyz, Catalog, Nina Protocol, Subvert.fm — nothing this week. The web3/NFT music space appears broadly dormant in this window.


### PR DESCRIPTION
This week's Unstream Dispatch, covering April 9–16, 2026.

## What's in it

The lead story is a study published April 14 showing 55% of artists earned less than €1,000 from music in 2025 — running directly alongside Spotify's record $11B industry payout. The streaming paradox at peak sharpness. The dispatch covers that, plus the Beatport/Beatsource consolidation, WMG's acquisition of Revelator, Deezer's AI detection tool going commercial, and the ongoing SAG-AFTRA/AMPTP talks.

The file has `draft: true` so it won't publish to the RSS feed until you merge and remove that flag (or just merge it as-is and edit the frontmatter in a follow-up commit to flip it to live).

## Sections

- **Platform watch**: Beatport absorbs Beatsource, Bandcamp stable, Qobuz at Brick Lane Jazz, Patreon podcast numbers, Mirlo/Ampwall/Faircamp quiet
- **Emerging & alternative**: WMG acquires Revelator (notable consolidation), UMG x Udio licensed AI platform still coming
- **Streaming economics**: The satisfaction paradox study, Spotify video opt-out, Deezer's AI flood stats + detection tool going commercial
- **Industry pulse**: SAG-AFTRA talks resume April 27, AI litigation status, 87% artist AI tool adoption, RIAA $11.5B year-end
- **Unstream implications**: Concrete actions — update Beatport entry, use the paradox study in homepage copy, consider AI policy badging
- **Confidence**: Honest breakdown of what's solid vs. thin vs. not found

## Fediverse / decentralized

Omitted — genuinely nothing to report this week for Funkwhale, PeerTube, or ActivityPub music projects.