### PR TITLE
Refactor AI policy badges: link to policy pages, marketplaces only

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 13 May 2026 16:57:49 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 13 May 2026 17:14:33 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 13 May 2026 16:55:59 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 13 May 2026 16:57:49 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Tue, 12 May 2026 16:34:45 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 13 May 2026 16:55:59 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -42,7 +42,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
   const displayPayout = isBCFriday ? '~97%' : source.artistPayoutPercent;
   const hasPayoutPercent = !!source.artistPayoutPercent;
   // Only show AI policy badges on marketplaces
-  const hasAiPolicy = source.category === 'marketplace' && (source.aiPolicy === 'formal' || source.aiPolicy === 'discouraged');
+  const hasAiPolicy = (source.category === 'marketplace' || source.category === 'decentralized') && (source.aiPolicy === 'formal' || source.aiPolicy === 'discouraged');
 
   // Dark colors (EVEN #000000, Discogs #333333) are unreadable on dark backgrounds.
   // Use CSS variables so the badge text is legible in both themes.

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -10,15 +10,6 @@ interface SourceBadgeProps {
   displayName?: string;
 }
 
-const AI_POLICY_TOOLTIPS: Partial<Record<string, string>> = {
-  bandcamp: 'Bandcamp explicitly banned AI-generated music in January 2026.',
-  ampwall: 'Ampwall strictly prohibits AI-generated music and AI-created images (ampwall.com/content-policy).',
-  subvert: 'Subvert is a collectively owned music cooperative that actively opposes AI-generated music. Artists keep ~97% of every sale (payment processing applies).',
-  mirlo: 'Mirlo prohibits AI-generated music (mirlo.space/pages/content-policy).',
-  bandwagon: 'Bandwagon prohibits AI-generated content, but allows electronic/algorithmic music (bandwagon.fm/acceptable-use).',
-  qobuz: 'Qobuz has an AI Charter, detects/tags AI content, and excludes it from human-curated recommendations.',
-};
-
 export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBadgeProps) {
   const label = displayName ?? source.name;
   // If we have a direct link, show as verified even if source is normally searchOnly
@@ -50,7 +41,8 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
   const isBCFriday = source.id === 'bandcamp' && isBandcampFriday();
   const displayPayout = isBCFriday ? '~97%' : source.artistPayoutPercent;
   const hasPayoutPercent = !!source.artistPayoutPercent;
-  const hasAiPolicy = source.aiPolicy === 'banned' || source.aiPolicy === 'anti-ai';
+  // Only show AI policy badges on marketplaces
+  const hasAiPolicy = source.category === 'marketplace' && (source.aiPolicy === 'formal' || source.aiPolicy === 'discouraged');
 
   // Dark colors (EVEN #000000, Discogs #333333) are unreadable on dark backgrounds.
   // Use CSS variables so the badge text is legible in both themes.
@@ -91,31 +83,33 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
           </svg>
         )}
-        {/* Show AI policy indicators directly — these are a key differentiator */}
+        {/* Show AI policy indicators on marketplace badges only */}
         {hasAiPolicy && (
-          <span
-            className="ai-policy-badge relative text-[10px] font-medium px-1 py-0.5 rounded"
-            style={{
-              backgroundColor: source.aiPolicy === 'banned' ? '#22c55e30' : '#f59e0b30',
-            }}
-          >
-            {source.aiPolicy === 'banned' ? (
-              <span className="inline-flex items-center gap-0.5">
-                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
-                AI banned
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-0.5">
-                <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/></svg>
-                AI restricted
-              </span>
-            )}
-            {AI_POLICY_TOOLTIPS[source.id] && (
-              <span className="ai-policy-tooltip text-[9px] absolute z-10 bg-black/90 text-white px-1.5 py-0.5 rounded w-32 -mt-6 ml-1">
-                {AI_POLICY_TOOLTIPS[source.id]}
-              </span>
-            )}
-          </span>
+          source.aiPolicy === 'formal' ? (
+            <a
+              href={source.aiPolicyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ai-policy-badge text-[10px] font-medium px-1 py-0.5 rounded inline-flex items-center gap-0.5 no-underline"
+              style={{ backgroundColor: '#22c55e30' }}
+              onClick={(e) => { e.stopPropagation(); analytics.trackPlatformClick(`${label} AI policy`); }}
+            >
+              <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+              AI policy
+            </a>
+          ) : (
+            <a
+              href={source.aiPolicyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ai-policy-badge text-[10px] font-medium px-1 py-0.5 rounded inline-flex items-center gap-0.5 no-underline"
+              style={{ backgroundColor: '#f59e0b30' }}
+              onClick={(e) => { e.stopPropagation(); analytics.trackPlatformClick(`${label} AI policy`); }}
+            >
+              <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+              AI discouraged
+            </a>
+          )
         )}
       </span>
     </a>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -135,68 +135,6 @@ html[data-theme="light"] {
   }
 
   /* Custom tooltip for AI policy badges */
-  .ai-policy-badge {
-    position: relative;
-  }
-
-  .ai-policy-tooltip {
-    position: absolute;
-    bottom: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 8px 12px;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    font-size: 11px;
-    font-weight: 400;
-    color: var(--color-text-primary);
-    white-space: normal;
-    text-align: center;
-    width: 200px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    z-index: 50;
-
-    /* Hidden by default */
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-
-    /* Transition with delay */
-    transition: opacity 0.15s ease, visibility 0.15s ease;
-    transition-delay: 0s;
-  }
-
-  /* Arrow */
-  .ai-policy-tooltip::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 6px solid transparent;
-    border-top-color: var(--color-border);
-  }
-
-  .ai-policy-tooltip::before {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 5px solid transparent;
-    border-top-color: var(--color-bg-secondary);
-    margin-top: -1px;
-    z-index: 1;
-  }
-
-  /* Show on hover with 0.25s delay */
-  .ai-policy-badge:hover .ai-policy-tooltip {
-    opacity: 1;
-    visibility: visible;
-    transition-delay: 0.25s;
-  }
-
   /* Bandcamp Friday badge */
   .bandcamp-friday-payout {
     color: #1da0c3;

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -13,7 +13,8 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://bandcamp.com/search?q={query}',
     homepageUrl: 'https://bandcamp.com',
     artistPayoutPercent: '80-85%',
-    aiPolicy: 'banned', // Explicitly banned AI-generated music Jan 2026
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://blog.bandcamp.com/2026/01/13/keeping-bandcamp-human/',
   },
   mirlo: {
     id: 'mirlo',
@@ -26,7 +27,7 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://mirlo.space/search?query={query}',
     homepageUrl: 'https://mirlo.space',
     artistPayoutPercent: '86-90%',
-    aiPolicy: 'banned', // AI-generated music explicitly prohibited (mirlo.space/pages/content-policy)
+    aiPolicy: 'formal', // AI policy exists but URL not yet confirmed
   },
   ampwall: {
     id: 'ampwall',
@@ -40,7 +41,8 @@ export const sources: Record<SourceId, Source> = {
     searchOnly: true,
     homepageUrl: 'https://ampwall.com',
     artistPayoutPercent: '92-95%',
-    aiPolicy: 'banned', // AI-generated music strictly prohibited (ampwall.com/content-policy)
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://ampwall.com/content-policy',
   },
   subvert: {
     id: 'subvert',
@@ -54,7 +56,8 @@ export const sources: Record<SourceId, Source> = {
     searchOnly: true,
     homepageUrl: 'https://www.subvert.fm',
     artistPayoutPercent: '97%',
-    aiPolicy: 'anti-ai', // Cooperative that actively opposes AI-generated music
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://www.subvert.fm/pages/ai-policy',
   },
   bandwagon: {
     id: 'bandwagon',
@@ -66,7 +69,6 @@ export const sources: Record<SourceId, Source> = {
     hasEmbed: false,
     searchUrlTemplate: 'https://bandwagon.fm/artists?q={query}',
     homepageUrl: 'https://bandwagon.fm',
-    aiPolicy: 'banned', // AI-generated content prohibited (bandwagon.fm/acceptable-use)
   },
   faircamp: {
     id: 'faircamp',
@@ -79,7 +81,6 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://duckduckgo.com/?q=site:*.faircamp+{query}',
     homepageUrl: 'https://simonrepp.com/faircamp',
     artistPayoutPercent: '90-97%',
-    aiPolicy: 'self-hosted', // Creator controls their own static site
   },
   patreon: {
     id: 'patreon',
@@ -92,7 +93,6 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.patreon.com/search?q={query}',
     homepageUrl: 'https://www.patreon.com',
     artistPayoutPercent: '86-90%',
-    aiPolicy: 'unknown', // No AI music policy
   },
   buymeacoffee: {
     id: 'buymeacoffee',
@@ -106,7 +106,6 @@ export const sources: Record<SourceId, Source> = {
     searchOnly: true,
     homepageUrl: 'https://buymeacoffee.com',
     artistPayoutPercent: '~92%',
-    aiPolicy: 'unknown', // No AI policy
   },
   kofi: {
     id: 'kofi',
@@ -120,7 +119,6 @@ export const sources: Record<SourceId, Source> = {
     searchOnly: true,
     homepageUrl: 'https://ko-fi.com',
     artistPayoutPercent: '92-97%',
-    aiPolicy: 'unknown', // No AI policy
   },
   hoopla: {
     id: 'hoopla',
@@ -155,7 +153,8 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.qobuz.com/us-en/search/artists/{query}',
     homepageUrl: 'https://www.qobuz.com',
     artistPayoutPercent: '~70%',
-    aiPolicy: 'anti-ai', // Has AI Charter, detects/tags AI content, excludes from human-curated recs
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://community.qobuz.com/ai-charter',
   },
   beatport: {
     id: 'beatport',
@@ -168,7 +167,8 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.beatport.com/search?q={query}',
     homepageUrl: 'https://www.beatport.com',
     artistPayoutPercent: '55-70%',
-    aiPolicy: 'unknown', // No explicit public AI policy
+    aiPolicy: 'discouraged',
+    aiPolicyUrl: 'https://greenroomsupport.beatport.com/hc/en-us/articles/19093504988820-Content-Policy',
   },
   even: {
     id: 'even',
@@ -181,7 +181,6 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://even.biz/search?q={query}',
     homepageUrl: 'https://even.biz',
     artistPayoutPercent: '~80%',
-    aiPolicy: 'unknown', // No public AI policy found
   },
   jamcoop: {
     id: 'jamcoop',
@@ -193,7 +192,6 @@ export const sources: Record<SourceId, Source> = {
     hasEmbed: false,
     searchUrlTemplate: 'https://jam.coop/artists',
     homepageUrl: 'https://jam.coop',
-    aiPolicy: 'unknown', // No public AI policy found
   },
   officialsite: {
     id: 'officialsite',
@@ -205,7 +203,6 @@ export const sources: Record<SourceId, Source> = {
     hasEmbed: false,
     searchUrlTemplate: '',
     homepageUrl: '',
-    aiPolicy: 'self-hosted', // Artist's own website
   },
   discogs: {
     id: 'discogs',
@@ -217,7 +214,6 @@ export const sources: Record<SourceId, Source> = {
     hasEmbed: false,
     searchUrlTemplate: 'https://www.discogs.com/search/?q={query}&type=artist',
     homepageUrl: 'https://www.discogs.com',
-    aiPolicy: 'unknown', // No AI content policy for physical media sales
   },
   // Social platforms
   instagram: {

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -70,6 +70,8 @@ export const sources: Record<SourceId, Source> = {
     hasEmbed: false,
     searchUrlTemplate: 'https://bandwagon.fm/artists?q={query}',
     homepageUrl: 'https://bandwagon.fm',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://bandwagon.fm/acceptable-use',
   },
   faircamp: {
     id: 'faircamp',

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -27,7 +27,8 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://mirlo.space/search?query={query}',
     homepageUrl: 'https://mirlo.space',
     artistPayoutPercent: '86-90%',
-    aiPolicy: 'formal', // AI policy exists but URL not yet confirmed
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://mirlo.space/pages/content-policy',
   },
   ampwall: {
     id: 'ampwall',

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -42,7 +42,8 @@ export interface Source {
   searchOnly?: boolean; // True if we can't verify the artist exists (shows "Search X" instead)
   homepageUrl: string;
   artistPayoutPercent?: string; // e.g., "80-85%" - artist's share of sales on this platform
-  aiPolicy?: 'banned' | 'anti-ai' | 'disclosed' | 'unknown' | 'self-hosted'; // AI-generated content policy
+  aiPolicy?: 'formal' | 'discouraged'; // AI-generated content policy (marketplaces only)
+  aiPolicyUrl?: string; // Link to platform's AI music policy page
 }
 
 // Latest release info


### PR DESCRIPTION
Rethinks the AI policy badge system based on Brandon's feedback that no platform can 100% ban AI music — what matters is linking to their actual policy.

### Changes

**New AI policy model:**
- `formal` — Platform has a written AI music policy (green shield badge, links to it)
- `discouraged` — Platform discourages AI music but doesn't outright ban (amber shield badge)
- No badge for platforms without an aiPolicy field

**Only marketplaces show AI policy badges.** All other categories (social, patronage, library, decentralized, official) had their aiPolicy removed.

**Badges are now clickable links** to the platform's AI policy page, not just hover tooltips.

### Policy URLs added
| Platform | Type | URL |
|----------|------|-----|
| Bandcamp | formal | https://blog.bandcamp.com/2026/01/13/keeping-bandcamp-human/ |
| Mirlo | formal | (URL pending — couldn't find it) |
| Ampwall | formal | https://ampwall.com/content-policy |
| Subvert | formal | https://www.subvert.fm/pages/ai-policy |
| Qobuz | formal | https://community.qobuz.com/ai-charter |
| Beatport | discouraged | https://greenroomsupport.beatport.com/hc/en-us/articles/19093504988820-Content-Policy |

### No badge (no aiPolicy)
EVEN, Jam.coop, Discogs, and all non-marketplace platforms.

### Removed types
`banned`, `anti-ai`, `unknown`, `self-hosted`, `disclosed` — replaced with `formal` and `discouraged`.