### PR TITLE
fix(UNS-99): restore React Router <Link> for /a/ navigation

### DIFF
--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { SearchResult } from '../types';
 import { typeLabel, typeIcon } from './ResultCardUtils';
 
@@ -76,17 +77,18 @@ export function ResultCardHeader({
                 </svg>
                 Verified
               </span>
-              {/* Hard navigation (not React Router <Link>): claimed /a/{slug} pages are
-                  server-rendered by the claimed-artist-page edge function. A client-side
-                  transition would mount the SPA's ArtistPage (a plain result card) instead
-                  of the rich profile layout — the UNS-97 bug. */}
-              <a
-                href={`/a/${result.claimedSlug || result.id}`}
+              {/* React Router <Link>: the SPA's ArtistPage renders the unclaimed
+                  clean-profile branch. The full rich layout lives in the edge
+                  function today, but UNS-100 will port it to React so this is
+                  the right long-term path. UNS-99's broken back button on Safari
+                  is the MPA <-> SPA boundary that plain <a href> created. */}
+              <Link
+                to={`/a/${result.claimedSlug || result.id}`}
                 className="text-xs px-1.5 py-0.5 rounded bg-bg-hover text-text-secondary hover:text-text-primary transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >
                 View profile
-              </a>
+              </Link>
             </>
           )}
           {result.matchConfidence === 'unverified' && (

--- a/apps/web/src/pages/ArtistDashboardPage.tsx
+++ b/apps/web/src/pages/ArtistDashboardPage.tsx
@@ -142,13 +142,12 @@ export function ArtistDashboardPage() {
                         >
                           Edit
                         </Link>
-                        {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-                        <a
-                          href={`/a/${profile.slug}`}
+                        <Link
+                          to={`/a/${profile.slug}`}
                           className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                         >
                           View
-                        </a>
+                        </Link>
                         <button
                           onClick={() => handleShareProfile(profile.slug)}
                           className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors flex items-center gap-1.5"

--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
@@ -95,14 +96,13 @@ export function ArtistDirectoryPage() {
                     <h2 className="text-xl font-bold pb-2 border-b border-border mb-1">{letter}</h2>
                     <div className="grid gap-0.5">
                       {grouped[letter].map(artist => (
-                        // Hard navigation (not React Router <Link>): /a/{slug} is server-rendered
-                        // by the claimed-artist-page edge function. A client-side transition would
-                        // mount the SPA's ArtistPage (a plain result card) instead of the rich
-                        // profile layout, which is the UNS-97 bug. A real anchor lets the edge
-                        // function own the page so the profile renders identically to a direct visit.
-                        <a
+                        // React Router <Link>: SPA's ArtistPage handles /a/{slug} client-side.
+                        // Plain <a href> here caused UNS-99's broken back button on Safari 26
+                        // (MPA <-> SPA boundary + PWA service worker). The rich profile layout
+                        // is in the edge function today; UNS-100 ports it into React.
+                        <Link
                           key={artist.slug}
-                          href={`/a/${artist.slug}`}
+                          to={`/a/${artist.slug}`}
                           className="flex items-center gap-3 px-3.5 py-2.5 rounded-lg hover:bg-bg-secondary border border-transparent hover:border-border transition-colors"
                         >
                           <div className="w-9 h-9 rounded-full bg-bg-secondary flex-shrink-0 flex items-center justify-center font-semibold text-sm text-text-muted overflow-hidden">
@@ -122,7 +122,7 @@ export function ArtistDirectoryPage() {
                           <svg className="ml-auto flex-shrink-0 w-3.5 h-3.5 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                           </svg>
-                        </a>
+                        </Link>
                       ))}
                     </div>
                   </div>

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -375,13 +375,12 @@ export function ArtistEditPage() {
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-2xl font-bold">Edit {form.artistName}</h1>
-              {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-              <a
-                href={`/a/${form.currentSlug}`}
+              <Link
+                to={`/a/${form.currentSlug}`}
                 className="text-sm text-accent-primary hover:underline"
               >
                 View live profile
-              </a>
+              </Link>
             </div>
             <Link
               to="/artist-dashboard"

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -363,6 +363,45 @@ export function ArtistPage() {
                   />
                 ))}
               </div>
+            ) : isProfileRoute && results.length > 0 ? (
+              /* Unclaimed artist on profile route (/a/{slug}) — clean profile layout, no search chrome.
+                 Routing was already correct (UNS-94), but unclaimed profiles were rendering the
+                 search-results branch with "Found N results" + Save button — which the user reads
+                 as a search results page (UNS-97/UNS-98). Use the same quiet layout as the claimed
+                 branch, with a small inline Save button above the result card. */
+              <div className="space-y-4">
+                <div className="flex items-center justify-end">
+                  {primaryArtist && (
+                    <button
+                      onClick={handleSaveArtist}
+                      disabled={!primaryArtist.id}
+                      aria-label={isSaved ? `Unsave ${primaryArtist.name}` : `Save ${primaryArtist.name}`}
+                      title={isSaved ? 'Saved' : 'Save artist'}
+                      className={`inline-flex items-center gap-1.5 text-sm transition-colors ${
+                        isSaved ? 'text-accent-secondary' : 'text-text-muted hover:text-accent-secondary'
+                      } disabled:opacity-50 disabled:cursor-not-allowed`}
+                    >
+                      <svg
+                        className={`w-4 h-4 transition-all ${
+                          isSaved ? 'fill-accent-secondary' : 'fill-transparent stroke-current'
+                        }`}
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                      </svg>
+                      {isSaved ? 'Saved' : 'Save'}
+                    </button>
+                  )}
+                </div>
+                {results.map((result) => (
+                  <ResultCard
+                    key={result.id}
+                    result={result}
+                  />
+                ))}
+              </div>
             ) : results.length > 0 ? (
               /* Search results — with count header and save button. UNCHANGED. */
               <div className="space-y-4">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -310,13 +310,12 @@ export function DashboardPage() {
                           >
                             Edit
                           </Link>
-                          {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-                          <a
-                            href={`/a/${profile.slug}`}
+                          <Link
+                            to={`/a/${profile.slug}`}
                             className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                           >
                             View
-                          </a>
+                          </Link>
                           <button
                             onClick={() => handleRemoveClaimedProfile(profile.id, profile.artistId, profile.slug)}
                             className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-red-400 hover:border-red-500/30 transition-colors"
@@ -399,13 +398,12 @@ export function DashboardPage() {
                         )}
                         <div className="flex items-center gap-2 mt-3 flex-wrap">
                           {artist.claimed && artist.slug ? (
-                            // Hard nav: claimed /a/{slug} is edge-rendered (rich profile). See UNS-97.
-                            <a
-                              href={`/a/${artist.slug}`}
+                            <Link
+                              to={`/a/${artist.slug}`}
                               className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                             >
                               View
-                            </a>
+                            </Link>
                           ) : (
                             <Link
                               to={`/?q=${encodeURIComponent(artist.name)}`}


### PR DESCRIPTION
## Hotfix for UNS-99 + UNS-97

Reverts the React side of PR #269 (UNS-97). The bad parts of #269 are undone; the good parts (edge function drop, fetch-order swap, `!!slug` from `useParams`) stay on main and form the foundation for UNS-100.

### What this PR restores

**`React Router <Link to>` for all `/a/` navigation** (5 files, 6 link sites):
- `apps/web/src/components/ResultCardHeader.tsx` (View profile)
- `apps/web/src/pages/ArtistDirectoryPage.tsx` (artist list)
- `apps/web/src/pages/ArtistDashboardPage.tsx` (View)
- `apps/web/src/pages/ArtistEditPage.tsx` (View live profile)
- `apps/web/src/pages/DashboardPage.tsx` (claimed profile View, twice)

Plain `<a href>` here caused a hard navigation out of the React SPA into the edge function for `/a/{slug}`, which crosses an MPA ↔ SPA boundary that breaks the back button on Safari 26 (UNS-99, bfcache + PWA service worker interaction, reproducible in private browsing).

**The unclaimed clean-profile branch in `ArtistPage`.** UNS-97's other symptom was that unclaimed `/a/{slug}` visits rendered with "Found N results" chrome. This adds a third layout branch (`isProfileRoute && results.length > 0`) that uses the same quiet layout as the claimed branch. Removes a dead `isEnriching` reference in the new branch (the state was dropped by #269 since no enrichment happens on profile routes).

### What this PR does NOT do (out of scope)

- **Doesn't port the rich profile into React.** That's UNS-100b. Until that lands, direct visits to `/a/{slug}` for a claimed artist still hit the `claimed-artist-page` edge function (which is the intent — direct visits and crawlers get the rich SSR; SPA clicks stay in the SPA).
- **Doesn't remove the `claimed-artist-page` edge function.** That's UNS-100d.
- **Doesn't change the service worker denylist.** The `/a/*` and `/artist/*` entries in `vite.config.ts` stay so the SW doesn't intercept the edge function's HTML on direct visits.

### Verification

- `npm run build` — clean.
- `npm test:unit` — 244/244 pass.
- Lint — no new errors or warnings from this PR (4 pre-existing errors in `ArtistEditPage.tsx`/`DashboardPage.tsx` exist on main, not introduced here).

### Long-term fix

UNS-100 (this branch's parent issue): collapse the MPA ↔ SPA bifurcation by porting the rich profile from `claimed-artist-page.ts` into React and removing the edge function entirely. The SPA becomes the single renderer for `/a/{slug}`. UNS-100 includes a no-JS accessibility fallback per Brandon's guiding principle.

This is a stopgap to stop the bleeding in production while UNS-100 is built.

Refs UNS-99, UNS-97, UNS-100.

## Stale-base check

`git diff origin/main..HEAD --stat` shows 6 files, no deletions of files merged into main in the last 7 days. Safe to merge.

🤖 Generated with [Claude Code](https://claude.ai/code)