### PR TITLE
Fix admin verification approval

### DIFF
--- a/api/functions/admin-verify.ts
+++ b/api/functions/admin-verify.ts
@@ -4,16 +4,19 @@
 import { getClient } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
   body?: string;
 }) {
-  if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers: buildCorsHeaders(event.headers['origin'] || event.headers['Origin'], false), body: '' };
-  }
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
 
-  const CORS_HEADERS = buildCorsHeaders(event.headers['origin'] || event.headers['Origin'], false);
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
 
   const admin = await authenticateAdmin(event.headers['authorization'] || event.headers['Authorization'] || undefined);
   if (!admin) {
@@ -132,6 +135,14 @@ export async function handler(event: {
       statusCode: 400,
       headers: CORS_HEADERS,
       body: JSON.stringify({ error: 'requestId is required' }),
+    };
+  }
+
+  if (!UUID_REGEX.test(requestId)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'requestId must be a UUID' }),
     };
   }
 

--- a/api/functions/admin-verify.ts
+++ b/api/functions/admin-verify.ts
@@ -2,14 +2,7 @@
 // Admin-only endpoint for reviewing artist verification requests.
 
 import { getClient } from './db';
-import { authenticateAdmin } from './middleware';
-
-const CORS_HEADERS = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
 
 export async function handler(event: {
   httpMethod: string;
@@ -17,8 +10,10 @@ export async function handler(event: {
   body?: string;
 }) {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+    return { statusCode: 204, headers: buildCorsHeaders(event.headers['origin'] || event.headers['Origin'], false), body: '' };
   }
+
+  const CORS_HEADERS = buildCorsHeaders(event.headers['origin'] || event.headers['Origin'], false);
 
   const admin = await authenticateAdmin(event.headers['authorization'] || event.headers['Authorization'] || undefined);
   if (!admin) {
@@ -115,6 +110,14 @@ export async function handler(event: {
   }
 
   const { action, requestId, reviewerNotes } = body;
+
+  if (reviewerNotes && reviewerNotes.length > 2000) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'reviewerNotes must be 2000 characters or fewer' }),
+    };
+  }
 
   if (!action || !['approve', 'reject'].includes(action)) {
     return {

--- a/api/functions/admin-verify.ts
+++ b/api/functions/admin-verify.ts
@@ -42,7 +42,7 @@ export async function handler(event: {
   if (event.httpMethod === 'GET') {
     const { data, error } = await client
       .from('verification_requests')
-      .select('*')
+      .select('id, email, message, status, reviewer_notes, created_at, reviewed_at, artist_id, user_id, artists(name, slug)')
       .order('status', { ascending: true }) // 'pending' sorts before others alphabetically
       .order('created_at', { ascending: false });
 
@@ -55,10 +55,37 @@ export async function handler(event: {
       };
     }
 
+    const requests = (data || []).map((r: {
+      id: string;
+      email: string;
+      message: string | null;
+      status: string;
+      reviewer_notes: string | null;
+      created_at: string;
+      reviewed_at: string | null;
+      artist_id: string;
+      user_id: string;
+      artists: { name: string; slug: string } | { name: string; slug: string }[] | null;
+    }) => {
+      const artist = Array.isArray(r.artists) ? r.artists[0] : r.artists;
+      return {
+        id: r.id,
+        artist_name: artist?.name ?? '(unknown)',
+        artist_slug: artist?.slug ?? '',
+        email: r.email,
+        website_url: null,
+        message: r.message,
+        status: r.status,
+        reviewer_notes: r.reviewer_notes,
+        created_at: r.created_at,
+        reviewed_at: r.reviewed_at,
+      };
+    });
+
     return {
       statusCode: 200,
       headers: CORS_HEADERS,
-      body: JSON.stringify({ requests: data || [] }),
+      body: JSON.stringify({ requests }),
     };
   }
 
@@ -131,48 +158,68 @@ export async function handler(event: {
   const now = new Date().toISOString();
 
   if (action === 'approve') {
-    // 1. Find the artist profile associated with this request
-    const { data: profile, error: profileError } = await client
+    // An artist_profiles row may not exist yet if the user submitted a manual
+    // review without first attempting the automated link-back claim flow.
+    const { data: existingProfile, error: profileLookupError } = await client
       .from('artist_profiles')
-      .select('id, artist_id')
-      .eq('id', request.artist_profile_id)
-      .single();
+      .select('id')
+      .eq('artist_id', request.artist_id)
+      .maybeSingle();
 
-    if (profileError || !profile) {
+    if (profileLookupError) {
+      console.error('[Admin] Failed to look up artist profile:', profileLookupError);
       return {
         statusCode: 500,
         headers: CORS_HEADERS,
-        body: JSON.stringify({ error: 'Artist profile not found for this request' }),
+        body: JSON.stringify({ error: 'Failed to look up artist profile' }),
       };
     }
 
-    // 2. Set verified_at on artist_profiles
-    const { error: verifyError } = await client
-      .from('artist_profiles')
-      .update({ verified_at: now })
-      .eq('id', profile.id);
+    if (existingProfile) {
+      const { error: verifyError } = await client
+        .from('artist_profiles')
+        .update({ verified_at: now })
+        .eq('id', existingProfile.id);
 
-    if (verifyError) {
-      console.error('[Admin] Failed to verify artist profile:', verifyError);
-      return {
-        statusCode: 500,
-        headers: CORS_HEADERS,
-        body: JSON.stringify({ error: 'Failed to update artist profile' }),
-      };
+      if (verifyError) {
+        console.error('[Admin] Failed to verify artist profile:', verifyError);
+        return {
+          statusCode: 500,
+          headers: CORS_HEADERS,
+          body: JSON.stringify({ error: 'Failed to update artist profile' }),
+        };
+      }
+    } else {
+      const { error: createError } = await client
+        .from('artist_profiles')
+        .insert({
+          artist_id: request.artist_id,
+          user_id: request.user_id,
+          email: request.email,
+          website_url: null,
+          verified_at: now,
+        });
+
+      if (createError) {
+        console.error('[Admin] Failed to create artist profile:', createError);
+        return {
+          statusCode: 500,
+          headers: CORS_HEADERS,
+          body: JSON.stringify({ error: 'Failed to create artist profile' }),
+        };
+      }
     }
 
-    // 3. Update artists table match_confidence to 'claimed'
     const { error: artistError } = await client
       .from('artists')
       .update({ match_confidence: 'claimed' })
-      .eq('id', profile.artist_id);
+      .eq('id', request.artist_id);
 
     if (artistError) {
       console.error('[Admin] Failed to update artist match_confidence:', artistError);
       // Non-fatal: the profile is verified even if this fails
     }
 
-    // 4. Update the verification request status
     const { error: updateError } = await client
       .from('verification_requests')
       .update({

--- a/supabase/migration-010-nullable-website-url.sql
+++ b/supabase/migration-010-nullable-website-url.sql
@@ -1,0 +1,7 @@
+-- Migration 010: Make website_url nullable on artist_profiles
+-- Admin-approved manual verification requests may not include a website URL;
+-- the artist can add one later via the artist-edit flow. Parallels migration 008
+-- which did the same for verification_code after the old code-based flow was retired.
+
+alter table artist_profiles
+  alter column website_url drop not null;


### PR DESCRIPTION
## Summary

- **Primary bug:** admin approval was failing with "Artist profile not found for this request" for every pending request (e.g. Tye Newton). Root cause: `admin-verify.ts` looked up `artist_profiles` by a non-existent `artist_profile_id` column. The real link is `verification_requests.artist_id` → `artists.id` ← `artist_profiles.artist_id`. Fixed.
- **Missing artist in admin UI:** GET `/api/admin/verify` now joins `artists(name, slug)` and flattens, so the admin UI displays the artist name and slug on pending requests (previously blank).
- **Missing-profile edge case:** approve now handles the case where no `artist_profiles` row exists (user submitted a manual review without completing the automated link-back flow). A row is created with `verified_at` set and the user_id/email carried over from the request.
- **Migration 010:** drops `NOT NULL` on `artist_profiles.website_url` — vestigial from the old verification-code flow, parallels migration 008's same change for `verification_code`. **Already applied to prod.**

## From security review

- **CORS tightening:** replaced hardcoded `Access-Control-Allow-Origin: *` with `buildCorsHeaders()` from middleware, which restricts to `https://unstream.stream` for non-API-key requests. Defense-in-depth — admin JWT remains the actual gate.
- **UUID validation on `requestId`:** rejects malformed values with a 400 before they hit the DB (previously fell through to a Postgres type error → 404).

## Not addressed in this PR (tracked separately)

- **Manual-review ownership gap:** `claim-artist.ts`'s `request-manual-review` action lets any authenticated user file a verification request for any unclaimed artist, and admin approval then assigns them ownership via `request.user_id`. Admin is the human gate but rubber-stamping = artist hijack. Tracked in Things; fix belongs in `claim-artist.ts`, not here.
- **Approval-step atomicity:** three sequential DB ops (profile, artists, verification_requests) with no transaction. Current order is intentionally kept because failure mid-way leaves the request `pending`, which allows the admin to simply re-click Approve (all operations are idempotent). Inverting the order would require manual SQL recovery on failure. Low-priority given low approval volume.

## Test plan

- [ ] Deploy to prod, visit `/admin/verify` — Tye Newton's request shows artist name and `/tye-newton` slug.
- [ ] Approve Tye Newton's request: response 200, `verification_requests.status = 'approved'`, `artist_profiles.verified_at` set, `artists.match_confidence = 'claimed'`.
- [ ] Have Tye log in and confirm `/artist-edit/tye-newton` works.
- [ ] Smoke test: call `/api/admin/verify` POST with a non-UUID `requestId` → expect 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)