### PR TITLE
Fix Subvert metadata on verified artist pages

### DIFF
--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -37,6 +37,7 @@ const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string;
   bandcamp: { name: 'Bandcamp', color: '#1da0c3', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
   mirlo: { name: 'Mirlo', color: '#6366f1', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
   ampwall: { name: 'Ampwall', color: '#ef4444', icon: '🔊', category: 'marketplace', searchOnly: true, payoutPercent: '92-95%' },
+  subvert: { name: 'Subvert', color: '#f97316', icon: '✊', category: 'marketplace', searchOnly: true, payoutPercent: '~100%' },
   bandwagon: { name: 'Bandwagon', color: '#8b5cf6', icon: '🚐', category: 'decentralized' },
   faircamp: { name: 'Faircamp', color: '#22c55e', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
   patreon: { name: 'Patreon', color: '#ff424d', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },

--- a/api/edge/claimed-artist-page.ts
+++ b/api/edge/claimed-artist-page.ts
@@ -15,6 +15,7 @@ const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string;
   bandcamp: { name: 'Bandcamp', color: '#1da0c3', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
   mirlo: { name: 'Mirlo', color: '#6366f1', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
   ampwall: { name: 'Ampwall', color: '#ef4444', icon: '🔊', category: 'marketplace', payoutPercent: '92-95%' },
+  subvert: { name: 'Subvert', color: '#f97316', icon: '✊', category: 'marketplace', payoutPercent: '~100%' },
   bandwagon: { name: 'Bandwagon', color: '#8b5cf6', icon: '🚐', category: 'decentralized' },
   faircamp: { name: 'Faircamp', color: '#22c55e', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
   patreon: { name: 'Patreon', color: '#ff424d', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },

--- a/api/edge/noscript-search.ts
+++ b/api/edge/noscript-search.ts
@@ -26,6 +26,7 @@ const PLATFORM_INFO: Record<string, { name: string; icon: string; category: stri
   bandcamp: { name: 'Bandcamp', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
   mirlo: { name: 'Mirlo', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
   ampwall: { name: 'Ampwall', icon: '🔊', category: 'marketplace', searchOnly: true, payoutPercent: '92-95%' },
+  subvert: { name: 'Subvert', icon: '✊', category: 'marketplace', searchOnly: true, payoutPercent: '~100%' },
   bandwagon: { name: 'Bandwagon', icon: '🚐', category: 'decentralized' },
   faircamp: { name: 'Faircamp', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
   patreon: { name: 'Patreon', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },


### PR DESCRIPTION
Subvert was missing from the PLATFORM_INFO dictionaries in the edge functions that render verified artist pages, search result pages, and the no-JS fallback.

Without this fix, Subvert links on claimed artist pages showed the raw platform key instead of proper name, color, icon, and payout info.

Added Subvert to:
- `api/edge/claimed-artist-page.ts` — verified artist profile pages
- `api/edge/artist-page.ts` — search result pages  
- `api/edge/noscript-search.ts` — no-JS fallback