### PR TITLE
UNS-62/63/64/65: Web UI fixes (login copy, claim actions, layout, contrast)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -199,8 +199,22 @@ function App() {
 
       <Header />
 
+      {/* Hero — heading always visible, download buttons hidden in PWA mode */}
+      <div className={isStandalone ? "pt-12 pb-6 px-4" : "pt-6 pb-8 px-4"}>
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-8">
+            <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
+              Directly support the artist you&rsquo;re listening to right now
+            </h1>
+            <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
+              Unstream finds the places where your favorite music artists &mdash; not big tech companies &mdash; keep up to 97% of every sale.
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Search section */}
-      <main className={isStandalone ? "pt-12 pb-16 px-4" : "pt-6 pb-16 px-4"}>
+      <main className="px-4 pb-16">
         <div className="max-w-4xl mx-auto">
           <SearchBar
             onSearch={handleSearch}
@@ -209,18 +223,9 @@ function App() {
             onReset={hasSearched ? handleGoHome : undefined}
           />
 
-          {/* Hero — heading and download buttons, hidden in PWA mode */}
+          {/* Download buttons — below search, hidden in PWA mode */}
           {!isStandalone && (
-          <div className="pb-8">
-            <div className="text-center mb-8">
-              <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
-                Directly support the artist you&rsquo;re listening to right now
-              </h1>
-              <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
-                Unstream finds the places where your favorite music artists &mdash; not big tech companies &mdash; keep up to 97% of every sale.
-              </p>
-            </div>
-
+          <div className="mt-8">
             <DownloadGrid />
           </div>
           )}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -200,9 +200,9 @@ function App() {
       <Header />
 
       {/* Hero — heading always visible, download buttons hidden in PWA mode */}
-      <div className={isStandalone ? "pt-12 pb-4 px-4" : "pt-6 pb-4 px-4"}>
+      <div className={isStandalone ? "pt-12 px-4" : "pt-6 px-4"}>
         <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-8">
+          <div className="text-center mb-[30px]">
             <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
               Directly support the artist you&rsquo;re listening to right now
             </h1>
@@ -225,7 +225,7 @@ function App() {
 
           {/* Download buttons — below search, hidden in PWA mode */}
           {!isStandalone && (
-          <div className="mt-4">
+          <div className="mt-[30px]">
             <DownloadGrid />
           </div>
           )}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -198,34 +198,32 @@ function App() {
     <div className="min-h-screen">
 
       <Header />
-      {/* Hero — heading always visible, download buttons hidden in PWA mode */}
-      <div className={isStandalone ? "pt-12 pb-6 px-4" : "pt-6 pb-8 px-4"}>
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-8">
-            <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
-              Directly support the artist you&rsquo;re listening to right now
-            </h1>
-            <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
-              Unstream finds the places where your favorite music artists &mdash; not big tech companies &mdash; keep up to 97% of every sale.
-            </p>
-          </div>
-
-          <DownloadGrid />
-        </div>
-      </div>
 
       {/* Search section */}
-      <main className="px-4 pb-16">
+      <main className={isStandalone ? "pt-12 pb-16 px-4" : "pt-6 pb-16 px-4"}>
         <div className="max-w-4xl mx-auto">
-                    {!isStandalone && (
-          <p className="text-text-secondary text-center mb-4">Search for any artist to see where they keep the most money:</p>
-          )}
           <SearchBar
             onSearch={handleSearch}
             isLoading={isLoading || isResolving}
             initialQuery={resolvedQuery}
             onReset={hasSearched ? handleGoHome : undefined}
           />
+
+          {/* Hero — heading and download buttons, hidden in PWA mode */}
+          {!isStandalone && (
+          <div className="pb-8">
+            <div className="text-center mb-8">
+              <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
+                Directly support the artist you&rsquo;re listening to right now
+              </h1>
+              <p className="text-text-secondary text-lg md:text-xl max-w-2xl mx-auto">
+                Unstream finds the places where your favorite music artists &mdash; not big tech companies &mdash; keep up to 97% of every sale.
+              </p>
+            </div>
+
+            <DownloadGrid />
+          </div>
+          )}
 
           {/* Resolving URL state */}
           {isResolving && (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -200,7 +200,7 @@ function App() {
       <Header />
 
       {/* Hero — heading always visible, download buttons hidden in PWA mode */}
-      <div className={isStandalone ? "pt-12 pb-6 px-4" : "pt-6 pb-8 px-4"}>
+      <div className={isStandalone ? "pt-12 pb-2 px-4" : "pt-6 pb-2 px-4"}>
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-8">
             <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -200,7 +200,7 @@ function App() {
       <Header />
 
       {/* Hero — heading always visible, download buttons hidden in PWA mode */}
-      <div className={isStandalone ? "pt-12 pb-2 px-4" : "pt-6 pb-2 px-4"}>
+      <div className={isStandalone ? "pt-12 pb-4 px-4" : "pt-6 pb-4 px-4"}>
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-8">
             <h1 className="font-display text-4xl md:text-5xl font-bold mb-4 text-text-primary">
@@ -225,7 +225,7 @@ function App() {
 
           {/* Download buttons — below search, hidden in PWA mode */}
           {!isStandalone && (
-          <div className="mt-8">
+          <div className="mt-4">
             <DownloadGrid />
           </div>
           )}

--- a/apps/web/src/components/LoginInterstitial.tsx
+++ b/apps/web/src/components/LoginInterstitial.tsx
@@ -85,7 +85,7 @@ export function LoginInterstitial({ artistId, artistName, onClose }: LoginInters
           </div>
         ) : (
           <>
-            <h3 className="font-semibold text-text-primary mb-1">Sign in to save this artist</h3>
+            <h3 className="font-semibold text-text-primary mb-1">Sign up or log in to save this artist</h3>
             <p className="text-sm text-text-secondary mb-4">
               With Unstream, keep track of artists you want to support, get new release alerts, and more.
             </p>

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -6,6 +6,7 @@ import { ResultCardRelease } from './ResultCardRelease';
 import { ResultCardPlatforms } from './ResultCardPlatforms';
 import { LoginInterstitial } from './LoginInterstitial';
 import { ResultCardSocial } from './ResultCardSocial';
+import { ResultCardActions } from './ResultCardActions';
 
 import {
   categorizePlatforms,
@@ -169,6 +170,8 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
               category="curated"
             />
           )}
+
+          <ResultCardActions result={result} />
         </div>
 
       {showLoginInterstitial && (

--- a/apps/web/src/components/ResultCardActions.tsx
+++ b/apps/web/src/components/ResultCardActions.tsx
@@ -68,7 +68,7 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
             {result.type === 'artist' && result.matchConfidence !== 'claimed' ? (
               <Link
                 to={`/claim/${result.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
-                className="text-xs text-text-muted hover:text-accent-primary transition-colors flex items-center gap-1"
+                className="text-xs text-text-secondary hover:text-accent-primary transition-colors flex items-center gap-1"
                 onClick={(e) => e.stopPropagation()}
               >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -82,7 +82,7 @@ export function ResultCardActions({ result }: ResultCardActionsProps) {
             {/* Report - right */}
             <button
               onClick={(e) => { e.stopPropagation(); setShowReportForm(true); }}
-              className="text-xs text-text-muted hover:text-text-secondary transition-colors flex items-center gap-1"
+              className="text-xs text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
             >
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />

--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -117,7 +117,7 @@ export function ResultCardHeader({
             className={`text-xs font-medium px-2 py-1 rounded-lg transition-colors flex items-center gap-1.5 ${
               isSaved
                 ? 'bg-accent-secondary/15 text-accent-secondary hover:bg-accent-secondary/20'
-                : 'text-text-muted hover:text-text-primary hover:bg-bg-secondary'
+                : 'text-text-secondary hover:text-text-primary hover:bg-bg-secondary'
             }`}
           >
             <svg className="w-3.5 h-3.5" fill={isSaved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
@@ -129,7 +129,7 @@ export function ResultCardHeader({
         {/* Share button */}
         <button
           onClick={onShare}
-          className="text-xs font-medium px-2 py-1 rounded-lg text-text-muted hover:text-text-primary hover:bg-bg-secondary transition-colors flex items-center gap-1.5"
+          className="text-xs font-medium px-2 py-1 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-secondary transition-colors flex items-center gap-1.5"
           title="Share this result"
         >
           {shareCopied ? (

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { signInWithMagicLink, signInWithPassword, resetPasswordForEmail } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -194,7 +194,7 @@ export function LoginPage() {
                   </button>
 
                   <p className="text-center text-xs text-text-muted">
-                    Don't have a password yet? Use the sign-in link, then set one from your dashboard.
+                    Don't have an account yet? Search for an artist you like and click "Save" to sign up.
                   </p>
                 </>
               )}
@@ -237,11 +237,7 @@ export function LoginPage() {
 
           <div className="text-center space-y-2">
             <p className="text-xs text-text-muted">
-              Not on Unstream yet?{' '}
-              <Link to="/" className="text-accent-primary hover:underline">
-                Search for your artist
-              </Link>{' '}
-              and claim their profile to get started.
+              Artists: Click the "Claim" button on your listing to customize your links, fix inaccuracies, and more.
             </p>
           </div>
         </div>

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -194,7 +194,7 @@ export function LoginPage() {
                   </button>
 
                   <p className="text-center text-xs text-text-muted">
-                    Don't have an account yet? Search for an artist you like and click "Save" to sign up.
+                    Don't have an account yet? <a href="https://unstream.stream" className="text-accent-primary hover:underline">Search for an artist</a> you like and click Save.
                   </p>
                 </>
               )}


### PR DESCRIPTION
Consolidates PRs #227, #228, #229, and #230 into a single clean PR.

**Changes:**
- **UNS-62**: Update login page copy for organic signups
- **UNS-62**: Update login interstitial header to 'Sign up or log in'
- **UNS-63**: Restore ResultCardActions in search results
- **UNS-64**: Move search above hero/download section, remove instructional copy
- **UNS-65**: Bump dark mode button contrast (text-text-muted → text-text-secondary)

Closes #227, closes #228, closes #229, closes #230