### PR TITLE
fix(UNS-99): restore React Router <Link> for /a/ navigation (targeted revert of #269)

### DIFF
--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { SearchResult } from '../types';
 import { typeLabel, typeIcon } from './ResultCardUtils';
 
@@ -76,17 +77,17 @@ export function ResultCardHeader({
                 </svg>
                 Verified
               </span>
-              {/* Hard navigation (not React Router <Link>): claimed /a/{slug} pages are
-                  server-rendered by the claimed-artist-page edge function. A client-side
-                  transition would mount the SPA's ArtistPage (a plain result card) instead
-                  of the rich profile layout — the UNS-97 bug. */}
-              <a
-                href={`/a/${result.claimedSlug || result.id}`}
+              {/* React Router <Link>: SPA-internal navigation keeps history in the SPA
+                  (back button works on Safari 26). The rich profile lives in the edge
+                  function today; UNS-100 ports it into React. The hard-navigation path
+                  was a regression in #269 (UNS-99) — see hotfix/uns-99-restore-link-routing. */}
+              <Link
+                to={`/a/${result.claimedSlug || result.id}`}
                 className="text-xs px-1.5 py-0.5 rounded bg-bg-hover text-text-secondary hover:text-text-primary transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >
                 View profile
-              </a>
+              </Link>
             </>
           )}
           {result.matchConfidence === 'unverified' && (

--- a/apps/web/src/pages/ArtistDashboardPage.tsx
+++ b/apps/web/src/pages/ArtistDashboardPage.tsx
@@ -142,13 +142,12 @@ export function ArtistDashboardPage() {
                         >
                           Edit
                         </Link>
-                        {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-                        <a
-                          href={`/a/${profile.slug}`}
+                        <Link
+                          to={`/a/${profile.slug}`}
                           className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                         >
                           View
-                        </a>
+                        </Link>
                         <button
                           onClick={() => handleShareProfile(profile.slug)}
                           className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors flex items-center gap-1.5"

--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
@@ -95,14 +96,12 @@ export function ArtistDirectoryPage() {
                     <h2 className="text-xl font-bold pb-2 border-b border-border mb-1">{letter}</h2>
                     <div className="grid gap-0.5">
                       {grouped[letter].map(artist => (
-                        // Hard navigation (not React Router <Link>): /a/{slug} is server-rendered
-                        // by the claimed-artist-page edge function. A client-side transition would
-                        // mount the SPA's ArtistPage (a plain result card) instead of the rich
-                        // profile layout, which is the UNS-97 bug. A real anchor lets the edge
-                        // function own the page so the profile renders identically to a direct visit.
-                        <a
+                        // React Router <Link>: SPA-internal navigation keeps the back button
+                        // working on Safari 26 (UNS-99). The rich profile lives in the edge
+                        // function today; UNS-100 ports it to React.
+                        <Link
                           key={artist.slug}
-                          href={`/a/${artist.slug}`}
+                          to={`/a/${artist.slug}`}
                           className="flex items-center gap-3 px-3.5 py-2.5 rounded-lg hover:bg-bg-secondary border border-transparent hover:border-border transition-colors"
                         >
                           <div className="w-9 h-9 rounded-full bg-bg-secondary flex-shrink-0 flex items-center justify-center font-semibold text-sm text-text-muted overflow-hidden">
@@ -122,7 +121,7 @@ export function ArtistDirectoryPage() {
                           <svg className="ml-auto flex-shrink-0 w-3.5 h-3.5 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                           </svg>
-                        </a>
+                        </Link>
                       ))}
                     </div>
                   </div>

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -375,13 +375,12 @@ export function ArtistEditPage() {
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-2xl font-bold">Edit {form.artistName}</h1>
-              {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-              <a
-                href={`/a/${form.currentSlug}`}
+              <Link
+                to={`/a/${form.currentSlug}`}
                 className="text-sm text-accent-primary hover:underline"
               >
                 View live profile
-              </a>
+              </Link>
             </div>
             <Link
               to="/artist-dashboard"

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -310,13 +310,12 @@ export function DashboardPage() {
                           >
                             Edit
                           </Link>
-                          {/* Hard nav: /a/{slug} is edge-rendered (rich profile). See UNS-97. */}
-                          <a
-                            href={`/a/${profile.slug}`}
+                          <Link
+                            to={`/a/${profile.slug}`}
                             className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                           >
                             View
-                          </a>
+                          </Link>
                           <button
                             onClick={() => handleRemoveClaimedProfile(profile.id, profile.artistId, profile.slug)}
                             className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-red-400 hover:border-red-500/30 transition-colors"
@@ -399,13 +398,12 @@ export function DashboardPage() {
                         )}
                         <div className="flex items-center gap-2 mt-3 flex-wrap">
                           {artist.claimed && artist.slug ? (
-                            // Hard nav: claimed /a/{slug} is edge-rendered (rich profile). See UNS-97.
-                            <a
-                              href={`/a/${artist.slug}`}
+                            <Link
+                              to={`/a/${artist.slug}`}
                               className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
                             >
                               View
-                            </a>
+                            </Link>
                           ) : (
                             <Link
                               to={`/?q=${encodeURIComponent(artist.name)}`}


### PR DESCRIPTION
## Targeted hotfix for UNS-99 (back button) + preservation of UNS-97 fix

Reverts the **bad** parts of #269 (the `<a href>` reversion) while **keeping** the good parts (edge function drop, unclaimed clean-branch, fetch-order swap, `!!slug` from `useParams`). A strict git revert of #269 would regress UNS-97 for unclaimed `/a/{slug}` direct visits; this targeted revert is the right shape for a production hotfix.

### What this PR restores (5 files, 6 link sites)

**React Router `<Link to>`** for all `/a/` navigation:
- `apps/web/src/components/ResultCardHeader.tsx` (View profile)
- `apps/web/src/pages/ArtistDirectoryPage.tsx` (artist list — the one UNS-99 actually exercises)
- `apps/web/src/pages/ArtistDashboardPage.tsx` (View)
- `apps/web/src/pages/ArtistEditPage.tsx` (View live profile)
- `apps/web/src/pages/DashboardPage.tsx` (claimed profile View, twice)

Plain `<a href>` here caused a hard navigation out of the React SPA into the edge function for `/a/{slug}`, which crosses an MPA ↔ SPA boundary that breaks the back button on Safari 26 (bfcache + PWA service worker interaction, reproducible in private browsing on macOS Tahoe and iOS 26).

### What this PR does NOT touch (kept from #269)

- `api/edge/artist-directory-page.ts` deletion — UNS-100 prep.
- `netlify.toml` `/artists` edge function registration removal.
- The unclaimed clean-profile branch in `ArtistPage.tsx` — UNS-97 fix for unclaimed `/a/{slug}` direct visits.
- The fetch-order swap: DB API first, pre-generated JSON fallback — fixes the `matchConfidence: 'claimed'` issue for claimed artists.
- `isProfileRoute = !!slug` from `useParams` — route-synchronous, fixes the route-transition race.

### Why a strict git revert would be wrong

A `git revert 9c93e69` would undo the entire squash, including the unclaimed clean-branch in `ArtistPage.tsx` that #269 added. That branch is the **only positive contribution** #269 made to UNS-97. A strict revert regresses UNS-97 for unclaimed `/a/{slug}` direct visits, which is the opposite of what we want.

The targeted revert above is the minimum diff that fixes UNS-99 without regressing UNS-97.

### Verification

- `npm run build` — clean.
- `npm test:unit` — 244/244 pass.
- Lint — no new errors or warnings (4 pre-existing errors in `ArtistEditPage.tsx`/`DashboardPage.tsx` exist on main, not introduced here).

### Test plan on the Netlify deploy preview

1. `/artists` → click any artist → SPA's `<ArtistPage>` mounts (no full reload, no MPA boundary). Back button returns to `/artists`.
2. `/a/{slug}` direct visit on a claimed artist → still shows the rich profile (from `claimed-artist-page` edge function, unchanged).
3. `/a/{slug}` direct visit on an unclaimed artist → SPA's `<ArtistPage>` renders the clean unclaimed branch (UNS-97 fix from #269, kept on main).
4. Back button on `/a/{slug}` direct visit → still bfcache-broken on Safari 26 (UNS-100 fix).

### Stale-base warning (UNS-91 postmortem)

All 5 files in this PR were modified in #269 (within 7 days). The deletions in this commit are exactly the `<a href>` lines that #269 added. **The deletion is justified by UNS-99** (back button broken on Safari 26 due to the MPA ↔ SPA boundary the `<a href>` created). Reviewer must specifically acknowledge the deletion in their review per the UNS-91 postmortem rule.

### Long-term fix

UNS-100 (this branch's parent issue): collapse the MPA ↔ SPA bifurcation by porting the rich profile from `claimed-artist-page.ts` into React and removing the edge function entirely. The SPA becomes the single renderer for `/a/{slug}`, with a no-JS accessibility fallback (UNS-100h) per Brandon's sign-off.

This is a stopgap to stop the bleeding in production while UNS-100 is built.

Refs UNS-99, UNS-97, UNS-100.

🤖 Generated with [Claude Code](https://claude.ai/code)