### PR TITLE
Fix Buffer API AssetInput format in social post generator

### DIFF
--- a/scripts/generate-social-posts.ts
+++ b/scripts/generate-social-posts.ts
@@ -862,7 +862,7 @@ async function createBufferPost(opts: CreatePostOpts) {
   };
 
   if (opts.imageUrl) {
-    input.assets = { images: [{ url: opts.imageUrl }] };
+    input.assets = [{ image: { url: opts.imageUrl } }];
   }
 
   if (opts.metadata) {


### PR DESCRIPTION
Fixes UNS-60

Buffer's GraphQL API changed: `CreatePostInput.assets` now takes `[AssetInput!]` where each `AssetInput` has a single variant (`image`, `video`, `document`, `link`). The old format `{ images: [{ url }] }` is no longer valid.

Changed: `input.assets = { images: [{ url }] }` → `[{ image: { url } }]`

One-line fix. The GitHub Action should work again after merging.