### PR TITLE
fix: remove stray line from project.pbxproj causing Xcode parse error

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -717,4 +717,3 @@
 	};
 	rootObject = 92F0EC298B5852597D2AC7A5 /* Project object */;
 }
-				6FDAA62519174D2D98B0818F /* SafariView.swift */,


### PR DESCRIPTION
A dangling SafariView.swift group reference was left outside the root
object closing brace after the PR #162 merge, corrupting the file.

https://claude.ai/code/session_01TWYFZFXM9hBMvNSqaoC96G