### PR TITLE
fix(UNS-94): use React Router Link for internal /a/ navigation

### DIFF
--- a/apps/web/src/components/ClaimDoneStep.tsx
+++ b/apps/web/src/components/ClaimDoneStep.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 interface ClaimDoneStepProps {
   slug: string | undefined;
   discoveredLinks: number;
@@ -19,12 +21,12 @@ export function ClaimDoneStep({ slug, discoveredLinks, alreadyVerified }: ClaimD
           {discoveredLinks === 1 ? ' link' : ' links'} from your website.
         </p>
       )}
-      <a
-        href={`/a/${slug}?claimed`}
+      <Link
+        to={`/a/${slug}?claimed`}
         className="inline-block px-6 py-2 rounded-lg bg-accent-primary text-white font-medium hover:bg-accent-primary/90 transition-colors"
       >
         View your artist page
-      </a>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { SearchResult } from '../types';
 import { typeLabel, typeIcon } from './ResultCardUtils';
 
@@ -76,13 +77,13 @@ export function ResultCardHeader({
                 </svg>
                 Verified
               </span>
-              <a
-                href={`/a/${result.claimedSlug || result.id}`}
+              <Link
+                to={`/a/${result.claimedSlug || result.id}`}
                 className="text-xs px-1.5 py-0.5 rounded bg-bg-hover text-text-secondary hover:text-text-primary transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >
                 View profile
-              </a>
+              </Link>
             </>
           )}
           {result.matchConfidence === 'unverified' && (

--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
@@ -94,9 +95,9 @@ export function ArtistDirectoryPage() {
                     <h2 className="text-xl font-bold pb-2 border-b border-border mb-1">{letter}</h2>
                     <div className="grid gap-0.5">
                       {grouped[letter].map(artist => (
-                        <a
+                        <Link
                           key={artist.slug}
-                          href={`/a/${artist.slug}`}
+                          to={`/a/${artist.slug}`}
                           className="flex items-center gap-3 px-3.5 py-2.5 rounded-lg hover:bg-bg-secondary border border-transparent hover:border-border transition-colors"
                         >
                           <div className="w-9 h-9 rounded-full bg-bg-secondary flex-shrink-0 flex items-center justify-center font-semibold text-sm text-text-muted overflow-hidden">
@@ -116,7 +117,7 @@ export function ArtistDirectoryPage() {
                           <svg className="ml-auto flex-shrink-0 w-3.5 h-3.5 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                           </svg>
-                        </a>
+                        </Link>
                       ))}
                     </div>
                   </div>


### PR DESCRIPTION
## UNS-94: Verified artist pages — back button doesn't work

**Root cause:** The artist directory, search result cards, and post-claim step all used plain `<a href="/a/{slug}">` links, which trigger full-page navigations to the Netlify edge-function-served static HTML at `/a/{slug}`. This crosses the SPA boundary — the browser history entry points to the static page, so pressing back bounces the user back to the artist page instead of returning to `/artists` (or the prior search view).

**Fix:** Replace all three `<a href>` occurrences with React Router `<Link to>`, keeping navigation within the SPA so the history API handles back-button correctly.

### Files changed
- `apps/web/src/pages/ArtistDirectoryPage.tsx` — artist directory links (the reported case)
- `apps/web/src/components/ResultCardHeader.tsx` — search result "View profile" link
- `apps/web/src/components/ClaimDoneStep.tsx` — post-claim "View your artist page" link

### Consistency
This aligns with the same pattern already used by Header, Footer, and ArtistPage's "Back to artists" links, which all use `<Link>`.

**Linear:** [UNS-94](https://linear.app/unstream/issue/UNS-94)