### PR TITLE
polish: improve share extension loading state, header spacing, and filter manual-search platforms

### DIFF
--- a/apps/mac/UnstreamShareExtension/ShareViewController.swift
+++ b/apps/mac/UnstreamShareExtension/ShareViewController.swift
@@ -29,11 +29,21 @@ struct PlatformMeta {
     let icon: String
     let payoutPercent: String?
     let isSocial: Bool
-    var isManualSearch: Bool = false
 }
 
-// Platforms that only produce generic search URLs, not real artist pages
-private let manualSearchPlatforms: Set<String> = ["hoopla", "freegal"]
+// Returns true when the API has produced a generic search URL rather than a real artist page.
+// These links only appear when an artist hasn't claimed their profile; claimed profiles always
+// supply direct URLs, so this check lets those through while hiding useless search placeholders.
+private func isSearchOnlyURL(sourceId: String, url: String) -> Bool {
+    switch sourceId {
+    case "kofi":         return !url.contains("ko-fi.com/")
+    case "buymeacoffee": return url.contains("explore-creators")
+    case "ampwall":      return url.contains("explore?searchStyle")
+    case "hoopla":       return url.contains("/search?")
+    case "freegal":      return url.contains("/search-page/")
+    default:             return false
+    }
+}
 
 private let allPlatformMeta: [String: PlatformMeta] = [
     "bandcamp":     .init(name: "Bandcamp",        icon: "🎵", payoutPercent: "80–85%", isSocial: false),
@@ -44,8 +54,8 @@ private let allPlatformMeta: [String: PlatformMeta] = [
     "patreon":      .init(name: "Patreon",         icon: "🎨", payoutPercent: "86–90%", isSocial: false),
     "buymeacoffee": .init(name: "Buy Me a Coffee", icon: "☕", payoutPercent: "~92%",   isSocial: false),
     "kofi":         .init(name: "Ko-fi",           icon: "🍵", payoutPercent: "92–97%", isSocial: false),
-    "hoopla":       .init(name: "Hoopla",          icon: "🎧", payoutPercent: nil,       isSocial: false, isManualSearch: true),
-    "freegal":      .init(name: "Freegal",         icon: "🎵", payoutPercent: nil,       isSocial: false, isManualSearch: true),
+    "hoopla":       .init(name: "Hoopla",          icon: "🎧", payoutPercent: nil,       isSocial: false),
+    "freegal":      .init(name: "Freegal",         icon: "🎵", payoutPercent: nil,       isSocial: false),
     "qobuz":        .init(name: "Qobuz",           icon: "💿", payoutPercent: "~70%",   isSocial: false),
     "beatport":     .init(name: "Beatport",        icon: "🎛️", payoutPercent: "55–70%", isSocial: false),
     "even":         .init(name: "EVEN",            icon: "🎤", payoutPercent: "~80%",   isSocial: false),
@@ -214,7 +224,7 @@ private struct ResultsView: View {
     private var primary: [PlatformLinkData] {
         platforms.filter {
             allPlatformMeta[$0.sourceId]?.isSocial != true &&
-            !manualSearchPlatforms.contains($0.sourceId)
+            !isSearchOnlyURL(sourceId: $0.sourceId, url: $0.url)
         }
     }
 

--- a/apps/mac/UnstreamShareExtension/ShareViewController.swift
+++ b/apps/mac/UnstreamShareExtension/ShareViewController.swift
@@ -29,7 +29,11 @@ struct PlatformMeta {
     let icon: String
     let payoutPercent: String?
     let isSocial: Bool
+    var isManualSearch: Bool = false
 }
+
+// Platforms that only produce generic search URLs, not real artist pages
+private let manualSearchPlatforms: Set<String> = ["hoopla", "freegal"]
 
 private let allPlatformMeta: [String: PlatformMeta] = [
     "bandcamp":     .init(name: "Bandcamp",        icon: "🎵", payoutPercent: "80–85%", isSocial: false),
@@ -40,8 +44,8 @@ private let allPlatformMeta: [String: PlatformMeta] = [
     "patreon":      .init(name: "Patreon",         icon: "🎨", payoutPercent: "86–90%", isSocial: false),
     "buymeacoffee": .init(name: "Buy Me a Coffee", icon: "☕", payoutPercent: "~92%",   isSocial: false),
     "kofi":         .init(name: "Ko-fi",           icon: "🍵", payoutPercent: "92–97%", isSocial: false),
-    "hoopla":       .init(name: "Hoopla",          icon: "🎧", payoutPercent: nil,       isSocial: false),
-    "freegal":      .init(name: "Freegal",         icon: "🎵", payoutPercent: nil,       isSocial: false),
+    "hoopla":       .init(name: "Hoopla",          icon: "🎧", payoutPercent: nil,       isSocial: false, isManualSearch: true),
+    "freegal":      .init(name: "Freegal",         icon: "🎵", payoutPercent: nil,       isSocial: false, isManualSearch: true),
     "qobuz":        .init(name: "Qobuz",           icon: "💿", payoutPercent: "~70%",   isSocial: false),
     "beatport":     .init(name: "Beatport",        icon: "🎛️", payoutPercent: "55–70%", isSocial: false),
     "even":         .init(name: "EVEN",            icon: "🎤", payoutPercent: "~80%",   isSocial: false),
@@ -148,17 +152,18 @@ struct ShareSearchView: View {
         VStack(spacing: 0) {
             HStack {
                 Text("Unstream")
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 17, weight: .semibold))
                 Spacer()
                 Button("Done", action: onDismiss)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.system(size: 17, weight: .medium))
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
 
             Divider()
             mainContent
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color(.systemBackground))
     }
 
@@ -207,7 +212,10 @@ private struct ResultsView: View {
     let onSave: () -> Void
 
     private var primary: [PlatformLinkData] {
-        platforms.filter { allPlatformMeta[$0.sourceId]?.isSocial != true }
+        platforms.filter {
+            allPlatformMeta[$0.sourceId]?.isSocial != true &&
+            !manualSearchPlatforms.contains($0.sourceId)
+        }
     }
 
     private var socialCount: Int {


### PR DESCRIPTION
- Fix blank space above header in loading state by using frame(maxWidth/maxHeight: .infinity) so the root VStack always fills the container, pinning the header to the top regardless of content size
- Increase header font size (15→17pt) and padding (12→16pt vertical, 16→20pt horizontal) for more breathing room
- Exclude hoopla and freegal from share extension results since they produce generic search URLs, not real artist profile links

https://claude.ai/code/session_01CEwg2c4KRsbZdGC8U82Ta6