### PR TITLE
feat(UNS-81): changelog entries for PWA features

### DIFF
--- a/data/shipped-features.json
+++ b/data/shipped-features.json
@@ -68,5 +68,26 @@
     "description": "When the extension detects a new artist during playback, it sends a browser notification showing where to support them directly.",
     "date": "2026-05-22",
     "announced": true
+  },
+  {
+    "id": "pwa-save-artists",
+    "title": "Save artists on web",
+    "description": "You can now save artists you care about on unstream.stream — sign in and tap the heart on any artist page to keep them in your dashboard.",
+    "date": "2026-05-31",
+    "announced": false
+  },
+  {
+    "id": "pwa-dashboard-search",
+    "title": "Search from your dashboard",
+    "description": "Find a new artist without leaving the app. The Saved Artists section on your dashboard has its own search bar that takes you straight to results.",
+    "date": "2026-05-31",
+    "announced": false
+  },
+  {
+    "id": "pwa-simplified-ui",
+    "title": "Add Unstream to your Home Screen",
+    "description": "Unstream is now a Progressive Web App. Add it to your Home Screen on iOS or Android for a full-screen, app-like experience — no browser chrome, faster loads, and offline-ready.",
+    "date": "2026-05-31",
+    "announced": false
   }
 ]


### PR DESCRIPTION
## Summary
Adds 3 changelog entries to `data/shipped-features.json` for the PWA work that shipped over the last two weeks, backdated to 2026-05-31 per UNS-81.

## Entries added
- **Save artists on web** (UNS-56) — saved artists on `unstream.stream` with a heart icon
- **Search from your dashboard** (UNS-77) — search bar in the Saved Artists section
- **Add Unstream to your Home Screen** (UNS-55, UNS-74, UNS-78) — Progressive Web App with full-screen mode, installable on iOS and Android

## Notes
- All entries are `announced: false` — they will be set to true once social posts ship
- Tone matches existing changelog entries (concise, user-focused)
- No code changes, just data file update
- Branched from main (no other commits included)

## Test plan
- [x] Verify `data/shipped-features.json` is valid JSON (13 entries)
- [ ] Verify the 3 new entries appear on `/changelog` once deployed
- [ ] Verify the dated sort puts them under 2026-05-31

Closes #248 (reopened as clean PR branched from main).

Refs UNS-81