### PR TITLE
fix(UNS-78): Redirect logged-in PWA users to /dashboard on launch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -41,6 +41,13 @@ function App() {
     if (session) loadSavedArtists();
   }, [session]);
 
+  // PWA: redirect logged-in users to dashboard on app launch
+  useEffect(() => {
+    if (isStandalone && session && !searchParams.get('q') && !searchParams.get('url')) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isStandalone, session]);
+
   // Track current search to handle race conditions
   const currentSearchRef = useRef<number>(0);
   // Track if we just went home to prevent re-triggering search from stale URL


### PR DESCRIPTION
When the PWA opens in standalone mode and the user has a session, they now get redirected to `/dashboard` instead of landing on the homepage.\n\n- Only triggers in PWA standalone mode\n- Skips redirect if the user has a search query (`?q=`) or URL resolution (`?url=`) in the URL\n- Uses `navigate('/dashboard', { replace: true })` so it doesn't add a history entry\n- Logged-out PWA users still see the homepage normally