### PR TITLE
fix(UNS-67): remove Roadmap link from footer

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
           <Link to="/guides" className="hover:text-text-primary transition-colors">Guides</Link>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/changelog" className="hover:text-text-primary transition-colors">Changelog</Link>
-
+          <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <a
             href="https://github.com/brandonlucasgreen/unstream"
             target="_blank"

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -11,16 +11,7 @@ export function Footer() {
           <Link to="/guides" className="hover:text-text-primary transition-colors">Guides</Link>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/changelog" className="hover:text-text-primary transition-colors">Changelog</Link>
-          <span className="text-text-muted/40 text-xs">&#x2022;</span>
-          <a
-            href="https://github.com/users/brandonlucasgreen/projects/4"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-text-primary transition-colors"
-          >
-            Roadmap
-          </a>
-          <span className="text-text-muted/40 text-xs">&#x2022;</span>
+
           <a
             href="https://github.com/brandonlucasgreen/unstream"
             target="_blank"


### PR DESCRIPTION
Removes the Roadmap footer link per UNS-67 — redundant since Codebase link goes to the same GitHub project.