### PR TITLE
feat(UNS-86): add Sentry captureMessage warnings for server-side bad states

### DIFF
--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -4,6 +4,7 @@
 //   action: 'verify' — scrape website, verify link-back, discover platform links
 
 import { createClient } from '@supabase/supabase-js';
+import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
@@ -109,7 +110,11 @@ interface ScrapeError {
 async function scrapeWebsite(websiteUrl: string): Promise<{ result: ScrapeResult | null; error?: ScrapeError }> {
   const urlCheck = isUrlSafeToFetch(websiteUrl);
   if (!urlCheck.safe) {
-    // TODO(UNS-86): Sentry.captureMessage('Claim verify: SSRF block triggered') — requires server-side Sentry init
+    Sentry.captureMessage('Claim verify: SSRF block triggered', {
+      level: 'info',
+      extra: { websiteUrl, reason: urlCheck.reason },
+      tags: { ssrfReason: urlCheck.reason || 'unknown' },
+    });
     console.warn(`[Claim] SSRF blocked: ${websiteUrl} — ${urlCheck.reason}`);
     return { result: null, error: { type: 'ssrf_blocked', message: urlCheck.reason || 'URL not allowed' } };
   }
@@ -535,8 +540,17 @@ export async function handler(event: {
 
     // Check that the website actually belongs to this artist
     // The page must reference the artist name in its title, text, or meta tags
-    // TODO(UNS-86): Sentry.captureMessage('Claim verify: page does not reference artist name') — requires server-side Sentry init
     if (!pageReferencesArtist(html, artist.name)) {
+      Sentry.captureMessage('Claim verify: page does not reference artist name', {
+        level: 'warning',
+        extra: {
+          artistSlug: slug,
+          artistName: artist.name,
+          websiteUrl: profile.website_url,
+          htmlLength: html.length,
+          linksFound: links.length,
+        },
+      });
       console.log(`[Claim] Website ${profile.website_url} does not reference artist "${artist.name}"`);
       return {
         statusCode: 422,
@@ -570,8 +584,12 @@ export async function handler(event: {
       }
     }
 
-    // TODO(UNS-86): Sentry.captureMessage('Claim verify: unstream link-back not found') — requires server-side Sentry init
     if (!hasUnstreamLink) {
+      Sentry.captureMessage('Claim verify: unstream link-back not found', {
+        level: 'warning',
+        extra: { artistSlug: slug, artistName: artist.name, websiteUrl: profile.website_url, linksFound: links.length },
+        tags: { failureMode: 'missing_linkback' },
+      });
       return {
         statusCode: 422,
         headers: CORS_HEADERS,
@@ -790,7 +808,10 @@ export async function handler(event: {
       };
     }
 
-    // TODO(UNS-86): Sentry.captureMessage('Manual verification request submitted') — requires server-side Sentry init
+    Sentry.captureMessage('Manual verification request submitted', {
+      level: 'info',
+      extra: { artistSlug: slug, artistName: artist.name, userId, messageLength: message?.trim().length || 0 },
+    });
     console.log(`[Claim] Manual verification request submitted for "${artist.name}" by ${userEmail}`);
 
     return {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1,4 +1,5 @@
 import { parse } from 'node-html-parser';
+import { Sentry } from '../lib/sentry';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
@@ -1694,6 +1695,30 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
     searchMusicBrainz(query),
   ]);
 
+  // UC6: Capture partial platform failures for monitoring
+  const platformSettledResults: [string, PromiseSettledResult<unknown>][] = [
+    ['bandwagon', bandwagonResults],
+    ['mirlo', mirloResults],
+    ['faircamp', faircampResults],
+    ['jamcoop', jamcoopResults],
+    ['patreon', patreonResults],
+    ['qobuz', qobuzResults],
+    ['ampwall', ampwallResults],
+    ['beatport', beatportResults],
+    ['even', evenResults],
+    ['musicbrainz', musicbrainzResult],
+  ];
+  for (const [platform, result] of platformSettledResults) {
+    if (result.status === 'rejected') {
+      const error = result.reason as Error;
+      Sentry.captureMessage('Search platform failed', {
+        level: 'warning',
+        extra: { platform, query, errorMessage: error?.message || String(result.reason) },
+        tags: { platform },
+      });
+    }
+  }
+
   const allResults: PlatformResult[] = [];
   if (mirloResults.status === 'fulfilled') allResults.push(...mirloResults.value.filter(r => r.type === 'artist'));
 
@@ -1909,9 +1934,16 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     const searchResult = await searchAllPlatforms(normalizedQuery);
     const results = searchResult.results;
 
-    // TODO(UNS-86): Sentry.captureMessage('Search returned 0 results') + 'Search platform failed' — requires server-side Sentry init
-    // These would capture zero-result searches and partial platform failures for monitoring.
-    // See: https://linear.app/unstream/issue/UNS-86
+    // UC5: Capture zero-result searches for monitoring (volume signal for coverage gaps)
+    if (results.length === 0) {
+      Sentry.captureMessage('Search returned 0 results', {
+        level: 'info',
+        extra: {
+          query,
+          normalizedQuery,
+        },
+      });
+    }
 
     // If we have a claimed artist, put it first and remove any duplicate from live results
     if (claimedResult) {

--- a/api/lib/sentry.ts
+++ b/api/lib/sentry.ts
@@ -1,0 +1,52 @@
+/**
+ * Server-side Sentry initialization for Netlify Functions.
+ *
+ * Reads SENTRY_DSN from the environment. If set, initializes Sentry so that
+ * api functions can call Sentry.captureException / Sentry.captureMessage.
+ * If unset, the exported Sentry instance is a no-op stub — functions still
+ * work without any Sentry dependency at runtime.
+ *
+ * The DSN can be the same one used by the web client:
+ *   https://a1c8d202cd8df4fc88a2fd54f2e4490b@o4510896048242688.ingest.us.sentry.io/4511275115151360
+ *
+ * Server-side events will appear in the same Sentry project but are
+ * distinguishable via `platform: 'node'` in the Sentry UI.
+ *
+ * Set the env var in Netlify UI:
+ *   SENTRY_DSN = https://a1c8d202cd8df4fc88a2fd54f2e4490b@o4510896048242688.ingest.us.sentry.io/4511275115151360
+ *   SENTRY_ENV  = production  (or staging, etc.)
+ */
+
+import * as Sentry from '@sentry/node';
+
+let initialized = false;
+
+export function initSentry(): void {
+  const dsn = process.env.SENTRY_DSN;
+
+  if (!dsn) {
+    // No DSN → Sentry stays uninitialized. captureException / captureMessage
+    // become no-ops, so functions work fine without it.
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENV || process.env.NODE_ENV || 'development',
+    release: process.env.COMMIT_SHA || 'unknown',
+    tracesSampleRate: 0.0, // no performance tracing — only error/message events
+  });
+
+  initialized = true;
+}
+
+/** Returns true if Sentry was initialized (i.e., SENTRY_DSN was set). */
+export function isSentryInitialized(): boolean {
+  return initialized;
+}
+
+// Auto-init on first import so that any function that imports Sentry
+// gets a ready-to-use instance without boilerplate.
+initSentry();
+
+export { Sentry };

--- a/api/lib/sentry.ts
+++ b/api/lib/sentry.ts
@@ -33,7 +33,10 @@ export function initSentry(): void {
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENV || process.env.NODE_ENV || 'development',
-    release: process.env.COMMIT_SHA || 'unknown',
+    // Netlify provides COMMIT_REF (branch/ref) in all deploys; COMMIT_SHA is
+    // not standard. Fall back through COMMIT_REF → COMMIT_SHA → 'unknown'
+    // so version tracking works reliably on Netlify.
+    release: process.env.COMMIT_REF || process.env.COMMIT_SHA || 'unknown',
     tracesSampleRate: 0.0, // no performance tracing — only error/message events
   });
 

--- a/api/scripts/sentry-test.ts
+++ b/api/scripts/sentry-test.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env npx tsx
+/**
+ * Smoke test for server-side Sentry init.
+ *
+ * Usage:
+ *   SENTRY_DSN=<dsn> SENTRY_ENV=development npx tsx api/scripts/sentry-test.ts
+ *
+ * Without SENTRY_DSN, the script logs a message and exits 0.
+ * With a real DSN, it sends a test captureMessage event to Sentry.
+ */
+
+import { Sentry, isSentryInitialized } from '../lib/sentry';
+
+async function main(): Promise<void> {
+  if (!isSentryInitialized()) {
+    console.log('Sentry DSN not set, skipping test');
+    return;
+  }
+
+  console.log('Sentry initialized — sending test event…');
+
+  Sentry.captureMessage('[UNS-87] Sentry server-side init test', {
+    level: 'info',
+    extra: { context: 'sentry.init.test' },
+  });
+
+  // Give Sentry time to flush the event before the process exits.
+  await Sentry.flush(5000);
+
+  console.log('Test event sent. Check your Sentry project for a message event with context=sentry.init.test');
+}
+
+main().catch((err) => {
+  console.error('sentry-test failed:', err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "unstream",
       "version": "0.0.0",
       "dependencies": {
+        "@sentry/node": "^10.56.0",
         "@sentry/react": "^10.50.0",
         "@supabase/supabase-js": "^2.99.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -2339,6 +2340,101 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -2873,6 +2969,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.56.0.tgz",
+      "integrity": "sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/server-utils/node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
@@ -3096,6 +3213,114 @@
       "version": "10.50.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
       "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.56.0.tgz",
+      "integrity": "sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry-internal/server-utils": "10.56.0",
+        "@sentry/core": "10.56.0",
+        "@sentry/node-core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.56.0.tgz",
+      "integrity": "sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node-core/node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.56.0.tgz",
+      "integrity": "sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4167,13 +4392,21 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -4615,6 +4848,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6191,6 +6430,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -8113,6 +8367,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8841,6 +9101,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "cd apps/web && npx vite preview"
   },
   "dependencies": {
+    "@sentry/node": "^10.56.0",
     "@sentry/react": "^10.50.0",
     "@supabase/supabase-js": "^2.99.1",
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## UNS-86: Server-side Sentry captureMessage warnings

Follow-up to PR #255 (client-side captureMessage) and PR #256 (UNS-87 — server-side Sentry init).

### Use cases wired

| # | Use case | File | Level | Line |
|---|----------|------|-------|------|
| UC1 | Claim verify — page does not reference artist name | `api/functions/claim-artist.ts` | `warning` | ~543 |
| UC2 | Claim verify — Unstream link-back not found | `api/functions/claim-artist.ts` | `warning` | ~587 |
| UC3 | Claim verify — SSRF block triggered | `api/functions/claim-artist.ts` | `info` | ~113 |
| UC4 | Manual verification request submitted | `api/functions/claim-artist.ts` | `info` | ~811 |
| UC5 | Search returned 0 results | `api/functions/search-sources.ts` | `info` | ~1939 |
| UC6 | Search platform failed (partial failure) | `api/functions/search-sources.ts` | `warning` | ~1714 |

### What changed

- Added `import { Sentry } from "../lib/sentry"` to both api function files
- Replaced all `TODO(UNS-86)` comments from PR #255 with actual `Sentry.captureMessage()` calls
- UC6 uses a centralized approach: iterates over `Promise.allSettled` results after the parallel platform search to capture each rejected platform

### Dependency

This branch includes a merge commit from `feat/uns-87-sentry-server-init` (PR #256) which provides `api/lib/sentry.ts`. GitHub will detect this as a linked PR.

### Known limitation

Source maps for `api/` are not configured, so server stack traces in Sentry will be minified. This will be addressed in a follow-up.

### Verification

- ✅ `tsc -b` (apps/web) — passes
- ✅ `vitest run tests/unit` — 194/194 pass
- ✅ `vite build` — succeeds
- ✅ No new TypeScript errors introduced in api/ (pre-existing errors in search-sources.ts are unrelated)