### PR TITLE
feat(UNS-86): add Sentry captureMessage warnings for known-bad product states

### DIFF
--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -109,6 +109,7 @@ interface ScrapeError {
 async function scrapeWebsite(websiteUrl: string): Promise<{ result: ScrapeResult | null; error?: ScrapeError }> {
   const urlCheck = isUrlSafeToFetch(websiteUrl);
   if (!urlCheck.safe) {
+    // TODO(UNS-86): Sentry.captureMessage('Claim verify: SSRF block triggered') — requires server-side Sentry init
     console.warn(`[Claim] SSRF blocked: ${websiteUrl} — ${urlCheck.reason}`);
     return { result: null, error: { type: 'ssrf_blocked', message: urlCheck.reason || 'URL not allowed' } };
   }
@@ -534,6 +535,7 @@ export async function handler(event: {
 
     // Check that the website actually belongs to this artist
     // The page must reference the artist name in its title, text, or meta tags
+    // TODO(UNS-86): Sentry.captureMessage('Claim verify: page does not reference artist name') — requires server-side Sentry init
     if (!pageReferencesArtist(html, artist.name)) {
       console.log(`[Claim] Website ${profile.website_url} does not reference artist "${artist.name}"`);
       return {
@@ -568,6 +570,7 @@ export async function handler(event: {
       }
     }
 
+    // TODO(UNS-86): Sentry.captureMessage('Claim verify: unstream link-back not found') — requires server-side Sentry init
     if (!hasUnstreamLink) {
       return {
         statusCode: 422,
@@ -787,6 +790,7 @@ export async function handler(event: {
       };
     }
 
+    // TODO(UNS-86): Sentry.captureMessage('Manual verification request submitted') — requires server-side Sentry init
     console.log(`[Claim] Manual verification request submitted for "${artist.name}" by ${userEmail}`);
 
     return {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1909,6 +1909,10 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     const searchResult = await searchAllPlatforms(normalizedQuery);
     const results = searchResult.results;
 
+    // TODO(UNS-86): Sentry.captureMessage('Search returned 0 results') + 'Search platform failed' — requires server-side Sentry init
+    // These would capture zero-result searches and partial platform failures for monitoring.
+    // See: https://linear.app/unstream/issue/UNS-86
+
     // If we have a claimed artist, put it first and remove any duplicate from live results
     if (claimedResult) {
       const claimedName = normalizeForComparison(claimedResult.name);

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -79,6 +79,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Listen for auth state changes (sign in, sign out, token refresh)
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, newSession) => {
       if (!cancelled) {
+        if (newSession === null && session !== null) {
+          Sentry.captureMessage('Auth session ended unexpectedly', {
+            level: 'info',
+            extra: { previousUserId: session?.user?.id, previousExpiry: session?.expires_at },
+            tags: { context: 'auth.session' },
+          });
+        }
         setSession(newSession);
         setUser(newSession?.user ?? null);
         // Clear saved artists on sign out
@@ -110,7 +117,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const supabase = getSupabaseClient();
     if (!supabase) throw new Error('Auth not available');
     const { error } = await supabase.auth.signInWithOtp({ email });
-    if (error) throw error;
+    if (error) {
+      Sentry.captureMessage('Magic link sign-in failed', {
+        level: 'warning',
+        extra: { errorMessage: error.message, errorCode: error.status },
+        tags: { context: 'auth.magicLink' },
+      });
+      throw error;
+    }
   }, []);
 
   const handleSignInWithPassword = useCallback(async (email: string, password: string) => {
@@ -145,6 +159,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const data = await response.json();
         setSavedArtists(prev => [...prev, data.savedArtist]);
       } else {
+        Sentry.captureMessage('Save artist failed (rolled back)', {
+          level: 'warning',
+          extra: { artistId, artistName, hasSession: !!session },
+          tags: { context: 'auth.saveArtist' },
+        });
         // Rollback on error: remove from both Set and array
         setSavedArtistIds(prev => {
           const next = new Set(prev);
@@ -155,6 +174,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'auth.saveArtist' } });
+      Sentry.captureMessage('Save artist failed (rolled back)', {
+        level: 'warning',
+        extra: { artistId, artistName, hasSession: !!session },
+        tags: { context: 'auth.saveArtist' },
+      });
       // Rollback on network error
       setSavedArtistIds(prev => {
         const next = new Set(prev);
@@ -190,6 +214,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
 
       if (!response.ok) {
+        Sentry.captureMessage('Remove artist failed (rolled back)', {
+          level: 'warning',
+          extra: { artistId, artistName: removedFromList?.name, hasSession: !!session },
+          tags: { context: 'auth.removeSavedArtist' },
+        });
         // Rollback on error: restore both Set and array
         setSavedArtistIds(prev => new Set(prev).add(artistId));
         if (removedFromList) {
@@ -198,6 +227,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'auth.removeSavedArtist' } });
+      Sentry.captureMessage('Remove artist failed (rolled back)', {
+        level: 'warning',
+        extra: { artistId, artistName: removedFromList?.name, hasSession: !!session },
+        tags: { context: 'auth.removeSavedArtist' },
+      });
       // Rollback on network error
       setSavedArtistIds(prev => new Set(prev).add(artistId));
       if (removedFromList) {
@@ -234,6 +268,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSavedArtists(data.savedArtists || []);
         setSavedArtistIds(new Set((data.savedArtists || []).map((a: SavedArtist) => a.artistId)));
         setArtistsLoaded(true);
+      } else {
+        Sentry.captureMessage('Dashboard saved-artists load failed', {
+          level: 'warning',
+          extra: { statusCode: response.status, hasSession: !!session },
+          tags: { context: 'auth.loadSavedArtists' },
+        });
       }
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'auth.loadSavedArtists' } });


### PR DESCRIPTION
## UNS-86: Add Sentry captureMessage warnings for known-bad product states

Adds proactive `Sentry.captureMessage` calls for known-bad product states that aren't exceptions but signal something is off in the product.

### Frontend use cases wired (4 of 10)

| # | Use case | File:Line | Level |
|---|----------|-----------|-------|
| 7 | Save artist failed (rolled back) | `AuthContext.tsx:162,177` | warning |
| 8 | Magic link sign-in failed | `AuthContext.tsx:120` | warning |
| 9 | Auth session ended unexpectedly | `AuthContext.tsx:82` | info |
| 10 | Dashboard saved-artists load failed | `AuthContext.tsx:271` | warning |

Each call follows the convention from PR #254:
```ts
Sentry.captureMessage('description', { level: 'warning'|'info', extra: { context: '...' }, tags: { context: 'namespace.action' } })
```

### Server-side use cases deferred (6 of 10)

Use cases 1–6 are in `api/functions/` files (claim-artist.ts, search-sources.ts). Sentry is **not initialized server-side**, so `captureMessage` calls would be no-ops. TODO comments have been added at each location noting they require server-side Sentry init first:

- `api/functions/claim-artist.ts`: UC1 (page doesn't reference artist), UC2 (link-back not found), UC3 (SSRF block), UC4 (manual verification request)
- `api/functions/search-sources.ts`: UC5 (0 results), UC6 (platform partial failure)

### Verification

- ✅ `npx tsc -b` — passes
- ✅ `npx vitest run tests/unit` — 194 tests pass
- ✅ `npx vite build` — builds successfully

Ref: UNS-86