### PR TITLE
fix(mac): extract IndieArtist to shared model so macOS build resolves the type

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52C116B5CC91BC40D028AF /* GlobalHotkeyManager.swift */; platformFilters = (macos, ); };
 		8A4181366EB270C58A708C65 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AC0E531396E8C63A2001CF /* SearchBarView.swift */; platformFilters = (macos, ); };
 		8C94768621D55383151FD59F /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1581BE8FAF07C7C9D3CD99F5 /* SearchResponse.swift */; };
+		AA11BB22CC33DD44EE55FF66 /* IndieArtist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AA11BB22CC33DD44EE55FF /* IndieArtist.swift */; };
 		917C407BBA300BE70B9BDEFB /* ScrobbleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEE83E95439F19BFC679216 /* ScrobbleManager.swift */; platformFilters = (macos, ); };
 		A3526462820B7494F5463BE2 /* UnstreamApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913EEE8809001930E4F88F8C /* UnstreamApp.swift */; };
 		A8FD43FE100F214CA8E6241C /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9E59C365D8F116C435B8BC /* EmptyStateView.swift */; };
@@ -87,6 +88,7 @@
 /* Begin PBXFileReference section */
 		1003A79CD2A20BF7227C6FB0 /* SupportEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportEntry.swift; sourceTree = "<group>"; };
 		1581BE8FAF07C7C9D3CD99F5 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
+		99AA11BB22CC33DD44EE55FF /* IndieArtist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndieArtist.swift; sourceTree = "<group>"; };
 		1CDD15E71A80A31952A7720C /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		1D967BFF6EECB9BFC4835ABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1F71936662EEAC06B0C1F008 /* ReleaseAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAlert.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				DC148A11F868801384A78672 /* AppState.swift */,
+				99AA11BB22CC33DD44EE55FF /* IndieArtist.swift */,
 				BC8C8A39D8800BDBA893E0EA /* NowPlaying.swift */,
 				E488821D948022DCF94F9759 /* PlatformCatalog.swift */,
 				1F71936662EEAC06B0C1F008 /* ReleaseAlert.swift */,
@@ -426,6 +429,7 @@
 				A8FD43FE100F214CA8E6241C /* EmptyStateView.swift in Sources */,
 				194D5CB6D2373174426884C5 /* FaircampReleaseChecker.swift in Sources */,
 				8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */,
+				AA11BB22CC33DD44EE55FF66 /* IndieArtist.swift in Sources */,
 				4195335F3B43DDF10D2131CD /* KeychainHelper.swift in Sources */,
 				7FA2720BFA00323DC8E66A9A /* ListenBrainzService.swift in Sources */,
 				DAF5726D4B93EA321E5D4643 /* MediaObserver.swift in Sources */,

--- a/apps/mac/Unstream/Models/IndieArtist.swift
+++ b/apps/mac/Unstream/Models/IndieArtist.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct IndieArtist: Codable, Identifiable, Equatable {
+    let slug: String
+    let name: String
+    let imageUrl: String?
+
+    var id: String { slug }
+}

--- a/apps/mac/Unstream/Services/IndieArtistDirectoryService.swift
+++ b/apps/mac/Unstream/Services/IndieArtistDirectoryService.swift
@@ -1,16 +1,6 @@
 import Foundation
 import SwiftUI
 
-// MARK: - Model
-
-struct IndieArtist: Codable, Identifiable, Equatable {
-    let slug: String
-    let name: String
-    let imageUrl: String?
-
-    var id: String { slug }
-}
-
 // MARK: - Service
 
 @MainActor


### PR DESCRIPTION
## Summary

- `IndieArtist` was defined inside `IndieArtistDirectoryService.swift`, which has `platformFilters = (ios, )` in the Xcode project (iOS-only compilation)
- `UnstreamAPI.swift` has no platform filter and compiles for both macOS and iOS — it references `IndieArtist` as the return type of `fetchArtistDirectory()` and inside a local `DirectoryResponse` struct
- macOS builds failed with two errors: `Cannot find type 'IndieArtist' in scope` (lines 68 & 81) and the cascading `Type 'DirectoryResponse' does not conform to protocol 'Decodable'` (line 80)

**Fix:** move `IndieArtist` into a new `apps/mac/Unstream/Models/IndieArtist.swift` with no platform filter, and remove the duplicate definition from `IndieArtistDirectoryService.swift`. The new file is wired into the Xcode project as a shared source (no `platformFilters`) so both macOS and iOS compilation units can see the type.

## Test plan

- [x] `xcodebuild -scheme Unstream -destination 'platform=macOS' -configuration Debug build` — **BUILD SUCCEEDED**
- [ ] Confirm iOS simulator build still passes (`-destination 'platform=iOS Simulator,...'`)