### PR TITLE
fix(ios): scroll to top when tapping featured artist on Search screen

### DIFF
--- a/apps/mac/Unstream/Views/iOS/SearchTab.swift
+++ b/apps/mac/Unstream/Views/iOS/SearchTab.swift
@@ -7,35 +7,43 @@ struct SearchTab: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 16) {
-                    if appState.isSearching {
-                        ProgressView("Searching...")
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        Color.clear.frame(height: 0).id("searchTop")
+                        if appState.isSearching {
+                            ProgressView("Searching...")
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, 40)
+                        } else if let error = appState.searchError {
+                            VStack(spacing: 8) {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .font(.title2)
+                                    .foregroundColor(.orange)
+                                Text(error)
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, 40)
-                    } else if let error = appState.searchError {
-                        VStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle")
-                                .font(.title2)
-                                .foregroundColor(.orange)
-                            Text(error)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                        } else if appState.hasSearched {
+                            ResultsView(
+                                title: nil,
+                                results: appState.searchResults
+                            )
+                            .environmentObject(supportListManager)
+                            .environmentObject(appState)
+                        } else {
+                            IndieArtistSuggestionsView()
                         }
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, 40)
-                    } else if appState.hasSearched {
-                        ResultsView(
-                            title: nil,
-                            results: appState.searchResults
-                        )
-                        .environmentObject(supportListManager)
-                        .environmentObject(appState)
-                    } else {
-                        IndieArtistSuggestionsView()
+                    }
+                    .padding()
+                }
+                .onChange(of: appState.hasSearched) { hasSearched in
+                    if hasSearched {
+                        proxy.scrollTo("searchTop", anchor: .top)
                     }
                 }
-                .padding()
             }
             .navigationTitle("Unstream")
             .searchable(text: $appState.searchQuery, prompt: "Search for an artist...")


### PR DESCRIPTION
When a user scrolled through the featured artists grid and tapped one,
the ScrollView preserved its position, hiding the results behind the fold.
Wraps the ScrollView in a ScrollViewReader and scrolls to the top anchor
whenever hasSearched transitions to true.

https://claude.ai/code/session_01AVooxiwz6quemdXUv37N3L