### PR TITLE
feat(UNS-88): rate-limit Sentry UC5 and UC6 to prevent event spam

### DIFF
--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -358,6 +358,35 @@ export async function checkApiRateLimit(
 }
 
 /**
+ * Deduplicates Sentry captureMessage calls by key. Once a key has been
+ * captured, subsequent calls with the same key within `ttlSeconds` return
+ * false (skip the capture). This prevents high-volume Sentry noise from
+ * zero-result searches, repeated platform failures, etc.
+ *
+ * Returns true if the capture should proceed (this is the first occurrence
+ * in the TTL window), false if it should be skipped (already captured
+ * within the window).
+ *
+ * If Redis is not configured, returns true (capture always proceeds) so
+ * Sentry still works in local dev.
+ */
+export async function checkSentryDedup(key: string, ttlSeconds: number): Promise<boolean> {
+  const r = getRedis();
+  if (!r) return true; // Redis unavailable → don't gate Sentry on it
+  try {
+    const cacheKey = `sentry:dedup:${key}`;
+    const seen = await r.get(cacheKey);
+    if (seen) return false;
+    await r.set(cacheKey, '1', { ex: ttlSeconds });
+    return true;
+  } catch (err) {
+    // On Redis error, don't block Sentry capture — fail open
+    console.warn('[RateLimit] checkSentryDedup error, allowing capture:', err);
+    return true;
+  }
+}
+
+/**
  * Extract client IP from Netlify function event headers.
  */
 export function getClientIp(headers: Record<string, string | undefined>): string {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
 import {
   type SourceId,
@@ -1711,11 +1711,16 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   for (const [platform, result] of platformSettledResults) {
     if (result.status === 'rejected') {
       const error = result.reason as Error;
-      Sentry.captureMessage('Search platform failed', {
-        level: 'warning',
-        extra: { platform, query, errorMessage: error?.message || String(result.reason) },
-        tags: { platform },
-      });
+      const errorMessage = error?.message || String(result.reason);
+      // Dedupe: only capture once per (platform, error message) pair per 24h
+      const shouldCapture = await checkSentryDedup(`uc6:${platform}:${errorMessage}`, 24 * 60 * 60);
+      if (shouldCapture) {
+        Sentry.captureMessage('Search platform failed', {
+          level: 'warning',
+          extra: { platform, query, errorMessage },
+          tags: { platform },
+        });
+      }
     }
   }
 
@@ -1936,13 +1941,17 @@ export async function handler(event: { queryStringParameters?: Record<string, st
 
     // UC5: Capture zero-result searches for monitoring (volume signal for coverage gaps)
     if (results.length === 0) {
-      Sentry.captureMessage('Search returned 0 results', {
-        level: 'info',
-        extra: {
-          query,
-          normalizedQuery,
-        },
-      });
+      // Dedupe: only capture once per unique normalized query per 24h
+      const shouldCapture = await checkSentryDedup(`uc5:${normalizedQuery}`, 24 * 60 * 60);
+      if (shouldCapture) {
+        Sentry.captureMessage('Search returned 0 results', {
+          level: 'info',
+          extra: {
+            query,
+            normalizedQuery,
+          },
+        });
+      }
     }
 
     // If we have a claimed artist, put it first and remove any duplicate from live results

--- a/apps/web/tests/unit/ratelimit.test.ts
+++ b/apps/web/tests/unit/ratelimit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// checkSentryDedup unit tests
+// ---------------------------------------------------------------------------
+//
+// Strategy: We mock @upstash/redis at the module level. The ratelimit module
+// has a module-level `redis` variable that caches the Redis client created by
+// getRedis(). To test different scenarios (Redis configured vs not), we
+// manipulate environment variables and use vi.resetModules() to force
+// re-evaluation.
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+
+// The mock factory must return a class (constructable function) since
+// getRedis() calls `new Redis(...)`. Using vi.fn().mockImplementation()
+// creates a proper mock constructor.
+vi.mock('@upstash/redis', () => ({
+  Redis: vi.fn().mockImplementation(function(this: any) {
+    this.get = mockGet;
+    this.set = mockSet;
+  }),
+}));
+
+// Also mock @upstash/ratelimit so existing code in the module doesn't fail
+vi.mock('@upstash/ratelimit', () => ({
+  Ratelimit: vi.fn().mockImplementation(() => ({
+    limit: vi.fn(),
+  })),
+}));
+
+describe('checkSentryDedup', () => {
+  let checkSentryDedup: (key: string, ttlSeconds: number) => Promise<boolean>;
+
+  beforeEach(async () => {
+    // Reset modules to clear cached `redis` variable in ratelimit.ts
+    vi.resetModules();
+    mockGet.mockReset();
+    mockSet.mockReset();
+
+    // Set env vars so getRedis() returns a client
+    process.env.UPSTASH_REDIS_REST_URL = 'https://test.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+    // Re-import to get fresh module state
+    const mod = await import('../../../../api/functions/ratelimit');
+    checkSentryDedup = mod.checkSentryDedup;
+  });
+
+  afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it('returns true on first call (key not seen before)', async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue('OK');
+
+    const result = await checkSentryDedup('uc5:radiohead', 86400);
+    expect(result).toBe(true);
+    expect(mockGet).toHaveBeenCalledWith('sentry:dedup:uc5:radiohead');
+    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc5:radiohead', '1', { ex: 86400 });
+  });
+
+  it('returns false on second call (key already seen within TTL)', async () => {
+    mockGet.mockResolvedValue('1');
+
+    const result = await checkSentryDedup('uc5:radiohead', 86400);
+    expect(result).toBe(false);
+    // Should NOT set again when already seen
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('returns true (fail-open) when Redis throws an error', async () => {
+    mockGet.mockRejectedValue(new Error('Redis connection failed'));
+
+    const result = await checkSentryDedup('uc5:radiohead', 86400);
+    expect(result).toBe(true);
+  });
+
+  it('uses the provided key and TTL correctly', async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue('OK');
+
+    await checkSentryDedup('uc6:bandcamp:fetch failed', 3600);
+    expect(mockGet).toHaveBeenCalledWith('sentry:dedup:uc6:bandcamp:fetch failed');
+    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc6:bandcamp:fetch failed', '1', { ex: 3600 });
+  });
+
+  it('handles empty key strings', async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue('OK');
+
+    // Edge case: empty normalizedQuery or errorMessage
+    const result = await checkSentryDedup('uc5:', 86400);
+    expect(result).toBe(true);
+  });
+
+  it('returns true (fail-open) when Redis is not configured', async () => {
+    // Remove env vars to simulate no Redis config
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    // Re-import to clear cached Redis client
+    vi.resetModules();
+    const mod = await import('../../../../api/functions/ratelimit');
+    const freshDedup = mod.checkSentryDedup;
+
+    const result = await freshDedup('uc5:radiohead', 86400);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## UNS-88: Rate-limit Sentry UC5 and UC6 to avoid event spam

This is the last Sentry follow-up item. UC5 and UC6 `Sentry.captureMessage` calls could spam Sentry at high volume — UC5 fires on every zero-result search, and UC6 fires on every individual platform failure in `Promise.allSettled`.

### Changes

**New helper: `checkSentryDedup(key, ttlSeconds)`** in `api/functions/ratelimit.ts`
- Uses the existing `getRedis()` client (no new Redis connection or env vars)
- Returns `true` if the capture should proceed, `false` if already seen within the TTL
- **Fail-open:** if Redis is not configured or errors, returns `true` so Sentry still works in dev/degraded modes

**UC5 wrap** (zero-result searches, line ~1939):
```ts
const shouldCapture = await checkSentryDedup(`uc5:${normalizedQuery}`, 24 * 60 * 60);
if (shouldCapture) { Sentry.captureMessage(...) }
```
- Key: `uc5:{normalizedQuery}` — dedupes "Radiohead", "radiohead", "  RADIOHEAD  " together
- TTL: 24 hours → one event per unique query per day

**UC6 wrap** (platform failures, line ~1714):
```ts
const errorMessage = error?.message || String(result.reason);
const shouldCapture = await checkSentryDedup(`uc6:${platform}:${errorMessage}`, 24 * 60 * 60);
if (shouldCapture) { Sentry.captureMessage(...) }
```
- Key: `uc6:{platform}:{errorMessage}` — same platform + same error dedupes; different errors still surface
- TTL: 24 hours

### Verification
- ✅ TypeScript builds (`npx tsc -b apps/web`) — clean
- ✅ All 200 unit tests pass (6 new + 194 existing)
- ✅ New `checkSentryDedup` unit tests cover: first call, dedup on repeat, fail-open on Redis error, fail-open when Redis not configured, key/TTL correctness, empty key strings
- ✅ Semantic-revert check: no deletions in recently modified source files

### Fail-open behavior
If `UPSTASH_REDIS_REST_URL` or `UPSTASH_REDIS_REST_TOKEN` are unset, `getRedis()` returns `null`, and `checkSentryDedup` returns `true` — Sentry captures proceed normally. Same if Redis throws any error during `get`/`set`.

### Edge cases
- **Empty `normalizedQuery`:** UC5 key becomes `uc5:` — still a valid Redis key, dedupes all empty queries together
- **Empty `errorMessage`:** UC6 key becomes `uc6:bandcamp:` — dedupes all errors with no message from that platform
- **Redis unavailable:** All captures proceed (fail-open)