### PR TITLE
fix: restore SafariView.swift to Shared group in Xcode project

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -717,4 +717,3 @@
 	};
 	rootObject = 92F0EC298B5852597D2AC7A5 /* Project object */;
 }
-				6FDAA62519174D2D98B0818F /* SafariView.swift */,

--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 				2724397667CCEE30A098B9CE /* ColorExtensions.swift */,
 				BE9E59C365D8F116C435B8BC /* EmptyStateView.swift */,
 				CC8A2405B5A74531E19338D9 /* PlatformBadge.swift */,
+				6FDAA62519174D2D98B0818F /* SafariView.swift */,
 				7EFEA3443AD56B9950B43AAE /* SocialIconButton.swift */,
 				89D2DBDD53C2C9158EA698C4 /* SupportListView.swift */,
 				752695EB82D70EEE00B921FA /* TipJarView.swift */,


### PR DESCRIPTION
## Summary

- Removes the stray `SafariView.swift` group reference that ended up outside the root object closing brace (causing the parse error from PR #164)
- Adds `SafariView.swift` back into the correct location — the `Shared` children array in `PBXGroup` — so Xcode can resolve the file path at build time

## Root cause

The merge in PR #164 left a dangling group entry after the final `}` of `project.pbxproj`. Removing that line (PR #165) fixed the parse error but left the file orphaned from any group, causing the "build input file cannot be found" error.

## Test plan

- [ ] Xcode build succeeds for iOS target
- [ ] Xcode build succeeds for macOS target

https://claude.ai/code/session_01TWYFZFXM9hBMvNSqaoC96G