### PR TITLE
fix: use extensionContext.open() to redirect to app from share sheet

### DIFF
--- a/apps/mac/UnstreamShareExtension/ShareViewController.swift
+++ b/apps/mac/UnstreamShareExtension/ShareViewController.swift
@@ -110,11 +110,11 @@ class ShareViewController: UIViewController {
 
         let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         if let appURL = URL(string: "unstream://search?q=\(encodedQuery)") {
-            openURL(appURL)
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.close()
+            extensionContext?.open(appURL) { [weak self] _ in
+                DispatchQueue.main.async { self?.close() }
+            }
+        } else {
+            close()
         }
     }
 
@@ -233,21 +233,6 @@ class ShareViewController: UIViewController {
     }
 
     // MARK: - Helpers
-
-    /// Open a URL from a share extension via the responder chain.
-    /// This is the standard workaround since extensionContext?.open() is not
-    /// available in share extensions.
-    private func openURL(_ url: URL) {
-        var responder: UIResponder? = self
-        while let r = responder {
-            let selector = sel_registerName("openURL:")
-            if r.responds(to: selector) {
-                r.perform(selector, with: url)
-                return
-            }
-            responder = r.next
-        }
-    }
 
     private func close() {
         extensionContext?.completeRequest(returningItems: nil)


### PR DESCRIPTION
The previous responder-chain openURL: hack stopped working on modern iOS
because UIApplication is no longer in the extension's responder chain.
Additionally, calling completeRequest() 0.3 s later returned the user to
the host app (Spotify/Apple Music) rather than Unstream.

Replacing with extensionContext?.open(_:completionHandler:) — the official
API for opening a URL from within a share extension — which opens Unstream
immediately and only calls completeRequest in its completion handler.

https://claude.ai/code/session_01TYgMYEHjGJHi5mDD6tCw7c