### PR TITLE
Fix UNS-35: View live profile link for claimed artists

### DIFF
--- a/apps/web/public/dispatch.xml
+++ b/apps/web/public/dispatch.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://unstream.stream/dispatch.xml" rel="self" type="application/rss+xml" />
     <description>Weekly music industry intelligence — platform news, streaming economics, and what it means for independent artists. Written by Unstream.</description>
     <language>en-us</language>
-    <lastBuildDate>Fri, 15 May 2026 20:41:23 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 15 May 2026 22:24:15 GMT</lastBuildDate>
     <item>
       <title>Week of April 16, 2026</title>
       <link>https://unstream.stream/dispatch/2026-W16</link>

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -82,10 +82,30 @@ export function ArtistPage() {
           }
         }
       } catch {
-        // Fall through to live search
+        // Fall through to live fetch
       }
 
-      // Fallback: live search using the slug as query
+      // Fallback: fetch from API for claimed artists (no pre-generated JSON)
+      // This ensures artists can view their claimed profiles even without pre-built JSON
+      try {
+        const response = await fetch(`/api/artist?slug=${encodeURIComponent(slug)}`);
+        if (response.ok && !cancelled) {
+          const data: SearchResult = await response.json();
+          // Convert single artist result to array format
+          const resultsArray: SearchResult[] = data ? [data] : [];
+          setResults(resultsArray);
+          if (resultsArray.length > 0) {
+            const firstArtist = resultsArray.find(r => r.type === 'artist');
+            if (firstArtist) setArtistName(firstArtist.name);
+          }
+          setIsLoading(false);
+          return;
+        }
+      } catch {
+        // Fall through to search
+      }
+
+      // Last resort: live search using the slug as query
       const query = slug!.replace(/-/g, ' ');
       try {
         const response = await searchPlatforms(query);

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -62,6 +62,7 @@ export function ArtistPage() {
   useEffect(() => {
     if (!slug) return;
 
+    const artistSlug = slug;
     let cancelled = false;
 
     async function loadArtist() {
@@ -70,7 +71,7 @@ export function ArtistPage() {
 
       // Try pre-generated data first
       try {
-        const res = await fetch(`/data/artists/${slug}.json`);
+        const res = await fetch(`/data/artists/${artistSlug}.json`);
         if (res.ok) {
           const data: SearchResult[] = await res.json();
           if (!cancelled && data.length > 0) {
@@ -88,7 +89,7 @@ export function ArtistPage() {
       // Fallback: fetch from API for claimed artists (no pre-generated JSON)
       // This ensures artists can view their claimed profiles even without pre-built JSON
       try {
-        const response = await fetch(`/api/artist?slug=${encodeURIComponent(slug)}`);
+        const response = await fetch(`/api/artist?slug=${encodeURIComponent(artistSlug)}`);
         if (response.ok && !cancelled) {
           const data: SearchResult = await response.json();
           // Convert single artist result to array format
@@ -106,7 +107,7 @@ export function ArtistPage() {
       }
 
       // Last resort: live search using the slug as query
-      const query = slug!.replace(/-/g, ' ');
+      const query = artistSlug.replace(/-/g, ' ');
       try {
         const response = await searchPlatforms(query);
         if (cancelled) return;


### PR DESCRIPTION
## What this fixes

On the artist's Edit Profile page, the 'View live profile' link was taking artists to search results instead of their actual claimed profile.

## Root cause

In ArtistPage.tsx, the page first tries to load pre-generated JSON at /data/artists/slug.json, then falls back to searchPlatforms() which shows generic search results, not the claimed profile. For claimed artists who don't have pre-generated JSON files, this caused them to see search results.

## The fix

Added a fallback to fetch artist data from /api/artist?slug=slug when the pre-generated JSON file doesn't exist. This ensures claimed artists can always view their verified profile data.

## Steps

1. Try to load /data/artists/slug.json (unchanged - still first priority)
2. If that fails, fetch from /api/artist?slug=slug (new - for claimed artists)
3. If that fails, fall back to live search (unchanged - fallback for unclaimed artists)

This preserves the existing behavior for pre-generated artists while fixing the issue for claimed artists.

Fixes UNS-35