### PR TITLE
Fix duplicate Qobuz standalone result for same-name artists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ data/guides/guides-manifest.json
 
 # Fartrun reports
 apps/web/.fartrun/
+.netlify/db/

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -626,14 +626,22 @@ export function createOrphanedQobuzStandalones(
   qobuzMatches: Map<string, string>,
 ): void {
   const attachedUrls = new Set<string>();
+  // Also track names of existing results to avoid creating duplicates
+  // when Qobuz was attached but later removed as a dead link
+  const existingNames = new Set<string>();
   for (const r of aggregated) {
     for (const p of r.platforms) {
       if (p.sourceId === 'qobuz') attachedUrls.add(p.url);
     }
+    existingNames.add(normalizeForComparison(r.name));
   }
 
   for (const [qobuzName, qobuzUrl] of qobuzMatches) {
     if (attachedUrls.has(qobuzUrl)) continue;
+    // Don't create a standalone if a result with the same name already exists
+    // (Qobuz may have been attached then removed as a dead link)
+    const normalizedQobuzName = normalizeForComparison(qobuzName);
+    if (existingNames.has(normalizedQobuzName)) continue;
 
     const displayName = qobuzDisplayName(qobuzUrl, qobuzName);
     const standaloneId = `qobuz-standalone-${qobuzName}`;


### PR DESCRIPTION
The Scandroid search was returning two results — one verified with all platforms, one unverified with just Qobuz + search-only links.

**Root cause:** `removeDeadQobuzLinks()` strips Qobuz platforms that have no release data. Then `createOrphanedQobuzStandalones()` sees the Qobuz URL as 'not attached' and creates a duplicate standalone result.

**Fix:** Check existing result names before creating a Qobuz standalone. If a result with the same normalized name already exists, don't create a standalone — the Qobuz was already attached to that artist and just got cleaned up as a dead link.