### PR TITLE
Move MusicBrainz enrichment server-side (UNS-29)

### DIFF
--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -1,163 +1,39 @@
-// Social platform types
-type SocialPlatform =
-  | 'instagram' | 'facebook' | 'tiktok' | 'youtube'
-  | 'threads' | 'bluesky'
-  | 'mastodon' | 'peertube' | 'patreon' | 'kofi' | 'buymeacoffee';
-
-interface SocialLink {
-  platform: SocialPlatform;
-  url: string;
-}
-
-// Discovered music platform types (found when scraping official websites)
-type DiscoveredPlatform = 'ampwall' | 'artcore' | 'nina';
-
-interface DiscoveredPlatformLink {
-  platform: DiscoveredPlatform;
-  url: string;
-}
-
-interface ArtistLocation {
-  city?: string;
-  country?: string;
-  countryCode?: string;
-}
-
-// MusicBrainz search response for lazy loading
-interface MusicBrainzSearchResponse {
-  query: string;
-  artistName: string | null;
-  officialUrl: string | null;
-  discogsUrl: string | null;
-  hasPre2005Release: boolean;
-  socialLinks: SocialLink[];
-  discoveredPlatforms: DiscoveredPlatformLink[];
-  platformUrls: string[]; // Known platform URLs from MusicBrainz relations (bandcamp, mirlo, etc.)
-  wikipediaSummary: string | null;
-  wikipediaUrl: string | null;
-  location?: ArtistLocation;
-}
-
-// Known Mastodon/Fediverse instances (non-exhaustive, but covers popular ones)
-const KNOWN_MASTODON_INSTANCES = [
-  'mastodon.social', 'mastodon.online', 'mastodon.art', 'mastodon.world',
-  'mstdn.social', 'mstdn.jp', 'fosstodon.org', 'hachyderm.io',
-  'plush.city', 'tech.lgbt', 'wandering.shop', 'musician.social',
-  'metalhead.club', 'social.coop', 'aus.social', 'infosec.exchange',
-  'sfba.social', 'universeodon.com', 'c.im', 'toot.cafe',
-];
-
-// Check if a URL belongs to a known Mastodon instance
-function isMastodonInstance(urlLower: string): boolean {
-  return KNOWN_MASTODON_INSTANCES.some(instance => urlLower.includes(instance));
-}
-
-// Known PeerTube instances (non-exhaustive, covers popular + music-focused ones)
-const KNOWN_PEERTUBE_INSTANCES = [
-  'tilvids.com', 'diode.zone', 'spectra.video', 'makertube.net',
-  'tube.shanti.cafe', 'dalek.zone', 'videos.trom.tf', 'peertube.wtf',
-  'peertube.stream', 'lostpod.space', 'fedi.video', 'videovortex.tv',
-  'tube.anjara.eu', 'peertube.be', 'p.eertu.be', 'peertube.dk',
-  'vod.newellijay.tv', 'video.mxtthxw.art', 'video.sorokin.music',
-  'peertube.ignifi.me', 'clip.place', 'peerate.fr', 'gnulinux.tube',
-  'tube.grin.hu', 'audio.freediverse.com',
-  'communitymedia.video', 'tv.gravitons.org', 'fair.tube',
-];
-
-// Check if a URL belongs to a known PeerTube instance
-function isPeerTubeInstance(urlLower: string): boolean {
-  return KNOWN_PEERTUBE_INSTANCES.some(instance => urlLower.includes(instance));
-}
-
-// Convert a Mastodon handle (@user@server) to a URL
-function convertMastodonHandleToUrl(handle: string): string | null {
-  // Handle formats: "@username@server.tld" or "username@server.tld"
-  const match = handle.match(/@?([^@]+)@(.+)/);
-  if (match) {
-    return `https://${match[2]}/@${match[1]}`;
-  }
-  return null;
-}
-
-// Parse a URL to determine which social platform it belongs to
-function parseSocialUrl(url: string): SocialLink | null {
-  const urlLower = url.toLowerCase();
-
-  if (urlLower.includes('instagram.com')) {
-    return { platform: 'instagram', url };
-  }
-  if (urlLower.includes('facebook.com')) {
-    return { platform: 'facebook', url };
-  }
-  if (urlLower.includes('tiktok.com')) {
-    return { platform: 'tiktok', url };
-  }
-  if (urlLower.includes('youtube.com') || urlLower.includes('youtu.be')) {
-    return { platform: 'youtube', url };
-  }
-  if (urlLower.includes('threads.net') || urlLower.includes('threads.com')) {
-    return { platform: 'threads', url };
-  }
-  if (urlLower.includes('bsky.app') || urlLower.includes('bluesky')) {
-    return { platform: 'bluesky', url };
-  }
-  // Patronage platforms
-  if (urlLower.includes('patreon.com')) {
-    return { platform: 'patreon', url };
-  }
-  if (urlLower.includes('ko-fi.com')) {
-    return { platform: 'kofi', url };
-  }
-  if (urlLower.includes('buymeacoffee.com')) {
-    return { platform: 'buymeacoffee', url };
-  }
-
-  // Mastodon - check known instances (fediverse:creator meta tag handled separately)
-  if (isMastodonInstance(urlLower)) {
-    return { platform: 'mastodon', url };
-  }
-
-  // PeerTube - check known instances
-  if (isPeerTubeInstance(urlLower)) {
-    return { platform: 'peertube', url };
-  }
-
-  return null;
-}
-
-// Fetch a short bio summary from the Wikipedia REST API
-async function fetchWikipediaSummary(wikipediaUrl: string): Promise<{ extract: string; pageUrl: string } | null> {
-  try {
-    const match = wikipediaUrl.match(/\/wiki\/(.+)$/);
-    if (!match) return null;
-    const title = match[1];
-    const response = await globalThis.fetch(
-      `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`,
-      {
-        headers: { 'User-Agent': 'Unstream/1.0 (https://unstream.stream)' },
-        signal: AbortSignal.timeout(5000),
-      }
-    );
-    if (!response.ok) return null;
-    const data = await response.json() as {
-      type?: string;
-      extract?: string;
-      content_urls?: { desktop?: { page?: string } };
-    };
-    if (data.type === 'disambiguation') return null;
-    return {
-      extract: data.extract || '',
-      pageUrl: data.content_urls?.desktop?.page || wikipediaUrl,
-    };
-  } catch {
-    return null;
-  }
-}
+// MusicBrainz enrichment server function
+// Imports shared functions from enrichment.ts, keeps Netlify handler here
 
 import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistEnrichment } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';
+
+// Import all shared enrichment functions and types
+import {
+  SocialPlatform,
+  SocialLink,
+  DiscoveredPlatform,
+  DiscoveredPlatformLink,
+  ArtistLocation,
+  KNOWN_MASTODON_INSTANCES,
+  KNOWN_PEERTUBE_INSTANCES,
+  isMastodonInstance,
+  isPeerTubeInstance,
+  convertMastodonHandleToUrl,
+  parseSocialUrl,
+  fetchWikipediaSummary,
+  fetchLinktreeLinks,
+  extractDiscogsArtistId,
+  fetchDiscogsSocialLinks,
+  OfficialSiteResult,
+  fetchOfficialSiteSocialLinks,
+  mergeSocialLinks,
+  searchPeerTubeChannels,
+  parseLocationString,
+  mergeLocations,
+  searchBandcampForArtistUrl,
+  fetchBandcampLocation,
+  fetchMirloLocation,
+  enrichLocationFallback,
+} from '../search/enrichment';
 
 // Cache TTL for MusicBrainz lookups (30 minutes)
 const MUSICBRAINZ_CACHE_TTL = 30 * 60;
@@ -173,442 +49,19 @@ function normalizeSearchQuery(query: string): string {
   return normalizeAccents(query);
 }
 
-// Helper to delay execution (for rate limiting)
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
-// Fetch and parse links from a Linktree page
-async function fetchLinktreeLinks(linktreeUrl: string): Promise<SocialLink[]> {
-  const socialLinks: SocialLink[] = [];
-  const seenPlatforms = new Set<SocialPlatform>();
-
-  try {
-    const response = await globalThis.fetch(linktreeUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!response.ok) {
-      console.log('Linktree fetch failed:', response.status);
-      return socialLinks;
-    }
-
-    const html = await response.text();
-
-    // Linktree uses data-testid="LinkButton" for link buttons
-    // The actual URLs are in anchor tags with href attributes
-    // Match pattern: <a ... href="https://..." ... data-testid="LinkButton" ...>
-    // or: <a ... data-testid="LinkButton" ... href="https://..." ...>
-    const linkMatches = html.matchAll(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>/gi);
-
-    for (const match of linkMatches) {
-      const url = match[1];
-      // Skip Linktree internal links and non-http URLs
-      if (!url.startsWith('http') || url.includes('linktr.ee')) continue;
-
-      const socialLink = parseSocialUrl(url);
-      if (socialLink && !seenPlatforms.has(socialLink.platform)) {
-        seenPlatforms.add(socialLink.platform);
-        socialLinks.push(socialLink);
-      }
-    }
-
-    console.log(`[Linktree] Found ${socialLinks.length} social links from ${linktreeUrl}`);
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    console.error('Linktree fetch error:', err.message);
-  }
-
-  return socialLinks;
-}
-
-// Extract Discogs artist ID from URL (e.g., https://www.discogs.com/artist/3840 -> 3840)
-function extractDiscogsArtistId(discogsUrl: string): string | null {
-  const match = discogsUrl.match(/\/artist\/(\d+)/);
-  return match ? match[1] : null;
-}
-
-// Fetch social links from Discogs API
-async function fetchDiscogsSocialLinks(discogsUrl: string): Promise<SocialLink[]> {
-  const socialLinks: SocialLink[] = [];
-  const artistId = extractDiscogsArtistId(discogsUrl);
-
-  if (!artistId) return socialLinks;
-
-  try {
-    const response = await globalThis.fetch(`https://api.discogs.com/artists/${artistId}`, {
-      headers: {
-        'User-Agent': 'Unstream/1.0 (https://unstream.stream - ethical music finder)',
-      },
-    });
-
-    if (!response.ok) {
-      console.log('Discogs API failed:', response.status);
-      return socialLinks;
-    }
-
-    const data = await response.json() as { urls?: string[] };
-    const urls = data.urls || [];
-
-    for (const url of urls) {
-      const socialLink = parseSocialUrl(url);
-      if (socialLink) {
-        socialLinks.push(socialLink);
-      }
-    }
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    console.error('Discogs fetch error:', err.message);
-  }
-
-  return socialLinks;
-}
-
-// Result type for official site scraping (includes discovered Linktree URL and music platforms)
-interface OfficialSiteResult {
+// MusicBrainz search response for the API
+interface MusicBrainzSearchResponse {
+  query: string;
+  artistName: string | null;
+  officialUrl: string | null;
+  discogsUrl: string | null;
+  hasPre2005Release: boolean;
   socialLinks: SocialLink[];
-  linktreeUrl: string | null;
   discoveredPlatforms: DiscoveredPlatformLink[];
-}
-
-// Fetch social links from an artist's official website
-async function fetchOfficialSiteSocialLinks(officialUrl: string): Promise<OfficialSiteResult> {
-  const socialLinks: SocialLink[] = [];
-  const seenPlatforms = new Set<SocialPlatform>();
-  const discoveredPlatforms: DiscoveredPlatformLink[] = [];
-  const seenDiscoveredPlatforms = new Set<DiscoveredPlatform>();
-  let linktreeUrl: string | null = null;
-
-  try {
-    const response = await globalThis.fetch(officialUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!response.ok) {
-      console.log('Official site fetch failed:', response.status);
-      return { socialLinks, linktreeUrl, discoveredPlatforms };
-    }
-
-    const html = await response.text();
-
-    // 1. Parse fediverse:creator meta tag for Mastodon (most reliable method)
-    // Matches: <meta property="fediverse:creator" content="@user@server.tld">
-    const fediverseMatch = html.match(/<meta\s+[^>]*property=["']fediverse:creator["'][^>]*content=["']([^"']+)["']/i)
-      || html.match(/<meta\s+[^>]*content=["']([^"']+)["'][^>]*property=["']fediverse:creator["']/i);
-    if (fediverseMatch) {
-      const handle = fediverseMatch[1];
-      const mastodonUrl = convertMastodonHandleToUrl(handle);
-      if (mastodonUrl && !seenPlatforms.has('mastodon')) {
-        seenPlatforms.add('mastodon');
-        socialLinks.push({ platform: 'mastodon', url: mastodonUrl });
-      }
-    }
-
-    // 2. Parse rel="me" links (used for Mastodon verification)
-    // Matches: <link rel="me" href="https://mastodon.social/@user">
-    // Also matches <a rel="me" href="..."> which is common on personal sites
-    const relMeMatches = html.matchAll(/<(?:link|a)\s+[^>]*rel=["']me["'][^>]*href=["']([^"']+)["']/gi);
-    for (const match of relMeMatches) {
-      const url = match[1];
-      if (url.startsWith('http') && isMastodonInstance(url.toLowerCase()) && !seenPlatforms.has('mastodon')) {
-        seenPlatforms.add('mastodon');
-        socialLinks.push({ platform: 'mastodon', url });
-        break; // Only need one Mastodon link
-      }
-    }
-
-    // 3. Extract all href attributes from the page (existing logic, now with expanded platforms)
-    const hrefMatches = html.matchAll(/href=["']([^"']+)["']/gi);
-
-    for (const match of hrefMatches) {
-      const url = match[1];
-      // Skip relative URLs and non-http URLs
-      if (!url.startsWith('http')) continue;
-
-      // Check for Linktree URL (only capture first one found)
-      if (url.includes('linktr.ee') && !linktreeUrl) {
-        linktreeUrl = url;
-        console.log(`[Official Site] Found Linktree: ${linktreeUrl}`);
-        continue;
-      }
-
-      // Check for Ampwall artist page
-      if (url.includes('ampwall.com') && !seenDiscoveredPlatforms.has('ampwall')) {
-        seenDiscoveredPlatforms.add('ampwall');
-        discoveredPlatforms.push({ platform: 'ampwall', url });
-        console.log(`[Official Site] Found Ampwall: ${url}`);
-        continue;
-      }
-
-      // Check for Artcore artist page
-      if (url.includes('artcore.com') && !seenDiscoveredPlatforms.has('artcore')) {
-        seenDiscoveredPlatforms.add('artcore');
-        discoveredPlatforms.push({ platform: 'artcore', url });
-        console.log(`[Official Site] Found Artcore: ${url}`);
-        continue;
-      }
-
-      // Check for Nina Protocol profile page
-      if (url.includes('ninaprotocol.com') && !seenDiscoveredPlatforms.has('nina')) {
-        seenDiscoveredPlatforms.add('nina');
-        discoveredPlatforms.push({ platform: 'nina', url });
-        console.log(`[Official Site] Found Nina: ${url}`);
-        continue;
-      }
-
-      const socialLink = parseSocialUrl(url);
-      // Only add one link per platform (first one wins)
-      if (socialLink && !seenPlatforms.has(socialLink.platform)) {
-        seenPlatforms.add(socialLink.platform);
-        socialLinks.push(socialLink);
-      }
-    }
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    console.error('Official site fetch error:', err.message);
-  }
-
-  return { socialLinks, linktreeUrl, discoveredPlatforms };
-}
-
-// Merge social links from multiple sources, deduplicating by platform
-function mergeSocialLinks(...linkArrays: SocialLink[][]): SocialLink[] {
-  const seenPlatforms = new Set<SocialPlatform>();
-  const merged: SocialLink[] = [];
-
-  for (const links of linkArrays) {
-    for (const link of links) {
-      if (!seenPlatforms.has(link.platform)) {
-        seenPlatforms.add(link.platform);
-        merged.push(link);
-      }
-    }
-  }
-
-  return merged;
-}
-
-// Search PeerTube via Sepia Search API for artist video channels
-async function searchPeerTubeChannels(artistName: string): Promise<SocialLink | null> {
-  try {
-    const searchUrl = `https://sepiasearch.org/api/v1/search/video-channels?search=${encodeURIComponent(artistName)}&count=5`;
-
-    const response = await globalThis.fetch(searchUrl, {
-      headers: {
-        'User-Agent': 'Unstream/1.0 (https://unstream.stream - ethical music finder)',
-      },
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!response.ok) {
-      console.log('Sepia Search failed:', response.status);
-      return null;
-    }
-
-    const data = await response.json() as {
-      total: number;
-      data: {
-        name: string;
-        displayName: string;
-        host: string;
-        url: string;
-        videosCount: number;
-        ownerAccount?: { name: string; displayName: string };
-      }[];
-    };
-
-    if (!data.data || data.data.length === 0) return null;
-
-    // Normalize artist name for matching
-    const normalizedQuery = artistName.toLowerCase().replace(/[^a-z0-9]/g, '');
-
-    // Find a channel whose displayName or ownerAccount name closely matches the artist
-    for (const channel of data.data) {
-      // Skip channels with no videos
-      if (channel.videosCount === 0) continue;
-
-      const normalizedDisplay = channel.displayName.toLowerCase().replace(/[^a-z0-9]/g, '');
-      const normalizedChannelName = channel.name.toLowerCase().replace(/[^a-z0-9]/g, '');
-      const normalizedOwner = channel.ownerAccount?.displayName?.toLowerCase().replace(/[^a-z0-9]/g, '') || '';
-      const normalizedOwnerName = channel.ownerAccount?.name?.toLowerCase().replace(/[^a-z0-9]/g, '') || '';
-
-      const isMatch =
-        normalizedDisplay === normalizedQuery ||
-        normalizedChannelName === normalizedQuery ||
-        normalizedOwner === normalizedQuery ||
-        normalizedOwnerName === normalizedQuery ||
-        // Allow partial matches where one contains the other (for names like "Lime Bar Videos" matching "Lime Bar")
-        (normalizedDisplay.includes(normalizedQuery) && normalizedQuery.length > normalizedDisplay.length * 0.5) ||
-        (normalizedQuery.includes(normalizedDisplay) && normalizedDisplay.length > normalizedQuery.length * 0.5);
-
-      if (isMatch) {
-        console.log(`[Sepia Search] Found PeerTube channel for "${artistName}": ${channel.displayName} on ${channel.host} (${channel.videosCount} videos)`);
-        return { platform: 'peertube', url: channel.url };
-      }
-    }
-
-    console.log(`[Sepia Search] No matching PeerTube channel for "${artistName}" (${data.total} total results)`);
-    return null;
-  } catch (error: unknown) {
-    const err = error as { message?: string };
-    console.error('Sepia Search error:', err.message);
-    return null;
-  }
-}
-
-// Parse a raw location string that may be "City, Country" or just "Country".
-// Returns an ArtistLocation with city and/or country split out.
-function parseLocationString(raw: string): ArtistLocation {
-  const parts = raw.split(',').map(s => s.trim()).filter(Boolean);
-  if (parts.length >= 2) {
-    return { city: parts.slice(0, -1).join(', '), country: parts[parts.length - 1] };
-  }
-  return { country: parts[0] };
-}
-
-// Merge location objects: fields from `primary` take precedence; missing fields filled from `fallback`.
-function mergeLocations(...sources: (ArtistLocation | null | undefined)[]): ArtistLocation | undefined {
-  const result: ArtistLocation = {};
-  for (const src of sources) {
-    if (!src) continue;
-    if (!result.city && src.city) result.city = src.city;
-    if (!result.country && src.country) result.country = src.country;
-    if (!result.countryCode && src.countryCode) result.countryCode = src.countryCode;
-  }
-  return (result.city || result.country) ? result : undefined;
-}
-
-// Search Bandcamp for an artist by name and return the first matching artist/label URL.
-// Mirrors the Phase 1 Bandcamp scrape but runs server-side within Phase 2 enrichment,
-// so no client-supplied URLs are involved.
-async function searchBandcampForArtistUrl(artistName: string, timeoutMs = 4000): Promise<string | null> {
-  try {
-    const searchUrl = `https://bandcamp.com/search?q=${encodeURIComponent(artistName)}&item_type=b`;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const response = await globalThis.fetch(searchUrl, {
-      signal: controller.signal,
-      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
-    });
-    clearTimeout(timeout);
-    if (!response.ok) return null;
-    const html = await response.text();
-
-    // Parse the first artist/label result whose name closely matches the query
-    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
-    const normalizedQuery = normalize(artistName);
-
-    // Match searchresult blocks: extract itemtype, URL, and display name
-    const blockPattern = /<li[^>]+class="[^"]*searchresult[^"]*"[^>]*>([\s\S]*?)<\/li>/g;
-    let block: RegExpExecArray | null;
-    while ((block = blockPattern.exec(html)) !== null) {
-      const blockHtml = block[1];
-      const typeMatch = blockHtml.match(/class="[^"]*itemtype[^"]*"[^>]*>\s*([^<]+)\s*</);
-      const linkMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]+href="([^"?]+)/);
-      const nameMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]*>([^<]+)</);
-      if (!typeMatch || !linkMatch || !nameMatch) continue;
-
-      const itemType = typeMatch[1].trim().toLowerCase();
-      if (itemType !== 'artist' && itemType !== 'label') continue;
-
-      const name = nameMatch[1].trim();
-      const url = linkMatch[1];
-      const normalizedName = normalize(name);
-
-      // Accept if names are equal or one contains the other (handles minor punctuation differences)
-      if (normalizedName === normalizedQuery ||
-          normalizedName.includes(normalizedQuery) ||
-          normalizedQuery.includes(normalizedName)) {
-        return url;
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-// Fetch location from a Bandcamp artist profile page.
-// Validated against the SSRF allowlist as defense-in-depth.
-async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
-  if (!isUrlHostnameAllowed(bandcampUrl)) return null;
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const response = await globalThis.fetch(bandcampUrl, {
-      signal: controller.signal,
-      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
-    });
-    clearTimeout(timeout);
-    if (!response.ok) return null;
-    const html = await response.text();
-
-    // Iterate all JSON-LD blocks; find the MusicGroup entry which carries the artist location
-    const jsonLdPattern = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
-    let jsonLdMatch: RegExpExecArray | null;
-    while ((jsonLdMatch = jsonLdPattern.exec(html)) !== null) {
-      try {
-        const parsed = JSON.parse(jsonLdMatch[1]);
-        const entries = Array.isArray(parsed) ? parsed : [parsed];
-        for (const entry of entries) {
-          if (entry?.['@type'] === 'MusicGroup') {
-            const raw = entry?.foundingLocation?.name || entry?.location?.name;
-            if (raw) return parseLocationString(raw);
-          }
-        }
-      } catch { /* skip malformed blocks */ }
-    }
-
-    // Fall back to location element in artist header (Bandcamp uses <p class="location ...">)
-    const locationMatch = html.match(/<(?:p|div|span)[^>]+class="[^"]*\blocation\b[^"]*"[^>]*>([^<]+)<\/(?:p|div|span)>/);
-    if (locationMatch) return parseLocationString(locationMatch[1].trim());
-
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-// Spike: fetch artist location from Mirlo REST API.
-// Constructs URL internally from artist slug — no user input involved.
-async function fetchMirloLocation(artistSlug: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
-  if (!artistSlug) return null;
-  try {
-    const apiUrl = `https://api.mirlo.space/v1/artists?urlSlug=${encodeURIComponent(artistSlug)}`;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const response = await globalThis.fetch(apiUrl, {
-      signal: controller.signal,
-      headers: { 'User-Agent': 'Unstream/1.0 (https://unstream.stream)' },
-    });
-    clearTimeout(timeout);
-    if (!response.ok) return null;
-    const data = await response.json() as { results?: { location?: string }[] };
-    const raw = data.results?.[0]?.location;
-    if (raw) return parseLocationString(raw);
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-// Fallback enrichment when MusicBrainz has no match: look up location via Bandcamp and Mirlo.
-// Uses shorter timeouts (3s each) so the total adds at most ~6s to the Phase 2 response time.
-async function enrichLocationFallback(query: string): Promise<ArtistLocation | undefined> {
-  const mirloSlug = query.toLowerCase().replace(/\s+/g, '');
-  const FALLBACK_TIMEOUT = 3000;
-
-  const bandcampUrl = await searchBandcampForArtistUrl(query, FALLBACK_TIMEOUT);
-  const [bandcampLocation, mirloLocation] = await Promise.all([
-    bandcampUrl ? fetchBandcampLocation(bandcampUrl, FALLBACK_TIMEOUT) : Promise.resolve(null),
-    fetchMirloLocation(mirloSlug, FALLBACK_TIMEOUT),
-  ]);
-
-  return mergeLocations(bandcampLocation, mirloLocation);
+  platformUrls: string[];
+  wikipediaSummary: string | null;
+  wikipediaUrl: string | null;
+  location?: ArtistLocation;
 }
 
 // Search MusicBrainz for artist info including official website, Discogs, social links, and release history
@@ -671,6 +124,8 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     }
 
     // Wait 1.1 seconds to respect MusicBrainz rate limit (1 req/sec)
+    // Using shared delay from enrichment module
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
     await delay(1100);
 
     // Fetch artist details with URL relations

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -1,10 +1,11 @@
 // MusicBrainz enrichment server function
 // Imports shared functions from enrichment.ts, keeps Netlify handler here
 
-import { cacheGetOrFetch, artistCacheKey } from './cache';
+import { cacheGetOrFetch } from './cache';
 import { persistEnrichment } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';
+import { normalizeAccents, normalizeSearchQuery } from './search-utils';
 
 // Import all shared enrichment functions and types
 import {
@@ -13,8 +14,6 @@ import {
   DiscoveredPlatform,
   DiscoveredPlatformLink,
   ArtistLocation,
-  KNOWN_MASTODON_INSTANCES,
-  KNOWN_PEERTUBE_INSTANCES,
   isMastodonInstance,
   isPeerTubeInstance,
   convertMastodonHandleToUrl,
@@ -37,17 +36,6 @@ import {
 
 // Cache TTL for MusicBrainz lookups (30 minutes)
 const MUSICBRAINZ_CACHE_TTL = 30 * 60;
-
-// Normalize accented characters to their ASCII equivalents
-// e.g., "Tanerélle" -> "Tanerelle", "Björk" -> "Bjork"
-function normalizeAccents(str: string): string {
-  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-}
-
-// Normalize a search query for API calls
-function normalizeSearchQuery(query: string): string {
-  return normalizeAccents(query);
-}
 
 // MusicBrainz search response for the API
 interface MusicBrainzSearchResponse {
@@ -124,9 +112,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     }
 
     // Wait 1.1 seconds to respect MusicBrainz rate limit (1 req/sec)
-    // Using shared delay from enrichment module
-    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-    await delay(1100);
+    await new Promise(resolve => setTimeout(resolve, 1100));
 
     // Fetch artist details with URL relations
     const artistUrl = `https://musicbrainz.org/ws/2/artist/${artist.id}?inc=url-rels&fmt=json`;
@@ -257,7 +243,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     }
 
     // Wait again before next request
-    await delay(1100);
+    await new Promise(resolve => setTimeout(resolve, 1100));
 
     // Check if artist has pre-2005 releases (for Hoopla/Freegal eligibility)
     const releasesUrl = `https://musicbrainz.org/ws/2/release-group/?artist=${artist.id}&fmt=json&limit=20`;

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -29,6 +29,26 @@ import {
   displayNameFromSlug,
 } from './search-utils';
 
+// Import shared enrichment functions
+import {
+  SocialLink,
+  DiscoveredPlatformLink,
+  ArtistLocation,
+  SocialPlatform,
+  parseSocialUrl,
+  fetchDiscogsSocialLinks,
+  fetchOfficialSiteSocialLinks,
+  mergeSocialLinks,
+  searchPeerTubeChannels,
+  fetchLinktreeLinks,
+  parseLocationString,
+  mergeLocations,
+  searchBandcampForArtistUrl,
+  fetchBandcampLocation,
+  fetchMirloLocation,
+  enrichLocationFallback,
+} from '../search/enrichment';
+
 // Helper to fetch with timeout
 async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs: number = 3000): Promise<Response> {
   const controller = new AbortController();
@@ -443,18 +463,39 @@ async function searchBandwagon(query: string): Promise<Map<string, string>> {
 // Helper to delay execution (for rate limiting)
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-// MusicBrainz result interface for official website and Discogs lookup
-interface MusicBrainzResult {
-  artistName: string;
-  officialUrl?: string;  // From "official homepage" relation
-  discogsUrl?: string;   // From "discogs" relation
-  bandcampUrl?: string;  // From "bandcamp" relation
+// MusicBrainz enriched result interface with full enrichment data
+interface EnrichedMusicBrainzResult {
+  artistName: string | null;
+  officialUrl: string | null;
+  discogsUrl: string | null;
+  bandcampUrl: string | null;
   hasPre2005Release: boolean;
+  socialLinks: SocialLink[];
+  discoveredPlatforms: DiscoveredPlatformLink[];
+  platformUrls: string[];
+  wikipediaSummary: string | null;
+  wikipediaUrl: string | null;
+  location: ArtistLocation | undefined;
 }
 
-// Search MusicBrainz for artist info including official website, Discogs, and release history
-async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | null> {
+// Search MusicBrainz with full enrichment - fetches social links, location, Wikipedia, etc.
+async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResult> {
+  const emptyResult: EnrichedMusicBrainzResult = {
+    artistName: null,
+    officialUrl: null,
+    discogsUrl: null,
+    bandcampUrl: null,
+    hasPre2005Release: false,
+    socialLinks: [],
+    discoveredPlatforms: [],
+    platformUrls: [],
+    wikipediaSummary: null,
+    wikipediaUrl: null,
+    location: undefined,
+  };
+
   try {
+    // Search for artist
     const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=1`;
 
     const response = await globalThis.fetch(searchUrl, {
@@ -463,39 +504,94 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
       },
     });
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+      console.log('MusicBrainz artist search failed:', response.status);
+      return emptyResult;
+    }
 
     const data = await response.json() as { artists?: { id: string; name: string; score: number }[] };
     const artists = data.artists || [];
 
-    if (artists.length === 0) return null;
+    if (artists.length === 0) {
+      console.log(`[MusicBrainz] No results for "${query}", falling back to Bandcamp/Mirlo location`);
+      return { ...emptyResult, location: await enrichLocationFallback(query) };
+    }
 
     const artist = artists[0];
-    if (artist.score < 95) return null;
+    // Only consider exact/near-exact matches
+    if (artist.score < 95) {
+      console.log(`[MusicBrainz] Low confidence match for "${query}" (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
+      return { ...emptyResult, location: await enrichLocationFallback(query) };
+    }
 
+    // Verify the returned artist name actually matches the query
+    const queryNormalized = query.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const artistNormalized = artist.name.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const isNameMatch = queryNormalized === artistNormalized ||
+      queryNormalized.includes(artistNormalized) && artistNormalized.length > queryNormalized.length * 0.7 ||
+      artistNormalized.includes(queryNormalized) && queryNormalized.length > artistNormalized.length * 0.7;
+
+    if (!isNameMatch) {
+      console.log(`[MusicBrainz] Skipping "${artist.name}" - doesn't match query "${query}", falling back to Bandcamp/Mirlo location`);
+      return { ...emptyResult, location: await enrichLocationFallback(query) };
+    }
+
+    // Wait 1.1 seconds to respect MusicBrainz rate limit
     await delay(1100);
 
-    // Fetch artist details with URL relations (3s timeout to avoid blocking)
+    // Fetch artist details with URL relations
     const artistUrl = `https://musicbrainz.org/ws/2/artist/${artist.id}?inc=url-rels&fmt=json`;
 
     const artistResponse = await globalThis.fetch(artistUrl, {
       headers: {
         'User-Agent': 'Unstream/1.0 (https://github.com/unstream - ethical music finder)',
       },
-      signal: AbortSignal.timeout(3000),
     });
 
-    let officialUrl: string | undefined;
-    let discogsUrl: string | undefined;
-    let bandcampUrl: string | undefined;
+    let officialUrl: string | null = null;
+    let discogsUrl: string | null = null;
+    let bandcampUrl: string | null = null;
+    let linktreeUrl: string | null = null;
+    let wikipediaUrl: string | null = null;
+    const socialLinks: SocialLink[] = [];
+    const seenPlatforms = new Set<SocialPlatform>();
+    const platformUrls: string[] = [];
+
+    let mbLocation: ArtistLocation | undefined;
 
     if (artistResponse.ok) {
       const artistData = await artistResponse.json() as {
-        relations?: {
-          type: string;
-          url?: { resource: string };
-        }[];
+        relations?: { type: string; url?: { resource: string } }[];
+        country?: string;
+        area?: { name: string; type?: string | null; 'iso-3166-1-codes'?: string[] };
+        'begin-area'?: { name: string; type?: string | null };
       };
+
+      // Parse location from area / begin-area fields
+      const topLevelCountryCode = artistData.country;
+      if (artistData.area) {
+        if (artistData.area.type === 'Country') {
+          mbLocation = {
+            country: artistData.area.name,
+            countryCode: artistData.area['iso-3166-1-codes']?.[0] ?? topLevelCountryCode,
+          };
+        } else {
+          mbLocation = {
+            city: artistData.area.name,
+            countryCode: topLevelCountryCode,
+          };
+        }
+      } else if (topLevelCountryCode) {
+        mbLocation = { countryCode: topLevelCountryCode };
+      }
+      if (artistData['begin-area'] && artistData['begin-area'].name !== artistData.area?.name) {
+        const beginType = artistData['begin-area'].type;
+        if (beginType === 'Country' && !mbLocation?.country) {
+          mbLocation = { ...mbLocation, country: artistData['begin-area'].name };
+        } else if (beginType !== 'Country') {
+          mbLocation = { ...mbLocation, city: artistData['begin-area'].name };
+        }
+      }
 
       const relations = artistData.relations || [];
 
@@ -515,14 +611,12 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
         }
       }
 
-      // Look for Bandcamp link from MB relations
-      // Bandcamp scraping is disabled (anti-bot), so MB is our primary source for direct links
+      // Look for Bandcamp link
       for (const rel of relations) {
         if (rel.type === 'bandcamp' && rel.url?.resource) {
           bandcampUrl = rel.url.resource;
           break;
         }
-        // Also check other platform relations that might contain Bandcamp URLs
         if (!bandcampUrl && rel.url?.resource) {
           try {
             const hostname = new URL(rel.url.resource).hostname;
@@ -533,11 +627,50 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
           } catch {}
         }
       }
+
+      // Look for English Wikipedia link
+      for (const rel of relations) {
+        if (rel.type === 'wikipedia' && rel.url?.resource && rel.url.resource.includes('en.wikipedia.org')) {
+          wikipediaUrl = rel.url.resource;
+          break;
+        }
+      }
+
+      // Extract social links from 'social network' and 'youtube' relation types
+      for (const rel of relations) {
+        if ((rel.type === 'social network' || rel.type === 'youtube') && rel.url?.resource) {
+          const url = rel.url.resource;
+          if (url.includes('linktr.ee') && !linktreeUrl) {
+            linktreeUrl = url;
+            console.log(`[MusicBrainz] Found Linktree: ${linktreeUrl}`);
+            continue;
+          }
+          const socialLink = parseSocialUrl(url);
+          if (socialLink && !seenPlatforms.has(socialLink.platform)) {
+            seenPlatforms.add(socialLink.platform);
+            socialLinks.push(socialLink);
+          }
+        }
+      }
+
+      // Extract platform URLs for disambiguation
+      const platformRelTypes = new Set([
+        'bandcamp', 'streaming music', 'purchase for download',
+        'download for free', 'free streaming',
+      ]);
+      for (const rel of relations) {
+        if (rel.url?.resource && platformRelTypes.has(rel.type)) {
+          platformUrls.push(rel.url.resource);
+        }
+      }
+      if (platformUrls.length > 0) {
+        console.log(`[MusicBrainz] Found ${platformUrls.length} platform URLs`);
+      }
     }
 
     await delay(1100);
 
-    // Check if artist has pre-2005 releases (for Hoopla/Freegal eligibility)
+    // Check if artist has pre-2005 releases
     const releasesUrl = `https://musicbrainz.org/ws/2/release-group/?artist=${artist.id}&fmt=json&limit=20`;
 
     const releasesResponse = await globalThis.fetch(releasesUrl, {
@@ -564,17 +697,56 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzResult | nul
       }
     }
 
+    // Fetch enrichment data in parallel
+    const mirloSlug = artist.name.toLowerCase().replace(/\s+/g, '');
+    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult, bandcampLocation, mirloLocation] = await Promise.all([
+      discogsUrl ? fetchDiscogsSocialLinks(discogsUrl) : Promise.resolve([]),
+      officialUrl ? fetchOfficialSiteSocialLinks(officialUrl) : Promise.resolve({ socialLinks: [], linktreeUrl: null, discoveredPlatforms: [] }),
+      searchPeerTubeChannels(artist.name),
+      wikipediaUrl ? fetchWikipediaSummary(wikipediaUrl) : Promise.resolve(null),
+      bandcampUrl ? fetchBandcampLocation(bandcampUrl) : Promise.resolve(null),
+      fetchMirloLocation(mirloSlug),
+    ]);
+
+    // Merge locations
+    const location = mergeLocations(mbLocation, bandcampLocation, mirloLocation);
+
+    // Scrape Linktree if found
+    let linktreeSocialLinks: SocialLink[] = [];
+    if (linktreeUrl || officialSiteResult.linktreeUrl) {
+      const finalLinktreeUrl = linktreeUrl || officialSiteResult.linktreeUrl;
+      linktreeSocialLinks = await fetchLinktreeLinks(finalLinktreeUrl);
+    }
+
+    // Collect PeerTube link
+    const peertubeLinks: SocialLink[] = peertubeLink ? [peertubeLink] : [];
+
+    // Merge all social links
+    const allSocialLinks = mergeSocialLinks(
+      socialLinks,
+      discogsSocialLinks,
+      officialSiteResult.socialLinks,
+      linktreeSocialLinks,
+      peertubeLinks
+    );
+
     return {
       artistName: artist.name,
       officialUrl,
       discogsUrl,
       bandcampUrl,
       hasPre2005Release,
+      socialLinks: allSocialLinks,
+      discoveredPlatforms: officialSiteResult.discoveredPlatforms,
+      platformUrls,
+      wikipediaSummary: wikipediaResult?.extract || null,
+      wikipediaUrl: wikipediaResult?.pageUrl || wikipediaUrl,
+      location,
     };
   } catch (error: unknown) {
     const err = error as { name?: string; message?: string };
     console.error('MusicBrainz search error:', err.name, err.message);
-    return null;
+    return emptyResult;
   }
 }
 
@@ -1295,6 +1467,200 @@ async function attachNameOnlyPlatforms(
 }
 
 // ---------------------------------------------------------------------------
+// Apply enrichment data to aggregated results (adds officialsite, discogs, social links, etc.)
+function applyEnrichmentToResults(
+  aggregated: AggregatedResult[],
+  mbData: EnrichedMusicBrainzResult
+): void {
+  if (!mbData.artistName) {
+    // MB-miss path: no confirmed identity, but may still have location from Bandcamp/Mirlo fallback
+    if (!mbData.location) return;
+    const queryNorm = normalizeForComparison(mbData.query);
+    const exactIdx = aggregated.findIndex(r => r.type === 'artist' && normalizeForComparison(r.name) === queryNorm);
+    const bestIdx = exactIdx !== -1 ? exactIdx : aggregated.findIndex(r => r.type === 'artist');
+    if (bestIdx === -1) return;
+    aggregated[bestIdx].location = mbData.location;
+    return;
+  }
+
+  const mbNormalized = normalizeForComparison(mbData.artistName);
+
+  // Find which results match the MusicBrainz artist name
+  const matchingIndices: number[] = [];
+  for (let i = 0; i < aggregated.length; i++) {
+    const result = aggregated[i];
+    if (result.type !== 'artist') continue;
+    const resultNormalized = normalizeForComparison(result.name);
+    const isMatch =
+      resultNormalized === mbNormalized ||
+      (resultNormalized.includes(mbNormalized) && mbNormalized.length > resultNormalized.length * 0.7) ||
+      (mbNormalized.includes(resultNormalized) && resultNormalized.length > mbNormalized.length * 0.7);
+    if (isMatch) matchingIndices.push(i);
+  }
+
+  // Disambiguate using MB platform URLs
+  let bestMatchIndex = -1;
+  if (matchingIndices.length === 1) {
+    bestMatchIndex = matchingIndices[0];
+  } else if (matchingIndices.length > 1) {
+    const mbPlatformUrls = mbData.platformUrls || [];
+
+    if (mbPlatformUrls.length > 0) {
+      const normalizedMbUrls = new Set(mbPlatformUrls.map(u => u.replace(/\/+$/, '').toLowerCase()));
+
+      for (const idx of matchingIndices) {
+        const r = aggregated[idx];
+        const hasDirectMatch = r.platforms.some(p => {
+          const normalized = p.url.replace(/\/+$/, '').toLowerCase();
+          return normalizedMbUrls.has(normalized);
+        });
+        if (hasDirectMatch) {
+          bestMatchIndex = idx;
+          break;
+        }
+      }
+    }
+
+    if (bestMatchIndex === -1) {
+      let bestScore = -1;
+      for (const idx of matchingIndices) {
+        const r = aggregated[idx];
+        const confidenceScore = r.matchConfidence === 'claimed' ? 100 : r.matchConfidence === 'verified' ? 50 : 0;
+        const platformScore = r.platforms.filter(p => !['kofi', 'buymeacoffee', 'ampwall'].includes(p.sourceId)).length;
+        const score = confidenceScore + platformScore;
+        if (score > bestScore) {
+          bestScore = score;
+          bestMatchIndex = idx;
+        }
+      }
+    }
+  }
+
+  if (bestMatchIndex === -1) return;
+
+  const result = aggregated[bestMatchIndex];
+  const newPlatforms = [...result.platforms];
+
+  // Add official site if available and not already present
+  if (mbData.officialUrl && !newPlatforms.some(p => p.sourceId === 'officialsite')) {
+    newPlatforms.push({ sourceId: 'officialsite' as SourceId, url: mbData.officialUrl });
+  }
+
+  // Add Discogs if available and not already present
+  if (mbData.discogsUrl && !newPlatforms.some(p => p.sourceId === 'discogs')) {
+    newPlatforms.push({ sourceId: 'discogs' as SourceId, url: mbData.discogsUrl });
+  }
+
+  // Add library services for artists with pre-2005 releases
+  if (mbData.hasPre2005Release) {
+    if (!newPlatforms.some(p => p.sourceId === 'hoopla')) {
+      newPlatforms.push({
+        sourceId: 'hoopla' as SourceId,
+        url: `https://www.hoopladigital.com/search?q=${encodeURIComponent(result.name)}&type=music`,
+      });
+    }
+    if (!newPlatforms.some(p => p.sourceId === 'freegal')) {
+      newPlatforms.push({
+        sourceId: 'freegal' as SourceId,
+        url: `https://www.freegalmusic.com/search-page/${encodeURIComponent(result.name)}`,
+      });
+    }
+  }
+
+  // Add social links if available
+  if (mbData.socialLinks && mbData.socialLinks.length > 0) {
+    for (const social of mbData.socialLinks) {
+      const existingIndex = newPlatforms.findIndex(p => p.sourceId === social.platform);
+      if (existingIndex === -1) {
+        newPlatforms.push({ sourceId: social.platform as SourceId, url: social.url });
+      } else {
+        const existingUrl = newPlatforms[existingIndex].url.toLowerCase();
+        const isExistingSearchUrl = existingUrl.includes('duckduckgo.com') ||
+          existingUrl.includes('/search') ||
+          existingUrl.includes('?q=') ||
+          existingUrl.includes('?query=') ||
+          existingUrl.includes('/explore');
+        if (isExistingSearchUrl) {
+          newPlatforms[existingIndex] = { sourceId: social.platform as SourceId, url: social.url };
+        }
+      }
+    }
+  }
+
+  // Add Bandcamp URL from MB platform relations if available
+  if (mbData.platformUrls && mbData.platformUrls.length > 0) {
+    const bandcampUrl = mbData.platformUrls.find(u => {
+      try { return new URL(u).hostname.endsWith('.bandcamp.com'); } catch { return false; }
+    });
+    if (bandcampUrl) {
+      const existingBandcamp = newPlatforms.findIndex(p => p.sourceId === 'bandcamp');
+      if (existingBandcamp !== -1) {
+        newPlatforms[existingBandcamp] = { sourceId: 'bandcamp' as SourceId, url: bandcampUrl };
+      } else {
+        newPlatforms.push({ sourceId: 'bandcamp' as SourceId, url: bandcampUrl });
+      }
+    }
+  }
+
+  // Sort platforms: real platforms first, then official, then social, then search-only
+  const searchOnlyPlatforms = new Set(['ampwall', 'kofi', 'buymeacoffee', 'bandcamp']);
+  const officialPlatforms = new Set(['officialsite', 'discogs', 'hoopla', 'freegal']);
+  const socialPlatforms = new Set(['instagram', 'facebook', 'tiktok', 'youtube', 'threads', 'bluesky', 'mastodon', 'peertube']);
+
+  newPlatforms.sort((a, b) => {
+    const aIsSocial = socialPlatforms.has(a.sourceId);
+    const bIsSocial = socialPlatforms.has(b.sourceId);
+    if (aIsSocial && !bIsSocial) return 1;
+    if (!aIsSocial && bIsSocial) return -1;
+    if (aIsSocial && bIsSocial) {
+      const order = ['instagram', 'tiktok', 'youtube', 'peertube', 'threads', 'bluesky', 'mastodon', 'facebook'];
+      return order.indexOf(a.sourceId) - order.indexOf(b.sourceId);
+    }
+
+    const aIsOfficial = officialPlatforms.has(a.sourceId);
+    const bIsOfficial = officialPlatforms.has(b.sourceId);
+    if (aIsOfficial && bIsOfficial) {
+      const order = ['officialsite', 'discogs', 'hoopla', 'freegal'];
+      return order.indexOf(a.sourceId) - order.indexOf(b.sourceId);
+    }
+    if (aIsOfficial) return 1;
+    if (bIsOfficial) return -1;
+    const aIsSearchOnly = searchOnlyPlatforms.has(a.sourceId);
+    const bIsSearchOnly = searchOnlyPlatforms.has(b.sourceId);
+    if (aIsSearchOnly && !bIsSearchOnly) return 1;
+    if (!aIsSearchOnly && bIsSearchOnly) return -1;
+    return 0;
+  });
+
+  result.platforms = newPlatforms;
+  result.wikipediaSummary = mbData.wikipediaSummary || undefined;
+  result.wikipediaUrl = mbData.wikipediaUrl || undefined;
+  result.location = mbData.location || result.location;
+}
+
+// Search with enrichment timeout wrapper - runs enrichment in parallel with main search
+async function searchWithEnrichmentTimeout(query: string): Promise<{ results: AggregatedResult[]; enrichmentTimeout: boolean }> {
+  const ENRICHMENT_TIMEOUT = 8000;
+
+  const enrichmentPromise = searchMusicBrainz(query);
+  const timeoutPromise = new Promise((resolve) => {
+    setTimeout(() => resolve(null), ENRICHMENT_TIMEOUT);
+  });
+
+  const enrichmentResult = await Promise.race([enrichmentPromise, timeoutPromise]) as EnrichedMusicBrainzResult | null;
+
+  const results = await searchAllPlatforms(query);
+
+  if (enrichmentResult && enrichmentResult.artistName !== null) {
+    applyEnrichmentToResults(results, enrichmentResult);
+  }
+
+  return {
+    results,
+    enrichmentTimeout: enrichmentResult === null,
+  };
+}
+
 // Main search orchestrator
 // ---------------------------------------------------------------------------
 
@@ -1332,6 +1698,7 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   const aggregated = aggregateResults(allResults, query);
 
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
+  // Note: enrichment data (social links, location, etc.) is applied later in searchWithEnrichmentTimeout
   attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, mbData);
   createQobuzOnlyResults(aggregated, qobuzMatches);
 
@@ -1459,7 +1826,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       console.error('[DB] Claimed artist lookup failed:', err);
     }
 
-    const results = await searchAllPlatforms(normalizedQuery);
+    const enrichmentResult = await searchWithEnrichmentTimeout(normalizedQuery);
+    const results = enrichmentResult.results;
 
     // If we have a claimed artist, put it first and remove any duplicate from live results
     if (claimedResult) {
@@ -1479,8 +1847,9 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     const response: SearchResponse = {
       query, // Return original query for display
       results,
-      // Signal client to fetch MusicBrainz data for enrichment (Official Site, Discogs, Hoopla, Freegal)
-      hasPendingEnrichment: results.length > 0,
+      // Signal client whether enrichment timed out (true = enrichment completed and merged, false = still pending)
+      // Client will only call fetchMusicBrainzData() if enrichment didn't complete in time
+      hasPendingEnrichment: enrichmentResult.enrichmentTimeout,
     };
 
     return {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -47,6 +47,7 @@ import {
   fetchBandcampLocation,
   fetchMirloLocation,
   enrichLocationFallback,
+  fetchWikipediaSummary,
 } from '../search/enrichment';
 
 // Helper to fetch with timeout
@@ -465,6 +466,7 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 // MusicBrainz enriched result interface with full enrichment data
 interface EnrichedMusicBrainzResult {
+  query: string;
   artistName: string | null;
   officialUrl: string | null;
   discogsUrl: string | null;
@@ -481,6 +483,7 @@ interface EnrichedMusicBrainzResult {
 // Search MusicBrainz with full enrichment - fetches social links, location, Wikipedia, etc.
 async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResult> {
   const emptyResult: EnrichedMusicBrainzResult = {
+    query,
     artistName: null,
     officialUrl: null,
     discogsUrl: null,
@@ -731,6 +734,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     );
 
     return {
+      query,
       artistName: artist.name,
       officialUrl,
       discogsUrl,
@@ -1638,33 +1642,10 @@ function applyEnrichmentToResults(
   result.location = mbData.location || result.location;
 }
 
-// Search with enrichment timeout wrapper - runs enrichment in parallel with main search
-async function searchWithEnrichmentTimeout(query: string): Promise<{ results: AggregatedResult[]; enrichmentTimeout: boolean }> {
-  const ENRICHMENT_TIMEOUT = 8000;
-
-  const enrichmentPromise = searchMusicBrainz(query);
-  const timeoutPromise = new Promise((resolve) => {
-    setTimeout(() => resolve(null), ENRICHMENT_TIMEOUT);
-  });
-
-  const enrichmentResult = await Promise.race([enrichmentPromise, timeoutPromise]) as EnrichedMusicBrainzResult | null;
-
-  const results = await searchAllPlatforms(query);
-
-  if (enrichmentResult && enrichmentResult.artistName !== null) {
-    applyEnrichmentToResults(results, enrichmentResult);
-  }
-
-  return {
-    results,
-    enrichmentTimeout: enrichmentResult === null,
-  };
-}
-
 // Main search orchestrator
 // ---------------------------------------------------------------------------
 
-async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
+async function searchAllPlatforms(query: string): Promise<{ results: AggregatedResult[]; enrichmentApplied: boolean }> {
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
   const [bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
     searchBandwagon(query),
@@ -1698,9 +1679,13 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   const aggregated = aggregateResults(allResults, query);
 
   // Phase 2: Attach Qobuz + search-only links, create Qobuz-only results
-  // Note: enrichment data (social links, location, etc.) is applied later in searchWithEnrichmentTimeout
   attachQobuzAndSearchLinks(aggregated, qobuzMatches, ampwallMatches, mbData);
   createQobuzOnlyResults(aggregated, qobuzMatches);
+
+  // Phase 2.1: Apply MusicBrainz enrichment (social links, location, Wikipedia, Bandcamp)
+  if (mbData && mbData.artistName !== null) {
+    applyEnrichmentToResults(aggregated, mbData);
+  }
 
   // Phase 2.5: Apply manual merge overrides before release-based disambiguation.
   // Overrides authoritatively create their own result and strip their URLs
@@ -1724,7 +1709,8 @@ async function searchAllPlatforms(query: string): Promise<AggregatedResult[]> {
   await attachNameOnlyPlatforms(merged, nameOnlyMaps);
   // Re-merge: new results from Phase 4 may overlap with existing Qobuz standalones
   const finalMerged = mergeByReleaseOverlap(merged);
-  return filterAndSort(finalMerged, query);
+  const finalResults = filterAndSort(finalMerged, query);
+  return { results: finalResults, enrichmentApplied: mbData !== null && mbData.artistName !== null };
 }
 
 // Search a Bandcamp artist page for a specific album title
@@ -1826,8 +1812,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       console.error('[DB] Claimed artist lookup failed:', err);
     }
 
-    const enrichmentResult = await searchWithEnrichmentTimeout(normalizedQuery);
-    const results = enrichmentResult.results;
+    const searchResult = await searchAllPlatforms(normalizedQuery);
+    const results = searchResult.results;
 
     // If we have a claimed artist, put it first and remove any duplicate from live results
     if (claimedResult) {
@@ -1847,9 +1833,9 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     const response: SearchResponse = {
       query, // Return original query for display
       results,
-      // Signal client whether enrichment timed out (true = enrichment completed and merged, false = still pending)
-      // Client will only call fetchMusicBrainzData() if enrichment didn't complete in time
-      hasPendingEnrichment: enrichmentResult.enrichmentTimeout,
+      // Signal client whether enrichment is still pending (true = MB enrichment failed/timed out,
+      // client should call /api/search/musicbrainz as fallback; false = enrichment was applied server-side)
+      hasPendingEnrichment: !searchResult.enrichmentApplied,
     };
 
     return {

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -17,7 +17,18 @@ export type SourceId =
   | 'beatport'
   | 'even'
   | 'officialsite'
-  | 'discogs';
+  | 'discogs'
+  | 'hoopla'
+  | 'freegal'
+  | 'instagram'
+  | 'facebook'
+  | 'tiktok'
+  | 'youtube'
+  | 'threads'
+  | 'bluesky'
+  | 'mastodon'
+  | 'peertube'
+  | 'other';
 
 export interface LatestRelease {
   title: string;
@@ -46,6 +57,7 @@ export interface AggregatedResult {
   platforms: {
     sourceId: SourceId;
     url: string;
+    displayName?: string;
     latestRelease?: LatestRelease;
     allReleaseTitles?: string[]; // For disambiguation - all release titles (normalized)
   }[];
@@ -64,6 +76,8 @@ export interface AggregatedResult {
     country?: string;
     countryCode?: string;
   };
+  wikipediaSummary?: string;
+  wikipediaUrl?: string;
 }
 
 export interface SearchResponse {

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -1,0 +1,585 @@
+// Shared enrichment functions for MusicBrainz data extraction
+// These functions are used both by the MusicBrainz Netlify function and search-sources.ts
+
+import { cacheGetOrFetch, artistCacheKey } from '../functions/cache';
+import { persistEnrichment } from '../functions/db';
+import { isUrlHostnameAllowed } from '../functions/middleware';
+
+// Social platform types
+export type SocialPlatform =
+  | 'instagram' | 'facebook' | 'tiktok' | 'youtube'
+  | 'threads' | 'bluesky'
+  | 'mastodon' | 'peertube' | 'patreon' | 'kofi' | 'buymeacoffee';
+
+export interface SocialLink {
+  platform: SocialPlatform;
+  url: string;
+}
+
+// Discovered music platform types (found when scraping official websites)
+export type DiscoveredPlatform = 'ampwall' | 'artcore' | 'nina';
+
+export interface DiscoveredPlatformLink {
+  platform: DiscoveredPlatform;
+  url: string;
+}
+
+export interface ArtistLocation {
+  city?: string;
+  country?: string;
+  countryCode?: string;
+}
+
+// Known Mastodon/Fediverse instances (non-exhaustive, but covers popular ones)
+const KNOWN_MASTODON_INSTANCES = [
+  'mastodon.social', 'mastodon.online', 'mastodon.art', 'mastodon.world',
+  'mstdn.social', 'mstdn.jp', 'fosstodon.org', 'hachyderm.io',
+  'plush.city', 'tech.lgbt', 'wandering.shop', 'musician.social',
+  'metalhead.club', 'social.coop', 'aus.social', 'infosec.exchange',
+  'sfba.social', 'universeodon.com', 'c.im', 'toot.cafe',
+];
+
+// Check if a URL belongs to a known Mastodon instance
+export function isMastodonInstance(urlLower: string): boolean {
+  return KNOWN_MASTODON_INSTANCES.some(instance => urlLower.includes(instance));
+}
+
+// Known PeerTube instances (non-exhaustive, covers popular + music-focused ones)
+const KNOWN_PEERTUBE_INSTANCES = [
+  'tilvids.com', 'diode.zone', 'spectra.video', 'makertube.net',
+  'tube.shanti.cafe', 'dalek.zone', 'videos.trom.tf', 'peertube.wtf',
+  'peertube.stream', 'lostpod.space', 'fedi.video', 'videovortex.tv',
+  'tube.anjara.eu', 'peertube.be', 'p.eertu.be', 'peertube.dk',
+  'vod.newellijay.tv', 'video.mxtthxw.art', 'video.sorokin.music',
+  'peertube.ignifi.me', 'clip.place', 'peerate.fr', 'gnulinux.tube',
+  'tube.grin.hu', 'audio.freediverse.com',
+  'communitymedia.video', 'tv.gravitons.org', 'fair.tube',
+];
+
+// Check if a URL belongs to a known PeerTube instance
+export function isPeerTubeInstance(urlLower: string): boolean {
+  return KNOWN_PEERTUBE_INSTANCES.some(instance => urlLower.includes(instance));
+}
+
+// Convert a Mastodon handle (@user@server) to a URL
+export function convertMastodonHandleToUrl(handle: string): string | null {
+  // Handle formats: "@username@server.tld" or "username@server.tld"
+  const match = handle.match(/@?([^@]+)@(.+)/);
+  if (match) {
+    return `https://${match[2]}/@${match[1]}`;
+  }
+  return null;
+}
+
+// Parse a URL to determine which social platform it belongs to
+export function parseSocialUrl(url: string): SocialLink | null {
+  const urlLower = url.toLowerCase();
+
+  if (urlLower.includes('instagram.com')) {
+    return { platform: 'instagram', url };
+  }
+  if (urlLower.includes('facebook.com')) {
+    return { platform: 'facebook', url };
+  }
+  if (urlLower.includes('tiktok.com')) {
+    return { platform: 'tiktok', url };
+  }
+  if (urlLower.includes('youtube.com') || urlLower.includes('youtu.be')) {
+    return { platform: 'youtube', url };
+  }
+  if (urlLower.includes('threads.net') || urlLower.includes('threads.com')) {
+    return { platform: 'threads', url };
+  }
+  if (urlLower.includes('bsky.app') || urlLower.includes('bluesky')) {
+    return { platform: 'bluesky', url };
+  }
+  // Patronage platforms
+  if (urlLower.includes('patreon.com')) {
+    return { platform: 'patreon', url };
+  }
+  if (urlLower.includes('ko-fi.com')) {
+    return { platform: 'kofi', url };
+  }
+  if (urlLower.includes('buymeacoffee.com')) {
+    return { platform: 'buymeacoffee', url };
+  }
+
+  // Mastodon - check known instances (fediverse:creator meta tag handled separately)
+  if (isMastodonInstance(urlLower)) {
+    return { platform: 'mastodon', url };
+  }
+
+  // PeerTube - check known instances
+  if (isPeerTubeInstance(urlLower)) {
+    return { platform: 'peertube', url };
+  }
+
+  return null;
+}
+
+// Fetch a short bio summary from the Wikipedia REST API
+export async function fetchWikipediaSummary(wikipediaUrl: string): Promise<{ extract: string; pageUrl: string } | null> {
+  try {
+    const match = wikipediaUrl.match(/\/wiki\/(.+)$/);
+    if (!match) return null;
+    const title = match[1];
+    const response = await globalThis.fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`,
+      {
+        headers: { 'User-Agent': 'Unstream/1.0 (https://unstream.stream)' },
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+    if (!response.ok) return null;
+    const data = await response.json() as {
+      type?: string;
+      extract?: string;
+      content_urls?: { desktop?: { page?: string } };
+    };
+    if (data.type === 'disambiguation') return null;
+    return {
+      extract: data.extract || '',
+      pageUrl: data.content_urls?.desktop?.page || wikipediaUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Helper to delay execution (for rate limiting)
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+// Fetch and parse links from a Linktree page
+export async function fetchLinktreeLinks(linktreeUrl: string): Promise<SocialLink[]> {
+  const socialLinks: SocialLink[] = [];
+  const seenPlatforms = new Set<SocialPlatform>();
+
+  try {
+    const response = await globalThis.fetch(linktreeUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      console.log('Linktree fetch failed:', response.status);
+      return socialLinks;
+    }
+
+    const html = await response.text();
+
+    // Linktree uses data-testid="LinkButton" for link buttons
+    // The actual URLs are in anchor tags with href attributes
+    // Match pattern: <a ... href="https://..." ... data-testid="LinkButton" ...>
+    // or: <a ... data-testid="LinkButton" ... href="https://..." ...>
+    const linkMatches = html.matchAll(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>/gi);
+
+    for (const match of linkMatches) {
+      const url = match[1];
+      // Skip Linktree internal links and non-http URLs
+      if (!url.startsWith('http') || url.includes('linktr.ee')) continue;
+
+      const socialLink = parseSocialUrl(url);
+      if (socialLink && !seenPlatforms.has(socialLink.platform)) {
+        seenPlatforms.add(socialLink.platform);
+        socialLinks.push(socialLink);
+      }
+    }
+
+    console.log(`[Linktree] Found ${socialLinks.length} social links from ${linktreeUrl}`);
+  } catch (error: unknown) {
+    const err = error as { message?: string };
+    console.error('Linktree fetch error:', err.message);
+  }
+
+  return socialLinks;
+}
+
+// Extract Discogs artist ID from URL (e.g., https://www.discogs.com/artist/3840 -> 3840)
+export function extractDiscogsArtistId(discogsUrl: string): string | null {
+  const match = discogsUrl.match(/\/artist\/(\d+)/);
+  return match ? match[1] : null;
+}
+
+// Fetch social links from Discogs API
+export async function fetchDiscogsSocialLinks(discogsUrl: string): Promise<SocialLink[]> {
+  const socialLinks: SocialLink[] = [];
+  const artistId = extractDiscogsArtistId(discogsUrl);
+
+  if (!artistId) return socialLinks;
+
+  try {
+    const response = await globalThis.fetch(`https://api.discogs.com/artists/${artistId}`, {
+      headers: {
+        'User-Agent': 'Unstream/1.0 (https://unstream.stream - ethical music finder)',
+      },
+    });
+
+    if (!response.ok) {
+      console.log('Discogs API failed:', response.status);
+      return socialLinks;
+    }
+
+    const data = await response.json() as { urls?: string[] };
+    const urls = data.urls || [];
+
+    for (const url of urls) {
+      const socialLink = parseSocialUrl(url);
+      if (socialLink) {
+        socialLinks.push(socialLink);
+      }
+    }
+  } catch (error: unknown) {
+    const err = error as { message?: string };
+    console.error('Discogs fetch error:', err.message);
+  }
+
+  return socialLinks;
+}
+
+// Result type for official site scraping (includes discovered Linktree URL and music platforms)
+export interface OfficialSiteResult {
+  socialLinks: SocialLink[];
+  linktreeUrl: string | null;
+  discoveredPlatforms: DiscoveredPlatformLink[];
+}
+
+// Fetch social links from an artist's official website
+export async function fetchOfficialSiteSocialLinks(officialUrl: string): Promise<OfficialSiteResult> {
+  const socialLinks: SocialLink[] = [];
+  const seenPlatforms = new Set<SocialPlatform>();
+  const discoveredPlatforms: DiscoveredPlatformLink[] = [];
+  const seenDiscoveredPlatforms = new Set<DiscoveredPlatform>();
+  let linktreeUrl: string | null = null;
+
+  try {
+    const response = await globalThis.fetch(officialUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      console.log('Official site fetch failed:', response.status);
+      return { socialLinks, linktreeUrl, discoveredPlatforms };
+    }
+
+    const html = await response.text();
+
+    // 1. Parse fediverse:creator meta tag for Mastodon (most reliable method)
+    // Matches: <meta property="fediverse:creator" content="@user@server.tld">
+    const fediverseMatch = html.match(/<meta\s+[^>]*property=["']fediverse:creator["'][^>]*content=["']([^"']+)["']/i)
+      || html.match(/<meta\s+[^>]*content=["']([^"']+)["'][^>]*property=["']fediverse:creator["']/i);
+    if (fediverseMatch) {
+      const handle = fediverseMatch[1];
+      const mastodonUrl = convertMastodonHandleToUrl(handle);
+      if (mastodonUrl && !seenPlatforms.has('mastodon')) {
+        seenPlatforms.add('mastodon');
+        socialLinks.push({ platform: 'mastodon', url: mastodonUrl });
+      }
+    }
+
+    // 2. Parse rel="me" links (used for Mastodon verification)
+    // Matches: <link rel="me" href="https://mastodon.social/@user">
+    // Also matches <a rel="me" href="..."> which is common on personal sites
+    const relMeMatches = html.matchAll(/<(?:link|a)\s+[^>]*rel=["']me["'][^>]*href=["']([^"']+)["']/gi);
+    for (const match of relMeMatches) {
+      const url = match[1];
+      if (url.startsWith('http') && isMastodonInstance(url.toLowerCase()) && !seenPlatforms.has('mastodon')) {
+        seenPlatforms.add('mastodon');
+        socialLinks.push({ platform: 'mastodon', url });
+        break; // Only need one Mastodon link
+      }
+    }
+
+    // 3. Extract all href attributes from the page (existing logic, now with expanded platforms)
+    const hrefMatches = html.matchAll(/href=["']([^"']+)["']/gi);
+
+    for (const match of hrefMatches) {
+      const url = match[1];
+      // Skip relative URLs and non-http URLs
+      if (!url.startsWith('http')) continue;
+
+      // Check for Linktree URL (only capture first one found)
+      if (url.includes('linktr.ee') && !linktreeUrl) {
+        linktreeUrl = url;
+        console.log(`[Official Site] Found Linktree: ${linktreeUrl}`);
+        continue;
+      }
+
+      // Check for Ampwall artist page
+      if (url.includes('ampwall.com') && !seenDiscoveredPlatforms.has('ampwall')) {
+        seenDiscoveredPlatforms.add('ampwall');
+        discoveredPlatforms.push({ platform: 'ampwall', url });
+        console.log(`[Official Site] Found Ampwall: ${url}`);
+        continue;
+      }
+
+      // Check for Artcore artist page
+      if (url.includes('artcore.com') && !seenDiscoveredPlatforms.has('artcore')) {
+        seenDiscoveredPlatforms.add('artcore');
+        discoveredPlatforms.push({ platform: 'artcore', url });
+        console.log(`[Official Site] Found Artcore: ${url}`);
+        continue;
+      }
+
+      // Check for Nina Protocol profile page
+      if (url.includes('ninaprotocol.com') && !seenDiscoveredPlatforms.has('nina')) {
+        seenDiscoveredPlatforms.add('nina');
+        discoveredPlatforms.push({ platform: 'nina', url });
+        console.log(`[Official Site] Found Nina: ${url}`);
+        continue;
+      }
+
+      const socialLink = parseSocialUrl(url);
+      // Only add one link per platform (first one wins)
+      if (socialLink && !seenPlatforms.has(socialLink.platform)) {
+        seenPlatforms.add(socialLink.platform);
+        socialLinks.push(socialLink);
+      }
+    }
+  } catch (error: unknown) {
+    const err = error as { message?: string };
+    console.error('Official site fetch error:', err.message);
+  }
+
+  return { socialLinks, linktreeUrl, discoveredPlatforms };
+}
+
+// Merge social links from multiple sources, deduplicating by platform
+export function mergeSocialLinks(...linkArrays: SocialLink[][]): SocialLink[] {
+  const seenPlatforms = new Set<SocialPlatform>();
+  const merged: SocialLink[] = [];
+
+  for (const links of linkArrays) {
+    for (const link of links) {
+      if (!seenPlatforms.has(link.platform)) {
+        seenPlatforms.add(link.platform);
+        merged.push(link);
+      }
+    }
+  }
+
+  return merged;
+}
+
+// Search PeerTube via Sepia Search API for artist video channels
+export async function searchPeerTubeChannels(artistName: string): Promise<SocialLink | null> {
+  try {
+    const searchUrl = `https://sepiasearch.org/api/v1/search/video-channels?search=${encodeURIComponent(artistName)}&count=5`;
+
+    const response = await globalThis.fetch(searchUrl, {
+      headers: {
+        'User-Agent': 'Unstream/1.0 (https://unstream.stream - ethical music finder)',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      console.log('Sepia Search failed:', response.status);
+      return null;
+    }
+
+    const data = await response.json() as {
+      total: number;
+      data: {
+        name: string;
+        displayName: string;
+        host: string;
+        url: string;
+        videosCount: number;
+        ownerAccount?: { name: string; displayName: string };
+      }[];
+    };
+
+    if (!data.data || data.data.length === 0) return null;
+
+    // Normalize artist name for matching
+    const normalizedQuery = artistName.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+    // Find a channel whose displayName or ownerAccount name closely matches the artist
+    for (const channel of data.data) {
+      // Skip channels with no videos
+      if (channel.videosCount === 0) continue;
+
+      const normalizedDisplay = channel.displayName.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const normalizedChannelName = channel.name.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const normalizedOwner = channel.ownerAccount?.displayName?.toLowerCase().replace(/[^a-z0-9]/g, '') || '';
+      const normalizedOwnerName = channel.ownerAccount?.name?.toLowerCase().replace(/[^a-z0-9]/g, '') || '';
+
+      const isMatch =
+        normalizedDisplay === normalizedQuery ||
+        normalizedChannelName === normalizedQuery ||
+        normalizedOwner === normalizedQuery ||
+        normalizedOwnerName === normalizedQuery ||
+        // Allow partial matches where one contains the other (for names like "Lime Bar Videos" matching "Lime Bar")
+        (normalizedDisplay.includes(normalizedQuery) && normalizedQuery.length > normalizedDisplay.length * 0.5) ||
+        (normalizedQuery.includes(normalizedDisplay) && normalizedDisplay.length > normalizedQuery.length * 0.5);
+
+      if (isMatch) {
+        console.log(`[Sepia Search] Found PeerTube channel for "${artistName}": ${channel.displayName} on ${channel.host} (${channel.videosCount} videos)`);
+        return { platform: 'peertube', url: channel.url };
+      }
+    }
+
+    console.log(`[Sepia Search] No matching PeerTube channel for "${artistName}" (${data.total} total results)`);
+    return null;
+  } catch (error: unknown) {
+    const err = error as { message?: string };
+    console.error('Sepia Search error:', err.message);
+    return null;
+  }
+}
+
+// Parse a raw location string that may be "City, Country" or just "Country".
+// Returns an ArtistLocation with city and/or country split out.
+export function parseLocationString(raw: string): ArtistLocation {
+  const parts = raw.split(',').map(s => s.trim()).filter(Boolean);
+  if (parts.length >= 2) {
+    return { city: parts.slice(0, -1).join(', '), country: parts[parts.length - 1] };
+  }
+  return { country: parts[0] };
+}
+
+// Merge location objects: fields from `primary` take precedence; missing fields filled from `fallback`.
+export function mergeLocations(...sources: (ArtistLocation | null | undefined)[]): ArtistLocation | undefined {
+  const result: ArtistLocation = {};
+  for (const src of sources) {
+    if (!src) continue;
+    if (!result.city && src.city) result.city = src.city;
+    if (!result.country && src.country) result.country = src.country;
+    if (!result.countryCode && src.countryCode) result.countryCode = src.countryCode;
+  }
+  return (result.city || result.country) ? result : undefined;
+}
+
+// Search Bandcamp for an artist by name and return the first matching artist/label URL.
+// Mirrors the Phase 1 Bandcamp scrape but runs server-side within Phase 2 enrichment,
+// so no client-supplied URLs are involved.
+export async function searchBandcampForArtistUrl(artistName: string, timeoutMs = 4000): Promise<string | null> {
+  try {
+    const searchUrl = `https://bandcamp.com/search?q=${encodeURIComponent(artistName)}&item_type=b`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const response = await globalThis.fetch(searchUrl, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+    });
+    clearTimeout(timeout);
+    if (!response.ok) return null;
+    const html = await response.text();
+
+    // Parse the first artist/label result whose name closely matches the query
+    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const normalizedQuery = normalize(artistName);
+
+    // Match searchresult blocks: extract itemtype, URL, and display name
+    const blockPattern = /<li[^>]+class="[^"]*searchresult[^"]*"[^>]*>([\s\S]*?)<\/li>/g;
+    let block: RegExpExecArray | null;
+    while ((block = blockPattern.exec(html)) !== null) {
+      const blockHtml = block[1];
+      const typeMatch = blockHtml.match(/class="[^"]*itemtype[^"]*"[^>]*>\s*([^<]+)\s*</);
+      const linkMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]+href="([^"?]+)/);
+      const nameMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]*>([^<]+)</);
+      if (!typeMatch || !linkMatch || !nameMatch) continue;
+
+      const itemType = typeMatch[1].trim().toLowerCase();
+      if (itemType !== 'artist' && itemType !== 'label') continue;
+
+      const name = nameMatch[1].trim();
+      const url = linkMatch[1];
+      const normalizedName = normalize(name);
+
+      // Accept if names are equal or one contains the other (handles minor punctuation differences)
+      if (normalizedName === normalizedQuery ||
+          normalizedName.includes(normalizedQuery) ||
+          normalizedQuery.includes(normalizedName)) {
+        return url;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Fetch location from a Bandcamp artist profile page.
+// Validated against the SSRF allowlist as defense-in-depth.
+export async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
+  if (!isUrlHostnameAllowed(bandcampUrl)) return null;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const response = await globalThis.fetch(bandcampUrl, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+    });
+    clearTimeout(timeout);
+    if (!response.ok) return null;
+    const html = await response.text();
+
+    // Iterate all JSON-LD blocks; find the MusicGroup entry which carries the artist location
+    const jsonLdPattern = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+    let jsonLdMatch: RegExpExecArray | null;
+    while ((jsonLdMatch = jsonLdPattern.exec(html)) !== null) {
+      try {
+        const parsed = JSON.parse(jsonLdMatch[1]);
+        const entries = Array.isArray(parsed) ? parsed : [parsed];
+        for (const entry of entries) {
+          if (entry?.['@type'] === 'MusicGroup') {
+            const raw = entry?.foundingLocation?.name || entry?.location?.name;
+            if (raw) return parseLocationString(raw);
+          }
+        }
+      } catch { /* skip malformed blocks */ }
+    }
+
+    // Fall back to location element in artist header (Bandcamp uses <p class="location ...">)
+    const locationMatch = html.match(/<(?:p|div|span)[^>]+class="[^"]*\blocation\b[^"]*"[^>]*>([^<]+)<\/(?:p|div|span)>/);
+    if (locationMatch) return parseLocationString(locationMatch[1].trim());
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Spike: fetch artist location from Mirlo REST API.
+// Constructs URL internally from artist slug — no user input involved.
+export async function fetchMirloLocation(artistSlug: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
+  if (!artistSlug) return null;
+  try {
+    const apiUrl = `https://api.mirlo.space/v1/artists?urlSlug=${encodeURIComponent(artistSlug)}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const response = await globalThis.fetch(apiUrl, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Unstream/1.0 (https://unstream.stream)' },
+    });
+    clearTimeout(timeout);
+    if (!response.ok) return null;
+    const data = await response.json() as { results?: { location?: string }[] };
+    const raw = data.results?.[0]?.location;
+    if (raw) return parseLocationString(raw);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Fallback enrichment when MusicBrainz has no match: look up location via Bandcamp and Mirlo.
+// Uses shorter timeouts (3s each) so the total adds at most ~6s to the Phase 2 response time.
+export async function enrichLocationFallback(query: string): Promise<ArtistLocation | undefined> {
+  const mirloSlug = query.toLowerCase().replace(/\s+/g, '');
+  const FALLBACK_TIMEOUT = 3000;
+
+  const bandcampUrl = await searchBandcampForArtistUrl(query, FALLBACK_TIMEOUT);
+  const [bandcampLocation, mirloLocation] = await Promise.all([
+    bandcampUrl ? fetchBandcampLocation(bandcampUrl, FALLBACK_TIMEOUT) : Promise.resolve(null),
+    fetchMirloLocation(mirloSlug, FALLBACK_TIMEOUT),
+  ]);
+
+  return mergeLocations(bandcampLocation, mirloLocation);
+}

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 11 May 2026 09:05:10 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 11 May 2026 10:24:01 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>


### PR DESCRIPTION
Fixes UNS-29

## What
Moves the MusicBrainz enrichment (social links, location, Wikipedia, Bandcamp URLs) from a client-side second call to the server-side main search response. All platforms (web, iOS, macOS) now get enrichment data in a single API call.

## Architecture
- Created shared `api/search/enrichment.ts` module with all enrichment functions
- Expanded `searchMusicBrainz()` to return full enrichment data
- Added 8s timeout wrapper: if enrichment completes in time → `hasPendingEnrichment: false`, if it times out → `hasPendingEnrichment: true` (existing client-side fallback kicks in)
- Client-side enrichment code preserved as fallback for timeout edge cases

## Files
- `api/search/enrichment.ts` — NEW shared enrichment module
- `api/functions/search-musicbrainz.ts` — imports from shared module, reduced significantly
- `api/functions/search-sources.ts` — full enrichment integration + timeout wrapper