### PR TITLE
feat(UNS-77): Dashboard search bar + heading + PWA fixes

### DIFF
--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -16,7 +16,7 @@ export function ArtistPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
-  const isProfileRoute = location.pathname.startsWith('/a/');
+  const isProfileRoute = location.pathname.startsWith('/a/') || location.pathname.startsWith('/artist/');
   const justClaimed = searchParams.get('claimed') !== null;
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { ArtistAnalytics } from '../components/ArtistAnalytics';
 import { Footer } from '../components/Footer';
+import { SearchBar } from '../components/SearchBar';
 
 interface ClaimedProfile {
   id: string;
@@ -200,6 +201,10 @@ export function DashboardPage() {
     }
   };
 
+  const handleDashboardSearch = (query: string) => {
+    navigate(`/?q=${encodeURIComponent(query)}`);
+  };
+
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-bg-primary flex items-center justify-center">
@@ -215,8 +220,7 @@ export function DashboardPage() {
       <main className="flex-1 p-6">
         <div className="max-w-6xl mx-auto space-y-8">
           <div>
-            <h1 className="text-2xl font-bold">Your Dashboard</h1>
-            <p className="text-text-muted text-sm mt-1">Manage your claimed artist profiles and saved artists</p>
+            <h1 className="text-2xl font-bold">Dashboard</h1>
           </div>
 
           {error && (
@@ -297,6 +301,9 @@ export function DashboardPage() {
               </svg>
               Saved Artists
             </h2>
+            <div className="mb-4">
+              <SearchBar onSearch={handleDashboardSearch} isLoading={false} />
+            </div>
 
             {savedArtists.length === 0 ? (
               <div className="text-center py-12 rounded-lg border border-border border-dashed">


### PR DESCRIPTION
## Changes

- **Search bar in dashboard**: Added SearchBar component to the Saved Artists section. Searches redirect to homepage with the query — makes the dashboard usable as a PWA home screen.
- **Heading simplified**: "Your Dashboard" → "Dashboard", removed helper text below it.
- **PWA back link fix**: "Back to artists" link now also appears on `/artist/:slug` routes, not just `/a/:slug`.

### About the PWA regression fixes
The "View" buttons for claimed artists already correctly link to `/a/:slug` in the current code. The service worker denylist (UNS-70) and the `isProfileRoute` detection (UNS-71) are both in main. If PWA users still see search results instead of artist profiles, they may need to clear their PWA cache after the next deploy — the old service worker may still be cached.

The `/artist/:slug` back link fix is new — those routes weren't showing the back arrow.