### PR TITLE
fix(UNS-89): make SENTRY_RELEASE optional with COMMIT_REF fallback

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -21,7 +21,8 @@ SENTRY_PROJECT=unstream-web
 SENTRY_AUTH_TOKEN=your-auth-token
 
 # Release identifier — used by both Sentry.init and sentry-cli upload.
-# Set to a literal release name (e.g. "unstream-api") in Netlify UI.
-# If unset, api/lib/sentry.ts falls back through COMMIT_REF → COMMIT_SHA → 'unknown',
-# which gives you a per-commit release name automatically.
-SENTRY_RELEASE=unstream-api
+# Optional. If unset, the code falls back through COMMIT_REF (set by Netlify
+# on every deploy) → COMMIT_SHA → 'unknown', giving you a per-commit release
+# name automatically. Set to a literal string only if you want a custom
+# release name (e.g. for tagged releases).
+# SENTRY_RELEASE=unstream-api

--- a/scripts/sentry-sourcemaps.sh
+++ b/scripts/sentry-sourcemaps.sh
@@ -11,7 +11,11 @@
 #   SENTRY_AUTH_TOKEN — auth token with `project:releases` and `org:read` scopes
 #   SENTRY_ORG        — Sentry organization slug
 #   SENTRY_PROJECT    — Sentry project slug
-#   SENTRY_RELEASE    — release name (used by both upload and api/lib/sentry.ts)
+# Optional:
+#   SENTRY_RELEASE    — release name override. If unset, falls back through
+#                       COMMIT_REF (Netlify) → COMMIT_SHA → 'unknown' (same chain
+#                       as api/lib/sentry.ts), so the upload and runtime init
+#                       always tag the same release.
 #
 # See api/.env.example for documentation.
 
@@ -23,10 +27,17 @@ if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
   exit 0
 fi
 
-if [ -z "${SENTRY_ORG:-}" ] || [ -z "${SENTRY_PROJECT:-}" ] || [ -z "${SENTRY_RELEASE:-}" ]; then
-  echo "[sentry-sourcemaps] ERROR: SENTRY_AUTH_TOKEN is set but one of SENTRY_ORG / SENTRY_PROJECT / SENTRY_RELEASE is missing." >&2
+if [ -z "${SENTRY_ORG:-}" ] || [ -z "${SENTRY_PROJECT:-}" ]; then
+  echo "[sentry-sourcemaps] ERROR: SENTRY_AUTH_TOKEN is set but one of SENTRY_ORG / SENTRY_PROJECT is missing." >&2
   echo "[sentry-sourcemaps] Aborting to avoid uploading source maps with incomplete metadata." >&2
   exit 1
+fi
+
+# Mirror the release env var priority chain from api/lib/sentry.ts so the upload
+# and the runtime Sentry.init() tag the same release.
+EFFECTIVE_RELEASE="${SENTRY_RELEASE:-${COMMIT_REF:-${COMMIT_SHA:-unknown}}}"
+if [ -z "${SENTRY_RELEASE:-}" ]; then
+  echo "[sentry-sourcemaps] SENTRY_RELEASE not set, using '${EFFECTIVE_RELEASE}' (from COMMIT_REF/CHA fallback chain)."
 fi
 
 # Resolve repo root regardless of where the script is invoked from.
@@ -40,7 +51,7 @@ if [ ! -d "$SOURCE_DIR" ]; then
 fi
 
 echo "[sentry-sourcemaps] Uploading source maps for $SOURCE_DIR"
-echo "[sentry-sourcemaps] Org: $SENTRY_ORG  Project: $SENTRY_PROJECT  Release: $SENTRY_RELEASE"
+echo "[sentry-sourcemaps] Org: $SENTRY_ORG  Project: $SENTRY_PROJECT  Release: $EFFECTIVE_RELEASE"
 
 # npx --yes avoids requiring a permanent install of @sentry/cli.
 # set +e so we capture the exit code for a clearer log line on failure.
@@ -49,7 +60,7 @@ npx --yes @sentry/cli@latest sourcemaps upload \
   --org="$SENTRY_ORG" \
   --project="$SENTRY_PROJECT" \
   --auth-token="$SENTRY_AUTH_TOKEN" \
-  --release="$SENTRY_RELEASE" \
+  --release="$EFFECTIVE_RELEASE" \
   "$SOURCE_DIR"
 EXIT=$?
 set -e


### PR DESCRIPTION
Follows up on PR #261. The original script required SENTRY_RELEASE to be set, but the runtime init in api/lib/sentry.ts already handles the unset case via the COMMIT_REF fallback chain (Netlify sets COMMIT_REF on every deploy). This commit mirrors that same fallback in the upload script, so the upload and runtime init always tag the same release.

**Why:** Brandon has 3 of 4 Sentry env vars set in Netlify already (SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT). He didn't set SENTRY_RELEASE because it's optional — Netlify's COMMIT_REF provides one automatically. The previous script blocked the upload in that case.

**Changes:**
- `scripts/sentry-sourcemaps.sh`: Mirrors the `SENTRY_RELEASE → COMMIT_REF → COMMIT_SHA → 'unknown'` fallback chain from `api/lib/sentry.ts`. Logs the effective release value.
- `api/.env.example`: Marks SENTRY_RELEASE as optional (commented out by default).

**Tested:** All 4 scenarios verified locally — no token (skips), no SENTRY_RELEASE but COMMIT_REF set (uses COMMIT_REF), explicit SENTRY_RELEASE (uses it), missing required var (errors out cleanly).

**Risk:** Low. The script behavior is a superset of before — same outcomes when SENTRY_RELEASE is set, plus a new working path when it's not.

Once merged, you can wire `&& npm run sentry:sourcemaps` into `netlify.toml` (was reverted in #261 to keep PR previews working). That'll be a separate, even-smaller PR.