### PR TITLE
Fix: Subvert in marketplace category

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 13 May 2026 17:14:33 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 13 May 2026 17:55:53 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -358,7 +358,7 @@ export const sourceCategories = {
   marketplace: {
     name: 'Music Marketplaces',
     description: 'Buy music directly from artists',
-    sources: ['bandcamp', 'mirlo', 'ampwall', 'qobuz', 'beatport', 'even', 'jamcoop', 'discogs'] as SourceId[],
+    sources: ['bandcamp', 'mirlo', 'ampwall', 'subvert', 'qobuz', 'beatport', 'even', 'jamcoop', 'discogs'] as SourceId[],
   },
   patronage: {
     name: 'Patronage Platforms',


### PR DESCRIPTION
Subvert was missing from `sourceCategories.marketplace.sources` in sources.ts, causing it to appear under 'Other links' instead of 'Music Marketplaces' on search results pages.

This was in PR #208 but got lost when #208 was closed in favor of #209 (which didn't include this change).