### PR TITLE
fix: custom link displayName in search results + other platform source entry

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1502,6 +1502,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
           platforms: dbArtist.platforms.map(p => ({
             sourceId: p.sourceId as SourceId,
             url: p.url,
+            displayName: p.displayName,
             latestRelease: p.latestRelease,
           })),
           matchConfidence: 'claimed',

--- a/apps/mac/Unstream/Models/PlatformCatalog.swift
+++ b/apps/mac/Unstream/Models/PlatformCatalog.swift
@@ -47,6 +47,8 @@ let platformCatalog: [String: PlatformConfig] = [
     "bluesky": PlatformConfig(name: "Bluesky", icon: "cloud", color: "#0085FF", searchOnly: false),
     "mastodon": PlatformConfig(name: "Mastodon", icon: "bubble.left.and.bubble.right", color: "#6364FF", searchOnly: false),
     "peertube": PlatformConfig(name: "PeerTube", icon: "play.circle", color: "#F1680D", searchOnly: false),
+    // Fallback for artist-added custom links (other, other_*)
+    "other": PlatformConfig(name: "Link", icon: "globe", color: "#888888", searchOnly: false),
 ]
 
 /// Social platform IDs for filtering

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Sat, 18 Apr 2026 01:05:38 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 20 Apr 2026 00:03:48 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -40,6 +40,9 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
   const [reportText, setReportText] = useState('');
   const [shareCopied, setShareCopied] = useState(false);
 
+  // Fallback to 'other' source for unknown/dynamic sourceIds (e.g. other_*)
+  const getSource = (sourceId: SourceId) => sources[sourceId] ?? sources['other'];
+
   // Helper to check if a URL is a direct link vs a search URL
   const isDirectLink = (url: string, sourceId: SourceId): boolean => {
     // If the source isn't searchOnly, it's always direct
@@ -52,7 +55,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
   // Separate verified matches from search-only links
   // A platform is verified if it's not searchOnly OR if we have a direct link to it
   const verifiedPlatforms = result.platforms.filter(p =>
-    !sources[p.sourceId]?.searchOnly || isDirectLink(p.url, p.sourceId)
+    !getSource(p.sourceId)?.searchOnly || isDirectLink(p.url, p.sourceId)
   );
 
   // Collect platforms that have latest release info
@@ -122,7 +125,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
   };
 
   const searchOnlyPlatforms = result.platforms.filter(p =>
-    sources[p.sourceId]?.searchOnly && !isDirectLink(p.url, p.sourceId)
+    getSource(p.sourceId)?.searchOnly && !isDirectLink(p.url, p.sourceId)
   );
 
   const handleReportSubmit = (e: React.MouseEvent) => {
@@ -158,6 +161,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
     }
   };
 
+  const allKnownSourceIds = new Set(
+    Object.values(sourceCategories).flatMap(cat => cat.sources as SourceId[])
+  );
+
   // Group verified platforms by category
   const categorizedPlatforms = {
     marketplace: verifiedPlatforms.filter(p =>
@@ -177,6 +184,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
     ),
     social: verifiedPlatforms.filter(p =>
       sourceCategories.social.sources.includes(p.sourceId)
+    ),
+    // Catch-all for artist-added custom links (other, other_*, or any unknown sourceId)
+    curated: verifiedPlatforms.filter(p =>
+      !allKnownSourceIds.has(p.sourceId) || sourceCategories.curated.sources.includes(p.sourceId)
     ),
   };
 
@@ -409,17 +420,17 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors hover:opacity-80"
                         style={{
-                          backgroundColor: `${sources[platform.sourceId].color}20`,
-                          color: sources[platform.sourceId].color,
+                          backgroundColor: `${getSource(platform.sourceId).color}20`,
+                          color: getSource(platform.sourceId).color,
                         }}
                         onClick={(e) => {
                           e.stopPropagation();
-                          analytics.trackPlatformClick(sources[platform.sourceId].name);
+                          analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
                           if (result.claimedSlug) analytics.trackArtistLinkClick(result.claimedSlug, platform.sourceId);
                         }}
                       >
-                        <span>{sources[platform.sourceId].icon}</span>
-                        <span>{sources[platform.sourceId].name}</span>
+                        <span>{getSource(platform.sourceId).icon}</span>
+                        <span>{platform.displayName ?? getSource(platform.sourceId).name}</span>
                       </a>
                     ))}
                   </div>
@@ -480,9 +491,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                 {categorizedPlatforms.marketplace.map(platform => (
                   <SourceBadge
                     key={platform.sourceId}
-                    source={sources[platform.sourceId]}
+                    source={getSource(platform.sourceId)}
                     url={platform.url}
                     isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
                   />
                 ))}
               </div>
@@ -498,9 +510,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                 {categorizedPlatforms.patronage.map(platform => (
                   <SourceBadge
                     key={platform.sourceId}
-                    source={sources[platform.sourceId]}
+                    source={getSource(platform.sourceId)}
                     url={platform.url}
                     isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
                   />
                 ))}
               </div>
@@ -516,9 +529,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                 {categorizedPlatforms.decentralized.map(platform => (
                   <SourceBadge
                     key={platform.sourceId}
-                    source={sources[platform.sourceId]}
+                    source={getSource(platform.sourceId)}
                     url={platform.url}
                     isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
                   />
                 ))}
               </div>
@@ -534,9 +548,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                 {categorizedPlatforms.library.map(platform => (
                   <SourceBadge
                     key={platform.sourceId}
-                    source={sources[platform.sourceId]}
+                    source={getSource(platform.sourceId)}
                     url={platform.url}
                     isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
                   />
                 ))}
               </div>
@@ -552,9 +567,29 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                 {categorizedPlatforms.official.map(platform => (
                   <SourceBadge
                     key={platform.sourceId}
-                    source={sources[platform.sourceId]}
+                    source={getSource(platform.sourceId)}
                     url={platform.url}
                     isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {categorizedPlatforms.curated.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider">
+                Links
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {categorizedPlatforms.curated.map(platform => (
+                  <SourceBadge
+                    key={platform.sourceId}
+                    source={getSource(platform.sourceId)}
+                    url={platform.url}
+                    isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+                    displayName={platform.displayName}
                   />
                 ))}
               </div>
@@ -575,10 +610,10 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
                     target="_blank"
                     rel="noopener noreferrer"
                     className="w-8 h-8 flex items-center justify-center rounded-full bg-bg-secondary hover:bg-bg-tertiary transition-colors"
-                    title={sources[platform.sourceId].name}
+                    title={platform.displayName ?? getSource(platform.sourceId).name}
                     onClick={(e) => {
                       e.stopPropagation();
-                      analytics.trackPlatformClick(sources[platform.sourceId].name);
+                      analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
                       if (result.claimedSlug) analytics.trackArtistLinkClick(result.claimedSlug, platform.sourceId);
                     }}
                   >
@@ -596,8 +631,9 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
               {searchOnlyPlatforms.map(platform => (
                 <SourceBadge
                   key={platform.sourceId}
-                  source={sources[platform.sourceId]}
+                  source={getSource(platform.sourceId)}
                   url={platform.url}
+                  displayName={platform.displayName}
                 />
               ))}
             </div>
@@ -718,21 +754,21 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
 
           {/* Badge legend — explains payout % and AI policy icons */}
           {/* Check if any visible platform has aiPolicy or artistPayoutPercent */}
-          {verifiedPlatforms.some(p => sources[p.sourceId]?.artistPayoutPercent || sources[p.sourceId]?.aiPolicy) && (
+          {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent || getSource(p.sourceId)?.aiPolicy) && (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-muted pt-2 mt-2 border-t border-border/50">
-              {verifiedPlatforms.some(p => sources[p.sourceId]?.artistPayoutPercent) && (
+              {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) && (
                 <span className="flex items-center gap-1">
                   <span className="px-1 py-0.5 rounded bg-bg-secondary text-[10px] font-semibold">%</span>
                   Artist's share of each sale
                 </span>
               )}
-              {verifiedPlatforms.some(p => sources[p.sourceId]?.aiPolicy === 'banned') && (
+              {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'banned') && (
                 <span className="flex items-center gap-1">
                   <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
                   AI-generated music banned
                 </span>
               )}
-              {verifiedPlatforms.some(p => sources[p.sourceId]?.aiPolicy === 'anti-ai') && (
+              {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'anti-ai') && (
                 <span className="flex items-center gap-1">
                   <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
                   AI content restricted/tagged

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -7,6 +7,7 @@ interface SourceBadgeProps {
   source: Source;
   url: string;
   isDirectLink?: boolean;
+  displayName?: string;
 }
 
 const AI_POLICY_TOOLTIPS: Partial<Record<string, string>> = {
@@ -17,7 +18,8 @@ const AI_POLICY_TOOLTIPS: Partial<Record<string, string>> = {
   qobuz: 'Qobuz has an AI Charter, detects/tags AI content, and excludes it from human-curated recommendations.',
 };
 
-export function SourceBadge({ source, url, isDirectLink }: SourceBadgeProps) {
+export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBadgeProps) {
+  const label = displayName ?? source.name;
   // If we have a direct link, show as verified even if source is normally searchOnly
   const isSearchOnly = isDirectLink ? false : (source.searchOnly ?? false);
 
@@ -29,13 +31,13 @@ export function SourceBadge({ source, url, isDirectLink }: SourceBadgeProps) {
         target="_blank"
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1.5 px-2 py-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
-        title={`Search for this artist on ${source.name}`}
-        onClick={() => analytics.trackPlatformClick(source.name)}
+        title={`Search for this artist on ${label}`}
+        onClick={() => analytics.trackPlatformClick(label)}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
-        <span>{source.name}</span>
+        <span>{label}</span>
         <svg className="w-3.5 h-3.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
         </svg>
@@ -64,11 +66,11 @@ export function SourceBadge({ source, url, isDirectLink }: SourceBadgeProps) {
         backgroundColor: `${source.color}20`,
         color: textColor,
       }}
-      onClick={() => analytics.trackPlatformClick(source.name)}
+      onClick={() => analytics.trackPlatformClick(label)}
     >
       <PlatformIcon sourceId={source.id} color={textColor} emoji={source.icon} />
       <span className="flex items-center gap-1">
-        {source.name}
+        {label}
         {hasPayoutPercent ? (
           <>
             <span

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -293,6 +293,17 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: '',
     homepageUrl: 'https://joinpeertube.org',
   },
+  other: {
+    id: 'other',
+    name: 'Link',
+    description: 'Custom link added by artist',
+    color: '#888888',
+    icon: '🔗',
+    category: 'curated',
+    hasEmbed: false,
+    searchUrlTemplate: '',
+    homepageUrl: '',
+  },
 };
 
 export const sourceCategories = {
@@ -325,6 +336,11 @@ export const sourceCategories = {
     name: 'Social',
     description: 'Artist social media profiles',
     sources: ['instagram', 'facebook', 'tiktok', 'youtube', 'threads', 'bluesky', 'mastodon', 'peertube'] as SourceId[],
+  },
+  curated: {
+    name: 'Links',
+    description: 'Custom links added by the artist',
+    sources: ['other'] as SourceId[],
   },
 };
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -23,7 +23,8 @@ export type SourceId =
   | 'threads'
   | 'bluesky'
   | 'mastodon'
-  | 'peertube';
+  | 'peertube'
+  | 'other';
 
 export interface Source {
   id: SourceId;
@@ -31,7 +32,7 @@ export interface Source {
   description: string;
   color: string;
   icon: string;
-  category: 'marketplace' | 'patronage' | 'library' | 'decentralized' | 'official' | 'social';
+  category: 'marketplace' | 'patronage' | 'library' | 'decentralized' | 'official' | 'social' | 'curated';
   hasEmbed: boolean;
   searchUrlTemplate: string;
   searchOnly?: boolean; // True if we can't verify the artist exists (shows "Search X" instead)


### PR DESCRIPTION
## Problem
Custom links added by claimed artists (platform `other_*`) are broken across all clients:
- **App/extension search**: shows raw ID like `index_0` or `Other_0` instead of the artist's custom name (e.g. "Weblog")
- **Web search**: custom links don't render at all — no source entry exists for `other_*`, so they get filtered out
- **Artist profile page**: works correctly (reads `display_name` from DB directly)

## Root Cause
Two bugs working together:

1. **`search-sources.ts` drops `displayName`** — When mapping claimed artist platforms into search results (line ~1500), the `displayName` field from the DB is not included in the output.

2. **No `other` source entry** — `sources.ts` (web) and `PlatformCatalog.swift` (native) have no entry for `other` or `other_*` sourceIds. Web filters them out entirely; native falls back to the raw sourceId string.

## Changes
- `api/functions/search-sources.ts`: Add `displayName` to claimed artist platform mapping
- `apps/web/src/services/sources.ts`: Add `other` source entry (name: "Link", icon: 🔗) + `curated` source category
- `apps/mac/Unstream/Models/PlatformCatalog.swift`: Add `other` entry (name: "Link", icon: globe)
- `apps/web/src/components/SourceBadge.tsx`: Accept optional `displayName` prop, prefer it over `source.name`
- `apps/web/src/components/ResultCard.tsx`: Use `getSource()` helper that falls back to `other` for unknown sourceIds; pass `displayName` through to badges; render custom links in new "Links" section
- `apps/web/src/types/index.ts`: Add `other` to `SourceId` union, `curated` to category type

## Testing
- TypeScript compiles clean (`npx tsc -b`)
- Full web build passes (`npm run build`)
- Reported by: Glen (Things task triage)