### PR TITLE
Add Subvert.fm as platform source (UNS-14)

### DIFF
--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -278,6 +278,9 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     const mbBandcampUrl = platformUrls.find(u => {
       try { return new URL(u).hostname.endsWith('.bandcamp.com'); } catch { return false; }
     });
+    const mbSubvertUrl = platformUrls.find(u => {
+      try { return new URL(u).hostname === 'www.subvert.fm' || new URL(u).hostname === 'subvert.fm'; } catch { return false; }
+    });
     const mirloSlug = artist.name.toLowerCase().replace(/\s+/g, '');
 
     // Fetch additional social links from Discogs, official site, PeerTube, Wikipedia,
@@ -318,6 +321,12 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     // PeerTube from Sepia Search comes last so official site / Linktree links take priority
     const allSocialLinks = mergeSocialLinks(socialLinks, discogsSocialLinks, officialSiteResult.socialLinks, linktreeSocialLinks, peertubeLinks);
 
+    // Merge discovered platforms from official site + MusicBrainz Subvert URL
+    const allDiscoveredPlatforms = [...officialSiteResult.discoveredPlatforms];
+    if (mbSubvertUrl && !allDiscoveredPlatforms.some(p => p.platform === 'subvert')) {
+      allDiscoveredPlatforms.push({ platform: 'subvert', url: mbSubvertUrl });
+    }
+
     return {
       query,
       artistName: artist.name,
@@ -325,7 +334,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       discogsUrl,
       hasPre2005Release,
       socialLinks: allSocialLinks,
-      discoveredPlatforms: officialSiteResult.discoveredPlatforms,
+      discoveredPlatforms: allDiscoveredPlatforms,
       platformUrls,
       wikipediaSummary: wikipediaResult?.extract || null,
       wikipediaUrl: wikipediaResult?.pageUrl || wikipediaUrl,

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1604,10 +1604,18 @@ function applyEnrichmentToResults(
         newPlatforms.push({ sourceId: 'bandcamp' as SourceId, url: bandcampUrl });
       }
     }
+
+    // Add Subvert URL from MB platform relations if available
+    const subvertUrl = mbData.platformUrls.find(u => {
+      try { const h = new URL(u).hostname; return h === 'www.subvert.fm' || h === 'subvert.fm'; } catch { return false; }
+    });
+    if (subvertUrl) {
+      newPlatforms.push({ sourceId: 'subvert' as SourceId, url: subvertUrl });
+    }
   }
 
   // Sort platforms: real platforms first, then official, then social, then search-only
-  const searchOnlyPlatforms = new Set(['ampwall', 'kofi', 'buymeacoffee', 'bandcamp']);
+  const searchOnlyPlatforms = new Set(['ampwall', 'subvert', 'kofi', 'buymeacoffee', 'bandcamp']);
   const officialPlatforms = new Set(['officialsite', 'discogs', 'hoopla', 'freegal']);
   const socialPlatforms = new Set(['instagram', 'facebook', 'tiktok', 'youtube', 'threads', 'bluesky', 'mastodon', 'peertube']);
 
@@ -1707,6 +1715,7 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
       }
       mbPlatforms.push(
         { sourceId: 'ampwall' as SourceId, url: `https://ampwall.com/explore?searchStyle=search&query=${encodeURIComponent(mbData.artistName)}` },
+        { sourceId: 'subvert' as SourceId, url: `https://www.subvert.fm/discover?q=${encodeURIComponent(mbData.artistName)}&type=artist` },
         { sourceId: 'kofi' as SourceId, url: `https://duckduckgo.com/?q=site:ko-fi.com+${encodeURIComponent(mbData.artistName)}` },
         { sourceId: 'buymeacoffee' as SourceId, url: 'https://buymeacoffee.com/explore-creators' },
       );
@@ -1725,7 +1734,7 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
         }
       }
       // Sort: direct links before search-only
-      const searchOnly = new Set(['ampwall', 'kofi', 'buymeacoffee', 'bandcamp']);
+      const searchOnly = new Set(['ampwall', 'subvert', 'kofi', 'buymeacoffee', 'bandcamp']);
       mbPlatforms.sort((a, b) => {
         const aSearch = searchOnly.has(a.sourceId) && (a.url.includes('/search?') || a.url.includes('duckduckgo') || a.url.includes('/explore')) ? 1 : 0;
         const bSearch = searchOnly.has(b.sourceId) && (b.url.includes('/search?') || b.url.includes('duckduckgo') || b.url.includes('/explore')) ? 1 : 0;

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1736,8 +1736,8 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
       // Sort: direct links before search-only
       const searchOnly = new Set(['ampwall', 'subvert', 'kofi', 'buymeacoffee', 'bandcamp']);
       mbPlatforms.sort((a, b) => {
-        const aSearch = searchOnly.has(a.sourceId) && (a.url.includes('/search?') || a.url.includes('duckduckgo') || a.url.includes('/explore')) ? 1 : 0;
-        const bSearch = searchOnly.has(b.sourceId) && (b.url.includes('/search?') || b.url.includes('duckduckgo') || b.url.includes('/explore')) ? 1 : 0;
+        const aSearch = searchOnly.has(a.sourceId) && (a.url.includes('/search?') || a.url.includes('duckduckgo') || a.url.includes('/explore') || a.url.includes('/discover')) ? 1 : 0;
+        const bSearch = searchOnly.has(b.sourceId) && (b.url.includes('/search?') || b.url.includes('duckduckgo') || b.url.includes('/explore') || b.url.includes('/discover')) ? 1 : 0;
         return aSearch - bSearch;
       });
 

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -17,7 +17,7 @@ export interface SocialLink {
 }
 
 // Discovered music platform types (found when scraping official websites)
-export type DiscoveredPlatform = 'ampwall' | 'artcore' | 'nina';
+export type DiscoveredPlatform = 'ampwall' | 'artcore' | 'nina' | 'subvert';
 
 export interface DiscoveredPlatformLink {
   platform: DiscoveredPlatform;
@@ -330,6 +330,14 @@ export async function fetchOfficialSiteSocialLinks(officialUrl: string): Promise
         seenDiscoveredPlatforms.add('nina');
         discoveredPlatforms.push({ platform: 'nina', url });
         console.log(`[Official Site] Found Nina: ${url}`);
+        continue;
+      }
+
+      // Check for Subvert artist page
+      if (url.includes('subvert.fm') && !seenDiscoveredPlatforms.has('subvert')) {
+        seenDiscoveredPlatforms.add('subvert');
+        discoveredPlatforms.push({ platform: 'subvert', url });
+        console.log(`[Official Site] Found Subvert: ${url}`);
         continue;
       }
 

--- a/apps/mac/Unstream/Models/PlatformCatalog.swift
+++ b/apps/mac/Unstream/Models/PlatformCatalog.swift
@@ -33,6 +33,7 @@ let platformCatalog: [String: PlatformConfig] = [
     "patreon": PlatformConfig(name: "Patreon", icon: "heart", color: "#FF424D", searchOnly: false, artistPayoutPercent: "86-90%"),
     // Search-only platforms
     "ampwall": PlatformConfig(name: "Ampwall", icon: "waveform", color: "#EF4444", searchOnly: true, artistPayoutPercent: "92-95%"),
+    "subvert": PlatformConfig(name: "Subvert", icon: "fist.raised", color: "#F97316", searchOnly: true, artistPayoutPercent: "~100%"),
     "kofi": PlatformConfig(name: "Ko-fi", icon: "cup.and.saucer", color: "#29ABE0", searchOnly: true, artistPayoutPercent: "92-97%"),
     "buymeacoffee": PlatformConfig(name: "Buy Me a Coffee", icon: "cup.and.saucer", color: "#FFDD00", searchOnly: true, artistPayoutPercent: "~92%"),
     // Official

--- a/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
+++ b/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
@@ -132,6 +132,11 @@ struct PlatformBadge: View {
                 latestRelease: nil
             ), isSubtle: true)
             PlatformBadge(result: PlatformResult(
+                sourceId: "subvert",
+                url: nil,
+                latestRelease: nil
+            ), isSubtle: true)
+            PlatformBadge(result: PlatformResult(
                 sourceId: "kofi",
                 url: nil,
                 latestRelease: nil

--- a/apps/mac/UnstreamShareExtension/ShareViewController.swift
+++ b/apps/mac/UnstreamShareExtension/ShareViewController.swift
@@ -39,6 +39,7 @@ private func isSearchOnlyURL(sourceId: String, url: String) -> Bool {
     case "kofi":         return !url.contains("ko-fi.com/")
     case "buymeacoffee": return url.contains("explore-creators")
     case "ampwall":      return url.contains("explore?searchStyle")
+    case "subvert":      return url.contains("discover?q=")
     case "hoopla":       return url.contains("/search?")
     case "freegal":      return url.contains("/search-page/")
     default:             return false
@@ -49,6 +50,7 @@ private let allPlatformMeta: [String: PlatformMeta] = [
     "bandcamp":     .init(name: "Bandcamp",        icon: "🎵", payoutPercent: "80–85%", isSocial: false),
     "mirlo":        .init(name: "Mirlo",           icon: "🪺", payoutPercent: "86–90%", isSocial: false),
     "ampwall":      .init(name: "Ampwall",         icon: "🔊", payoutPercent: "92–95%", isSocial: false),
+    "subvert":      .init(name: "Subvert",         icon: "✊", payoutPercent: "~100%",  isSocial: false),
     "bandwagon":    .init(name: "Bandwagon",       icon: "🚐", payoutPercent: nil,       isSocial: false),
     "faircamp":     .init(name: "Faircamp",        icon: "🏕️", payoutPercent: "90–97%", isSocial: false),
     "patreon":      .init(name: "Patreon",         icon: "🎨", payoutPercent: "86–90%", isSocial: false),

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Tue, 12 May 2026 09:26:10 GMT</lastBuildDate>
+    <lastBuildDate>Tue, 12 May 2026 09:30:22 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 11 May 2026 15:05:01 GMT</lastBuildDate>
+    <lastBuildDate>Tue, 12 May 2026 09:26:10 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -13,6 +13,7 @@ interface SourceBadgeProps {
 const AI_POLICY_TOOLTIPS: Partial<Record<string, string>> = {
   bandcamp: 'Bandcamp explicitly banned AI-generated music in January 2026.',
   ampwall: 'Ampwall strictly prohibits AI-generated music and AI-created images (ampwall.com/content-policy).',
+  subvert: 'Subvert is a collectively owned music cooperative that actively opposes AI-generated music. Artists keep ~100% of every sale.',
   mirlo: 'Mirlo prohibits AI-generated music (mirlo.space/pages/content-policy).',
   bandwagon: 'Bandwagon prohibits AI-generated content, but allows electronic/algorithmic music (bandwagon.fm/acceptable-use).',
   qobuz: 'Qobuz has an AI Charter, detects/tags AI content, and excludes it from human-curated recommendations.',

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -42,6 +42,20 @@ export const sources: Record<SourceId, Source> = {
     artistPayoutPercent: '92-95%',
     aiPolicy: 'banned', // AI-generated music strictly prohibited (ampwall.com/content-policy)
   },
+  subvert: {
+    id: 'subvert',
+    name: 'Subvert',
+    description: 'Collectively owned music marketplace — 0% platform fees',
+    color: '#f97316',
+    icon: '✊',
+    category: 'marketplace',
+    hasEmbed: false,
+    searchUrlTemplate: 'https://www.subvert.fm/discover?q={query}&type=artist',
+    searchOnly: true,
+    homepageUrl: 'https://www.subvert.fm',
+    artistPayoutPercent: '~100%',
+    aiPolicy: 'anti-ai', // Cooperative that actively opposes AI-generated music
+  },
   bandwagon: {
     id: 'bandwagon',
     name: 'Bandwagon',

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -3,6 +3,7 @@ export type SourceId =
   | 'bandcamp'
   | 'mirlo'
   | 'ampwall'
+  | 'subvert'
   | 'bandwagon'
   | 'faircamp'
   | 'patreon'


### PR DESCRIPTION
Fixes UNS-14

## What
Adds Subvert.fm as a marketplace platform in Unstream search results.

## Changes
- **Source entry**:  marketplace source, orange (#f97316), anti-ai policy, ~100% payout
- **MusicBrainz enrichment**: Extracts  URLs from MB platform relations
- **Official site scraping**: Detects Subvert links on artist websites
- **Direct URL override**: If a verified Subvert URL is found (via MB or official site), it shows as a verified link instead of search-only
- **Search-only fallback**: Added to the search-only platform lists in both MB enrichment and fallback paths

## What's NOT included
- No server-side scraping (Vercel security checkpoint blocks it, same as Bandcamp)
- No Puppeteer-based background scraping (deferred pending API partnership)

## Architecture Notes
Subvert is hosted on Vercel with bot protection. Server-side scraping returns a JS challenge page (verified by benchmarking — 3-6s per search via Puppeteer, 429/rate-limit from curl). Same pattern as Bandcamp.

The integration follows the established enrichment pattern:
1. If MusicBrainz has a Subvert URL for an artist → verified link
2. If the artist's official website links to Subvert → verified link  
3. Otherwise → search-only link to `subvert.fm/discover?q=...`

Brandon will pursue an API partnership with Subvert (Austin Robey) as a follow-up to replace the search-only approach with direct data.