### PR TITLE
fix: iOS links open in-app Safari, remove Open in browser button

### DIFF
--- a/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
+++ b/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
@@ -41,7 +41,7 @@ struct ArtistResultView: View {
     @EnvironmentObject var appState: AppState
 
     #if os(iOS)
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
     #endif
 
     private var isSaved: Bool {
@@ -141,17 +141,7 @@ struct ArtistResultView: View {
                 }
             }
 
-            // Open in browser button
-            Button(action: { openInUnstream(artist: artist.name) }) {
-                HStack {
-                    Image(systemName: "arrow.up.right.square")
-                    Text("Open in browser")
-                }
-                .font(.caption)
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
+
 
             // Report issue link
             Button(action: { reportIssue(artist: artist) }) {
@@ -169,6 +159,9 @@ struct ArtistResultView: View {
         .padding(10)
         .background(cardBackgroundColor)
         .cornerRadius(8)
+        #if os(iOS)
+        .safariSheet(safariItem: $safariItem)
+        #endif
     }
 
     // MARK: - Subviews
@@ -258,16 +251,6 @@ struct ArtistResultView: View {
         return "Here's how you can support \(artist.name) directly: \(url)"
     }
 
-    private func openInUnstream(artist: String) {
-        guard let encodedQuery = artist.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "https://unstream.stream/?q=\(encodedQuery)") else { return }
-        #if os(macOS)
-        NSWorkspace.shared.open(url)
-        #else
-        openURL(url)
-        #endif
-    }
-
     private func reportIssue(artist: ArtistResult) {
         let platformList = artist.platforms.map { "- \($0.sourceId): \($0.url ?? "N/A")" }.joined(separator: "\n")
         let subject = "Issue Report: \(artist.name)"
@@ -288,7 +271,8 @@ struct ArtistResultView: View {
         #if os(macOS)
         NSWorkspace.shared.open(url)
         #else
-        openURL(url)
+        // Open mailto links in Safari sheet so user can compose in-app
+        safariItem = SafariURL(url: url)
         #endif
     }
 

--- a/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
+++ b/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
@@ -271,8 +271,8 @@ struct ArtistResultView: View {
         #if os(macOS)
         NSWorkspace.shared.open(url)
         #else
-        // Open mailto links in Safari sheet so user can compose in-app
-        safariItem = SafariURL(url: url)
+        // SFSafariViewController only accepts http/https, so route mailto: through UIApplication
+        UIApplication.shared.open(url)
         #endif
     }
 

--- a/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
+++ b/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
@@ -10,7 +10,7 @@ struct PlatformBadge: View {
     var onOpen: (() -> Void)? = nil
 
     #if os(iOS)
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
     #endif
 
     private var isBCFriday: Bool {
@@ -72,6 +72,9 @@ struct PlatformBadge: View {
         #if os(macOS)
         .help(helpText)
         #endif
+        #if os(iOS)
+        .safariSheet(safariItem: $safariItem)
+        #endif
     }
 
     private var displayPayout: String? {
@@ -101,7 +104,7 @@ struct PlatformBadge: View {
             #if os(macOS)
             NSWorkspace.shared.open(url)
             #else
-            openURL(url)
+            safariItem = SafariURL(url: url)
             #endif
             onOpen?()
         }

--- a/apps/mac/Unstream/Views/Shared/SafariView.swift
+++ b/apps/mac/Unstream/Views/Shared/SafariView.swift
@@ -33,4 +33,10 @@ struct SafariSheetModifier: ViewModifier {
         }
     }
 }
+
+extension View {
+    func safariSheet(safariItem: Binding<SafariURL?>) -> some View {
+        modifier(SafariSheetModifier(safariItem: safariItem))
+    }
+}
 #endif

--- a/apps/mac/Unstream/Views/Shared/SafariView.swift
+++ b/apps/mac/Unstream/Views/Shared/SafariView.swift
@@ -1,0 +1,36 @@
+#if os(iOS)
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let controller = SFSafariViewController(url: url)
+        controller.dismissButtonStyle = .close
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+        // No updates needed
+    }
+}
+
+/// Wrapper to make URL identifiable for sheet presentation
+struct SafariURL: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+/// Modifier that presents an in-app Safari sheet when a URL is set.
+struct SafariSheetModifier: ViewModifier {
+    @Binding var safariItem: SafariURL?
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $safariItem) { item in
+            SafariView(url: item.url)
+                .ignoresSafeArea()
+        }
+    }
+}
+#endif

--- a/apps/mac/Unstream/Views/Shared/SocialIconButton.swift
+++ b/apps/mac/Unstream/Views/Shared/SocialIconButton.swift
@@ -10,7 +10,7 @@ struct SocialIconButton: View {
     @Environment(\.colorScheme) var colorScheme
 
     #if os(iOS)
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
     #endif
 
     // Platforms that have brand SVG icons
@@ -47,6 +47,9 @@ struct SocialIconButton: View {
         #if os(macOS)
         .help("Open \(result.displayName)")
         #endif
+        #if os(iOS)
+        .safariSheet(safariItem: $safariItem)
+        #endif
     }
 
     private var iconColor: Color {
@@ -62,7 +65,7 @@ struct SocialIconButton: View {
             #if os(macOS)
             NSWorkspace.shared.open(url)
             #else
-            openURL(url)
+            safariItem = SafariURL(url: url)
             #endif
             onOpen?()
         }

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -281,7 +281,7 @@ struct SavedPlatformBadge: View {
     @Environment(\.colorScheme) var colorScheme
 
     #if os(iOS)
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
     #endif
 
     private let socialPlatformIds: Set<String> = ["instagram", "facebook", "tiktok", "youtube", "threads", "bluesky", "mastodon", "peertube"]
@@ -343,6 +343,9 @@ struct SavedPlatformBadge: View {
         #if os(macOS)
         .help("Open \(platform.displayName)")
         #endif
+        #if os(iOS)
+        .safariSheet(safariItem: $safariItem)
+        #endif
     }
 
     @ViewBuilder
@@ -365,7 +368,7 @@ struct SavedPlatformBadge: View {
         #if os(macOS)
         NSWorkspace.shared.open(url)
         #else
-        openURL(url)
+        safariItem = SafariURL(url: url)
         #endif
     }
 }
@@ -374,7 +377,7 @@ struct NewReleaseBadge: View {
     let release: NewRelease
 
     #if os(iOS)
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
     #endif
 
     #if os(iOS)
@@ -406,6 +409,9 @@ struct NewReleaseBadge: View {
         #if os(macOS)
         .help("Open \(release.releaseName) on \(release.platform.capitalized)")
         #endif
+        #if os(iOS)
+        .safariSheet(safariItem: $safariItem)
+        #endif
     }
 
     private func openRelease() {
@@ -413,7 +419,7 @@ struct NewReleaseBadge: View {
         #if os(macOS)
         NSWorkspace.shared.open(url)
         #else
-        openURL(url)
+        safariItem = SafariURL(url: url)
         #endif
     }
 }

--- a/apps/mac/Unstream/Views/iOS/ReleasesTab.swift
+++ b/apps/mac/Unstream/Views/iOS/ReleasesTab.swift
@@ -78,12 +78,12 @@ struct ReleasesTab: View {
 
 private struct ReleaseRow: View {
     let release: NewRelease
-    @Environment(\.openURL) private var openURL
+    @State private var safariItem: SafariURL?
 
     var body: some View {
         Button {
             if let url = URL(string: release.releaseUrl) {
-                openURL(url)
+                safariItem = SafariURL(url: url)
             }
         } label: {
             HStack(spacing: 12) {
@@ -114,6 +114,7 @@ private struct ReleaseRow: View {
             .cornerRadius(10)
         }
         .buttonStyle(.plain)
+        .safariSheet(safariItem: $safariItem)
     }
 }
 #endif


### PR DESCRIPTION
## What
Two changes from iOS testing feedback:

### 1. Remove "Open in browser" button
The button was unnecessary — platform badges and links are sufficient. Removed the dead `openInUnstream()` function too.

### 2. In-app Safari on iOS
All external links (platform badges, social icons, release links, report email) now open in an `SFSafariViewController` sheet on iOS instead of kicking users out to the default browser.

- Created `SafariView` + `SafariURL` helper for sheet-based Safari presentation
- Replaced all `@Environment(\.openURL)` calls on iOS with `safariItem` state + `.safariSheet()` modifier
- Mac behavior unchanged — links still open in default browser
- iOS users stay in the app when browsing platform links

### Files changed
- `SafariView.swift` — new helper (SafariView + SafariURL + SafariSheetModifier)
- `PlatformBadge.swift` — Safari sheet on iOS
- `SocialIconButton.swift` — Safari sheet on iOS
- `SupportListView.swift` — Safari sheet on iOS (SavedPlatformBadge + NewReleaseBadge)
- `ArtistResultView.swift` — Safari sheet on iOS, removed openInUnstream dead code
- `ReleasesTab.swift` — Safari sheet on iOS