### PR TITLE
feat: surface artist location in Mac/iOS app + browser extension

### DIFF
--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -141,6 +141,24 @@ body {
   text-overflow: ellipsis;
 }
 
+.artist-location {
+  font-size: 12px;
+  color: #9CA3AF;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.artist-location:empty {
+  display: none;
+}
+
+.saved-artist-location {
+  font-size: 12px;
+  color: #9CA3AF;
+  margin-top: 2px;
+}
+
 .source-badge {
   font-size: 11px;
   padding: 4px 8px;
@@ -435,6 +453,13 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
+}
+
+.saved-artist-name-wrap {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
 }
 
 .saved-artist-name {

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -33,6 +33,7 @@
           <div class="now-playing-card">
             <div class="track-info">
               <div id="artist-name" class="artist-name"></div>
+              <div id="artist-location" class="artist-location"></div>
               <div id="track-title" class="track-title"></div>
             </div>
             <div id="source-badge" class="source-badge"></div>

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -47,6 +47,7 @@ const elements = {
   searchInput: document.getElementById('search-input'),
   searchBtn: document.getElementById('search-btn'),
   artistName: document.getElementById('artist-name'),
+  artistLocation: document.getElementById('artist-location'),
   trackTitle: document.getElementById('track-title'),
   sourceBadge: document.getElementById('source-badge'),
   // Saved tab
@@ -65,7 +66,18 @@ const elements = {
 let currentArtist = null;
 let currentResults = null;
 let currentSocialLinks = null;
+let currentLocation = null;
 let newReleases = [];
+
+// Format ArtistLocation object to "City, Country" string
+function formatLocation(location) {
+  if (!location) return '';
+  const region = location.country || location.countryCode;
+  if (location.city && region) return `${location.city}, ${region}`;
+  if (location.city) return location.city;
+  if (region) return region;
+  return '';
+}
 
 // Initialize popup
 async function init() {
@@ -90,7 +102,9 @@ async function init() {
 // Show now playing
 function showNowPlaying(track) {
   currentArtist = track.artist;
+  currentLocation = null;
   elements.artistName.textContent = track.artist;
+  elements.artistLocation.textContent = '';
   elements.trackTitle.textContent = track.title || '';
   elements.sourceBadge.textContent = track.source;
 
@@ -105,6 +119,8 @@ function showNowPlaying(track) {
 function hideNowPlaying() {
   currentArtist = null;
   currentResults = null;
+  currentLocation = null;
+  elements.artistLocation.textContent = '';
   elements.nowPlaying.classList.add('hidden');
   elements.idleState.classList.remove('hidden');
   elements.resultsSection.classList.add('hidden');
@@ -150,6 +166,12 @@ function renderResults(results) {
   // Extract claimedSlug for analytics tracking
   const claimedResult = results.find(r => r.type === 'artist' && r.claimedSlug);
   const claimedSlug = claimedResult?.claimedSlug || null;
+
+  // Extract location: prefer claimed result, otherwise first artist-type result with location
+  const locationResult = (claimedResult?.location ? claimedResult : null)
+    || results.find(r => r.type === 'artist' && r.location);
+  currentLocation = locationResult?.location || null;
+  elements.artistLocation.textContent = formatLocation(currentLocation);
 
   const allPlatforms = [];
   for (const result of results) {
@@ -332,7 +354,7 @@ async function toggleSaveArtist() {
     delete savedArtistsData[currentArtist];
   } else {
     savedArtists.push(currentArtist);
-    const artistData = { platforms: [], socialLinks: [] };
+    const artistData = { platforms: [], socialLinks: [], location: currentLocation || null };
 
     // Save platforms
     if (currentResults && currentResults.length > 0) {
@@ -382,6 +404,7 @@ async function loadSavedArtists() {
     const artistData = savedArtistsData[artist] || {};
     const platforms = artistData.platforms || [];
     const socialLinks = artistData.socialLinks || [];
+    const location = artistData.location || null;
 
     const card = document.createElement('div');
     card.className = 'saved-artist-card';
@@ -390,6 +413,9 @@ async function loadSavedArtists() {
     const header = document.createElement('div');
     header.className = 'saved-artist-header';
 
+    const nameWrap = document.createElement('div');
+    nameWrap.className = 'saved-artist-name-wrap';
+
     const nameSpan = document.createElement('span');
     nameSpan.className = 'saved-artist-name';
     nameSpan.textContent = artist;
@@ -397,6 +423,15 @@ async function loadSavedArtists() {
       switchToTab('discover');
       searchArtist(artist);
     });
+    nameWrap.appendChild(nameSpan);
+
+    const locationText = formatLocation(location);
+    if (locationText) {
+      const locationSpan = document.createElement('div');
+      locationSpan.className = 'saved-artist-location';
+      locationSpan.textContent = locationText;
+      nameWrap.appendChild(locationSpan);
+    }
 
     const removeBtn = document.createElement('button');
     removeBtn.className = 'saved-artist-remove';
@@ -404,7 +439,7 @@ async function loadSavedArtists() {
     removeBtn.textContent = '\u00D7';
     removeBtn.addEventListener('click', () => removeSavedArtist(artist));
 
-    header.appendChild(nameSpan);
+    header.appendChild(nameWrap);
     header.appendChild(removeBtn);
     card.appendChild(header);
 

--- a/apps/mac/Unstream/Models/SearchResponse.swift
+++ b/apps/mac/Unstream/Models/SearchResponse.swift
@@ -11,6 +11,22 @@ struct SocialLink: Codable {
     let url: String
 }
 
+struct ArtistLocation: Codable, Hashable {
+    let city: String?
+    let country: String?
+    let countryCode: String?
+
+    var displayText: String? {
+        let region = country ?? countryCode
+        switch (city, region) {
+        case let (city?, region?): return "\(city), \(region)"
+        case let (city?, nil): return city
+        case let (nil, region?): return region
+        default: return nil
+        }
+    }
+}
+
 struct MusicBrainzResponse: Codable {
     let query: String
     let artistName: String?
@@ -28,6 +44,7 @@ struct ArtistResult: Codable, Identifiable {
     let platforms: [PlatformResult]
     let claimedSlug: String?
     let matchConfidence: String?
+    let location: ArtistLocation?
 
     /// Platforms that have verified artist presence (excluding social)
     var verifiedPlatforms: [PlatformResult] {

--- a/apps/mac/Unstream/Models/SupportEntry.swift
+++ b/apps/mac/Unstream/Models/SupportEntry.swift
@@ -7,13 +7,15 @@ struct SupportEntry: Codable, Identifiable {
     let imageUrl: String?
     let platforms: [SavedPlatform]
     let dateAdded: Date
+    let location: ArtistLocation?
 
-    init(id: UUID = UUID(), artistName: String, imageUrl: String?, platforms: [SavedPlatform], dateAdded: Date = Date()) {
+    init(id: UUID = UUID(), artistName: String, imageUrl: String?, platforms: [SavedPlatform], dateAdded: Date = Date(), location: ArtistLocation? = nil) {
         self.id = id
         self.artistName = artistName
         self.imageUrl = imageUrl
         self.platforms = platforms
         self.dateAdded = dateAdded
+        self.location = location
     }
 
     /// Create a SupportEntry from an ArtistResult
@@ -41,6 +43,7 @@ struct SupportEntry: Codable, Identifiable {
 
         self.platforms = allPlatforms
         self.dateAdded = Date()
+        self.location = artist.location
     }
 }
 

--- a/apps/mac/Unstream/SupportListManager.swift
+++ b/apps/mac/Unstream/SupportListManager.swift
@@ -132,7 +132,8 @@ class SupportListManager: ObservableObject {
                     artistName: entry.artistName,
                     imageUrl: artistResult.imageUrl ?? entry.imageUrl,
                     platforms: allPlatforms,
-                    dateAdded: entry.dateAdded
+                    dateAdded: entry.dateAdded,
+                    location: artistResult.location ?? entry.location
                 )
 
                 // Replace the entry in the array

--- a/apps/mac/Unstream/UnstreamAPI.swift
+++ b/apps/mac/Unstream/UnstreamAPI.swift
@@ -142,7 +142,7 @@ actor UnstreamAPI {
                 }
             }
 
-            return ArtistResult(id: result.id, name: result.name, type: result.type, imageUrl: result.imageUrl, platforms: newPlatforms, claimedSlug: result.claimedSlug, matchConfidence: result.matchConfidence)
+            return ArtistResult(id: result.id, name: result.name, type: result.type, imageUrl: result.imageUrl, platforms: newPlatforms, claimedSlug: result.claimedSlug, matchConfidence: result.matchConfidence, location: result.location)
         }
     }
 

--- a/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
+++ b/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
@@ -67,8 +67,16 @@ struct ArtistResultView: View {
                     artistPhoto
                 }
 
-                Text(artist.name)
-                    .font(.system(size: 14, weight: .semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(artist.name)
+                        .font(.system(size: 14, weight: .semibold))
+
+                    if let locationText = artist.location?.displayText {
+                        Text(locationText)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                    }
+                }
 
                 Spacer()
 

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -174,8 +174,16 @@ struct SupportEntryView: View {
                 // Artist photo
                 artistPhoto
 
-                Text(entry.artistName)
-                    .font(.system(size: 14, weight: .semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.artistName)
+                        .font(.system(size: 14, weight: .semibold))
+
+                    if let locationText = entry.location?.displayText {
+                        Text(locationText)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                    }
+                }
 
                 Spacer()
 


### PR DESCRIPTION
## Summary

Extends the Phase 1 location feature ([#184](https://github.com/brandonlucasgreen/unstream/pull/184)) to the non-web clients. The API already returns `location` on each search result; this plumbs it through the Swift and JS clients for display and persistence.

- **Mac/iOS**: `ArtistLocation` struct on `ArtistResult`, rendered under artist name on search cards and saved artist cards; location persists on `SupportEntry` and survives refresh (falling back to prior value if enrichment fails).
- **Browser extension**: location line under the now-playing artist name; `savedArtistsData` stores location and saved artist cards render it.

Part of the 3-phase location plan. Next: PR B (persist to `artist_enrichment` DB table) and PR C (claim/edit flow).

## Test plan

- [x] Mac app builds clean (`xcodebuild -scheme Unstream -destination 'platform=macOS'` → BUILD SUCCEEDED)
- [x] Web unit tests 165/165 pass (no web code changed — sanity check)
- [x] `popup.js` parses clean (`node --check`)
- [ ] Manual: search on Mac app for an artist with location (e.g. "Honeycrush" → Brooklyn, US) — confirm it appears under the name
- [ ] Manual: same on iOS
- [ ] Manual: save that artist, confirm location shows on saved-artist card
- [ ] Manual: extension — trigger now-playing card, confirm location line appears below artist name
- [ ] Manual: extension — save artist, confirm saved-artist card shows location

🤖 Generated with [Claude Code](https://claude.com/claude-code)