### PR TITLE
feat(UNS-106): <ClaimPage> post-claim redirect uses navigate() instead of window.location.href

### DIFF
--- a/apps/web/src/pages/ClaimPage.tsx
+++ b/apps/web/src/pages/ClaimPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { signInWithMagicLink } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
@@ -20,6 +20,7 @@ import type { ClaimStep, ReviewLink } from '../components/ClaimPageTypes';
 
 export function ClaimPage() {
   const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
 
   const [step, setStep] = useState<ClaimStep>('email');
   const [email, setEmail] = useState('');
@@ -296,7 +297,7 @@ export function ClaimPage() {
         return;
       }
 
-      window.location.href = `/a/${data.slug || slug}?claimed`;
+      navigate(`/a/${data.slug || slug}?claimed`);
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'claim.confirmReview' } });
       setError('Network error. Please try again.');


### PR DESCRIPTION
## UNS-106 — ClaimPage post-claim SPA redirect

Linear: [UNS-106](https://linear.app/cultoflightbulbs/issue/UNS-106)

### What changed

**`apps/web/src/pages/ClaimPage.tsx`** — 3 edits, 1 file:

| Line | Before | After |
|------|--------|-------|
| 2 | `import { useParams } from "react-router-dom"` | `import { useParams, useNavigate } from "react-router-dom"` |
| 22 | *(no hook)* | `const navigate = useNavigate();` |
| 299 | `window.location.href = \`/a/${data.slug \|\| slug}?claimed\`` | `navigate(\`/a/${data.slug \|\| slug}?claimed\`)` |

### Why

`window.location.href` is a hard navigation — it reloads the page, destroys SPA history, and re-initializes the service worker. The rest of UNS-100 assumes SPA navigation throughout. This was the one remaining hard redirect in the claim flow.

### Scope confirmation

- `grep -rn "href=.*\"/a/\"" apps/web/src/` returns **zero results** — no other `<a href="/a/...">` patterns to fix.
- No other files touched. No new tests (navigation isn't unit-tested; existing ClaimPage tests cover form/validation only).
- No comments, defensive checks, or wrapper logic added.

### Pre-review notes

- ClaimPage.tsx was last modified in #264, not #275 — no semantic-revert risk.
- PR #275 touched ArtistPage, RichArtistProfile, UnclaimedQuietCard, AuthContext, Header — none overlap with this change.

### CI

- `npm run build` — clean ✓
- `npm test` — 431/449 pass. 18 failures are pre-existing (4 stale import suites from #275 rename + search-accuracy integration flakiness). Zero failures related to ClaimPage or this change.