### PR TITLE
fix(UNS-83): initialize Sentry synchronously before React render

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,14 @@
 import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { Sentry } from './services/sentry.ts'
+import * as Sentry from '@sentry/react'
+import { initSentry } from './services/sentry'
 import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 import App from './App.tsx'
 import { ArtistPage } from './pages/ArtistPage.tsx'
 
-// Initialize Sentry asynchronously to avoid blocking initial render
-import('./services/sentry.ts').then(({ initSentry }) => initSentry())
+initSentry()
 
 // Lazy-load non-critical pages to reduce initial bundle size
 const ClaimPage = lazy(() => import('./pages/ClaimPage.tsx').then(m => ({ default: m.ClaimPage })))


### PR DESCRIPTION
## UNS-83: Sentry errors silently dropped during initial render

### Problem
`Sentry.init()` was called asynchronously via dynamic import, **after** React had already rendered the tree wrapped in `Sentry.ErrorBoundary`. Errors thrown during initial render were never captured because Sentry wasn't initialized yet.

### Fix
Replace the async dynamic import with a synchronous static import and call `initSentry()` before `createRoot(...).render(...)`.

**Before:**
```ts
import { Sentry } from './services/sentry.ts'                                    // static import — redundant
import('./services/sentry.ts').then(({ initSentry }) => initSentry())           // dynamic — runs too late
```

**After:**
```ts
import * as Sentry from '@sentry/react'
import { initSentry } from './services/sentry'

initSentry()  // sync, before createRoot
```

### Verification
- ✅ `npm run build` passes (all 194 unit tests + Vite build)
- ✅ Sentry code included in build output (now in main index chunk via static import)
- ✅ `Sentry.ErrorBoundary` still wraps the render tree
- ✅ No changes to `services/sentry.ts`, `vite.config.ts`, or any other files

Resolves [UNS-83](https://linear.app/unstream/issue/UNS-83)