### PR TITLE
Extend release alert lookback from 7 to 30 days

### DIFF
--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -71,12 +71,12 @@ function parseDateToISO(dateStr: string): string | null {
   return null;
 }
 
-// Check if release is within the last 8 days (slightly lenient for timezone/timing differences)
-function isWithinLastWeek(dateStr: string): boolean {
+// Check if release is within the last 30 days (slightly lenient for timezone/timing differences)
+function isWithinLastMonth(dateStr: string): boolean {
   const releaseDate = new Date(dateStr);
   const now = new Date();
   const daysDiff = (now.getTime() - releaseDate.getTime()) / (1000 * 60 * 60 * 24);
-  return daysDiff >= 0 && daysDiff <= 8;
+  return daysDiff >= 0 && daysDiff <= 31;
 }
 
 // Check Bandcamp for latest release
@@ -372,10 +372,10 @@ async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult
     platforms.qobuz ? checkQobuz(platforms.qobuz) : Promise.resolve(null),
   ]);
 
-  // Collect successful results that are within the last 7 days
+  // Collect successful results that are within the last 30 days
   for (const check of checks) {
     if (check.status === 'fulfilled' && check.value) {
-      if (isWithinLastWeek(check.value.releaseDate)) {
+      if (isWithinLastMonth(check.value.releaseDate)) {
         results.push(check.value);
       }
     }

--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -345,12 +345,13 @@ async function setupReleaseAlerts() {
   const { releaseCheckState = {} } = await chrome.storage.local.get('releaseCheckState');
   const lastCheck = releaseCheckState.lastCheckDate;
   const now = Date.now();
+  const thirtyDays = 30 * 24 * 60 * 60 * 1000;
   const sevenDays = 7 * 24 * 60 * 60 * 1000;
 
-  // Prune expired releases (older than 7 days)
+  // Prune expired releases (older than 30 days)
   if (releaseCheckState.newReleases && releaseCheckState.newReleases.length > 0) {
     releaseCheckState.newReleases = releaseCheckState.newReleases.filter(
-      r => now - new Date(r.detectedAt).getTime() < sevenDays
+      r => now - new Date(r.detectedAt).getTime() < thirtyDays
     );
     await chrome.storage.local.set({ releaseCheckState });
   }
@@ -515,11 +516,11 @@ async function getNewReleases() {
   const { releaseCheckState = {} } = await chrome.storage.local.get('releaseCheckState');
   const releases = releaseCheckState.newReleases || [];
 
-  // Filter to only active releases (within 7 days of detection)
+  // Filter to only active releases (within 30 days of detection)
   const now = Date.now();
-  const sevenDays = 7 * 24 * 60 * 60 * 1000;
+  const thirtyDays = 30 * 24 * 60 * 60 * 1000;
   const activeReleases = releases.filter(
-    r => now - new Date(r.detectedAt).getTime() < sevenDays
+    r => now - new Date(r.detectedAt).getTime() < thirtyDays
   );
 
   return activeReleases;

--- a/apps/mac/Unstream/Models/ReleaseAlert.swift
+++ b/apps/mac/Unstream/Models/ReleaseAlert.swift
@@ -10,9 +10,9 @@ struct NewRelease: Codable, Identifiable {
     let platform: String  // "bandcamp", "faircamp", "mirlo", or "qobuz"
     let detectedAt: Date
 
-    /// Returns true if this release should still be displayed (within 7 days of detection)
+    /// Returns true if this release should still be displayed (within 30 days of detection)
     var isActive: Bool {
-        Date().timeIntervalSince(detectedAt) < 7 * 24 * 60 * 60
+        Date().timeIntervalSince(detectedAt) < 30 * 24 * 60 * 60
     }
 
     init(artistName: String, releaseName: String, releaseDate: Date, releaseUrl: String, platform: String) {
@@ -83,7 +83,7 @@ struct ReleaseCheckState: Codable {
         return releases.contains { $0.releaseName.lowercased() == releaseName.lowercased() }
     }
 
-    /// Remove expired new releases (older than 7 days)
+    /// Remove expired new releases (older than 30 days)
     mutating func pruneExpiredReleases() {
         newReleases = newReleases.filter { $0.isActive }
     }


### PR DESCRIPTION
The API now considers any release published within the last 30 days as
alertable (up from ~7). Display expiry for detected alerts in both the
Mac app and browser extension is also extended to 30 days so alerts
don't disappear before the next weekly check cycle catches up.

https://claude.ai/code/session_01Pcn4E5P78P7yiV619yAEGv