### PR TITLE
Refactor: Shared platform registry + fix stale edge template data

### DIFF
--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -1,4 +1,5 @@
 import { Context } from "https://edge.netlify.com";
+import { PLATFORMS } from "../shared/platform-registry.ts";
 
 interface PlatformLink {
   sourceId: string;
@@ -32,32 +33,11 @@ function isBandcampFriday(): boolean {
   return BANDCAMP_FRIDAY_DATES.includes(pacificDate);
 }
 
-// Platform display names and colors for static rendering
-const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; searchOnly?: boolean; payoutPercent?: string }> = {
-  bandcamp: { name: 'Bandcamp', color: '#1da0c3', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
-  mirlo: { name: 'Mirlo', color: '#6366f1', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
-  ampwall: { name: 'Ampwall', color: '#ef4444', icon: '🔊', category: 'marketplace', searchOnly: true, payoutPercent: '92-95%' },
-  subvert: { name: 'Subvert', color: '#f97316', icon: '✊', category: 'marketplace', searchOnly: true, payoutPercent: '97%' },
-  bandwagon: { name: 'Bandwagon', color: '#8b5cf6', icon: '🚐', category: 'decentralized' },
-  faircamp: { name: 'Faircamp', color: '#22c55e', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
-  patreon: { name: 'Patreon', color: '#ff424d', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },
-  buymeacoffee: { name: 'Buy Me a Coffee', color: '#ffdd00', icon: '☕', category: 'patronage', searchOnly: true, payoutPercent: '~92%' },
-  kofi: { name: 'Ko-fi', color: '#29abe0', icon: '🍵', category: 'patronage', searchOnly: true, payoutPercent: '92-97%' },
-  hoopla: { name: 'Hoopla', color: '#9333ea', icon: '🎧', category: 'library' },
-  freegal: { name: 'Freegal', color: '#e91e63', icon: '🎵', category: 'library' },
-  qobuz: { name: 'Qobuz', color: '#0070f3', icon: '💿', category: 'marketplace', payoutPercent: '~70%' },
-  jamcoop: { name: 'Jam.coop', color: '#e11d48', icon: '🎸', category: 'marketplace' },
-  officialsite: { name: 'Official Site', color: '#71717a', icon: '🌐', category: 'official' },
-  discogs: { name: 'Discogs', color: '#333333', icon: '💿', category: 'marketplace' },
-  instagram: { name: 'Instagram', color: '#E4405F', icon: 'social', category: 'social' },
-  facebook: { name: 'Facebook', color: '#1877F2', icon: 'social', category: 'social' },
-  tiktok: { name: 'TikTok', color: '#E0E0E0', icon: 'social', category: 'social' },
-  youtube: { name: 'YouTube', color: '#FF0000', icon: 'social', category: 'social' },
-  threads: { name: 'Threads', color: '#E0E0E0', icon: 'social', category: 'social' },
-  bluesky: { name: 'Bluesky', color: '#0085FF', icon: 'social', category: 'social' },
-  mastodon: { name: 'Mastodon', color: '#6364FF', icon: 'social', category: 'social' },
-  peertube: { name: 'PeerTube', color: '#F1680D', icon: 'social', category: 'social' },
-};
+// Derive PLATFORM_INFO from shared registry
+const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; searchOnly?: boolean; payoutPercent?: string }> = {};
+for (const [id, p] of Object.entries(PLATFORMS)) {
+  PLATFORM_INFO[id] = { name: p.name, color: p.color, icon: p.icon, category: p.category, ...(p.searchOnly && { searchOnly: p.searchOnly }), ...(p.payoutPercent && { payoutPercent: p.payoutPercent }) };
+}
 
 const SOCIAL_ICONS: Record<string, string> = {
   instagram: '<svg width="16" height="16" viewBox="0 0 24 24" fill="#E4405F"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>',

--- a/api/edge/claimed-artist-page.ts
+++ b/api/edge/claimed-artist-page.ts
@@ -1,5 +1,6 @@
 import { Context } from "https://edge.netlify.com";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { PLATFORMS } from "../shared/platform-registry.ts";
 
 // UPDATE ANNUALLY: Bandcamp Friday dates from https://daily.bandcamp.com/features/bandcamp-fridays
 const BANDCAMP_FRIDAY_DATES = [
@@ -11,34 +12,11 @@ function isBandcampFriday(): boolean {
   return BANDCAMP_FRIDAY_DATES.includes(pacificDate);
 }
 
-const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; payoutPercent?: string }> = {
-  bandcamp: { name: 'Bandcamp', color: '#1da0c3', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
-  mirlo: { name: 'Mirlo', color: '#6366f1', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
-  ampwall: { name: 'Ampwall', color: '#ef4444', icon: '🔊', category: 'marketplace', payoutPercent: '92-95%' },
-  subvert: { name: 'Subvert', color: '#f97316', icon: '✊', category: 'marketplace', payoutPercent: '97%' },
-  bandwagon: { name: 'Bandwagon', color: '#8b5cf6', icon: '🚐', category: 'decentralized' },
-  faircamp: { name: 'Faircamp', color: '#22c55e', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
-  patreon: { name: 'Patreon', color: '#ff424d', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },
-  qobuz: { name: 'Qobuz', color: '#0070f3', icon: '💿', category: 'marketplace', payoutPercent: '~70%' },
-  jamcoop: { name: 'Jam.coop', color: '#e11d48', icon: '🎸', category: 'marketplace' },
-  officialsite: { name: 'Official Site', color: '#71717a', icon: '🌐', category: 'official' },
-  discogs: { name: 'Discogs', color: '#333333', icon: '💿', category: 'marketplace' },
-  hoopla: { name: 'Hoopla', color: '#9333ea', icon: '🎧', category: 'library' },
-  freegal: { name: 'Freegal', color: '#e91e63', icon: '🎵', category: 'library' },
-  funkwhale: { name: 'Funkwhale', color: '#0084c7', icon: '🐋', category: 'decentralized' },
-  internetarchive: { name: 'Internet Archive', color: '#428bca', icon: '🏛️', category: 'library' },
-  instagram: { name: 'Instagram', color: '#E4405F', icon: '📷', category: 'social' },
-  facebook: { name: 'Facebook', color: '#1877F2', icon: '📘', category: 'social' },
-  tiktok: { name: 'TikTok', color: '#E0E0E0', icon: '🎬', category: 'social' },
-  youtube: { name: 'YouTube', color: '#FF0000', icon: '▶️', category: 'social' },
-  threads: { name: 'Threads', color: '#E0E0E0', icon: '🧵', category: 'social' },
-  bluesky: { name: 'Bluesky', color: '#0085FF', icon: '🦋', category: 'social' },
-  mastodon: { name: 'Mastodon', color: '#6364FF', icon: '🦣', category: 'social' },
-  peertube: { name: 'PeerTube', color: '#F1680D', icon: '▶️', category: 'social' },
-  newsletter: { name: 'Newsletter', color: '#666', icon: '📧', category: 'social' },
-  wikipedia: { name: 'Wikipedia', color: '#636466', icon: '📖', category: 'social' },
-  liberapay: { name: 'Liberapay', color: '#F6C915', icon: '🤝', category: 'patronage' },
-};
+// Derive PLATFORM_INFO from shared registry (name, color, icon, category, payoutPercent)
+const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; payoutPercent?: string }> = {};
+for (const [id, p] of Object.entries(PLATFORMS)) {
+  PLATFORM_INFO[id] = { name: p.name, color: p.color, icon: p.icon, category: p.category, ...(p.payoutPercent && { payoutPercent: p.payoutPercent }) };
+}
 
 function escapeHtml(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');

--- a/api/edge/noscript-search.ts
+++ b/api/edge/noscript-search.ts
@@ -1,4 +1,5 @@
 import { Context } from "https://edge.netlify.com";
+import { PLATFORMS } from "../shared/platform-registry.ts";
 
 interface PlatformLink {
   sourceId: string;
@@ -22,31 +23,11 @@ interface SearchResult {
   matchConfidence?: 'verified' | 'unverified';
 }
 
-const PLATFORM_INFO: Record<string, { name: string; icon: string; category: string; searchOnly?: boolean; payoutPercent?: string }> = {
-  bandcamp: { name: 'Bandcamp', icon: '🎵', category: 'marketplace', payoutPercent: '80-85%' },
-  mirlo: { name: 'Mirlo', icon: '🪺', category: 'marketplace', payoutPercent: '86-90%' },
-  ampwall: { name: 'Ampwall', icon: '🔊', category: 'marketplace', searchOnly: true, payoutPercent: '92-95%' },
-  subvert: { name: 'Subvert', icon: '✊', category: 'marketplace', searchOnly: true, payoutPercent: '97%' },
-  bandwagon: { name: 'Bandwagon', icon: '🚐', category: 'decentralized' },
-  faircamp: { name: 'Faircamp', icon: '🏕️', category: 'decentralized', payoutPercent: '90-97%' },
-  patreon: { name: 'Patreon', icon: '🎨', category: 'patronage', payoutPercent: '86-90%' },
-  buymeacoffee: { name: 'Buy Me a Coffee', icon: '☕', category: 'patronage', searchOnly: true, payoutPercent: '~92%' },
-  kofi: { name: 'Ko-fi', icon: '🍵', category: 'patronage', searchOnly: true, payoutPercent: '92-97%' },
-  hoopla: { name: 'Hoopla', icon: '🎧', category: 'library' },
-  freegal: { name: 'Freegal', icon: '🎵', category: 'library' },
-  qobuz: { name: 'Qobuz', icon: '💿', category: 'marketplace', payoutPercent: '~70%' },
-  jamcoop: { name: 'Jam.coop', icon: '🎸', category: 'marketplace' },
-  officialsite: { name: 'Official Site', icon: '🌐', category: 'official' },
-  discogs: { name: 'Discogs', icon: '💿', category: 'marketplace' },
-  instagram: { name: 'Instagram', icon: '📷', category: 'social' },
-  facebook: { name: 'Facebook', icon: '👤', category: 'social' },
-  tiktok: { name: 'TikTok', icon: '🎬', category: 'social' },
-  youtube: { name: 'YouTube', icon: '▶️', category: 'social' },
-  threads: { name: 'Threads', icon: '🧵', category: 'social' },
-  bluesky: { name: 'Bluesky', icon: '🦋', category: 'social' },
-  mastodon: { name: 'Mastodon', icon: '🐘', category: 'social' },
-  peertube: { name: 'PeerTube', icon: '🎥', category: 'social' },
-};
+// Derive PLATFORM_INFO from shared registry
+const PLATFORM_INFO: Record<string, { name: string; icon: string; category: string; searchOnly?: boolean; payoutPercent?: string }> = {};
+for (const [id, p] of Object.entries(PLATFORMS)) {
+  PLATFORM_INFO[id] = { name: p.name, icon: p.icon, category: p.category, ...(p.searchOnly && { searchOnly: p.searchOnly }), ...(p.payoutPercent && { payoutPercent: p.payoutPercent }) };
+}
 
 const CATEGORY_ORDER = ['marketplace', 'patronage', 'library', 'decentralized', 'official'];
 const CATEGORY_LABELS: Record<string, string> = {

--- a/api/shared/platform-registry.ts
+++ b/api/shared/platform-registry.ts
@@ -1,0 +1,286 @@
+/**
+ * Shared platform registry — single source of truth for platform metadata.
+ *
+ * Used by:
+ * - apps/web/src/services/sources.ts (client-side source config)
+ * - api/edge/*.ts (SSR/SEO edge functions)
+ *
+ * When adding or updating a platform, edit ONLY this file.
+ * Then run: grep -r "PLATFORM_INFO" api/edge/ apps/web/src/ to find stale copies.
+ */
+
+export interface PlatformMeta {
+  name: string;
+  color: string;
+  icon: string;
+  category: string;
+  payoutPercent?: string;
+  searchOnly?: boolean;
+  homepageUrl?: string;
+  aiPolicy?: 'formal' | 'discouraged';
+  aiPolicyUrl?: string;
+}
+
+export const PLATFORMS: Record<string, PlatformMeta> = {
+  // Marketplaces
+  bandcamp: {
+    name: 'Bandcamp',
+    color: '#1da0c3',
+    icon: '🎵',
+    category: 'marketplace',
+    payoutPercent: '80-85%',
+    searchOnly: true,
+    homepageUrl: 'https://bandcamp.com',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://blog.bandcamp.com/2026/01/13/keeping-bandcamp-human/',
+  },
+  mirlo: {
+    name: 'Mirlo',
+    color: '#BE3455',
+    icon: '🪺',
+    category: 'marketplace',
+    payoutPercent: '86-90%',
+    homepageUrl: 'https://mirlo.space',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://mirlo.space/pages/content-policy',
+  },
+  ampwall: {
+    name: 'Ampwall',
+    color: '#1E1E24',
+    icon: '🔊',
+    category: 'marketplace',
+    payoutPercent: '92-95%',
+    searchOnly: true,
+    homepageUrl: 'https://ampwall.com',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://ampwall.com/content-policy',
+  },
+  subvert: {
+    name: 'Subvert',
+    color: '#D9DBDD',
+    icon: '🌐',
+    category: 'marketplace',
+    payoutPercent: '97%',
+    searchOnly: true,
+    homepageUrl: 'https://www.subvert.fm',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://www.subvert.fm/pages/ai-policy',
+  },
+  qobuz: {
+    name: 'Qobuz',
+    color: '#0070f3',
+    icon: '💿',
+    category: 'marketplace',
+    payoutPercent: '~70%',
+    homepageUrl: 'https://www.qobuz.com',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://community.qobuz.com/ai-charter',
+  },
+  beatport: {
+    name: 'Beatport',
+    color: '#01FF95',
+    icon: '🎛️',
+    category: 'marketplace',
+    payoutPercent: '55-70%',
+    homepageUrl: 'https://www.beatport.com',
+    aiPolicy: 'discouraged',
+    aiPolicyUrl: 'https://greenroomsupport.beatport.com/hc/en-us/articles/19093504988820-Content-Policy',
+  },
+  even: {
+    name: 'EVEN',
+    color: '#000000',
+    icon: '🎤',
+    category: 'marketplace',
+    payoutPercent: '~80%',
+    homepageUrl: 'https://even.biz',
+  },
+  jamcoop: {
+    name: 'Jam.coop',
+    color: '#D97706',
+    icon: '🎸',
+    category: 'marketplace',
+    homepageUrl: 'https://jam.coop',
+  },
+  discogs: {
+    name: 'Discogs',
+    color: '#333333',
+    icon: '💿',
+    category: 'marketplace',
+    homepageUrl: 'https://www.discogs.com',
+  },
+
+  // Self-hosted & Decentralized
+  bandwagon: {
+    name: 'Bandwagon',
+    color: '#8b5cf6',
+    icon: '🚐',
+    category: 'decentralized',
+    homepageUrl: 'https://bandwagon.fm',
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://bandwagon.fm/acceptable-use',
+  },
+  faircamp: {
+    name: 'Faircamp',
+    color: '#22c55e',
+    icon: '🏕️',
+    category: 'decentralized',
+    payoutPercent: '90-97%',
+    homepageUrl: 'https://simonrepp.com/faircamp',
+  },
+
+  // Patronage
+  patreon: {
+    name: 'Patreon',
+    color: '#ff424d',
+    icon: '🎨',
+    category: 'patronage',
+    payoutPercent: '86-90%',
+    homepageUrl: 'https://www.patreon.com',
+  },
+  buymeacoffee: {
+    name: 'Buy Me a Coffee',
+    color: '#ffdd00',
+    icon: '☕',
+    category: 'patronage',
+    payoutPercent: '~92%',
+    searchOnly: true,
+    homepageUrl: 'https://buymeacoffee.com',
+  },
+  kofi: {
+    name: 'Ko-fi',
+    color: '#29abe0',
+    icon: '🍵',
+    category: 'patronage',
+    payoutPercent: '92-97%',
+    searchOnly: true,
+    homepageUrl: 'https://ko-fi.com',
+  },
+  liberapay: {
+    name: 'Liberapay',
+    color: '#F6C915',
+    icon: '🤝',
+    category: 'patronage',
+    homepageUrl: 'https://liberapay.com',
+  },
+
+  // Library
+  hoopla: {
+    name: 'Hoopla',
+    color: '#9333ea',
+    icon: '🎧',
+    category: 'library',
+    homepageUrl: 'https://www.hoopladigital.com',
+  },
+  freegal: {
+    name: 'Freegal',
+    color: '#e91e63',
+    icon: '🎵',
+    category: 'library',
+    homepageUrl: 'https://www.freegalmusic.com',
+  },
+
+  // Official
+  officialsite: {
+    name: 'Official Site',
+    color: '#71717a',
+    icon: '⭐',
+    category: 'official',
+    homepageUrl: '',
+  },
+  wikipedia: {
+    name: 'Wikipedia',
+    color: '#636466',
+    icon: '📖',
+    category: 'official',
+    homepageUrl: 'https://en.wikipedia.org',
+  },
+
+  // Social
+  instagram: {
+    name: 'Instagram',
+    color: '#E4405F',
+    icon: 'instagram',
+    category: 'social',
+    homepageUrl: 'https://www.instagram.com',
+  },
+  facebook: {
+    name: 'Facebook',
+    color: '#1877F2',
+    icon: 'facebook',
+    category: 'social',
+    homepageUrl: 'https://www.facebook.com',
+  },
+  tiktok: {
+    name: 'TikTok',
+    color: '#E0E0E0',
+    icon: 'tiktok',
+    category: 'social',
+    homepageUrl: 'https://www.tiktok.com',
+  },
+  youtube: {
+    name: 'YouTube',
+    color: '#FF0000',
+    icon: 'youtube',
+    category: 'social',
+    homepageUrl: 'https://www.youtube.com',
+  },
+  threads: {
+    name: 'Threads',
+    color: '#E0E0E0',
+    icon: 'threads',
+    category: 'social',
+    homepageUrl: 'https://www.threads.net',
+  },
+  bluesky: {
+    name: 'Bluesky',
+    color: '#0085FF',
+    icon: 'bluesky',
+    category: 'social',
+    homepageUrl: 'https://bsky.app',
+  },
+  mastodon: {
+    name: 'Mastodon',
+    color: '#6364FF',
+    icon: 'mastodon',
+    category: 'social',
+    homepageUrl: 'https://mastodon.social',
+  },
+  peertube: {
+    name: 'PeerTube',
+    color: '#F1680D',
+    icon: 'peertube',
+    category: 'social',
+    homepageUrl: 'https://joinpeertube.org',
+  },
+  newsletter: {
+    name: 'Newsletter',
+    color: '#666',
+    icon: '📧',
+    category: 'social',
+    homepageUrl: '',
+  },
+
+  // Legacy/edge-only platforms (appear in MusicBrainz enrichment but not main search)
+  funkwhale: {
+    name: 'Funkwhale',
+    color: '#0084c7',
+    icon: '🐋',
+    category: 'decentralized',
+  },
+  internetarchive: {
+    name: 'Internet Archive',
+    color: '#428bca',
+    icon: '🏛️',
+    category: 'library',
+  },
+};
+
+/** Category display order and labels */
+export const CATEGORY_ORDER: { key: string; name: string; description: string }[] = [
+  { key: 'marketplace', name: 'Music Marketplaces', description: 'Buy music directly from artists' },
+  { key: 'patronage', name: 'Patronage Platforms', description: 'Support artists directly' },
+  { key: 'decentralized', name: 'Self-hosted & Decentralized', description: 'ActivityPub and self-hosted platforms' },
+  { key: 'library', name: 'Library Services', description: 'Access through your local library' },
+  { key: 'official', name: 'Official', description: 'Artist websites and profiles' },
+  { key: 'social', name: 'Social', description: 'Artist social media profiles' },
+];

--- a/apps/mac/Unstream/Models/PlatformCatalog.swift
+++ b/apps/mac/Unstream/Models/PlatformCatalog.swift
@@ -27,17 +27,17 @@ let platformCatalog: [String: PlatformConfig] = [
     "bandwagon": PlatformConfig(name: "Bandwagon", icon: "car", color: "#FF6B35", searchOnly: false),
     "faircamp": PlatformConfig(name: "Faircamp", icon: "tent", color: "#2D5A27", searchOnly: false, artistPayoutPercent: "90-97%"),
     "qobuz": PlatformConfig(name: "Qobuz", icon: "hifispeaker", color: "#4169E1", searchOnly: false, artistPayoutPercent: "~70%"),
-    "jamcoop": PlatformConfig(name: "Jam.coop", icon: "guitars", color: "#E11D48", searchOnly: false),
+    "jamcoop": PlatformConfig(name: "Jam.coop", icon: "guitars", color: "#D97706", searchOnly: false),
     "freegal": PlatformConfig(name: "Freegal", icon: "building.columns", color: "#00A651", searchOnly: false),
     "hoopla": PlatformConfig(name: "Hoopla", icon: "books.vertical", color: "#E31837", searchOnly: false),
     "patreon": PlatformConfig(name: "Patreon", icon: "heart", color: "#FF424D", searchOnly: false, artistPayoutPercent: "86-90%"),
     // Search-only platforms
-    "ampwall": PlatformConfig(name: "Ampwall", icon: "waveform", color: "#EF4444", searchOnly: true, artistPayoutPercent: "92-95%"),
-    "subvert": PlatformConfig(name: "Subvert", icon: "fist.raised", color: "#F97316", searchOnly: true, artistPayoutPercent: "97%"),
+    "ampwall": PlatformConfig(name: "Ampwall", icon: "waveform", color: "#1E1E24", searchOnly: true, artistPayoutPercent: "92-95%"),
+    "subvert": PlatformConfig(name: "Subvert", icon: "globe", color: "#D9DBDD", searchOnly: true, artistPayoutPercent: "97%"),
     "kofi": PlatformConfig(name: "Ko-fi", icon: "cup.and.saucer", color: "#29ABE0", searchOnly: true, artistPayoutPercent: "92-97%"),
     "buymeacoffee": PlatformConfig(name: "Buy Me a Coffee", icon: "cup.and.saucer", color: "#FFDD00", searchOnly: true, artistPayoutPercent: "~92%"),
     // Official
-    "officialsite": PlatformConfig(name: "Official Site", icon: "globe", color: "#71717A", searchOnly: false),
+    "officialsite": PlatformConfig(name: "Official Site", icon: "star", color: "#71717A", searchOnly: false),
     "discogs": PlatformConfig(name: "Discogs", icon: "opticaldisc", color: "#333333", searchOnly: false),
     // Social platforms
     "instagram": PlatformConfig(name: "Instagram", icon: "camera", color: "#E4405F", searchOnly: false),

--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Fri, 15 May 2026 10:42:31 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 15 May 2026 10:53:19 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -1,3 +1,6 @@
+// NOTE: Platform name, color, icon, and category are defined in api/shared/platform-registry.ts
+// as the single source of truth. When updating these fields, update the shared registry too.
+// The sources below add client-only fields (description, searchUrlTemplate, hasEmbed, aiPolicy, etc.).
 import type { Source, SourceId, SearchResponse, SearchResult } from '../types';
 
 export const sources: Record<SourceId, Source> = {


### PR DESCRIPTION
Creates a single source of truth for platform metadata so we stop forgetting to update 7+ files when a platform changes.

**Shared registry:** `api/shared/platform-registry.ts` defines name, color, icon, category, payoutPercent, searchOnly, aiPolicy, aiPolicyUrl, homepageUrl for every platform.

**Edge functions now import from the registry:**
- `api/edge/claimed-artist-page.ts` - 27 inline entries → import + loop
- `api/edge/artist-page.ts` - 24 inline entries → import + loop  
- `api/edge/noscript-search.ts` - 22 inline entries → import + loop

**Also fixes:**
- Subvert icon on verified artist pages: ✊ → 🌐 (was stale in edge templates)
- Official Site icon on verified pages: 🌐 → ⭐
- Stale brand colors in Swift: Ampwall #ef4444 → #1E1E24, Jam.coop #e11d48 → #D97706, Subvert #f97316 → #D9DBDD
- sources.ts has sync comment pointing to shared registry

Fixes UNS-34