### PR TITLE
fix(UNS-70): Exclude /a/ and /artist/ from SW navigation cache

### DIFF
--- a/api/edge/artist-page.ts
+++ b/api/edge/artist-page.ts
@@ -321,7 +321,7 @@ function generateArtistPageHtml(
   ${jsHref ? `<script type="module" src="${jsHref}"></script>` : '<script type="module" src="/src/main.tsx"></script>'}
 
   <!-- Analytics -->
-  <script defer src="https://cloud.umami.is/script.js" data-website-id="0b2ee6ec-0b7a-4ea6-9b79-8ebc3b280874"></script>
+  <script data-goatcounter="https://unstream.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>`;
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -67,6 +67,7 @@
       </div>
     </noscript>
     <script type="module" src="/src/main.tsx"></script>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="0b2ee6ec-0b7a-4ea6-9b79-8ebc3b280874"></script>
+    <script data-goatcounter="https://unstream.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
   </body>
 </html>

--- a/apps/web/src/services/analytics.ts
+++ b/apps/web/src/services/analytics.ts
@@ -1,10 +1,10 @@
 /**
- * Analytics tracking using Umami + Unstream artist analytics API
+ * Analytics tracking using GoatCounter + Unstream artist analytics API
  * + product analytics (app_events).
  *
- * General events (search, download, etc.) go to Umami only.
+ * General events (search, download, etc.) go to GoatCounter only.
  * Artist-specific events (search appearances, page views, link clicks)
- * go to BOTH Umami and our Supabase-backed analytics API so
+ * go to BOTH GoatCounter and our Supabase-backed analytics API so
  * verified artists can see their stats on the dashboard.
  * Product events (all user actions) go to the app_events endpoint for
  * the admin analytics dashboard. All product events are anonymized —
@@ -13,14 +13,14 @@
 
 declare global {
   interface Window {
-    umami?: {
-      track: (eventName: string, data?: Record<string, string | number | boolean>) => void;
+    goatcounter?: {
+      count: (vars: { path: string; event: boolean }) => void;
     };
   }
 }
 
-function trackEvent(eventName: string): void {
-  window.umami?.track(eventName);
+function trackEvent(path: string): void {
+  window.goatcounter?.count({ path, event: true });
 }
 
 /** Fire-and-forget POST to our analytics API for artist-level metrics. */
@@ -45,59 +45,59 @@ function trackAppEvent(
 }
 
 export const analytics = {
-  // Download events (Umami + product analytics)
+  // Download events (GoatCounter + product analytics)
   trackDownload: () => {
-    trackEvent('download');
+    trackEvent('/download');
     trackAppEvent('download', { platform: 'macos' });
   },
   trackDownloadChrome: () => {
-    trackEvent('download-chrome');
+    trackEvent('/download-chrome');
     trackAppEvent('download', { platform: 'chrome' });
   },
   trackDownloadFirefox: () => {
-    trackEvent('download-firefox');
+    trackEvent('/download-firefox');
     trackAppEvent('download', { platform: 'firefox' });
   },
   trackDownloadIosShortcut: () => {
-    trackEvent('download-ios-shortcut');
+    trackEvent('/download-ios-shortcut');
     trackAppEvent('download', { platform: 'ios-shortcut' });
   },
-  trackReportIssue: () => trackEvent('report-issue'),
+  trackReportIssue: () => trackEvent('/report-issue'),
 
-  // Search initiated (Umami + product analytics — fires before results arrive)
+  // Search initiated (GoatCounter + product analytics)
   trackSearch: () => {
-    trackEvent('search');
+    trackEvent('/search');
     trackAppEvent('search', {});
   },
 
-  // Search results received (product analytics — fires once results are known)
+  // Search results received (product analytics only)
   trackSearchResults: (hasResults: boolean, resultCount: number) => {
     trackAppEvent('search', { has_results: hasResults, result_count: resultCount });
   },
 
-  // Platform click (Umami + product analytics)
+  // Platform click (GoatCounter + product analytics)
   trackPlatformClick: (platformName: string) => {
-    trackEvent(`go-${platformName.toLowerCase()}`);
+    trackEvent(`/go/${platformName.toLowerCase()}`);
     trackAppEvent('platform_click', { platform: platformName.toLowerCase() });
   },
 
-  // Page views (product analytics only — Umami handles page views automatically)
+  // Page views (product analytics only — GoatCounter handles page views automatically)
   trackPageView: (page: string) => {
     trackAppEvent('page_view', { page });
   },
 
-  // Artist-specific events (Umami + Supabase artist analytics + product analytics)
+  // Artist-specific events (GoatCounter + Supabase artist analytics + product analytics)
   trackArtistPageView: (slug: string) => {
-    trackEvent(`artist-view`);
+    trackEvent('/artist-view');
     trackArtistEvent(slug, 'view');
     trackAppEvent('page_view', { page: 'artist' });
   },
   trackArtistSearchAppearance: (slug: string) => {
-    trackEvent(`artist-search`);
+    trackEvent('/artist-search');
     trackArtistEvent(slug, 'search');
   },
   trackArtistLinkClick: (slug: string, platform: string) => {
-    trackEvent(`artist-click-${platform.toLowerCase()}`);
+    trackEvent(`/artist-click/${platform.toLowerCase()}`);
     trackArtistEvent(slug, `click:${platform.toLowerCase()}`);
     trackAppEvent('platform_click', { platform: platform.toLowerCase() });
   },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -67,6 +67,11 @@ export default defineConfig({
       workbox: {
         skipWaiting: true,
         clientsClaim: true,
+        navigateFallbackDenylist: [
+          // Edge function routes that serve static HTML — don't let SW intercept them
+          /^\/a\//,
+          /^\/artist\//,
+        ],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/unstream\.stream\/api\//,

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' cloud.umami.is letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://cloud.umami.is https://api-gateway.umami.dev https://letterbird.co https://*.ingest.sentry.io; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' gc.zgo.at letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://unstream.goatcounter.com https://letterbird.co https://*.ingest.sentry.io; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
 
 [[edge_functions]]
   path = "/"


### PR DESCRIPTION
## Problem

Verified artist pages (`/a/kid-lightbulbs`, `/artist/{slug}`) were loading as search results pages instead of the dedicated profile pages served by Netlify edge functions.

The PWA service worker was intercepting **all** navigation requests via `NavigationRoute` and serving the cached SPA shell. This bypassed the Netlify edge functions (`claimed-artist-page.ts` and `artist-page.ts`) that serve proper static HTML profile pages with verified badges, bios, grouped platform links, social links, and embed widgets.

Users with the SW active saw the React SPA rendering claimed artists with `ResultCard` components (designed for search results) instead of the dedicated profile layout.

## Fix

Added `navigateFallbackDenylist` to the VitePWA workbox config, excluding `/a/` and `/artist/` paths from the SW's navigation handler. This lets the Netlify edge functions serve their proper static HTML for these routes.

The generated SW now registers:
```js
new NavigationRoute(createHandlerBoundToURL('index.html'), {
  denylist: [/^\/a\//, /^\/artist\//]
})
```

## Remaining work

This fixes the SW bypass. The React `ArtistPage` component should also be updated to render claimed artists with a proper profile layout (matching the edge function's design) as a fallback for when the SW isn't active or edge functions aren't reachable. That's a larger UI task best handled separately.

Fixes UNS-70