### PR TITLE
fix(ci): pull --rebase before push in social posts workflow

### DIFF
--- a/.github/workflows/schedule-social-posts.yml
+++ b/.github/workflows/schedule-social-posts.yml
@@ -39,4 +39,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/social-posts/history.json data/shipped-features.json
           git diff --cached --quiet || git commit -m "Update social post history for ${{ steps.week.outputs.week }}"
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
## Summary
- Adds `git pull --rebase origin main` before `git push` in the social posts GHA workflow
- Fixes the push rejection that occurs when other commits land on main while the workflow is running (generating + scheduling posts takes several minutes)

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow manually via workflow_dispatch to generate next week's posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)