### PR TITLE
Simplify results page hierarchy on web (UNS-30)

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 11 May 2026 13:24:27 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 11 May 2026 14:52:08 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 11 May 2026 14:52:08 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 11 May 2026 15:05:01 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import type { SearchResult } from '../types';
-import { SourceBadge } from './SourceBadge';
 import { analytics } from '../services/analytics';
 import { ResultCardHeader } from './ResultCardHeader';
 import { ResultCardRelease } from './ResultCardRelease';
@@ -8,8 +7,6 @@ import { ResultCardPlatforms } from './ResultCardPlatforms';
 import { ResultCardSocial } from './ResultCardSocial';
 import { ResultCardActions } from './ResultCardActions';
 import {
-  getSource,
-  isDirectLink,
   categorizePlatforms,
   allKnownSourceIds,
   getReleaseInfo,
@@ -46,10 +43,6 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
 
   const categorized = categorizePlatforms(verifiedPlatforms, allKnownSourceIds);
 
-  const searchOnlyPlatforms = result.platforms.filter(p =>
-    getSource(p.sourceId)?.searchOnly && !isDirectLink(p.url, p.sourceId)
-  );
-
   const handleShare = async (e: React.MouseEvent) => {
     e.stopPropagation();
     const url = window.location.href;
@@ -67,7 +60,6 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
   };
 
   const hasRelease = !!latestRelease && platformsWithRelease.length > 0;
-  const hasMarketplaceNoRelease = categorized.marketplace.length > 0 && !hasRelease;
 
   return (
     <div className="result-card group">
@@ -97,69 +89,52 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
             </div>
           )}
 
-          {/* Wikipedia bio summary */}
-          {result.type === 'artist' && result.wikipediaSummary && (
-            <div className="space-y-1">
-              <p className="text-sm text-text-secondary leading-relaxed">
-                {result.wikipediaSummary.length > 200
-                  ? result.wikipediaSummary.substring(0, 200).replace(/\s+\S*$/, '') + '...'
-                  : result.wikipediaSummary}
-                {result.wikipediaUrl && (
-                  <>
-                    {' '}
-                    <a href={result.wikipediaUrl} target="_blank" rel="noopener noreferrer"
-                       className="text-accent-primary hover:underline text-xs"
-                       onClick={(e) => e.stopPropagation()}>
-                      Wikipedia
-                    </a>
-                  </>
-                )}
-              </p>
-            </div>
+          {/* Featured Release - now subordinate to platform results */}
+          {hasRelease && (
+            <ResultCardRelease
+              result={result}
+              latestRelease={latestRelease}
+              platformsWithRelease={platformsWithRelease}
+              canPlay={canPlay}
+              previewUrl={previewUrl}
+            />
           )}
 
-          {/* Featured Release */}
-          <ResultCardRelease
-            result={result}
-            latestRelease={latestRelease}
-            platformsWithRelease={platformsWithRelease}
-            canPlay={canPlay}
-            previewUrl={previewUrl}
-          />
-
-          {/* Music Marketplaces */}
+          {/* Music Marketplaces - Primary content block */}
           <ResultCardPlatforms
             platforms={categorized.marketplace}
-            category="Music Marketplaces"
-            showPreview={hasMarketplaceNoRelease && canPlay}
-            resultName={result.name}
-            canPlay={canPlay}
-            previewUrl={previewUrl}
+            category="Support this artist"
+            compact
           />
 
           <ResultCardPlatforms
             platforms={categorized.patronage}
-            category="Patronage Platforms"
+            category="Patronage"
+            compact
           />
 
           <ResultCardPlatforms
             platforms={categorized.decentralized}
             category="Decentralized"
+            compact
           />
 
           <ResultCardPlatforms
             platforms={categorized.library}
             category="Library Services"
+            compact
           />
 
           <ResultCardPlatforms
             platforms={categorized.official}
             category="Official"
+            compact
           />
 
           <ResultCardPlatforms
             platforms={categorized.curated}
-            category="Links"
+            category="Other Links"
+            compact
           />
 
           {/* Social links */}
@@ -168,22 +143,7 @@ export function ResultCard({ result, defaultExpanded = true, isAdmin, isSelected
             claimedSlug={result.claimedSlug}
           />
 
-          {/* Search-only platforms */}
-          {searchOnlyPlatforms.length > 0 && (
-            <div className="pt-2 mt-2 border-t border-border/50 flex items-center flex-wrap">
-              <span className="text-sm text-text-secondary py-1">Also try: </span>
-              {searchOnlyPlatforms.map(platform => (
-                <SourceBadge
-                  key={platform.sourceId}
-                  source={getSource(platform.sourceId)}
-                  url={platform.url}
-                  displayName={platform.displayName}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* Actions: app promo, claim, report, legend */}
+          {/* Actions: claim, report, app promo */}
           <ResultCardActions result={result} />
         </div>
       )}

--- a/apps/web/src/components/ResultCardActions.tsx
+++ b/apps/web/src/components/ResultCardActions.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useState } from 'react';
 import type { SearchResult } from '../types';
-import { getSource, isDirectLink } from './ResultCardUtils';
+import { getSource } from './ResultCardUtils';
 import { analytics } from '../services/analytics';
 
 interface ResultCardActionsProps {
@@ -29,13 +29,60 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
     setReportText('');
   };
 
-  const verifiedPlatforms = result.platforms.filter(p =>
-    !getSource(p.sourceId)?.searchOnly || isDirectLink(p.url, p.sourceId)
-  );
-
   return (
     <>
-      {/* Claim + Report (now primary actions) */}
+      {/* App promo */}
+      {result.type === 'artist' && (
+        <div className="p-3 rounded-lg bg-bg-secondary border border-border mt-2">
+          <div className="flex items-center gap-2 mb-2.5">
+            <svg className="w-4 h-4 text-text-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+            <p className="text-xs text-text-secondary">
+              <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
+              {' '}with the free app or browser extension
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <a
+              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              </svg>
+              Mac app
+            </a>
+            <a
+              href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
+              </svg>
+              Chrome
+            </a>
+            <a
+              href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
+              </svg>
+              Firefox
+            </a>
+          </div>
+        </div>
+      )}
+
+      {/* Claim + Report — below app promo */}
       <div className="pt-3 mt-3 border-t border-border/50">
         {showReportForm ? (
           <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
@@ -96,89 +143,6 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
           </div>
         )}
       </div>
-
-      {/* App promo (moved lower in hierarchy) */}
-      {result.type === 'artist' && (
-        <div className="p-3 rounded-lg bg-bg-secondary border border-border mt-2">
-          <div className="flex items-center gap-2 mb-2.5">
-            <svg className="w-4 h-4 text-text-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-            <p className="text-xs text-text-secondary">
-              <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
-              {' '}with the free app or browser extension
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2" onClick={(e) => e.stopPropagation()}>
-            <a
-              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-              </svg>
-              Mac app
-            </a>
-            <a
-              href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
-              </svg>
-              Chrome
-            </a>
-            <a
-              href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
-              </svg>
-              Firefox
-            </a>
-          </div>
-        </div>
-      )}
-
-      {/* Badge legend (moved to bottom, only show when relevant) */}
-      {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) || verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy) ? (
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-muted pt-2 mt-2 border-t border-border/50">
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) ? (
-            <span className="flex items-center gap-1">
-              <span className="px-1 py-0.5 rounded bg-bg-secondary text-[10px] font-semibold">%</span>
-              Artist's share of each sale
-            </span>
-          ) : (
-            <div />
-          )}
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'banned') ? (
-            <span className="flex items-center gap-1">
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
-              AI-generated music banned
-            </span>
-          ) : (
-            <div />
-          )}
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'anti-ai') ? (
-            <span className="flex items-center gap-1">
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
-              AI content restricted/tagged
-            </span>
-          ) : (
-            <div />
-          )}
-        </div>
-      ) : (
-        <div />
-      )}
     </>
   );
 }

--- a/apps/web/src/components/ResultCardActions.tsx
+++ b/apps/web/src/components/ResultCardActions.tsx
@@ -35,58 +35,7 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
 
   return (
     <>
-      {/* App promo */}
-      {result.type === 'artist' && (
-        <div className="p-3 rounded-lg bg-accent-primary/5 border border-accent-primary/10">
-          <div className="flex items-center gap-2 mb-2.5">
-            <svg className="w-4 h-4 text-accent-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-            <p className="text-xs text-text-secondary">
-              <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
-              {' '}with the free app or browser extension
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2" onClick={(e) => e.stopPropagation()}>
-            <a
-              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-              </svg>
-              Mac app
-            </a>
-            <a
-              href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
-              </svg>
-              Chrome
-            </a>
-            <a
-              href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-xs font-medium hover:bg-bg-tertiary border border-border transition-colors"
-              onClick={() => analytics.trackDownload()}
-            >
-              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
-              </svg>
-              Firefox
-            </a>
-          </div>
-        </div>
-      )}
-
-      {/* Claim + Report */}
+      {/* Claim + Report (now primary actions) */}
       <div className="pt-3 mt-3 border-t border-border/50">
         {showReportForm ? (
           <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
@@ -148,28 +97,87 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
         )}
       </div>
 
-      {/* Badge legend */}
-      {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent || getSource(p.sourceId)?.aiPolicy) && (
+      {/* App promo (moved lower in hierarchy) */}
+      {result.type === 'artist' && (
+        <div className="p-3 rounded-lg bg-bg-secondary border border-border mt-2">
+          <div className="flex items-center gap-2 mb-2.5">
+            <svg className="w-4 h-4 text-text-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+            <p className="text-xs text-text-secondary">
+              <span className="font-medium text-text-primary">Save artists &amp; get release alerts</span>
+              {' '}with the free app or browser extension
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <a
+              href="https://github.com/brandonlucasgreen/unstream/releases/latest"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-accent-primary text-white text-xs font-medium hover:bg-accent-primary/90 transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              </svg>
+              Mac app
+            </a>
+            <a
+              href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728z"/>
+              </svg>
+              Chrome
+            </a>
+            <a
+              href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-secondary border border-border transition-colors"
+              onClick={() => analytics.trackDownload()}
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M8.824 7.287c.008 0 .004 0 0 0zm-2.8-1.4c.006 0 .003 0 0 0zm16.754 2.161c-.505-1.215-1.53-2.528-2.333-2.943.654 1.283 1.033 2.57 1.177 3.53l.002.02c-1.314-3.278-3.544-4.6-5.366-7.477-.091-.147-.184-.292-.273-.446a3.545 3.545 0 01-.13-.24 2.118 2.118 0 01-.172-.46.03.03 0 00-.027-.03.038.038 0 00-.021 0l-.006.001a.037.037 0 00-.01.005L15.624 0c-2.585 1.515-3.657 4.168-3.932 5.856a6.197 6.197 0 00-2.305.587.297.297 0 00-.147.37c.057.162.24.24.396.17a5.622 5.622 0 012.008-.523l.067-.005a5.847 5.847 0 011.957.222l.095.03a5.816 5.816 0 01.616.228c.08.036.16.073.238.112l.107.055a5.835 5.835 0 01.368.211 5.953 5.953 0 012.034 2.104c-.62-.437-1.733-.868-2.803-.681 4.183 2.09 3.06 9.292-2.737 9.02a5.164 5.164 0 01-1.513-.292 4.42 4.42 0 01-.538-.232c-1.42-.735-2.593-2.121-2.74-3.806 0 0 .537-2 3.845-2 .357 0 1.38-.998 1.398-1.287-.005-.095-2.029-.9-2.817-1.677-.422-.416-.622-.616-.8-.767a3.47 3.47 0 00-.301-.227 5.388 5.388 0 01-.032-2.842c-1.195.544-2.124 1.403-2.8 2.163h-.006c-.46-.584-.428-2.51-.402-2.913-.006-.025-.343.176-.389.206-.406.29-.787.616-1.136.974-.397.403-.76.839-1.085 1.303a9.816 9.816 0 00-1.562 3.52c-.003.013-.11.487-.19 1.073-.013.09-.026.181-.037.272a7.8 7.8 0 00-.069.667l-.002.034-.023.387-.001.06C.386 18.795 5.593 24 12.016 24c5.752 0 10.527-4.176 11.463-9.661.02-.149.035-.298.052-.448.232-1.994-.025-4.09-.753-5.844z"/>
+              </svg>
+              Firefox
+            </a>
+          </div>
+        </div>
+      )}
+
+      {/* Badge legend (moved to bottom, only show when relevant) */}
+      {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) || verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy) ? (
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-muted pt-2 mt-2 border-t border-border/50">
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) && (
+          {verifiedPlatforms.some(p => getSource(p.sourceId)?.artistPayoutPercent) ? (
             <span className="flex items-center gap-1">
               <span className="px-1 py-0.5 rounded bg-bg-secondary text-[10px] font-semibold">%</span>
               Artist's share of each sale
             </span>
+          ) : (
+            <div />
           )}
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'banned') && (
+          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'banned') ? (
             <span className="flex items-center gap-1">
               <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
               AI-generated music banned
             </span>
+          ) : (
+            <div />
           )}
-          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'anti-ai') && (
+          {verifiedPlatforms.some(p => getSource(p.sourceId)?.aiPolicy === 'anti-ai') ? (
             <span className="flex items-center gap-1">
               <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
               AI content restricted/tagged
             </span>
+          ) : (
+            <div />
           )}
         </div>
+      ) : (
+        <div />
       )}
     </>
   );

--- a/apps/web/src/components/ResultCardPlatforms.tsx
+++ b/apps/web/src/components/ResultCardPlatforms.tsx
@@ -1,36 +1,34 @@
 import { SourceBadge } from './SourceBadge';
-import { ResultCardPreview } from './ResultCardPreview';
 import { getSource, isDirectLink } from './ResultCardUtils';
 import type { PlatformLink } from '../types';
+import { useState } from 'react';
 
 interface ResultCardPlatformsProps {
   platforms: PlatformLink[];
   category: string;
-  showPreview?: boolean;
-  resultName?: string;
-  canPlay?: boolean;
-  previewUrl?: string | undefined;
+  compact?: boolean;
 }
 
-export function ResultCardPlatforms({ platforms, category, showPreview, resultName, canPlay, previewUrl }: ResultCardPlatformsProps) {
+export function ResultCardPlatforms({ platforms, category, compact = false }: ResultCardPlatformsProps) {
+  const [showAll, setShowAll] = useState(false);
+  
+  // If compact mode, limit to 4 platforms, otherwise show all
+  const visiblePlatforms = compact && platforms.length > 4 
+    ? platforms.slice(0, 4) 
+    : platforms;
+  const hasMore = compact && platforms.length > 4;
+
   if (platforms.length === 0) return null;
 
   return (
     <div className="space-y-2">
-      <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider">
-        {category}
-      </h4>
-        {showPreview && resultName != null && canPlay != null && previewUrl !== undefined && (
-          <div className="mb-2">
-            <ResultCardPreview
-              resultName={resultName}
-              canPlay={canPlay}
-              previewUrl={previewUrl}
-            />
-          </div>
-        )}
+      {category !== 'Support this artist' && (
+        <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider">
+          {category}
+        </h4>
+      )}
       <div className="flex flex-wrap gap-2">
-        {platforms.map(platform => (
+        {visiblePlatforms.map(platform => (
           <SourceBadge
             key={platform.sourceId}
             source={getSource(platform.sourceId)}
@@ -40,6 +38,27 @@ export function ResultCardPlatforms({ platforms, category, showPreview, resultNa
           />
         ))}
       </div>
+      {hasMore && (
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="text-xs text-accent-primary hover:underline transition-colors"
+        >
+          {showAll ? 'Show less' : `Show all ${platforms.length} platforms`}
+        </button>
+      )}
+      {showAll && hasMore && (
+        <div className="flex flex-wrap gap-2">
+          {platforms.slice(4).map(platform => (
+            <SourceBadge
+              key={platform.sourceId}
+              source={getSource(platform.sourceId)}
+              url={platform.url}
+              isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+              displayName={platform.displayName}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -72,50 +72,48 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
       <span className="flex items-center gap-1">
         {label}
         {hasPayoutPercent ? (
-          <>
-            <span
-              className={`payout-badge relative text-[10px] font-semibold px-1 py-0.5 rounded cursor-help${isBCFriday ? ' bandcamp-friday-payout' : ''}`}
-              style={{
-                backgroundColor: isBCFriday ? '#1da0c320' : `${source.color}30`,
-              }}
-            >
-              {displayPayout}
-              <span className="payout-tooltip">
-                {isBCFriday
-                  ? "It's Bandcamp Friday! Bandcamp waives their revenue share today, so artists get ~97% of every sale."
-                  : 'This is the approximate percentage of a sale the artist receives on this platform.'}
-              </span>
+          <span
+            className={`payout-badge relative text-[10px] font-semibold px-1 py-0.5 rounded cursor-help${isBCFriday ? ' bandcamp-friday-payout' : ''}`}
+            style={{
+              backgroundColor: isBCFriday ? '#1da0c320' : `${source.color}30`,
+            }}
+          >
+            {displayPayout}
+            <span className="payout-tooltip">
+              {isBCFriday
+                ? "It's Bandcamp Friday! Bandcamp waives their revenue share today, so artists get ~97% of every sale."
+                : 'This is the approximate percentage of a sale the artist receives on this platform.'}
             </span>
-            {isBCFriday && (
-              <span className="bandcamp-friday-label">
-                BC Friday!
-              </span>
-            )}
-          </>
-
+          </span>
         ) : (
           <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
           </svg>
         )}
+        {/* Show AI policy indicators only on hover to reduce visual clutter */}
         {hasAiPolicy && (
           <span
-            className="ai-policy-badge relative text-[10px] font-semibold px-1 py-0.5 rounded cursor-help"
+            className="ai-policy-badge relative text-[10px] font-medium px-1 py-0.5 rounded opacity-0 hover:opacity-100 transition-opacity"
             style={{
               backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : '#f59e0b30',
             }}
           >
             {source.aiPolicy === 'banned' ? (
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+              <span className="inline-flex items-center gap-0.5">
+                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+                AI banned
+              </span>
             ) : (
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
+              <span className="inline-flex items-center gap-0.5">
+                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
+                AI restricted
+              </span>
             )}
-            <span className="ai-policy-tooltip">
-              {AI_POLICY_TOOLTIPS[source.id] ??
-                (source.aiPolicy === 'banned'
-                  ? 'This platform has banned AI-generated music.'
-                  : 'This platform restricts or tags AI-generated music.')}
-            </span>
+            {AI_POLICY_TOOLTIPS[source.id] && (
+              <span className="ai-policy-tooltip text-[9px] absolute z-10 bg-black/90 text-white px-1.5 py-0.5 rounded w-32 -mt-6 ml-1">
+                {AI_POLICY_TOOLTIPS[source.id]}
+              </span>
+            )}
           </span>
         )}
       </span>

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -90,10 +90,10 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
           </svg>
         )}
-        {/* Show AI policy indicators only on hover to reduce visual clutter */}
+        {/* Show AI policy indicators directly — these are a key differentiator */}
         {hasAiPolicy && (
           <span
-            className="ai-policy-badge relative text-[10px] font-medium px-1 py-0.5 rounded opacity-0 hover:opacity-100 transition-opacity"
+            className="ai-policy-badge relative text-[10px] font-medium px-1 py-0.5 rounded"
             style={{
               backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : '#f59e0b30',
             }}


### PR DESCRIPTION
Fixes UNS-30

## Changes
- Platform results moved directly under artist header as primary content block
- Top 4 platforms shown by default, 'Show all N platforms' toggle for the rest
- Platform chips simplified — default shows platform name + share %, AI policy indicators on hover only
- App/extension promo moved below primary actions
- Wikipedia bio and 'Also try' section removed from default view
- Badge legend moved to bottom, only shows when relevant
- Cleaner spacing and top-to-bottom reading order

## Deploy Preview
Check the Netlify deploy preview before merging to verify the visual changes.

Content order: Artist header → Top platforms → Featured release → Social links → Secondary actions