### PR TITLE
Fix Subvert category + AI policy labels

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Tue, 12 May 2026 16:34:45 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 13 May 2026 15:59:31 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -17,6 +17,7 @@ const AI_POLICY_TOOLTIPS: Partial<Record<string, string>> = {
   mirlo: 'Mirlo prohibits AI-generated music (mirlo.space/pages/content-policy).',
   bandwagon: 'Bandwagon prohibits AI-generated content, but allows electronic/algorithmic music (bandwagon.fm/acceptable-use).',
   qobuz: 'Qobuz has an AI Charter, detects/tags AI content, and excludes it from human-curated recommendations.',
+  beatport: 'Beatport detects and tags AI-generated content, and excludes it from human-curated recommendations.',
 };
 
 export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBadgeProps) {
@@ -50,7 +51,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
   const isBCFriday = source.id === 'bandcamp' && isBandcampFriday();
   const displayPayout = isBCFriday ? '~97%' : source.artistPayoutPercent;
   const hasPayoutPercent = !!source.artistPayoutPercent;
-  const hasAiPolicy = source.aiPolicy === 'banned' || source.aiPolicy === 'anti-ai';
+  const hasAiPolicy = source.aiPolicy === 'banned' || source.aiPolicy === 'discouraged';
 
   // Dark colors (EVEN #000000, Discogs #333333) are unreadable on dark backgrounds.
   // Use CSS variables so the badge text is legible in both themes.
@@ -96,7 +97,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
           <span
             className="ai-policy-badge relative text-[10px] font-medium px-1 py-0.5 rounded"
             style={{
-              backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : '#f59e0b30',
+              backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : source.aiPolicy === 'discouraged' ? '#f59e0b30' : '#f59e0b30',
             }}
           >
             {source.aiPolicy === 'banned' ? (
@@ -104,12 +105,12 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
                 <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
                 AI banned
               </span>
-            ) : (
+            ) : source.aiPolicy === 'discouraged' ? (
               <span className="inline-flex items-center gap-0.5">
-                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
-                AI restricted
+                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+                AI discouraged
               </span>
-            )}
+            ) : null}
             {AI_POLICY_TOOLTIPS[source.id] && (
               <span className="ai-policy-tooltip text-[9px] absolute z-10 bg-black/90 text-white px-1.5 py-0.5 rounded w-32 -mt-6 ml-1">
                 {AI_POLICY_TOOLTIPS[source.id]}

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -54,7 +54,7 @@ export const sources: Record<SourceId, Source> = {
     searchOnly: true,
     homepageUrl: 'https://www.subvert.fm',
     artistPayoutPercent: '97%',
-    aiPolicy: 'anti-ai', // Cooperative that actively opposes AI-generated music
+    aiPolicy: 'banned', // Cooperatively owned; explicitly prohibits AI-generated music
   },
   bandwagon: {
     id: 'bandwagon',
@@ -155,7 +155,7 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.qobuz.com/us-en/search/artists/{query}',
     homepageUrl: 'https://www.qobuz.com',
     artistPayoutPercent: '~70%',
-    aiPolicy: 'anti-ai', // Has AI Charter, detects/tags AI content, excludes from human-curated recs
+    aiPolicy: 'discouraged', // Has AI Charter, detects/tags AI content, excludes from human-curated recs
   },
   beatport: {
     id: 'beatport',
@@ -168,7 +168,7 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.beatport.com/search?q={query}',
     homepageUrl: 'https://www.beatport.com',
     artistPayoutPercent: '55-70%',
-    aiPolicy: 'unknown', // No explicit public AI policy
+    aiPolicy: 'discouraged', // Detects/tags AI content, excludes from human-curated recs
   },
   even: {
     id: 'even',
@@ -359,7 +359,7 @@ export const sourceCategories = {
   marketplace: {
     name: 'Music Marketplaces',
     description: 'Buy music directly from artists',
-    sources: ['bandcamp', 'mirlo', 'ampwall', 'qobuz', 'beatport', 'even', 'jamcoop', 'discogs'] as SourceId[],
+    sources: ['bandcamp', 'mirlo', 'ampwall', 'subvert', 'qobuz', 'beatport', 'even', 'jamcoop', 'discogs'] as SourceId[],
   },
   patronage: {
     name: 'Patronage Platforms',

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -42,7 +42,7 @@ export interface Source {
   searchOnly?: boolean; // True if we can't verify the artist exists (shows "Search X" instead)
   homepageUrl: string;
   artistPayoutPercent?: string; // e.g., "80-85%" - artist's share of sales on this platform
-  aiPolicy?: 'banned' | 'anti-ai' | 'disclosed' | 'unknown' | 'self-hosted'; // AI-generated content policy
+  aiPolicy?: 'banned' | 'discouraged' | 'disclosed' | 'unknown' | 'self-hosted'; // AI-generated content policy
 }
 
 // Latest release info


### PR DESCRIPTION
Three fixes:

1. **Subvert → marketplace category** — Was missing from `sourceCategories.marketplace.sources`, causing it to fall through to the 'curated/other links' section. Now listed alongside Bandcamp, Mirlo, Ampwall, etc.

2. **Subvert → AI banned** — Changed from `anti-ai` to `banned`. Subvert prohibits AI-generated music, same tier as Bandcamp/Mirlo/Ampwall.

3. **'AI restricted' → 'AI discouraged'** — Replaced the `anti-ai` policy type with `discouraged`. Platforms that detect/tag AI content and exclude it from recommendations (Qobuz, Beatport) now show "AI discouraged" instead of "AI restricted". Beatport updated from `unknown` to `discouraged`.

Web only — Swift/PlatformCatalog doesn't have aiPolicy badges yet.