### PR TITLE
feat: artist-editable location + SSR display (Phase 3)

### DIFF
--- a/api/edge/claimed-artist-page.ts
+++ b/api/edge/claimed-artist-page.ts
@@ -104,6 +104,14 @@ export default async function handler(request: Request, context: Context) {
   const pageUrl = `https://unstream.stream/a/${slug}`;
   const description = bio || `Support ${artist.name} directly on platforms that pay artists fairly.`;
 
+  const locationRegion = artist.country || artist.country_code;
+  const locationText = artist.city && locationRegion
+    ? `${artist.city}, ${locationRegion}`
+    : artist.city || locationRegion || '';
+  const locationHtml = locationText
+    ? `<div style="margin-top:6px;color:var(--muted);font-size:14px">${escapeHtml(locationText)}</div>`
+    : '';
+
   // Separate main platforms from social; "other" and unknown platforms go to main
   const mainPlatforms = platforms.filter((p: { platform: string }) => {
     const info = PLATFORM_INFO[p.platform];
@@ -165,6 +173,7 @@ export default async function handler(request: Request, context: Context) {
     ...(imageUrl ? { image: imageUrl } : {}),
     ...(bio ? { description: profile.bio } : {}),
     ...(sameAsUrls.length > 0 ? { sameAs: sameAsUrls } : {}),
+    ...(locationText ? { foundingLocation: { '@type': 'Place', name: locationText } } : {}),
   };
 
   const html = `<!DOCTYPE html>
@@ -327,6 +336,7 @@ export default async function handler(request: Request, context: Context) {
         Verified
       </span>
     </div>
+    ${locationHtml}
   </div>
 
   <!-- Platform Links -->

--- a/api/functions/artist-profile.ts
+++ b/api/functions/artist-profile.ts
@@ -126,7 +126,16 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Authentication required' }) };
   }
 
-  let body: { slug: string; newSlug?: string; newName?: string; bio?: string; featuredEmbed?: string | null; customImageUrl?: string | null; links?: LinkUpdate[] };
+  let body: {
+    slug: string;
+    newSlug?: string;
+    newName?: string;
+    bio?: string;
+    featuredEmbed?: string | null;
+    customImageUrl?: string | null;
+    links?: LinkUpdate[];
+    location?: { city?: string; country?: string };
+  };
   try {
     body = JSON.parse(event.body || '{}');
   } catch {
@@ -221,6 +230,36 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update name' }) };
     }
     console.log(`[Profile] Name changed: "${artist.name}" → "${newName}" for slug "${finalSlug}"`);
+  }
+
+  // --- Update location (city, country) ---
+  // Stored on artists (not artist_profiles) so unclaimed artists can also carry
+  // enrichment-discovered locations. Artist's answer overrides MB enrichment,
+  // so we clear country_code whenever the artist sets country — the alpha-2
+  // fallback only makes sense when there's no full country name.
+  if (body.location !== undefined) {
+    const locationUpdate: { city?: string | null; country?: string | null; country_code?: null; updated_at: string } = {
+      updated_at: new Date().toISOString(),
+    };
+    if (body.location.city !== undefined) {
+      const city = body.location.city.trim().slice(0, 100);
+      locationUpdate.city = city || null;
+    }
+    if (body.location.country !== undefined) {
+      const country = body.location.country.trim().slice(0, 100);
+      locationUpdate.country = country || null;
+      locationUpdate.country_code = null;
+    }
+
+    const { error: locationError } = await client
+      .from('artists')
+      .update(locationUpdate)
+      .eq('id', artist.id);
+
+    if (locationError) {
+      console.error('[Profile] Location update failed:', locationError);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update location' }) };
+    }
   }
 
   // --- Update bio ---

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -91,6 +91,8 @@ interface FormState {
   customImageUrl: string | null;
   fetchingAvatar: string | null;
   links: LinkEntry[];
+  city: string;
+  country: string;
 }
 
 type FormAction =
@@ -122,6 +124,8 @@ const initialFormState: FormState = {
   customImageUrl: null,
   fetchingAvatar: null,
   links: [],
+  city: '',
+  country: '',
 };
 
 export function ArtistEditPage() {
@@ -172,6 +176,8 @@ export function ArtistEditPage() {
             bio: data.profile?.bio ?? '',
             featuredEmbed: data.profile?.featuredEmbed ?? '',
             links: existingLinks,
+            city: data.location?.city ?? '',
+            country: data.location?.country ?? data.location?.countryCode ?? '',
             loading: false,
           },
         });
@@ -299,6 +305,7 @@ export function ArtistEditPage() {
           bio: form.bio,
           featuredEmbed: form.featuredEmbed || null,
           customImageUrl: form.customImageUrl,
+          location: { city: form.city, country: form.country },
           links: validLinks.map(l => ({
             platform: l.platform,
             url: l.url,
@@ -493,6 +500,34 @@ export function ArtistEditPage() {
               placeholder="Tell fans about your music..."
               className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary resize-none"
             />
+          </section>
+
+          {/* Location */}
+          <section className="space-y-2">
+            <label className="block text-sm font-medium">Location</label>
+            <p className="text-xs text-text-muted">
+              Helps fans find you and disambiguates you from other artists with the same name.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <input
+                id="city"
+                type="text"
+                value={form.city}
+                onChange={e => set('city', e.target.value.slice(0, 100))}
+                placeholder="City"
+                aria-label="City"
+                className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+              />
+              <input
+                id="country"
+                type="text"
+                value={form.country}
+                onChange={e => set('country', e.target.value.slice(0, 100))}
+                placeholder="Country"
+                aria-label="Country"
+                className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+              />
+            </div>
           </section>
 
           {/* Featured Embed */}

--- a/apps/web/src/pages/ClaimPage.tsx
+++ b/apps/web/src/pages/ClaimPage.tsx
@@ -54,6 +54,8 @@ export function ClaimPage() {
   const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(null);
   const [customImageUrl, setCustomImageUrl] = useState<string | null>(null);
   const [fetchingAvatar, setFetchingAvatar] = useState<string | null>(null); // platform being fetched
+  const [city, setCity] = useState('');
+  const [country, setCountry] = useState('');
 
   // Manual review state
   const [manualReviewMessage, setManualReviewMessage] = useState('');
@@ -90,6 +92,10 @@ export function ClaimPage() {
           (p: { sourceId: string }) => p.sourceId === 'officialsite'
         );
         if (officialSite?.url) setWebsiteUrl(officialSite.url);
+        // Pre-fill location from enrichment so the artist can confirm/correct
+        if (data?.location?.city) setCity(data.location.city);
+        const enrichedCountry = data?.location?.country || data?.location?.countryCode;
+        if (enrichedCountry) setCountry(enrichedCountry);
       })
       .catch(() => {});
   }, [slug]);
@@ -279,6 +285,7 @@ export function ClaimPage() {
         body: JSON.stringify({
           slug,
           links: confirmedLinks,
+          location: { city, country },
           ...(customImageUrl ? { customImageUrl } : {}),
         }),
       });
@@ -654,6 +661,32 @@ export function ClaimPage() {
                       </div>
                     )}
                   </div>
+                </div>
+              </section>
+
+              {/* Location section */}
+              <section className="space-y-2">
+                <h2 className="text-sm font-medium">Location</h2>
+                <p className="text-xs text-text-muted">
+                  We pre-filled this from public data where we could. Correct it if it's wrong or leave blank to skip.
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <input
+                    type="text"
+                    value={city}
+                    onChange={e => setCity(e.target.value.slice(0, 100))}
+                    placeholder="City"
+                    aria-label="City"
+                    className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+                  />
+                  <input
+                    type="text"
+                    value={country}
+                    onChange={e => setCountry(e.target.value.slice(0, 100))}
+                    placeholder="Country"
+                    aria-label="Country"
+                    className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+                  />
                 </div>
               </section>
 


### PR DESCRIPTION
## Summary

Phase 3 closes out the location feature. Verified artists can now set and edit their own city + country, and the result renders on their public `/a/:slug` page.

- **Claim flow** — `ClaimPage` review step gains a Location section, pre-filled from MusicBrainz/Bandcamp/Mirlo enrichment so the artist confirms or corrects before submitting.
- **Edit page** — `ArtistEditPage` gains matching city + country inputs, pre-loaded from `/api/artist?slug=`.
- **API** — `PUT /api/artist-profile` accepts \`{ location: { city, country } }\`, trims + caps at 100 chars, and clears \`country_code\` when the artist sets country (their answer wins over the MB alpha-2 fallback).
- **SSR** — `/a/:slug` renders City, Country under the verified badge and adds \`foundingLocation\` to the JSON-LD \`MusicGroup\` payload for SEO.

Both city and country are free text per our earlier decision — no geocoding, no enum. We can normalize later if we ever build location filtering.

## Base

> **Targeted at [`location-phase2-db`](https://github.com/brandonlucasgreen/unstream/pull/186)** — Phase 3 depends on Phase 2's migration + schema. Rebase onto main once PR #186 merges.

## Test plan

- [x] Web unit tests 165/165
- [x] TypeScript clean
- [ ] Manual: claim a new artist — confirm pre-filled location, confirm save writes to the `artists` row
- [ ] Manual: edit an existing claimed artist — confirm load + save round-trip
- [ ] Manual: open `/a/<claimed-slug>` — confirm location renders under the verified badge
- [ ] Manual: view source on `/a/<claimed-slug>` — confirm JSON-LD has \`foundingLocation\`
- [ ] Manual: clear the country on edit — confirm DB stores NULL for both `country` and `country_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)