### PR TITLE
feat: persist artist location in DB (Phase 2)

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -73,6 +73,7 @@ interface ArtistResult {
   platforms: PlatformLink[];
   matchConfidence?: 'verified' | 'unverified' | 'claimed';
   profile?: ArtistProfile;
+  location?: { city?: string; country?: string; countryCode?: string };
 }
 
 // --- DB Row Types ---
@@ -86,6 +87,9 @@ interface ArtistRow {
   source: string;
   updated_at: string;
   last_enriched_at: string | null;
+  city: string | null;
+  country: string | null;
+  country_code: string | null;
 }
 
 interface LinkRow {
@@ -195,6 +199,14 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
       }
     }
 
+    const location = (row.city || row.country || row.country_code)
+      ? {
+          ...(row.city ? { city: row.city } : {}),
+          ...(row.country ? { country: row.country } : {}),
+          ...(row.country_code ? { countryCode: row.country_code } : {}),
+        }
+      : undefined;
+
     return {
       id: row.slug,
       name: row.name,
@@ -203,6 +215,7 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
       platforms,
       matchConfidence: (row.match_confidence as ArtistResult['matchConfidence']) || undefined,
       profile,
+      location,
     };
   } catch (error) {
     console.error('[DB] getArtistBySlug error:', error);
@@ -309,6 +322,7 @@ export async function persistEnrichment(
     hasPre2005Release: boolean;
     socialLinks: { platform: string; url: string }[];
     discoveredPlatforms?: { platform: string; url: string }[];
+    location?: { city?: string; country?: string; countryCode?: string };
   }
 ): Promise<void> {
   const client = getClient();
@@ -384,13 +398,27 @@ export async function persistEnrichment(
       }
     }
 
-    // Mark artist as enriched
+    // Mark artist as enriched; persist location if discovered
+    const artistUpdate: {
+      last_enriched_at: string;
+      city?: string | null;
+      country?: string | null;
+      country_code?: string | null;
+    } = { last_enriched_at: new Date().toISOString() };
+
+    if (mbData.location) {
+      artistUpdate.city = mbData.location.city ?? null;
+      artistUpdate.country = mbData.location.country ?? null;
+      artistUpdate.country_code = mbData.location.countryCode ?? null;
+    }
+
     await client
       .from('artists')
-      .update({ last_enriched_at: new Date().toISOString() })
+      .update(artistUpdate)
       .eq('id', artistId);
 
-    console.log(`[DB] Enriched "${artistName}" with ${enrichmentLinks.length} MusicBrainz links`);
+    const locationLog = mbData.location ? ` + location` : '';
+    console.log(`[DB] Enriched "${artistName}" with ${enrichmentLinks.length} MusicBrainz links${locationLog}`);
   } catch (error) {
     console.error(`[DB] Error enriching "${artistName}":`, error);
   }

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -930,10 +930,13 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       console.log(`[MusicBrainz] Cache hit for "${normalizedQuery}"`);
     }
 
-    // Persist enrichment to the artist database
-    if (result.artistName) {
+    // Persist enrichment to the artist database.
+    // Also persist on MB-miss if we at least captured location (from the
+    // Bandcamp/Mirlo fallback), keyed on the normalized query's slug.
+    const persistName = result.artistName || (result.location ? normalizedQuery : null);
+    if (persistName) {
       try {
-        await persistEnrichment(result.artistName, result);
+        await persistEnrichment(persistName, result);
       } catch (err) {
         console.error('[DB] Background enrichment persist failed:', err);
       }

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1507,6 +1507,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
           })),
           matchConfidence: 'claimed',
           claimedSlug: slug,
+          ...(dbArtist.location ? { location: dbArtist.location } : {}),
         };
       }
     } catch (err) {

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -57,6 +57,13 @@ export interface AggregatedResult {
   claimedSlug?: string;
   // Set to true when this result was merged via a manual override — protects it from later splitting
   overrideMerged?: boolean;
+  // Artist location — populated from the DB for claimed artists and from
+  // Phase 2 MusicBrainz/Bandcamp/Mirlo enrichment for unclaimed artists.
+  location?: {
+    city?: string;
+    country?: string;
+    countryCode?: string;
+  };
 }
 
 export interface SearchResponse {

--- a/supabase/migration-011-artist-location.sql
+++ b/supabase/migration-011-artist-location.sql
@@ -1,0 +1,11 @@
+-- Migration 011: Artist location columns
+-- Stores location data captured from MusicBrainz/Bandcamp/Mirlo enrichment.
+-- Free-text city + country (no geocoding). country_code is ISO alpha-2 from
+-- MusicBrainz when available, used as a country fallback for display.
+-- Written by persistEnrichment for unclaimed artists; claimed artists manage
+-- their own location via the claim/edit flow (Phase 3) and are skipped by
+-- the enrichment path (match_confidence='claimed' short-circuit in db.ts).
+
+alter table artists add column if not exists city text;
+alter table artists add column if not exists country text;
+alter table artists add column if not exists country_code text;


### PR DESCRIPTION
## Summary

Phase 2 of the location feature — persist what enrichment discovers, so location survives beyond the 30-min Redis cache.

- **Migration 011** adds three nullable columns to the `artists` table: `city`, `country`, `country_code` (all free text per our decision — no geocoding or country normalization).
- **`persistEnrichment`** accepts an optional `location` and upserts it alongside `last_enriched_at`. Claimed artists are already skipped (unchanged from before) so their self-reported location from the Phase 3 claim/edit flow won't get overwritten.
- **`search-musicbrainz`** persists location even on MB-miss (keyed on the normalized query's slug) so Bandcamp/Mirlo fallback location — the whole reason the MB-miss fallback exists — doesn't get dropped.
- **`getArtistBySlug`** projects the columns back into `ArtistResult.location`.
- **`AggregatedResult`** (the search wire format) gains `location`; the claimed-artist path in `search-sources` seeds location from the DB so claimed artists — which skip MB enrichment entirely — still surface location in search results.

Note: for unclaimed artists, the Phase 2 enrichment (MusicBrainz) still produces location on the first search response path via the existing `mergeWithMusicBrainzData` merge (shipped in #184). The DB backing is a durable cache that will light up on subsequent search responses via `persistEnrichment` → `last_enriched_at` → no further enrichment needed. Not seeding location on unclaimed results in the Phase 1 response path this PR — that would add a per-search DB lookup in the hot path and is redundant with MB enrichment that fires ~1-2s later.

## Deploy steps

- [ ] Run `supabase/migration-011-artist-location.sql` in the Supabase SQL editor before merging to main

## Test plan

- [x] Web unit tests 165/165
- [x] TypeScript clean on modified files
- [ ] Manual (post-deploy): search for a claimed artist with location in MB and confirm location appears in the search card immediately
- [ ] Manual (post-deploy): search "Honeycrush" twice; confirm the second search returns location on the first phase (no wait for MB enrichment)
- [ ] Manual: confirm `/api/artist?slug=<some-artist-with-location>` returns the `location` object in the JSON

## Follow-ups (PR C)

- Add location to claim flow (pre-filled from enrichment, editable by artist at claim + edit time)
- Render location on `/a/:slug` SSR edge function
- Precedence: claimed value > enrichment value

🤖 Generated with [Claude Code](https://claude.com/claude-code)