### PR TITLE
Improve claim flow email deliverability UX

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 16 Apr 2026 01:27:13 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 16 Apr 2026 01:16:56 GMT</lastBuildDate>
 
   </channel>
 </rss>

--- a/apps/web/src/pages/ClaimPage.tsx
+++ b/apps/web/src/pages/ClaimPage.tsx
@@ -59,6 +59,9 @@ export function ClaimPage() {
   const [manualReviewMessage, setManualReviewMessage] = useState('');
   const [manualReviewSubmitting, setManualReviewSubmitting] = useState(false);
 
+  // Resend cooldown state
+  const [resendCooldown, setResendCooldown] = useState(0);
+
   const { session: authSession, isLoading: authLoading } = useAuth();
 
   const displayName = artistName || slug?.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()) || '';
@@ -108,6 +111,25 @@ export function ClaimPage() {
       setError(error);
     } else {
       setStep('check-email');
+    }
+  }
+
+  async function handleResend() {
+    setError(null);
+    setLoading(true);
+    const redirectTo = `${window.location.origin}/claim/${slug}`;
+    const { error } = await signInWithMagicLink(email, redirectTo);
+    setLoading(false);
+    if (error) {
+      setError(error);
+    } else {
+      setResendCooldown(60);
+      const interval = setInterval(() => {
+        setResendCooldown(prev => {
+          if (prev <= 1) { clearInterval(interval); return 0; }
+          return prev - 1;
+        });
+      }, 1000);
     }
   }
 
@@ -396,6 +418,31 @@ export function ClaimPage() {
                 We sent a sign-in link to <strong className="text-text-primary">{email}</strong>.
                 Click the link to continue claiming your profile.
               </p>
+              <p className="text-xs text-text-muted">
+                Don't see it? Check your spam or junk folder.
+                {email.includes('privaterelay.appleid.com') && (
+                  <> If you used Apple's Hide My Email, delivery may take a few extra minutes.</>
+                )}
+              </p>
+              <div className="space-y-2">
+                <div>
+                  <button
+                    onClick={handleResend}
+                    disabled={resendCooldown > 0 || loading}
+                    className="text-sm text-accent-primary hover:underline disabled:opacity-50 disabled:no-underline"
+                  >
+                    {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend email'}
+                  </button>
+                </div>
+                <div>
+                  <button
+                    onClick={() => { setStep('email'); setEmail(''); setResendCooldown(0); }}
+                    className="text-xs text-text-muted hover:text-text-primary underline"
+                  >
+                    Use a different email
+                  </button>
+                </div>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Adds spam/junk folder tip to the check-email step
- Adds conditional note for Apple Hide My Email addresses (`@privaterelay.appleid.com`)
- Adds resend button with 60-second cooldown so users can retry without refreshing
- Adds "Use a different email" link to reset back to step 1

Pairs with infrastructure changes already in place: Resend custom SMTP (`support@unstream.stream`), SPF/DKIM/DMARC on the domain, and `unstream.stream` registered in Apple Developer Console for Private Email Relay.

## Test plan

- [ ] Enter email on `/claim/:slug`, confirm check-email step shows spam tip and resend button
- [ ] Click "Resend email" — confirm new email arrives and button shows countdown
- [ ] Click "Use a different email" — confirm form resets to step 1
- [ ] Enter an `@privaterelay.appleid.com` address — confirm the Hide My Email note appears
- [ ] `npm run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)