### PR TITLE
feat: surface silent errors to Sentry via captureException

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { SearchBar } from './components/SearchBar';
 import { ResultCard } from './components/ResultCard';
 
@@ -161,7 +162,7 @@ function App() {
             setResults(prev => mergeWithMusicBrainzData(prev, mbData));
           }
         } catch (enrichErr) {
-          // Silent failure for enrichment - don't show error to user
+          Sentry.captureException(enrichErr, { extra: { context: 'search.musicbrainzEnrichment' } });
           console.error('MusicBrainz enrichment failed:', enrichErr);
         } finally {
           if (currentSearchRef.current === searchId) {
@@ -170,6 +171,7 @@ function App() {
         }
       }
     } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'search.platformSearch' } });
       if (currentSearchRef.current === searchId) {
         setError('Failed to search. Please try again.');
         setIsLoading(false);

--- a/apps/web/src/components/ArtistAnalytics.tsx
+++ b/apps/web/src/components/ArtistAnalytics.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { sources } from '../services/sources';
 import type { SourceId } from '../types';
@@ -43,7 +44,7 @@ export function ArtistAnalytics({ slug }: { slug: string }) {
         return res.json();
       })
       .then(setData)
-      .catch(() => setError('Unable to load analytics'))
+      .catch(e => { Sentry.captureException(e, { extra: { context: 'artistDashboard.analytics' } }); setError('Unable to load analytics') })
       .finally(() => setLoading(false));
   }, [slug, period, session?.access_token]);
 

--- a/apps/web/src/components/LoginInterstitial.tsx
+++ b/apps/web/src/components/LoginInterstitial.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 
 interface LoginInterstitialProps {
@@ -28,7 +29,8 @@ export function LoginInterstitial({ artistId, artistName, onClose }: LoginInters
       localStorage.setItem('pendingSave', JSON.stringify({ artistId }));
       await signInWithMagicLink(email.trim());
       setMagicSent(true);
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.magicLinkInterstitial' } });
       setError('Failed to send magic link. Try again.');
       localStorage.removeItem('pendingSave');
     } finally {
@@ -48,7 +50,8 @@ export function LoginInterstitial({ artistId, artistName, onClose }: LoginInters
       localStorage.setItem('pendingSave', JSON.stringify({ artistId }));
       await signInWithPassword(email.trim(), password);
       onClose(); // AuthContext will pick up the pending save
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.passwordInterstitial' } });
       setError('Invalid email or password');
       localStorage.removeItem('pendingSave');
     } finally {

--- a/apps/web/src/components/PasswordSection.tsx
+++ b/apps/web/src/components/PasswordSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import * as Sentry from '@sentry/react';
 import { updatePassword } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -37,7 +38,8 @@ export function PasswordSection() {
         setConfirmPassword('');
         setExpanded(false);
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.updatePassword' } });
       setError('Something went wrong. Please try again.');
     }
     setLoading(false);

--- a/apps/web/src/components/ResultCardPreview.tsx
+++ b/apps/web/src/components/ResultCardPreview.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import * as Sentry from '@sentry/react';
 import type { EmbedData } from './ResultCardTypes';
 
 interface ResultCardPreviewProps {
@@ -38,6 +39,7 @@ export function ResultCardPreview({ resultName, canPlay, previewUrl }: ResultCar
       setEmbedData(data);
       setShowPlayer(true);
     } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'resultCard.embedPreview' } });
       console.error('Embed error:', err);
       setEmbedError(true);
     } finally {

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
+import * as Sentry from '@sentry/react';
 import { getSupabaseClient, waitForMagicLinkSession } from '../services/auth';
 
 const ADMIN_EMAIL = 'info@kidlightbulbs.com';
@@ -152,7 +153,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
         setSavedArtists(prev => prev.filter(a => a.artistId !== artistId));
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.saveArtist' } });
       // Rollback on network error
       setSavedArtistIds(prev => {
         const next = new Set(prev);
@@ -194,7 +196,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setSavedArtists(prev => [...prev, removedFromList]);
         }
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.removeSavedArtist' } });
       // Rollback on network error
       setSavedArtistIds(prev => new Set(prev).add(artistId));
       if (removedFromList) {
@@ -232,7 +235,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSavedArtistIds(new Set((data.savedArtists || []).map((a: SavedArtist) => a.artistId)));
         setArtistsLoaded(true);
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.loadSavedArtists' } });
       console.error('Failed to load saved artists');
     }
   }, [session, artistsLoaded]);

--- a/apps/web/src/pages/AdminAnalyticsPage.tsx
+++ b/apps/web/src/pages/AdminAnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
@@ -281,7 +282,7 @@ export function AdminAnalyticsPage() {
         return res.json();
       })
       .then((d: DashboardData) => setData(d))
-      .catch(e => setError(e.message))
+      .catch(e => { Sentry.captureException(e, { extra: { context: 'admin.analyticsDashboard' } }); setError(e.message) })
       .finally(() => setLoading(false));
   }, [authLoading, isAdmin, session, navigate]);
 

--- a/apps/web/src/pages/AdminMergePage.tsx
+++ b/apps/web/src/pages/AdminMergePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import type { SearchResult } from '../types';
 import { sources } from '../services/sources';
@@ -100,6 +101,7 @@ export function AdminMergePage() {
 
       navigate('/', { replace: true });
     } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.mergeOverride' } });
       setError(err instanceof Error ? err.message : 'Failed to save merge override.');
     } finally {
       setSaving(false);

--- a/apps/web/src/pages/AdminVerifyPage.tsx
+++ b/apps/web/src/pages/AdminVerifyPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 
@@ -43,6 +44,7 @@ export function AdminVerifyPage() {
       const data = await response.json();
       setRequests(data.requests || []);
     } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.verify.fetchRequests' } });
       setError(err instanceof Error ? err.message : 'Failed to load verification requests.');
     } finally {
       setLoading(false);
@@ -88,6 +90,7 @@ export function AdminVerifyPage() {
         return next;
       });
     } catch (err) {
+      Sentry.captureException(err, { extra: { context: `admin.verify.${action}` } });
       setError(err instanceof Error ? err.message : `Failed to ${action} request.`);
     } finally {
       setActionLoading(null);

--- a/apps/web/src/pages/ArtistDashboardPage.tsx
+++ b/apps/web/src/pages/ArtistDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 
 import { Header } from '../components/Header';
@@ -64,7 +65,8 @@ export function ArtistDashboardPage() {
 
         const data = await response.json();
         setProfiles(data.profiles || []);
-      } catch {
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'artistDashboard.loadProfiles' } });
         setError('Failed to load your profiles. Please try again.');
       }
       setLoading(false);

--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
@@ -24,7 +25,8 @@ export function ArtistDirectoryPage() {
             break;
           }
           if (attempt === 0 && res.status >= 500) continue;
-        } catch {
+        } catch (e) {
+          Sentry.captureException(e, { extra: { context: 'artistDirectory.fetch' } });
           if (attempt === 0) continue;
         }
         break;

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -1,5 +1,6 @@
 import { useReducer, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { sources } from '../services/sources';
 
@@ -181,7 +182,8 @@ export function ArtistEditPage() {
             loading: false,
           },
         });
-      } catch {
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'artistEdit.loadArtist' } });
         dispatch({ type: 'LOAD_DATA', data: { error: 'Failed to load artist data', loading: false } });
       }
     }
@@ -234,7 +236,8 @@ export function ArtistEditPage() {
       } else {
         set('error', data.error || 'Could not find a profile photo on that page');
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'artistEdit.fetchAvatar' } });
       set('error', 'Network error. Please try again.');
     }
     set('fetchingAvatar', null);
@@ -345,7 +348,8 @@ export function ArtistEditPage() {
       } else {
         set('success', 'Changes saved!');
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'artistEdit.saveProfile' } });
       set('error', 'Network error. Please try again.');
     }
     set('saving', false);

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams, useNavigate, useSearchParams, useLocation } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { SearchBar } from '../components/SearchBar';
 import { ResultCard } from '../components/ResultCard';
 import { LoginInterstitial } from '../components/LoginInterstitial';
@@ -115,7 +116,8 @@ export function ArtistPage() {
             return;
           }
         }
-      } catch {
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'artistPage.fetchCachedData' } });
         // Fall through to live fetch
       }
 
@@ -135,7 +137,8 @@ export function ArtistPage() {
           setIsLoading(false);
           return;
         }
-      } catch {
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'artistPage.fetchApiData' } });
         // Fall through to search
       }
 
@@ -162,13 +165,14 @@ export function ArtistPage() {
               if (!cancelled && mbData) {
                 setResults(prev => mergeWithMusicBrainzData(prev, mbData));
               }
-            } catch {
-              // Silent failure for enrichment
+            } catch (e) {
+              Sentry.captureException(e, { extra: { context: 'artistPage.musicbrainzEnrichment' } });
             } finally {
               if (!cancelled) setIsEnriching(false);
             }
           }
-        } catch {
+        } catch (e) {
+          Sentry.captureException(e, { extra: { context: 'artistPage.searchArtist' } });
           if (!cancelled) {
             setError('Failed to load artist data. Please try again.');
             setIsLoading(false);

--- a/apps/web/src/pages/ChangelogPage.tsx
+++ b/apps/web/src/pages/ChangelogPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
@@ -31,7 +32,7 @@ export function ChangelogPage() {
         const sorted = [...data].sort((a, b) => b.date.localeCompare(a.date));
         setEntries(sorted);
       })
-      .catch(() => setEntries([]))
+      .catch((e) => { Sentry.captureException(e, { extra: { context: 'changelog.fetchEntries' } }); setEntries([]) })
       .finally(() => setLoading(false));
 
     return () => {

--- a/apps/web/src/pages/ClaimPage.tsx
+++ b/apps/web/src/pages/ClaimPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { signInWithMagicLink } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -79,7 +80,7 @@ export function ClaimPage() {
         const enrichedCountry = data?.location?.country || data?.location?.countryCode;
         if (enrichedCountry) setCountry(enrichedCountry);
       })
-      .catch(() => {});
+      .catch((e) => { Sentry.captureException(e, { extra: { context: 'claim.fetchArtistInfo' } }); })
   }, [slug]);
 
   function getAuthToken(): string | null {
@@ -160,7 +161,8 @@ export function ClaimPage() {
 
       setVerifyUrl(data.verifyUrl);
       setStep('verify');
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'claim.startClaim' } });
       setError('Network error. Please try again.');
     }
     setLoading(false);
@@ -209,7 +211,8 @@ export function ClaimPage() {
       }
       setCurrentImageUrl(data.imageUrl || null);
       setStep('review');
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'claim.verify' } });
       setError('Network error. Please try again.');
     }
     setLoading(false);
@@ -242,7 +245,8 @@ export function ClaimPage() {
       } else {
         setError(data.error || 'Could not find a profile photo on that page');
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'claim.fetchAvatar' } });
       setError('Network error. Please try again.');
     }
     setFetchingAvatar(null);
@@ -293,7 +297,8 @@ export function ClaimPage() {
       }
 
       window.location.href = `/a/${data.slug || slug}?claimed`;
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'claim.confirmReview' } });
       setError('Network error. Please try again.');
     }
     setLoading(false);
@@ -335,7 +340,8 @@ export function ClaimPage() {
       }
 
       setStep('manual-review-submitted');
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'claim.manualReview' } });
       setError('Network error. Please try again.');
     }
     setManualReviewSubmitting(false);

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate, Navigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 
 import { Header } from '../components/Header';
@@ -81,7 +82,8 @@ export function DashboardPage() {
 
         const savedData = await savedResponse.json();
         setSavedArtists(savedData.savedArtists || []);
-      } catch {
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'dashboard.loadData' } });
         setError('Failed to load your profiles. Please try again.');
       }
       setLoading(false);
@@ -147,7 +149,8 @@ export function DashboardPage() {
         artistId,
         onUndo: () => handleUndoRemove(artistId),
       });
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'dashboard.removeSavedArtist' } });
       setError('Failed to remove artist. Please try again.');
     }
   };
@@ -172,7 +175,8 @@ export function DashboardPage() {
       const data = await response.json();
       setSavedArtists(prev => [...prev, data.savedArtist]);
       setToast({ message: 'Artist restored!', type: 'success' });
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'dashboard.undoRemove' } });
       setError('Failed to restore artist. Please try again.');
     }
   };
@@ -211,7 +215,8 @@ export function DashboardPage() {
       setSavedArtists(prev => prev.map(a =>
         a.artistId === slug ? { ...a, supported: data.savedArtist.supported, supportedAt: data.savedArtist.supportedAt } : a
       ));
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'dashboard.toggleSupport' } });
       setSavedArtists(prev => prev.map(a =>
         a.artistId === slug ? { ...a, supported: originalSupported, supportedAt: originalSupportedAt } : a
       ));

--- a/apps/web/src/pages/GuidePage.tsx
+++ b/apps/web/src/pages/GuidePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -42,7 +43,7 @@ export function GuidePage() {
           if (descTag) descTag.setAttribute('content', guideMeta.description);
         }
       })
-      .catch(() => setError(true));
+      .catch((e) => { Sentry.captureException(e, { extra: { context: 'guide.fetchContent' } }); setError(true) });
 
     return () => {
       document.title = 'Unstream - Support Artists Directly';

--- a/apps/web/src/pages/GuidesIndexPage.tsx
+++ b/apps/web/src/pages/GuidesIndexPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import * as Sentry from '@sentry/react';
 import { Link } from 'react-router-dom';
 
 import { Header } from '../components/Header';
@@ -37,7 +38,7 @@ export function GuidesIndexPage() {
         const sorted = data.sort((a, b) => b.published.localeCompare(a.published));
         setGuides(sorted);
       })
-      .catch(() => setGuides([]))
+      .catch((e) => { Sentry.captureException(e, { extra: { context: 'guides.fetchManifest' } }); setGuides([]) })
       .finally(() => setLoading(false));
   }, []);
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { signInWithMagicLink, signInWithPassword, resetPasswordForEmail } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -34,7 +35,8 @@ export function LoginPage() {
         setError(authError);
       }
       setLoading(false);
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.passwordLogin' } });
       setError('Network error. Please try again.');
       setLoading(false);
     }
@@ -54,7 +56,8 @@ export function LoginPage() {
         setView('magicLinkSent');
       }
       setLoading(false);
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.magicLink' } });
       setError('Network error. Please try again.');
       setLoading(false);
     }
@@ -79,7 +82,8 @@ export function LoginPage() {
         setView('resetSent');
       }
       setLoading(false);
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.resetPassword' } });
       setError('Network error. Please try again.');
       setLoading(false);
     }

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { updatePassword } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
@@ -37,7 +38,8 @@ export function ResetPasswordPage() {
         setSuccess(true);
         setTimeout(() => navigate('/artist-dashboard', { replace: true }), 2000);
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'auth.resetPasswordSubmit' } });
       setError('Something went wrong. Please try again.');
     }
     setLoading(false);

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -2,6 +2,7 @@
 // as the single source of truth. When updating these fields, update the shared registry too.
 // The sources below add client-only fields (description, searchUrlTemplate, hasEmbed, aiPolicy, etc.).
 import type { Source, SourceId, SearchResponse, SearchResult } from '../types';
+import * as Sentry from '@sentry/react';
 
 export const sources: Record<SourceId, Source> = {
   bandcamp: {
@@ -502,6 +503,7 @@ async function searchSingle(query: string): Promise<SearchResponse> {
     }
     return await response.json();
   } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'search.platformSearch' } });
     console.error('Failed to search platforms:', error);
     return {
       query,
@@ -550,6 +552,7 @@ export async function resolveArtistUrl(url: string): Promise<ResolveResult | nul
     }
     return await response.json();
   } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'search.resolveUrl' } });
     console.error('Failed to resolve URL:', error);
     return null;
   }
@@ -564,6 +567,7 @@ export async function fetchMusicBrainzData(query: string): Promise<import('../ty
     }
     return await response.json();
   } catch (error) {
+    Sentry.captureException(error, { extra: { context: 'search.musicbrainzEnrichment' } });
     console.error('Failed to fetch MusicBrainz data:', error);
     return null;
   }


### PR DESCRIPTION
## Why

Sentry is now initialized end-to-end (PR #253), but Unstream's error capture is purely reactive — only errors that bubble up unhandled are reported. The codebase has dozens of catch blocks that log errors via console.error/console.warn and then silently recover or show a generic user-facing message. These swallowed errors are invisible in production.

This PR adds `Sentry.captureException(e, { extra: { context: '...' } })` alongside every high-value catch block in the frontend so those errors become visible in Sentry.

## What changed

- 21 files touched, all in `apps/web/src/`
- Added `import * as Sentry from '@sentry/react'` where needed
- Added `Sentry.captureException(e, { extra: { context: '...' } })` to catch blocks for:
  - **Auth flows** — login, password reset, magic link, saved-artist load/save/remove
  - **Claim/verification flow** — start claim, verify, fetch avatar, confirm review, manual review
  - **Dashboard data fetching** — load profiles, remove/restore artists, toggle support
  - **Artist profile** — load cached data, fetch API data, search, MusicBrainz enrichment
  - **Artist edit** — load artist data, fetch avatar, save profile
  - **Admin actions** — merge override, verify approve/reject, analytics dashboard
  - **Search service** — platform search, URL resolution, MusicBrainz enrichment
  - **Content pages** — changelog, guides, artist directory
  - **Embed preview** — Bandcamp embed loading

## What was NOT changed

- **Skipped** navigator.share cancelled catches (benign AbortError)
- **Skipped** analytics fire-and-forget catches (expected to sometimes fail silently)
- **Skipped** URL validation catches (input validation, not exceptions)
- **Skipped** test files
- **Skipped** `services/sentry.ts` (init module, already correct)
- **Skipped** server-side (`api/`) — Sentry not initialized there (out of scope)
- **No new try/catch blocks added** — only modified existing ones

## Verification

- `npx tsc -b` — passes ✅
- `npx vitest run tests/unit` — 194 tests pass ✅
- `npx vite build` — succeeds ✅
- Diff is reviewable in one pass (92 insertions, 36 deletions — mostly 1-2 line additions per file)