### PR TITLE
feat(UNS-101): add /api/artist-page endpoint for the rich profile payload

### DIFF
--- a/api/edge/claimed-artist-page.ts
+++ b/api/edge/claimed-artist-page.ts
@@ -1,16 +1,7 @@
 import { Context } from "https://edge.netlify.com";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
-
-// UPDATE ANNUALLY: Bandcamp Friday dates from https://daily.bandcamp.com/features/bandcamp-fridays
-const BANDCAMP_FRIDAY_DATES = [
-  '2026-03-06', '2026-05-02', '2026-08-07',
-  '2026-09-04', '2026-10-02', '2026-11-06', '2026-12-04',
-];
-function isBandcampFriday(): boolean {
-  const pacificDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
-  return BANDCAMP_FRIDAY_DATES.includes(pacificDate);
-}
+import { BANDCAMP_FRIDAY_DATES, isBandcampFriday } from "../shared/bandcamp-friday.ts";
 
 // Derive PLATFORM_INFO from shared registry (name, color, icon, category, payoutPercent)
 const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; payoutPercent?: string }> = {};

--- a/api/edge/claimed-artist-page.ts
+++ b/api/edge/claimed-artist-page.ts
@@ -1,7 +1,7 @@
 import { Context } from "https://edge.netlify.com";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
-import { BANDCAMP_FRIDAY_DATES, isBandcampFriday } from "../shared/bandcamp-friday.ts";
+import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
 
 // Derive PLATFORM_INFO from shared registry (name, color, icon, category, payoutPercent)
 const PLATFORM_INFO: Record<string, { name: string; color: string; icon: string; category: string; payoutPercent?: string }> = {};

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -1,0 +1,145 @@
+// API endpoint: GET /api/artist-page?slug=...
+// Returns the full rich-profile payload for a claimed artist as JSON.
+// This is the data source for the React SPA artist page (UNS-102).
+
+import { getArtistProfileBySlug } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { PLATFORMS } from '../shared/platform-registry';
+import { isBandcampFriday } from '../shared/bandcamp-friday';
+import { sanitizeEmbed } from './artist-profile';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string>; httpMethod?: string }) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers || {});
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const slug = event.queryStringParameters?.slug;
+
+  if (!slug) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'slug parameter is required' }),
+    };
+  }
+
+  try {
+    const bundle = await getArtistProfileBySlug(slug);
+
+    // getArtistProfileBySlug returns null if artist not found or not claimed
+    if (!bundle) {
+      return {
+        statusCode: 404,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Artist not found' }),
+      };
+    }
+
+    const { artist: artistRow, profile, links: rawLinks } = bundle;
+
+    // Filter out junk links (same logic as the edge function)
+    const allLinks = rawLinks.filter(l => {
+      const u = l.url.toLowerCase();
+      return !u.includes('duckduckgo.com')
+        && !u.includes('google.com/search')
+        && !u.includes('searchstyle=search');
+    });
+
+    const bcFriday = isBandcampFriday();
+
+    // Split links into main (non-social) and social
+    const mainLinks = allLinks.filter(l => {
+      const info = PLATFORMS[l.platform];
+      return !info || info.category !== 'social';
+    });
+    const socialLinks = allLinks.filter(l => {
+      const info = PLATFORMS[l.platform];
+      return info?.category === 'social';
+    });
+
+    // Build the main links array with payout info
+    const links = mainLinks.map(l => {
+      const info = PLATFORMS[l.platform];
+      const isBCFriday = l.platform === 'bandcamp' && bcFriday;
+      const payoutPercent = isBCFriday ? '~97%' : (info?.payoutPercent ?? null);
+      const displayName = (l.platform === 'other' || l.platform.startsWith('other_'))
+        ? (l.display_name || null)
+        : (l.display_name || info?.name || null);
+
+      return {
+        platform: l.platform,
+        url: l.url,
+        displayName,
+        payoutPercent,
+        bandcampFriday: isBCFriday,
+      };
+    });
+
+    // Build the social links array
+    const social = socialLinks.map(l => {
+      const info = PLATFORMS[l.platform];
+      return {
+        platform: l.platform,
+        url: l.url,
+        displayName: l.display_name || info?.name || null,
+      };
+    });
+
+    // Sanitize the featured embed
+    const featuredEmbed = sanitizeEmbed(profile?.featured_embed ?? null);
+
+    // Build the image URL: custom > artist row > null
+    const imageUrl = profile?.custom_image_url || artistRow.image_url || null;
+
+    const payload = {
+      artist: {
+        id: artistRow.id,
+        slug: artistRow.slug,
+        name: artistRow.name,
+        imageUrl,
+        matchConfidence: artistRow.match_confidence as 'verified' | 'unverified' | 'claimed',
+        country: artistRow.country,
+        countryCode: artistRow.country_code,
+        city: artistRow.city,
+      },
+      profile: profile ? {
+        bio: profile.bio,
+        customImageUrl: profile.custom_image_url,
+        featuredEmbed,
+        verifiedAt: profile.verified_at,
+      } : null,
+      links,
+      socialLinks: social,
+      bandcampFriday: bcFriday,
+    };
+
+    return {
+      statusCode: 200,
+      headers: {
+        ...CORS_HEADERS,
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Netlify-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=86400',
+        'Cache-Tag': `artist-page-${slug}`,
+      },
+      body: JSON.stringify(payload),
+    };
+  } catch (error) {
+    console.error('[artist-page] Error:', error);
+    return {
+      statusCode: 500,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Internal server error' }),
+    };
+  }
+}

--- a/api/functions/artist-profile.ts
+++ b/api/functions/artist-profile.ts
@@ -39,7 +39,7 @@ interface LinkUpdate {
 }
 
 // Allowed embed domains for featured releases
-const ALLOWED_EMBED_DOMAINS = [
+export const ALLOWED_EMBED_DOMAINS = [
   'bandcamp.com',
   'youtube.com',
   'youtube-nocookie.com',
@@ -51,7 +51,7 @@ const ALLOWED_EMBED_DOMAINS = [
   'embed.tidal.com',
 ];
 
-function sanitizeEmbed(raw: string | null): string | null {
+export function sanitizeEmbed(raw: string | null): string | null {
   if (!raw || !raw.trim()) return null;
 
   // Extract iframe src and validate it's a proper URL

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -104,6 +104,68 @@ interface LinkRow {
   display_order: number | null;
 }
 
+// --- Artist Profile Bundle ---
+
+export interface ArtistProfileRow {
+  bio: string | null;
+  custom_image_url: string | null;
+  featured_embed: string | null;
+  verified_at: string | null;
+}
+
+export interface ArtistProfileBundle {
+  artist: ArtistRow;
+  profile: ArtistProfileRow | null;
+  links: LinkRow[];
+}
+
+/**
+ * Fetch the artist row + profile row + links for a claimed artist.
+ * Returns null if the artist doesn't exist or isn't claimed.
+ */
+export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfileBundle | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    // Find the artist row first
+    const { data: artist, error: artistError } = await client
+      .from('artists')
+      .select('*')
+      .eq('slug', slug)
+      .single();
+
+    if (artistError || !artist) return null;
+    if (artist.match_confidence !== 'claimed') return null;
+
+    const artistRow = artist as ArtistRow;
+    const artistId = artistRow.id;
+
+    // Fetch profile and links in parallel
+    const [profileResult, linksResult] = await Promise.all([
+      client
+        .from('artist_profiles')
+        .select('bio, custom_image_url, featured_embed, verified_at')
+        .eq('artist_id', artistId)
+        .single(),
+      client
+        .from('artist_links')
+        .select('*')
+        .eq('artist_id', artistId)
+        .order('display_order', { ascending: true, nullsFirst: false }),
+    ]);
+
+    return {
+      artist: artistRow,
+      profile: (profileResult.data as ArtistProfileRow | null) ?? null,
+      links: (linksResult.data as LinkRow[]) || [],
+    };
+  } catch (error) {
+    console.error('[DB] getArtistProfileBySlug error:', error);
+    return null;
+  }
+}
+
 // --- Merge Overrides ---
 
 export interface MergeOverrideRow {

--- a/api/shared/bandcamp-friday.ts
+++ b/api/shared/bandcamp-friday.ts
@@ -1,0 +1,12 @@
+// Bandcamp Friday dates — shared between the edge function and API endpoints.
+// UPDATE ANNUALLY: Bandcamp Friday dates from https://daily.bandcamp.com/features/bandcamp-fridays
+
+export const BANDCAMP_FRIDAY_DATES: string[] = [
+  '2026-03-06', '2026-05-02', '2026-08-07',
+  '2026-09-04', '2026-10-02', '2026-11-06', '2026-12-04',
+];
+
+export function isBandcampFriday(): boolean {
+  const pacificDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Los_Angeles' });
+  return BANDCAMP_FRIDAY_DATES.includes(pacificDate);
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -80,6 +80,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/artist-page"
+  to = "/.netlify/functions/artist-page"
+  status = 200
+
+[[redirects]]
   from = "/api/artist-profile"
   to = "/.netlify/functions/artist-profile"
   status = 200


### PR DESCRIPTION
## UNS-101: API contract for `/api/artist-page?slug=...`

Part of parent issue **UNS-100** (collapse edge/SPA bifurcation for artist pages).

### What this does

Adds a new Netlify function `GET /api/artist-page?slug=...` that returns the **full rich-profile payload** as JSON — the same data the edge function currently renders as HTML, but now available as a clean API for the React SPA to consume (UNS-102).

### Changes

- **`api/functions/artist-page.ts`** (new, ~145 lines) — handler returning `ArtistPagePayload` JSON with artist metadata, profile, links (split into main/social), payout info, Bandcamp Friday flag, and sanitized featured embed
- **`api/functions/db.ts`** — added `getArtistProfileBySlug(slug)` returning artist row + profile row + links in parallel
- **`api/shared/bandcamp-friday.ts`** (new) — extracted `BANDCAMP_FRIDAY_DATES` and `isBandcampFriday()` from edge function so both the new endpoint and future no-JS fallback (UNS-105) can use it
- **`api/functions/artist-profile.ts`** — exported `sanitizeEmbed` and `ALLOWED_EMBED_DOMAINS` for reuse
- **`api/edge/claimed-artist-page.ts`** — updated to import from shared module (no behavior change)
- **`netlify.toml`** — added redirect for `/api/artist-page`

### API contract

```typescript
interface ArtistPagePayload {
  artist: { id, slug, name, imageUrl, matchConfidence, country, countryCode, city };
  profile: { bio, customImageUrl, featuredEmbed, verifiedAt } | null;
  links: Array<{ platform, url, displayName, payoutPercent, bandcampFriday }>;
  socialLinks: Array<{ platform, url, displayName }>;
  bandcampFriday: boolean;
}
```

### Design decisions

- **Bandcamp Friday as shared module** — extracted from the edge function so UNS-105 (no-JS fallback) can also use it
- **Separate main/social link arrays** — matches the edge function's split; the React component can render them differently
- **Payout strings match edge function** — uses platform registry `payoutPercent` with `~97%` override on Bandcamp Fridays
- **Cache headers** — `s-maxage=300, stale-while-revalidate=86400` (5-min CDN cache, day-long stale revalidation) vs the existing 60s on `/api/artist`
- **404 for unclaimed** — the endpoint is specifically for the rich profile; unclaimed artists fall through to a different SPA code path

### Verification

- ✅ `npm run build` — clean
- ✅ `npm run test:unit` — 244/244 passing
- Manual endpoint test pending deployment

Refs: UNS-100, UNS-101