### PR TITLE
feat(UNS-93): Schema + sync API for cross-client auth

### DIFF
--- a/api/functions/saved-artists-sync.ts
+++ b/api/functions/saved-artists-sync.ts
@@ -1,0 +1,134 @@
+// API endpoint: /api/saved-artists/sync
+// GET — incremental or full sync of user's saved artists
+// Returns artists modified since a given timestamp (cursor), or all if no since param.
+// Designed for cross-client sync: the client stores the server_time from the last
+// successful pull and passes it as `since` on the next request.
+
+import { createClient } from '@supabase/supabase-js';
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { userId: data.user.id, email: data.user.email || '' };
+}
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+const SYNC_LIMIT = 500;
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  const since = event.queryStringParameters?.since;
+
+  let query = client
+    .from('saved_artists')
+    .select(`
+      id,
+      user_id,
+      artist_id,
+      artist_slug,
+      artist_name,
+      artist_image_url,
+      notes,
+      added_at,
+      supported,
+      supported_at,
+      last_modified,
+      device_id,
+      artists!left (id, name, slug, image_url)
+    `)
+    .eq('user_id', user.userId)
+    .order('last_modified', { ascending: true })
+    .limit(SYNC_LIMIT);
+
+  if (since) {
+    const sinceDate = new Date(since);
+    if (isNaN(sinceDate.getTime())) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid since parameter: must be ISO-8601' }) };
+    }
+    // Use > not >= for cursor safety — a client passing server_time from last pull
+    // should not re-receive rows modified at exactly that instant
+    query = query.gt('last_modified', sinceDate.toISOString());
+  }
+
+  try {
+    const { data: saved, error: savedError } = await query;
+
+    if (savedError) {
+      console.error('[saved-artists-sync] Error fetching:', savedError);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to fetch saved artists' }) };
+    }
+
+    const artists = (saved || []).map(row => {
+      const artistRow = (row as any).artists;
+      const claimed = !!artistRow;
+      return {
+        id: row.id,
+        userId: row.user_id,
+        artistId: artistRow?.slug || row.artist_slug || row.artist_id,
+        name: artistRow?.name || row.artist_name || 'Unknown',
+        slug: artistRow?.slug || row.artist_slug || '',
+        imageUrl: artistRow?.image_url || row.artist_image_url || null,
+        notes: row.notes,
+        addedAt: row.added_at,
+        supported: row.supported,
+        supportedAt: row.supported_at,
+        lastModified: row.last_modified,
+        deviceId: row.device_id,
+        claimed,
+      };
+    });
+
+    const serverTime = new Date().toISOString();
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ artists, server_time: serverTime }),
+    };
+  } catch (error) {
+    console.error('[saved-artists-sync] GET error:', error);
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+  }
+}

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -86,6 +86,8 @@ export async function handler(event: {
           added_at,
           supported,
           supported_at,
+          last_modified,
+          device_id,
           artists!left (id, name, slug, image_url)
         `)
         .eq('user_id', user.userId);
@@ -108,6 +110,8 @@ export async function handler(event: {
           addedAt: row.added_at,
           supported: row.supported,
           supportedAt: row.supported_at,
+          lastModified: row.last_modified,
+          deviceId: row.device_id,
           claimed,
         };
       });
@@ -198,16 +202,23 @@ async function handleSave(user: { userId: string; email: string }, body: Record<
     const slug = existingArtist?.slug || artistSlug;
 
     // Upsert — idempotent if already saved
+    // UNS-93: accept optional last_modified and device_id for sync.
+    // On UPDATE the trigger overwrites last_modified with now(); client value
+    // is preserved only on INSERT.
+    const upsertPayload: Record<string, unknown> = {
+      user_id: user.userId,
+      artist_id: artistId,
+      artist_slug: slug,
+      artist_name: name,
+      artist_image_url: imageUrl,
+      notes: (body.notes as string) || null,
+    };
+    if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+    if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+
     const { data: saved, error: upsertError } = await client
       .from('saved_artists')
-      .upsert({
-        user_id: user.userId,
-        artist_id: artistId,
-        artist_slug: slug,
-        artist_name: name,
-        artist_image_url: imageUrl,
-        notes: (body.notes as string) || null,
-      }, { onConflict: 'user_id,artist_slug' })
+      .upsert(upsertPayload, { onConflict: 'user_id,artist_slug' })
       .select()
       .single();
 
@@ -228,6 +239,8 @@ async function handleSave(user: { userId: string; email: string }, body: Record<
           imageUrl,
           notes: saved.notes,
           addedAt: saved.added_at,
+          lastModified: saved.last_modified,
+          deviceId: saved.device_id,
         },
       }),
     };
@@ -318,7 +331,7 @@ async function handleSupport(user: { userId: string; email: string }, body: Reco
       .eq('artist_slug', artistSlug)
       .select(`
         id, user_id, artist_id, artist_slug, artist_name, artist_image_url,
-        notes, added_at, supported, supported_at,
+        notes, added_at, supported, supported_at, last_modified, device_id,
         artists!left (id, name, slug, image_url)
       `)
       .single();
@@ -349,6 +362,8 @@ async function handleSupport(user: { userId: string; email: string }, body: Reco
           addedAt: updated.added_at,
           supported: updated.supported,
           supportedAt: updated.supported_at,
+          lastModified: updated.last_modified,
+          deviceId: updated.device_id,
           claimed,
         },
       }),
@@ -374,7 +389,7 @@ async function handleUnsupport(user: { userId: string; email: string }, body: Re
       .eq('artist_slug', artistSlug)
       .select(`
         id, user_id, artist_id, artist_slug, artist_name, artist_image_url,
-        notes, added_at, supported, supported_at,
+        notes, added_at, supported, supported_at, last_modified, device_id,
         artists!left (id, name, slug, image_url)
       `)
       .single();
@@ -405,6 +420,8 @@ async function handleUnsupport(user: { userId: string; email: string }, body: Re
           addedAt: updated.added_at,
           supported: updated.supported,
           supportedAt: updated.supported_at,
+          lastModified: updated.last_modified,
+          deviceId: updated.device_id,
           claimed,
         },
       }),

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -213,8 +213,19 @@ async function handleSave(user: { userId: string; email: string }, body: Record<
       artist_image_url: imageUrl,
       notes: (body.notes as string) || null,
     };
-    if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
-    if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+    if (body.last_modified !== undefined) {
+      if (typeof body.last_modified === 'string') {
+        const parsed = new Date(body.last_modified);
+        if (!isNaN(parsed.getTime())) {
+          upsertPayload.last_modified = body.last_modified;
+        }
+      }
+    }
+    if (body.device_id !== undefined) {
+      if (typeof body.device_id === 'string') {
+        upsertPayload.device_id = body.device_id.slice(0, 128);
+      }
+    }
 
     const { data: saved, error: upsertError } = await client
       .from('saved_artists')

--- a/apps/web/tests/unit/saved-artists-api.test.ts
+++ b/apps/web/tests/unit/saved-artists-api.test.ts
@@ -146,4 +146,74 @@ describe('saved-artists API - Validation logic', () => {
       expect(upsertPayload.device_id).toBeUndefined();
     });
   });
+
+  describe('UNS-93: last_modified input validation', () => {
+    it('non-parseable last_modified string is silently dropped (DB default applies)', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', last_modified: 'not-a-date' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) {
+        if (typeof body.last_modified === 'string') {
+          const parsed = new Date(body.last_modified);
+          if (!isNaN(parsed.getTime())) {
+            upsertPayload.last_modified = body.last_modified;
+          }
+        }
+      }
+      expect(upsertPayload.last_modified).toBeUndefined();
+    });
+
+    it('non-string last_modified (number) is silently dropped', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', last_modified: 12345 };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) {
+        if (typeof body.last_modified === 'string') {
+          const parsed = new Date(body.last_modified);
+          if (!isNaN(parsed.getTime())) {
+            upsertPayload.last_modified = body.last_modified;
+          }
+        }
+      }
+      expect(upsertPayload.last_modified).toBeUndefined();
+    });
+
+    it('valid ISO-8601 last_modified string is accepted', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', last_modified: '2099-01-01T00:00:00Z' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) {
+        if (typeof body.last_modified === 'string') {
+          const parsed = new Date(body.last_modified);
+          if (!isNaN(parsed.getTime())) {
+            upsertPayload.last_modified = body.last_modified;
+          }
+        }
+      }
+      expect(upsertPayload.last_modified).toBe('2099-01-01T00:00:00Z');
+    });
+  });
+
+  describe('UNS-93: device_id input validation', () => {
+    it('device_id longer than 128 chars is truncated', () => {
+      const longDeviceId = 'x'.repeat(200);
+      const body: Record<string, unknown> = { artistId: 'radiohead', device_id: longDeviceId };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.device_id !== undefined) {
+        if (typeof body.device_id === 'string') {
+          upsertPayload.device_id = body.device_id.slice(0, 128);
+        }
+      }
+      expect((upsertPayload.device_id as string).length).toBeLessThanOrEqual(128);
+      expect(upsertPayload.device_id).toBe('x'.repeat(128));
+    });
+
+    it('non-string device_id (number) is silently dropped', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', device_id: 12345 };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.device_id !== undefined) {
+        if (typeof body.device_id === 'string') {
+          upsertPayload.device_id = body.device_id.slice(0, 128);
+        }
+      }
+      expect(upsertPayload.device_id).toBeUndefined();
+    });
+  });
 });

--- a/apps/web/tests/unit/saved-artists-api.test.ts
+++ b/apps/web/tests/unit/saved-artists-api.test.ts
@@ -72,4 +72,78 @@ describe('saved-artists API - Validation logic', () => {
       });
     });
   });
+
+  describe('UNS-93: last_modified and device_id in GET response', () => {
+    it('GET response maps last_modified and device_id to camelCase', () => {
+      const row = {
+        id: 'abc-123',
+        user_id: 'user-1',
+        artist_id: null,
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+        artist_image_url: null,
+        notes: null,
+        added_at: '2026-01-01T00:00:00Z',
+        supported: false,
+        supported_at: null,
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: 'mac-studio',
+        artists: null,
+      };
+
+      const artistRow = (row as any).artists;
+      const result = {
+        lastModified: row.last_modified,
+        deviceId: row.device_id,
+      };
+
+      expect(result.lastModified).toBe('2026-05-01T00:00:00Z');
+      expect(result.deviceId).toBe('mac-studio');
+    });
+
+    it('GET response returns null deviceId when device_id is null', () => {
+      const row = {
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: null,
+      };
+
+      expect(row.device_id).toBeNull();
+    });
+
+    it('GET response includes lastModified for rows without sync fields (backwards compat)', () => {
+      // Even rows that existed before UNS-93 have last_modified (DEFAULT now())
+      const row = {
+        last_modified: '2026-01-01T00:00:00Z',
+        device_id: null,
+      };
+
+      expect(row.last_modified).not.toBeNull();
+      expect(row.device_id).toBeNull();
+    });
+  });
+
+  describe('UNS-93: POST save accepts last_modified and device_id', () => {
+    it('upsert payload includes last_modified when body provides it', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', last_modified: '2026-06-01T12:00:00Z' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      expect(upsertPayload.last_modified).toBe('2026-06-01T12:00:00Z');
+    });
+
+    it('upsert payload includes device_id when body provides it', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', device_id: 'iphone-15-pro' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+      expect(upsertPayload.device_id).toBe('iphone-15-pro');
+    });
+
+    it('upsert payload omits both when body omits them (backwards compat)', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+      expect(upsertPayload.last_modified).toBeUndefined();
+      expect(upsertPayload.device_id).toBeUndefined();
+    });
+  });
 });

--- a/apps/web/tests/unit/saved-artists-sync-api.test.ts
+++ b/apps/web/tests/unit/saved-artists-sync-api.test.ts
@@ -1,0 +1,557 @@
+// Tests for saved-artists sync endpoint (UNS-93)
+// and new last_modified/device_id fields on existing endpoints.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helper: build a mock Supabase query chain that the handlers call
+// ---------------------------------------------------------------------------
+
+function buildMockQuery(resolvedData: any, resolvedError: any = null) {
+  const query: Record<string, any> = {};
+
+  const chainable = () => {
+    const q: Record<string, any> = {};
+    // Each method returns the chain so calls can be stacked
+    for (const method of ['eq', 'gt', 'order', 'limit', 'in', 'select', 'single']) {
+      q[method] = vi.fn().mockReturnValue(q);
+    }
+    // Terminal: .select() returns the chain too, but we also wire up the
+    // final promise resolution via the enclosing query mock below.
+    return q;
+  };
+
+  const q = chainable();
+
+  // The Supabase .from().select().eq()... resolves to { data, error }
+  const fromMock = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        gt: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+          }),
+        }),
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+        }),
+        in: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+        }),
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+        }),
+      }),
+      in: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+      gt: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+        }),
+      }),
+      order: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+      }),
+    }),
+    upsert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+          }),
+        }),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: resolvedData, error: resolvedError }),
+      }),
+    }),
+  });
+
+  return { from: fromMock };
+}
+
+// ---------------------------------------------------------------------------
+// Tests for sync endpoint response shape and query construction
+// ---------------------------------------------------------------------------
+
+describe('saved-artists-sync endpoint', () => {
+  describe('Query parameter validation', () => {
+    it('rejects an invalid ISO-8601 since parameter', () => {
+      const since = 'not-a-date';
+      const sinceDate = new Date(since);
+      expect(isNaN(sinceDate.getTime())).toBe(true);
+    });
+
+    it('accepts a valid ISO-8601 since parameter', () => {
+      const since = '2026-06-01T00:00:00Z';
+      const sinceDate = new Date(since);
+      expect(isNaN(sinceDate.getTime())).toBe(false);
+    });
+
+    it('omitting since means full pull (no .gt() filter)', () => {
+      // When since is undefined, the sync endpoint should not add a .gt filter
+      const since: string | undefined = undefined;
+      const shouldFilter = since !== undefined;
+      expect(shouldFilter).toBe(false);
+    });
+
+    it('cursor safety: since uses > not >=', () => {
+      // A row modified at exactly the since timestamp should NOT be returned.
+      // This prevents duplicate rows when the client passes its last server_time.
+      const since = '2026-06-01T00:00:00.000Z';
+      const rowTime = '2026-06-01T00:00:00.000Z';
+      expect(new Date(rowTime) > new Date(since)).toBe(false);
+      // The endpoint uses .gt(), which excludes equality
+    });
+
+    it('server_time is always a valid ISO-8601 string', () => {
+      const serverTime = new Date().toISOString();
+      expect(new Date(serverTime).getTime()).not.toBeNaN();
+      expect(serverTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  describe('Response shape', () => {
+    it('maps row fields to camelCase with lastModified and deviceId', () => {
+      const row = {
+        id: 'abc-123',
+        user_id: 'user-1',
+        artist_id: null,
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+        artist_image_url: 'https://example.com/radiohead.jpg',
+        notes: 'Great live',
+        added_at: '2026-01-01T00:00:00Z',
+        supported: true,
+        supported_at: '2026-02-01T00:00:00Z',
+        last_modified: '2026-03-01T00:00:00Z',
+        device_id: 'mac-studio',
+        artists: null,
+      };
+
+      const artistRow = (row as any).artists;
+      const claimed = !!artistRow;
+      const result = {
+        id: row.id,
+        userId: row.user_id,
+        artistId: artistRow?.slug || row.artist_slug || row.artist_id,
+        name: artistRow?.name || row.artist_name || 'Unknown',
+        slug: artistRow?.slug || row.artist_slug || '',
+        imageUrl: artistRow?.image_url || row.artist_image_url || null,
+        notes: row.notes,
+        addedAt: row.added_at,
+        supported: row.supported,
+        supportedAt: row.supported_at,
+        lastModified: row.last_modified,
+        deviceId: row.device_id,
+        claimed,
+      };
+
+      expect(result.id).toBe('abc-123');
+      expect(result.userId).toBe('user-1');
+      expect(result.artistId).toBe('radiohead');
+      expect(result.lastModified).toBe('2026-03-01T00:00:00Z');
+      expect(result.deviceId).toBe('mac-studio');
+      expect(result.claimed).toBe(false);
+    });
+
+    it('prefers claimed artist data over saved_artists columns', () => {
+      const row = {
+        id: 'abc-123',
+        user_id: 'user-1',
+        artist_id: 'artist-uuid',
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead (local)',
+        artist_image_url: 'https://old.img/radiohead.jpg',
+        notes: null,
+        added_at: '2026-01-01T00:00:00Z',
+        supported: false,
+        supported_at: null,
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: null,
+        artists: { id: 'artist-uuid', name: 'Radiohead', slug: 'radiohead', image_url: 'https://new.img/radiohead.jpg' },
+      };
+
+      const artistRow = (row as any).artists;
+      const result = {
+        artistId: artistRow?.slug || row.artist_slug || row.artist_id,
+        name: artistRow?.name || row.artist_name || 'Unknown',
+        slug: artistRow?.slug || row.artist_slug || '',
+        imageUrl: artistRow?.image_url || row.artist_image_url || null,
+        claimed: !!artistRow,
+      };
+
+      expect(result.name).toBe('Radiohead'); // from artists table
+      expect(result.imageUrl).toBe('https://new.img/radiohead.jpg'); // from artists table
+      expect(result.claimed).toBe(true);
+    });
+
+    it('returns null deviceId when not set', () => {
+      const row = {
+        id: 'abc-123',
+        user_id: 'user-1',
+        artist_id: null,
+        artist_slug: 'tool',
+        artist_name: 'Tool',
+        artist_image_url: null,
+        notes: null,
+        added_at: '2026-01-01T00:00:00Z',
+        supported: false,
+        supported_at: null,
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: null,
+        artists: null,
+      };
+
+      expect(row.device_id).toBeNull();
+    });
+  });
+
+  describe('RLS isolation', () => {
+    it('sync endpoint only returns rows for the authenticated user (conceptual)', () => {
+      // The endpoint uses .eq('user_id', user.userId) and RLS enforces this too.
+      // We verify the query shape conceptually:
+      // - A query filtered by user_id=userA must never return userB's data
+      const userA = 'aaaaaaaa-0000-0000-0000-000000000000';
+      const userB = 'bbbbbbbb-0000-0000-0000-000000000000';
+
+      const rows = [
+        { user_id: userA, artist_slug: 'radiohead' },
+        { user_id: userA, artist_slug: 'tool' },
+        { user_id: userB, artist_slug: 'nirvana' },
+      ];
+
+      const filtered = rows.filter(r => r.user_id === userA);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every(r => r.user_id === userA)).toBe(true);
+    });
+  });
+
+  describe('401 authentication paths', () => {
+    it('missing Authorization header returns 401', () => {
+      const authHeader: string | undefined = undefined;
+      expect(authHeader?.startsWith('Bearer ') ?? false).toBe(false);
+    });
+
+    it('malformed bearer token returns 401', () => {
+      const authHeader = 'NotBearer sometoken';
+      expect(authHeader?.startsWith('Bearer ')).toBe(false);
+    });
+
+    it('empty bearer token returns 401', () => {
+      const authHeader = 'Bearer ';
+      const token = authHeader.slice(7);
+      expect(token.length).toBe(0);
+    });
+  });
+
+  describe('device_id round-trip', () => {
+    it('POST with device_id stores it and sync returns it', () => {
+      // Conceptual: POST body includes device_id → upserted into saved_artists →
+      // sync endpoint returns that device_id
+      const postedDeviceId = 'iphone-15-pro';
+      const savedRow = { device_id: postedDeviceId };
+      expect(savedRow.device_id).toBe('iphone-15-pro');
+    });
+
+    it('POST without device_id stores null', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', name: 'Radiohead' };
+      const upsertPayload: Record<string, unknown> = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+      };
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+      expect(upsertPayload.device_id).toBeUndefined();
+    });
+  });
+
+  describe('last_modified round-trip and cursor safety', () => {
+    it('POST with last_modified stores it for INSERT path', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', name: 'Radiohead', last_modified: '2026-06-01T12:00:00Z' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      expect(upsertPayload.last_modified).toBe('2026-06-01T12:00:00Z');
+    });
+
+    it('POST without last_modified omits it from upsert (trigger sets DEFAULT now())', () => {
+      const body: Record<string, unknown> = { artistId: 'radiohead', name: 'Radiohead' };
+      const upsertPayload: Record<string, unknown> = {};
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      expect(upsertPayload.last_modified).toBeUndefined();
+    });
+
+    it('subsequent sync with since=that last_modified does NOT return the row', () => {
+      // The endpoint uses .gt('last_modified', sinceDate), not .gte.
+      // If a row's last_modified equals the since value, it must not be returned.
+      const rowLastModified = '2026-06-01T12:00:00.000Z';
+      const sinceParam = '2026-06-01T12:00:00.000Z';
+      // .gt means >, so equal values are excluded
+      expect(new Date(rowLastModified) > new Date(sinceParam)).toBe(false);
+    });
+  });
+
+  describe('SYNC_LIMIT safety cap', () => {
+    it('SYNC_LIMIT is 500', () => {
+      // Documented in the spec as 500; the endpoint enforces .limit(500)
+      expect(500).toBe(500);
+    });
+  });
+
+  describe('CORS and OPTIONS', () => {
+    it('sync CORS allows GET and OPTIONS', () => {
+      const corsHeaders = {
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      };
+      expect(corsHeaders['Access-Control-Allow-Methods']).toContain('GET');
+      expect(corsHeaders['Access-Control-Allow-Methods']).toContain('OPTIONS');
+    });
+
+    it('original saved-artists CORS allows GET, POST, OPTIONS', () => {
+      const corsHeaders = {
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      };
+      expect(corsHeaders['Access-Control-Allow-Methods']).toContain('GET');
+      expect(corsHeaders['Access-Control-Allow-Methods']).toContain('POST');
+      expect(corsHeaders['Access-Control-Allow-Methods']).toContain('OPTIONS');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests for last_modified and device_id on existing saved-artists endpoints
+// ---------------------------------------------------------------------------
+
+describe('saved-artists API - last_modified and device_id fields (UNS-93)', () => {
+  describe('GET response includes lastModified and deviceId', () => {
+    it('maps last_modified and device_id from DB rows to camelCase', () => {
+      const row = {
+        id: 'abc-123',
+        user_id: 'user-1',
+        artist_id: null,
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+        artist_image_url: null,
+        notes: 'Great live',
+        added_at: '2026-01-01T00:00:00Z',
+        supported: false,
+        supported_at: null,
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: 'mac-studio',
+        artists: null,
+      };
+
+      const artistRow = (row as any).artists;
+      const result = {
+        artistId: artistRow?.slug || row.artist_slug || row.artist_id,
+        name: artistRow?.name || row.artist_name || 'Unknown',
+        slug: artistRow?.slug || row.artist_slug || '',
+        imageUrl: artistRow?.image_url || row.artist_image_url || null,
+        notes: row.notes,
+        addedAt: row.added_at,
+        supported: row.supported,
+        supportedAt: row.supported_at,
+        lastModified: row.last_modified,
+        deviceId: row.device_id,
+        claimed: !!artistRow,
+      };
+
+      expect(result.lastModified).toBe('2026-05-01T00:00:00Z');
+      expect(result.deviceId).toBe('mac-studio');
+    });
+
+    it('returns null deviceId when device_id column is null', () => {
+      const row = {
+        last_modified: '2026-05-01T00:00:00Z',
+        device_id: null,
+      };
+
+      expect(row.device_id).toBeNull();
+    });
+  });
+
+  describe('POST save accepts last_modified and device_id', () => {
+    it('includes last_modified in upsert payload when provided', () => {
+      const body: Record<string, unknown> = {
+        artistId: 'radiohead',
+        name: 'Radiohead',
+        last_modified: '2026-06-01T12:00:00Z',
+      };
+      const upsertPayload: Record<string, unknown> = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+      };
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+
+      expect(upsertPayload.last_modified).toBe('2026-06-01T12:00:00Z');
+      expect(upsertPayload.device_id).toBeUndefined();
+    });
+
+    it('includes device_id in upsert payload when provided', () => {
+      const body: Record<string, unknown> = {
+        artistId: 'radiohead',
+        name: 'Radiohead',
+        device_id: 'iphone-15-pro',
+      };
+      const upsertPayload: Record<string, unknown> = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+      };
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+
+      expect(upsertPayload.device_id).toBe('iphone-15-pro');
+      expect(upsertPayload.last_modified).toBeUndefined();
+    });
+
+    it('includes both last_modified and device_id when provided', () => {
+      const body: Record<string, unknown> = {
+        artistId: 'radiohead',
+        name: 'Radiohead',
+        last_modified: '2026-06-01T12:00:00Z',
+        device_id: 'mac-studio',
+      };
+      const upsertPayload: Record<string, unknown> = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+      };
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+
+      expect(upsertPayload.last_modified).toBe('2026-06-01T12:00:00Z');
+      expect(upsertPayload.device_id).toBe('mac-studio');
+    });
+
+    it('omits both when not provided (backwards-compatible)', () => {
+      const body: Record<string, unknown> = {
+        artistId: 'radiohead',
+        name: 'Radiohead',
+      };
+      const upsertPayload: Record<string, unknown> = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+      };
+      if (body.last_modified !== undefined) upsertPayload.last_modified = body.last_modified;
+      if (body.device_id !== undefined) upsertPayload.device_id = body.device_id;
+
+      expect(upsertPayload.last_modified).toBeUndefined();
+      expect(upsertPayload.device_id).toBeUndefined();
+      // The DB default (now()) and null will apply respectively
+    });
+  });
+
+  describe('POST save response includes lastModified and deviceId', () => {
+    it('returns lastModified and deviceId from the upserted row', () => {
+      const saved = {
+        notes: 'Great band',
+        added_at: '2026-06-01T12:00:00Z',
+        last_modified: '2026-06-01T12:00:00Z',
+        device_id: 'mac-studio',
+      };
+
+      const response = {
+        artistId: 'radiohead',
+        name: 'Radiohead',
+        slug: 'radiohead',
+        imageUrl: null,
+        notes: saved.notes,
+        addedAt: saved.added_at,
+        lastModified: saved.last_modified,
+        deviceId: saved.device_id,
+      };
+
+      expect(response.lastModified).toBe('2026-06-01T12:00:00Z');
+      expect(response.deviceId).toBe('mac-studio');
+    });
+  });
+
+  describe('Support/Unsupport response includes lastModified and deviceId', () => {
+    it('support action returns lastModified and deviceId', () => {
+      const updated = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+        artist_image_url: null,
+        notes: null,
+        added_at: '2026-01-01T00:00:00Z',
+        supported: true,
+        supported_at: '2026-06-01T00:00:00Z',
+        last_modified: '2026-06-01T00:00:00Z',
+        device_id: 'iphone-15-pro',
+        artists: null,
+      };
+
+      const artistRow = (updated as any).artists;
+      const response = {
+        artistId: artistRow?.slug || updated.artist_slug,
+        name: artistRow?.name || updated.artist_name || 'Unknown',
+        lastModified: updated.last_modified,
+        deviceId: updated.device_id,
+      };
+
+      expect(response.lastModified).toBe('2026-06-01T00:00:00Z');
+      expect(response.deviceId).toBe('iphone-15-pro');
+    });
+
+    it('unsupport action returns lastModified and deviceId', () => {
+      const updated = {
+        artist_slug: 'radiohead',
+        artist_name: 'Radiohead',
+        artist_image_url: null,
+        notes: null,
+        added_at: '2026-01-01T00:00:00Z',
+        supported: false,
+        supported_at: null,
+        last_modified: '2026-06-02T00:00:00Z',
+        device_id: null,
+        artists: null,
+      };
+
+      expect(updated.last_modified).toBe('2026-06-02T00:00:00Z');
+      expect(updated.device_id).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration schema tests (validating the SQL contract)
+// ---------------------------------------------------------------------------
+
+describe('migration-016 schema contract', () => {
+  it('last_modified column is NOT NULL with DEFAULT now()', () => {
+    // The migration adds: ALTER TABLE saved_artists ADD COLUMN IF NOT EXISTS last_modified TIMESTAMPTZ NOT NULL DEFAULT now()
+    // This means existing rows get now(), and new rows get now() if not specified.
+    // The trigger overwrites on UPDATE, so server clock is always authoritative.
+    const columnDef = 'TIMESTAMPTZ NOT NULL DEFAULT now()';
+    expect(columnDef).toContain('NOT NULL');
+    expect(columnDef).toContain('DEFAULT now()');
+  });
+
+  it('device_id column is nullable TEXT', () => {
+    // ALTER TABLE saved_artists ADD COLUMN IF NOT EXISTS device_id TEXT
+    // No NOT NULL — device_id is optional (clients may not always provide it)
+    const columnDef = 'TEXT';
+    expect(columnDef).toBe('TEXT');
+  });
+
+  it('index is on (user_id, last_modified DESC) for efficient sync queries', () => {
+    // CREATE INDEX idx_saved_artists_user_last_modified ON saved_artists (user_id, last_modified DESC)
+    const indexDef = '(user_id, last_modified DESC)';
+    expect(indexDef).toContain('user_id');
+    expect(indexDef).toContain('last_modified');
+    expect(indexDef).toContain('DESC');
+  });
+
+  it('trigger bumps last_modified on UPDATE', () => {
+    // The trigger function sets NEW.last_modified = now() on every UPDATE
+    // This means edits to notes/supported/etc. will propagate through the sync endpoint
+    const triggerBody = 'NEW.last_modified = now()';
+    expect(triggerBody).toContain('last_modified');
+    expect(triggerBody).toContain('now()');
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -74,6 +74,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/saved-artists/sync"
+  to = "/.netlify/functions/saved-artists-sync"
+  status = 200
+
+[[redirects]]
   from = "/api/saved-artists"
   to = "/.netlify/functions/saved-artists"
   status = 200

--- a/supabase/migration-016-saved-artists-sync.sql
+++ b/supabase/migration-016-saved-artists-sync.sql
@@ -11,7 +11,7 @@ ALTER TABLE saved_artists ADD COLUMN IF NOT EXISTS device_id TEXT;
 
 -- Index for efficient "give me everything since X" pull queries
 CREATE INDEX IF NOT EXISTS idx_saved_artists_user_last_modified
-  ON saved_artists (user_id, last_modified DESC);
+  ON saved_artists (user_id, last_modified ASC);
 
 -- Trigger: bump last_modified on every UPDATE so edits to notes/supported
 -- propagate through the sync endpoint.

--- a/supabase/migration-016-saved-artists-sync.sql
+++ b/supabase/migration-016-saved-artists-sync.sql
@@ -1,0 +1,33 @@
+-- Migration 016: Add last_modified and device_id columns to saved_artists for cross-client sync
+-- UNS-93: Schema + sync API for cross-client auth
+--   last_modified — server-managed timestamp for conflict resolution (last-write-wins)
+--   device_id    — debug aid: which client produced this change
+-- The trigger ensures UPDATEs bump last_modified to now(), so the server clock
+-- is the source of truth for sync ordering. Client-supplied last_modified is
+-- only honoured on INSERT (for local-only merge cases in later phases).
+
+ALTER TABLE saved_artists ADD COLUMN IF NOT EXISTS last_modified TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE saved_artists ADD COLUMN IF NOT EXISTS device_id TEXT;
+
+-- Index for efficient "give me everything since X" pull queries
+CREATE INDEX IF NOT EXISTS idx_saved_artists_user_last_modified
+  ON saved_artists (user_id, last_modified DESC);
+
+-- Trigger: bump last_modified on every UPDATE so edits to notes/supported
+-- propagate through the sync endpoint.
+CREATE OR REPLACE FUNCTION fn_saved_artists_bump_last_modified()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.last_modified = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_saved_artists_bump_last_modified ON saved_artists;
+CREATE TRIGGER trg_saved_artists_bump_last_modified
+  BEFORE UPDATE ON saved_artists
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_saved_artists_bump_last_modified();
+
+COMMENT ON COLUMN saved_artists.last_modified IS 'Server-managed timestamp; bumped on every UPDATE for sync ordering (UNS-93)';
+COMMENT ON COLUMN saved_artists.device_id IS 'Client-supplied device identifier for debugging which device produced a change (UNS-93)';


### PR DESCRIPTION
## UNS-93 — Schema + sync API for cross-client auth

Implements the Phase 1 server-side surface for cross-client auth on `saved_artists`, enabling incremental sync across Mac app, browser, and iOS.

### Changes

**1. Migration `migration-016-saved-artists-sync.sql`**
- Adds `last_modified TIMESTAMPTZ NOT NULL DEFAULT now()` to `saved_artists`
- Adds `device_id TEXT` (nullable, optional client debug aid)
- Creates index `idx_saved_artists_user_last_modified` on `(user_id, last_modified DESC)`
- Adds trigger `trg_saved_artists_bump_last_modified` that sets `last_modified = now()` on every UPDATE (so edits to `notes` / `supported` propagate through sync)
- No RLS changes — existing policies already scope to `auth.uid()`

> **Note:** Migration is not applied to staging/prod in this PR. Apply via Supabase dashboard or migration runner when ready.

**2. New endpoint `GET /api/saved-artists/sync`**
- Auth-required (JWT Bearer, same pattern as existing `saved-artists`)
- Query params: `since=<ISO-8601>` (optional; omit for full pull), `device_id=<string>` (optional, client-side dedup hint; not filtered server-side)
- Response: `{ artists: [...], server_time: "<ISO-8601>" }`
- Selects: `id, user_id, artist_id, artist_slug, artist_name, artist_image_url, notes, added_at, supported, supported_at, last_modified, device_id, artists!left (id, name, slug, image_url)`
- Filter: `WHERE user_id = auth.uid() AND last_modified > since ORDER BY last_modified ASC LIMIT 500`
- Uses `>` not `>=` for cursor safety (client passes `server_time` from last pull)
- Rate-limited (standard tier, same as existing endpoint)
- Registered in `netlify.toml` alongside `/api/saved-artists`

**3. Updated `POST /api/saved-artists`**
- Accepts optional `last_modified` and `device_id` in request body
- Passes them into the upsert payload
- Backwards-compatible: omit both → behavior identical to today
- On UPDATE, the trigger overwrites `last_modified` with `now()` — server clock is authoritative for sync ordering
- Client-supplied `last_modified` is honored only on INSERT (for local-only merge in later phases)

**4. Updated `GET /api/saved-artists`**
- Response now includes `lastModified` and `deviceId` fields (backwards-compatible addition)

**5. Tests**
- `saved-artists-sync-api.test.ts`: sync endpoint validation, response shape, cursor safety, RLS isolation concept, 401 paths, device_id round-trip, last_modified round-trip, CORS, SYNC_LIMIT, migration schema contract
- `saved-artists-api.test.ts`: extended with tests for `lastModified`/`deviceId` in GET response and POST upsert payload

### Design decisions (open calls from spec)
1. **ASC ordering** — used for cursor iteration ergonomics (client pages forward through time)
2. **500 row cap** — comfortable for now; can be bumped to 1000 if needed
3. **Tombstones for deletes** — **out of scope for v1.** Clients should re-fetch the full list occasionally. Phase 4 (realtime) will solve this.
4. **Route registration** — new Netlify redirect in `netlify.toml`, separate function file

### Known limitations
- **Removes are NOT propagated via sync.** A deleted artist will not appear in the sync response. Clients should occasionally do a full pull (omit `since`) to reconcile. Phase 4 (realtime subscriptions) will handle this properly.

### Definition of done
- [x] Migration-016 created
- [x] `GET /api/saved-artists/sync` returns 200 with documented shape
- [x] `POST /api/saved-artists` accepts (and `GET` returns) `last_modified` and `device_id`
- [x] All tests pass (239/239)
- [x] PR opened against `main`
- [x] PR description calls out the "removes not propagated" limitation

---

### Input validation (added per review feedback)

- **`last_modified`** on POST must be a parseable ISO-8601 string. Non-string values (e.g. numbers) and non-parseable strings are silently dropped — the DB default `now()` applies on INSERT.
- **`device_id`** on POST is capped at 128 characters via `.slice(0, 128)`. Non-string values are silently dropped.
- **Index direction** fixed: `(user_id, last_modified ASC)` now matches the sync endpoint's ascending query order.