### PR TITLE
fix: replace curly quotes in share extension to fix Swift build error

### DIFF
--- a/apps/mac/UnstreamShareExtension/ShareViewController.swift
+++ b/apps/mac/UnstreamShareExtension/ShareViewController.swift
@@ -150,7 +150,7 @@ struct ShareSearchView: View {
                 onOpenUnstream: { openInUnstream(artist: artistName) }
             )
         case .empty(let name):
-            statusView(spinner: false, message: "No results found for "\(name)"")
+            statusView(spinner: false, message: "No results found for \"\(name)\"")
                 .safeAreaInset(edge: .bottom) { openUnstreamButton(artist: name) }
         case .networkError:
             statusView(spinner: false, message: "Search unavailable. Open Unstream to try again.")


### PR DESCRIPTION
## Summary

- Replaces curly/smart quotes (`"…"`) with escaped straight quotes (`\"…\"`) in a string literal inside `ShareViewController.swift`. The curly quotes were valid unicode but caused a Swift parser error: `Expected ',' separator`.

## Test plan

- [ ] Confirm Xcode build succeeds for the UnstreamShareExtension target

https://claude.ai/code/session_01TYgMYEHjGJHi5mDD6tCw7c