### PR TITLE
fix(UNS-78): Redirect logged-out users from /dashboard to /login

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, Navigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
 import { Header } from '../components/Header';
@@ -205,10 +205,15 @@ export function DashboardPage() {
     navigate(`/?q=${encodeURIComponent(query)}`);
   };
 
+  // Redirect to login if not authenticated
+  if (!authLoading && !session) {
+    return <Navigate to="/login" replace />;
+  }
+
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading your profiles...</div>
+        <div className="text-text-muted">Loading...</div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem
Going directly to /dashboard (bookmark, PWA) while logged out shows a blank page that never renders — no redirect to login.

## Root Cause
The redirect to /login only happened in a `useEffect`, which runs after render. During the render, if `authLoading` is true, the loading screen shows. If auth resolves with no session, the useEffect would fire the redirect — but in some cases (slow network, stale SW cache), the page would appear stuck on a blank loading screen.

## Fix
Added a `<Navigate to="/login" replace />` in the render path: if auth is resolved and there's no session, redirect immediately in render — no flash, no waiting for useEffect. The useEffect redirect still exists as a safety net.

Also applies to PWA standalone mode where there's no browser UI for navigation.

Note: Other auth-required pages (ArtistEditPage, ClaimPage, admin pages) have the same useEffect-only pattern. This PR fixes DashboardPage per the bug report; a follow-up could add a `RequireAuth` wrapper component.