### PR TITLE
fix(UNS-95): guard artist directory fetch against non-JSON 2xx responses

### DIFF
--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -20,7 +20,8 @@ export function ArtistDirectoryPage() {
       for (let attempt = 0; attempt < 2; attempt++) {
         try {
           const res = await fetch('/api/artist-directory');
-          if (res.ok) {
+          const ctype = res.headers.get('content-type') || '';
+          if (res.ok && ctype.includes('application/json')) {
             const data = await res.json();
             setArtists(data.artists || []);
             break;


### PR DESCRIPTION
Closes UNS-95

**Sentry alert:** [UNSTREAM-WEB-4](https://unstream.sentry.io/issues/7541664724/) — `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON` on `/artists`

**Root cause:** `ArtistDirectoryPage.tsx` calls `fetch(/api/artist-directory)` and checks `res.ok` before calling `res.json()`. If the server returns a 200 with an HTML body (SPA fallback, stale service worker, or misconfigured proxy), `res.json()` throws a `SyntaxError` that Sentry captures. The fix adds a `Content-Type` guard so non-JSON 2xx responses are treated like failures without attempting to parse them.

**Diff:**
```diff
 const res = await fetch(/api/artist-directory);
+const ctype = res.headers.get(content-type) || ;
-if (res.ok) {
+if (res.ok && ctype.includes(application/json)) {
   const data = await res.json();
```

**Out of scope:** The dev server (`apps/web/server/api.ts`) has no `/api/artist-directory` handler, so the page is empty in `vite dev`. Adding a dev handler is a separate, larger change and not part of this PR.