### PR TITLE
UNS-62 + UNS-63: Login copy update and restore search result actions

### DIFF
--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -6,6 +6,7 @@ import { ResultCardRelease } from './ResultCardRelease';
 import { ResultCardPlatforms } from './ResultCardPlatforms';
 import { LoginInterstitial } from './LoginInterstitial';
 import { ResultCardSocial } from './ResultCardSocial';
+import { ResultCardActions } from './ResultCardActions';
 
 import {
   categorizePlatforms,
@@ -169,6 +170,8 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
               category="curated"
             />
           )}
+
+          <ResultCardActions result={result} />
         </div>
 
       {showLoginInterstitial && (

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { signInWithMagicLink, signInWithPassword, resetPasswordForEmail } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -194,7 +194,7 @@ export function LoginPage() {
                   </button>
 
                   <p className="text-center text-xs text-text-muted">
-                    Don't have a password yet? Use the sign-in link, then set one from your dashboard.
+                    Don't have an account yet? Search for an artist you like and click "Save" to sign up.
                   </p>
                 </>
               )}
@@ -237,11 +237,7 @@ export function LoginPage() {
 
           <div className="text-center space-y-2">
             <p className="text-xs text-text-muted">
-              Not on Unstream yet?{' '}
-              <Link to="/" className="text-accent-primary hover:underline">
-                Search for your artist
-              </Link>{' '}
-              and claim their profile to get started.
+              Artists: Click the "Claim" button on your listing to customize your links, fix inaccuracies, and more.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## UNS-63: Restore claim artist blurb in search results

`ResultCardActions` was orphaned when artist saving was added. Re-import and render `<ResultCardActions result={result} />` at the bottom of each `ResultCard`, after all platform sections.

Restores:
- "Are you {name}? Claim your artist page" link for non-claimed artists
- "Report this result" button

## UNS-62: Update login page copy for organic signups

Two copy changes in `LoginPage.tsx`:
- Helper text: "Don't have an account yet? Search for an artist you like and click \"Save\" to sign up."
- Bottom CTA: "Artists: Click the \"Claim\" button on your listing to customize your links, fix inaccuracies, and more."

Removed unused `Link` import.