### PR TITLE
fix: swap AI policy icons — shield for ban, flag for restricted

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Sat, 18 Apr 2026 00:04:05 GMT</lastBuildDate>
+    <lastBuildDate>Sat, 18 Apr 2026 01:05:38 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -728,13 +728,13 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
               )}
               {verifiedPlatforms.some(p => sources[p.sourceId]?.aiPolicy === 'banned') && (
                 <span className="flex items-center gap-1">
-                  <span className="text-xs">🚫</span>
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
                   AI-generated music banned
                 </span>
               )}
               {verifiedPlatforms.some(p => sources[p.sourceId]?.aiPolicy === 'anti-ai') && (
                 <span className="flex items-center gap-1">
-                  <span className="text-xs">🛡️</span>
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
                   AI content restricted/tagged
                 </span>
               )}

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -100,10 +100,14 @@ export function SourceBadge({ source, url, isDirectLink }: SourceBadgeProps) {
           <span
             className="ai-policy-badge relative text-[10px] font-semibold px-1 py-0.5 rounded cursor-help"
             style={{
-              backgroundColor: source.aiPolicy === 'banned' ? '#ef444430' : '#3b82f630',
+              backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : '#f59e0b30',
             }}
           >
-            {source.aiPolicy === 'banned' ? '🚫' : '🛡️'}
+            {source.aiPolicy === 'banned' ? (
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+            ) : (
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
+            )}
             <span className="ai-policy-tooltip">
               {AI_POLICY_TOOLTIPS[source.id] ??
                 (source.aiPolicy === 'banned'


### PR DESCRIPTION
## What\nSwaps the AI policy badge icons based on feedback that 🚫 reads as "broken/unavailable" rather than "protected."\n\n## Changes\n- **Banned (AI ban):** 🛡️ → SVG shield icon (green-tinted badge) — reads as "this platform protects human artists"\n- **Restricted (anti-ai):** → SVG flag icon (amber-tinted badge) — reads as "heads up, nuanced policy here"\n- Updated legend in ResultCard to use matching SVG icons\n- Removed emoji in favor of inline SVGs for consistency and cross-platform rendering