### PR TITLE
fix(UNS-82): use claimedSlug when saving artist from search

### DIFF
--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -39,9 +39,10 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
 
   useEffect(() => {
     if (result.type === 'artist' && result.id) {
-      setSaved(isArtistSaved(result.id));
+      // Match the slug we use for save so the saved state stays in sync
+      setSaved(isArtistSaved(result.claimedSlug || result.id));
     }
-  }, [result.type, result.id, isArtistSaved]);
+  }, [result.type, result.id, result.claimedSlug, isArtistSaved]);
 
   const handleSave = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -49,15 +50,21 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
 
     if (result.type !== 'artist' || !result.id) return;
 
+    // Prefer the verified /a/{slug} over the synthetic search-result id.
+    // For verified-but-not-claimed artists the result id is a "nameonly-..." key
+    // that won't match a row in the artists table, so findExistingArtist fails
+    // and the saved record falls back to "Saved from Search".
+    const saveId = result.claimedSlug || result.id;
+
     if (saved) {
-      await removeSavedArtist(result.id);
+      await removeSavedArtist(saveId);
       setSaved(false);
     } else {
       if (!session) {
         setShowLoginInterstitial(true);
         return;
       }
-      await saveArtist(result.id, undefined, result.name, result.imageUrl);
+      await saveArtist(saveId, undefined, result.name, result.imageUrl);
       setSaved(true);
     }
   };
@@ -176,7 +183,7 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
 
       {showLoginInterstitial && (
         <LoginInterstitial
-          artistId={result.id}
+          artistId={result.claimedSlug || result.id}
           artistName={result.name}
           onClose={() => setShowLoginInterstitial(false)}
         />


### PR DESCRIPTION
## Summary

When saving a verified-but-not-claimed artist from a search result, the
frontend was sending the synthetic search-result id (e.g. `nameonly-roberta-fidora`)
to `/api/saved-artists` instead of the verified slug (`roberta-fidora`). The
API's `findExistingArtist` couldn't find a matching row in the `artists`
table, so the saved record was stored with `artist_id = null` and the
dashboard fell back to 'Saved from Search'.

## Repro

1. Search 'roberta fidora'
2. Note the verified profile at `/a/roberta-fidora`
3. Click Save
4. `/dashboard` shows the artist but with 'Saved from Search' + search CTA

## Why it worked for some artists

For *claimed* artists the search id is `claimed-{slug}` (a real slug) so
`findExistingArtist` succeeds. For *verified-but-not-claimed* artists the
id is `nameonly-{normalized}` — a synthetic key that doesn't exist in the
`artists` table, so the API saves it as a generic search reference.

## Fix

Prefer `result.claimedSlug || result.id` everywhere we identify an artist
for save/remove/lookup in `ResultCard.tsx`:

- `handleSave` uses `saveId` for both `saveArtist` and `removeSavedArtist`
- `isArtistSaved` lookup uses the same id so the saved badge stays in sync
- `LoginInterstitial` receives the slug so the post-login pending save uses
  the correct identifier

No backend changes needed. `findExistingArtist` already does exact +
case-insensitive lookup. The upsert is idempotent on `user_id,artist_slug`,
so re-saving an existing row with the real slug correctly backfills the
`artist_id` FK.

## Verification

- `tsc -b`: clean
- `vitest run tests/unit`: 194/194 pass
- eslint: only the pre-existing `react-hooks/set-state-in-effect` warning
  on the unchanged `useEffect` block (was already there on main)

## Risks

Low. The only behavioral change is that `/dashboard` will now show the
real artist profile (including `/a/{slug}` link) for previously 'Saved
from Search' entries — which is the intended fix. No new writes or
migrations.