### PR TITLE
Fix Bandcamp not showing from MusicBrainz relations

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -448,6 +448,7 @@ interface MusicBrainzResult {
   artistName: string;
   officialUrl?: string;  // From "official homepage" relation
   discogsUrl?: string;   // From "discogs" relation
+  bandcampUrl?: string;  // From "bandcamp" relation
   hasPre2005Release: boolean;
 }
 
@@ -486,6 +487,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
 
     let officialUrl: string | undefined;
     let discogsUrl: string | undefined;
+    let bandcampUrl: string | undefined;
 
     if (artistResponse.ok) {
       const artistData = await artistResponse.json() as {
@@ -510,6 +512,25 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
         if (rel.type === 'discogs' && rel.url?.resource) {
           discogsUrl = rel.url.resource;
           break;
+        }
+      }
+
+      // Look for Bandcamp link from MB relations
+      // Bandcamp scraping is disabled (anti-bot), so MB is our primary source for direct links
+      for (const rel of relations) {
+        if (rel.type === 'bandcamp' && rel.url?.resource) {
+          bandcampUrl = rel.url.resource;
+          break;
+        }
+        // Also check other platform relations that might contain Bandcamp URLs
+        if (!bandcampUrl && rel.url?.resource) {
+          try {
+            const hostname = new URL(rel.url.resource).hostname;
+            if (hostname.endsWith('.bandcamp.com')) {
+              bandcampUrl = rel.url.resource;
+              break;
+            }
+          } catch {}
         }
       }
     }
@@ -547,6 +568,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
       artistName: artist.name,
       officialUrl,
       discogsUrl,
+      bandcampUrl,
       hasPre2005Release,
     };
   } catch (error: unknown) {
@@ -1278,7 +1300,7 @@ async function attachNameOnlyPlatforms(
 
 async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
-  const [bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults] = await Promise.allSettled([
+  const [bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
     searchBandwagon(query),
     searchMirlo(query),
     searchFaircamp(query),
@@ -1288,6 +1310,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
     searchAmpwall(query),
     searchBeatport(query),
     searchEven(query),
+    searchMusicBrainz(query),
   ]);
 
   const allResults: PlatformResult[] = [];
@@ -1304,10 +1327,12 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   const qobuzMatches = qobuzResults.status === 'fulfilled' ? qobuzResults.value : new Map<string, string>();
   const ampwallMatches = ampwallResults.status === 'fulfilled' ? ampwallResults.value : new Map<string, string>();
 
+  const mbData = musicbrainzResult.status === 'fulfilled' ? musicbrainzResult.value : null;
+
   const aggregated = aggregateResults(allResults, query);
 
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
-  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches);
+  attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, mbData);
   createQobuzOnlyResults(aggregated, qobuzMatches);
 
   // Phase 2.5: Apply manual merge overrides before release-based disambiguation.

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -416,6 +416,7 @@ export function attachQobuzAndSearchLinks(
   aggregated: AggregatedResult[],
   qobuzMatches: Map<string, string>,
   ampwallMatches: Map<string, string>,
+  mbData?: { artistName: string; bandcampUrl?: string } | null,
 ): void {
   const usedPlatformUrls = new Set<string>();
 
@@ -443,12 +444,22 @@ export function attachQobuzAndSearchLinks(
       { sourceId: 'buymeacoffee', url: 'https://buymeacoffee.com/explore-creators' },
     );
 
-    // Fallback Bandcamp search link when no direct Bandcamp URL from MusicBrainz
+    // Bandcamp: prefer direct URL from MusicBrainz relations, fall back to search link
     if (!result.platforms.some(p => p.sourceId === 'bandcamp')) {
-      result.platforms.push({
-        sourceId: 'bandcamp',
-        url: `https://bandcamp.com/search?q=${encodeURIComponent(result.name)}`,
-      });
+      // Check if MusicBrainz has a direct Bandcamp URL for this artist
+      const mbBandcampUrl = mbData?.bandcampUrl &&
+        normalizeForComparison(mbData.artistName) === normalizedName
+        ? mbData.bandcampUrl
+        : undefined;
+
+      if (mbBandcampUrl) {
+        result.platforms.push({ sourceId: 'bandcamp', url: mbBandcampUrl });
+      } else {
+        result.platforms.push({
+          sourceId: 'bandcamp',
+          url: `https://bandcamp.com/search?q=${encodeURIComponent(result.name)}`,
+        });
+      }
     }
 
     // Qobuz: attach ALL name variations (e.g. "morice", "morice1", "morice2")

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 11 May 2026 08:24:51 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 11 May 2026 09:05:10 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -689,12 +689,19 @@ export function mergeWithMusicBrainzData(
     // Add Bandcamp URL from MusicBrainz platform relations if available
     // Bandcamp scraping is disabled server-side (anti-bot protection), so MB
     // relations are our primary source for direct Bandcamp links.
+    // If the server already added a search-only Bandcamp fallback, replace it with the real URL.
     if (mbData.platformUrls && mbData.platformUrls.length > 0) {
       const bandcampUrl = mbData.platformUrls.find(u => {
         try { return new URL(u).hostname.endsWith('.bandcamp.com'); } catch { return false; }
       });
-      if (bandcampUrl && !newPlatforms.some(p => p.sourceId === 'bandcamp')) {
-        newPlatforms.push({ sourceId: 'bandcamp', url: bandcampUrl });
+      if (bandcampUrl) {
+        const existingBandcamp = newPlatforms.findIndex(p => p.sourceId === 'bandcamp');
+        if (existingBandcamp !== -1) {
+          // Replace search-only fallback with real Bandcamp URL
+          newPlatforms[existingBandcamp] = { sourceId: 'bandcamp', url: bandcampUrl };
+        } else {
+          newPlatforms.push({ sourceId: 'bandcamp', url: bandcampUrl });
+        }
       }
     }
     const searchOnlyPlatforms = new Set(['ampwall', 'kofi', 'buymeacoffee', 'bandcamp']);


### PR DESCRIPTION
Fixes UNS-28 (for real this time)

## Root Cause (Two-fold)

**Server-side:** `searchMusicBrainz()` extracted `officialUrl` and `discogsUrl` from MB relations but NOT `bandcampUrl`. The main search never included Bandcamp from MB, so `attachQobuzAndSearchLinks()` always added the search-only fallback (`bandcamp.com/search?q=...`).

**Client-side:** `mergeWithMusicBrainzData()` checked `!newPlatforms.some(p => p.sourceId === 'bandcamp')` before adding the real Bandcamp URL from MB enrichment. Since the search-only fallback was already present, it **skipped the real URL entirely**.

## Fix

1. **Server**: Added `bandcampUrl` extraction to `searchMusicBrainz()`, passed MB data to `attachQobuzAndSearchLinks()` which now prefers the direct MB Bandcamp URL over the search fallback
2. **Client**: Changed `mergeWithMusicBrainzData()` to **REPLACE** search-only Bandcamp fallbacks with real MB Bandcamp URLs instead of skipping them

## Testing

Verified MusicBrainz returns `bandcamp` relation type for Scandroid:
```
bandcamp: https://scandroid.bandcamp.com/
```

Verified enrichment API returns `platformUrls` with Bandcamp URL.
Build passes clean.