### PR TITLE
fix(UNS-65): improve dark mode contrast on Save/Share/Claim/Report buttons

### DIFF
--- a/apps/web/src/components/ResultCardActions.tsx
+++ b/apps/web/src/components/ResultCardActions.tsx
@@ -68,7 +68,7 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
             {result.type === 'artist' && result.matchConfidence !== 'claimed' ? (
               <Link
                 to={`/claim/${result.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
-                className="text-xs text-text-muted hover:text-accent-primary transition-colors flex items-center gap-1"
+                className="text-xs text-text-secondary hover:text-accent-primary transition-colors flex items-center gap-1"
                 onClick={(e) => e.stopPropagation()}
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -82,7 +82,7 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
             {/* Report - right */}
             <button
               onClick={(e) => { e.stopPropagation(); setShowReportForm(true); }}
-              className="text-xs text-text-muted hover:text-text-secondary transition-colors flex items-center gap-1"
+              className="text-xs text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
             >
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />

--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -117,7 +117,7 @@ export function ResultCardHeader({
             className={`text-xs font-medium px-2 py-1 rounded-lg transition-colors flex items-center gap-1.5 ${
               isSaved
                 ? 'bg-accent-secondary/15 text-accent-secondary hover:bg-accent-secondary/20'
-                : 'text-text-muted hover:text-text-primary hover:bg-bg-secondary'
+                : 'text-text-secondary hover:text-text-primary hover:bg-bg-secondary'
             }`}
           >
             <svg className="w-3.5 h-3.5" fill={isSaved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
@@ -129,7 +129,7 @@ export function ResultCardHeader({
         {/* Share button */}
         <button
           onClick={onShare}
-          className="text-xs font-medium px-2 py-1 rounded-lg text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-colors flex items-center gap-1.5"
+          className="text-xs font-medium px-2 py-1 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors flex items-center gap-1.5"
           title="Share this result"
         >
           {shareCopied ? (


### PR DESCRIPTION
## UNS-65: Low contrast on Save/Share/Claim buttons in dark mode

### Problem
In dark mode, the Save, Share, and Claim buttons in search results are nearly invisible due to low contrast between `text-text-muted` (#666666) and dark backgrounds (#0d0d0d, #161616, #1a1a1a). That's roughly 3:1 contrast — fails WCAG AA (needs 4.5:1 for normal text).

### Fix
Changed `text-text-muted` → `text-text-secondary` for action buttons only (not global theme variables):

**`ResultCardHeader.tsx`** — Save and Share buttons:
- Save (unsaved state): `text-text-muted` → `text-text-secondary`
- Share button: `text-text-muted` → `text-text-secondary`

**`ResultCardActions.tsx`** — Claim link and Report button:
- "Claim your artist page" link: `text-text-muted` → `text-text-secondary`
- "Report this result" button: `text-text-muted` → `text-text-secondary`, hover also upgraded from `hover:text-text-secondary` → `hover:text-text-primary`

### Result
Buttons now use #999999 in dark mode (~7:1 contrast on dark backgrounds), passing WCAG AA. Light mode unchanged since #555555 (light mode text-secondary) already has good contrast on white.

Closes UNS-65
