### PR TITLE
docs(UNS-100): post-merge retro + 'one route, one renderer' rule + supporting specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ Default to **simple, boring code that a human can read once and understand.** Th
 - **No dead weight.** Don't leave commented-out code, unused exports, speculative "might need later" branches, or TODOs without follow-through. Delete what isn't used.
 - **Scale through clarity, not premature optimization.** Write the straightforward version first; optimize only with a concrete reason (a real hot path, a measured cost). Note the trade-off when you do.
 - **Fail loudly and handle errors explicitly.** Validate inputs at boundaries, surface errors (Sentry is wired up — use it), and avoid silent catches that swallow problems.
+- **One route, one renderer.** If a URL is server-rendered by an edge function, it is not also client-rendered by the SPA. Pick one. The "two renderers for one URL" pattern causes back-button / bfcache breakage and creates bug loops where every fix is a partial revert of the previous fix. See `docs/retros/UNS-100-bifurcation-retro.md` for the full lesson (UNS-70/71/73/94/97/99/100 series). When you need both SEO/no-JS HTML *and* React interactivity, use a pure-SSR edge function as the no-JS/crawler fallback and the SPA as the in-app renderer, and ensure the SPA never tries to "take over" from the static response.
 
 ### Security practices
 

--- a/docs/retros/UNS-100-bifurcation-retro.md
+++ b/docs/retros/UNS-100-bifurcation-retro.md
@@ -1,0 +1,97 @@
+# UNS-100 retrospective: the MPA↔SPA bifurcation
+
+**Date:** 2026-06-17
+**Linear:** UNS-100 (closed 2026-06-17)
+**Author:** Wayne
+**Reviewers:** Brandon
+**Severity:** Process lesson, not an incident. No production damage. But the symptom — a 2-month bug loop on a single route — was real.
+
+## TL;DR
+
+`/a/{slug}` had two renderers — an edge function for claimed artists and the React SPA for unclaimed. Every bug fix for that route made things worse before they got better, because each fix was a partial revert of the previous fix. The only stable end state was: one route, one renderer.
+
+**Rule (added to CLAUDE.md and AGENTS.md on 2026-06-17):** *one route, one renderer.* If a URL is server-rendered by an edge function, it is not also client-rendered by the SPA. Pick one.
+
+## The bug loop (chronological)
+
+| PR / issue | Date | What it tried to fix | What it actually did |
+|---|---|---|---|
+| UNS-94 (PR #264) | early 2026 | `<Link to>` everywhere — SPA wins on direct visits | SPA-internal navigation worked, but rich profile was still in edge function → conflict on `/a/{slug}` (claimed) |
+| UNS-98 (PR #268, never merged) | 2026-06-14 | Drop `/artists` edge function | Would have left `/a/*` dual-rendered (claimed → edge fn, unclaimed → SPA) |
+| UNS-97 (PR #269) | 2026-06-14 | Drop `/artists` edge function (re-attempt) | Worked, but also reverted `<Link to>` back to `<a href>` → MPA↔SPA boundary restored, UNS-99 surfaced |
+| UNS-99 (PR #271, hotfix) | 2026-06-14 | Targeted revert of the `<a href>` reversion | SPA-internal click back button worked, but UNS-97 (claimed artists showing search-result card) was back |
+| UNS-71 (Done earlier) | 2026-Q1 | Same symptom: back button broken | Fixed in isolation, regressed |
+| UNS-70 (Done earlier) | 2026-Q1 | Same symptom: claimed artists showing search pages | Fixed in isolation, regressed |
+| UNS-73 (Done earlier) | 2026-Q1 | Slow render of static pages | Treated as performance; was actually the dual-renderer handoff cost |
+
+**Pattern:** every fix moved the line somewhere else. None of them fixed the bifurcation.
+
+## The UNS-100 series (the fix)
+
+UNS-100 was the explicit decision: stop iterating on partial fixes, do the work to make the SPA the single renderer. Sub-tasks:
+
+| Sub-task | What it did |
+|---|---|
+| UNS-101 (UNS-100a) | Extend `/api/artist-page` to return the full rich-profile payload |
+| UNS-102 (UNS-100b) | Port the edge function layout to React as `<RichArtistProfile>` |
+| UNS-103 (UNS-100c) | Rewrite `<ArtistPage>` to fetch from the new API and render `<RichArtistProfile>` for claimed, quiet layout for unclaimed |
+| UNS-104 (UNS-100d) | Delete `claimed-artist-page.ts` edge function (the dual-renderer half) |
+| UNS-105 (UNS-100e) | No-JS static HTML edge function for `/a/*` (accessibility fallback — pure SSR, no SPA conflict) |
+| UNS-106 (UNS-100f) | `ClaimPage` post-claim redirect uses `navigate()` instead of `window.location.href` |
+| UNS-108 (UNS-100h) | `<ArtistPage>` follow-ups: back-link, bfcache handling, footer blurb |
+| UNS-107 (UNS-100g) | Brandon's manual Safari 26 verification |
+
+**Key design choice:** UNS-105's no-JS fallback is *pure SSR with zero JavaScript*. It does not hydrate into a SPA. The SPA never tries to "take over" from the static page. They are two completely separate renderers for two completely separate use cases (in-app vs. external/crawler/no-JS) — not two renderers fighting over the same user.
+
+**Key operational choice:** UNS-104 (delete the old edge function) shipped in the same PR as UNS-105 (replace it), so there was never a moment where `/a/*` had no renderer.
+
+## Why the bifurcation was a bad design (the lesson)
+
+Two systems trying to render the same URL creates three classes of bug:
+
+1. **State divergence.** Edge function renders claimed artists only; SPA renders unclaimed only. User clicks a claimed artist from `/artists` → SPA's unclaimed code path fires → user sees "Found N results" chrome instead of rich profile. The two systems had to stay in sync about *who renders what*; they didn't.
+
+2. **Back-button / bfcache breakage.** Browser back stack tracks URLs. Both renderers respond to `/a/{slug}`. When the SPA's client-side router fired a `<Link>` navigation, the URL updated but the edge function still owned the page. Hit back → browser loaded the *previous URL* from history, not the previous SPA-internal state → MPA reload from scratch every time.
+
+3. **Fixes look like regressions.** Every fix to one renderer's behavior had to be matched in the other renderer's behavior, but the matching was implicit and easy to miss. UNS-94 added `<Link to>` everywhere → SPA won on direct visits → but rich profile was still in edge function → UNS-97 surfaced as a "regression" (it wasn't — it was the dual-renderer fighting back).
+
+The structural problem: **you cannot converge two systems onto one behavior with one-system-at-a-time fixes.** Partial fixes don't compose. Each fix is a partial revert of the previous fix, and the system never settles.
+
+## The rule and where it lives
+
+**Rule:** *One route, one renderer.* If a URL is server-rendered by an edge function, it is not also client-rendered by the SPA. Pick one.
+
+**Where the rule lives:**
+
+- `CLAUDE.md` — "Engineering principles" section, as a new bullet. This is the canonical reference for code conventions and architectural decisions.
+- `AGENTS.md` (workspace) — short pointer to the CLAUDE.md rule, so future agent sessions see it during red-lines review.
+- This retro doc — the *why*, not the *what*. When someone asks "why does this codebase have this rule?" the answer is here.
+
+## Watch-fors (next time the bifurcation temptation appears)
+
+Several places in the codebase have *something like* this pattern. None are broken today, but they're worth keeping an eye on:
+
+| URL pattern | Current state | Risk |
+|---|---|---|
+| `/guides/*` | `guide-page` edge function (pure SSR, no SPA conflict) | Low. Pure SSR, no JS, SPA doesn't try to take over. Safe. |
+| `/search` | `noscript-search` edge function (no-JS fallback) | Low. Same as `/a/*` post-UNS-100 — pure SSR fallback, SPA doesn't fight it. |
+| `/artists` | SPA only (post-UNS-98) | None. The edge function was deleted; SPA owns it. |
+| `/dispatch.xml` | Build-time generated static file | None. Not a route; generated at build time. |
+| `/login`, `/dashboard`, `/artist-edit/:slug` | SPA only | None. No edge functions compete. |
+
+**The temptation that creates bifurcations:** "I need OG meta tags / no-JS fallback / SEO-friendly HTML, AND I need React." The answer is not "have both" — it's "have the static fallback for crawlers and no-JS users, have the SPA for in-app users, and *never let them overlap.*" UNS-105 got this right (zero JS in the response = no handoff conflict).
+
+## What I'd do differently next time
+
+**Stop iterating sooner.** UNS-100 should have been filed in March when the pattern was already clear (UNS-70, UNS-71, UNS-73 all had the same root cause). I waited until the loop was 4 cycles deep before scoping the systemic fix.
+
+**Detect the pattern earlier.** A standing rule for me (Wayne): if 3+ bugs in the same area share a common root cause, file the structural fix as a separate issue immediately. Don't try to fix bug 4 with a partial revert when bugs 1-3 are already partial reverts of each other.
+
+**Sequencing matters.** UNS-100 worked because UNS-104 (delete the dual renderer) shipped in the same PR as UNS-105 (replace it). Never leave a route with two renderers even briefly — that's when the partial fixes sneak back in.
+
+## Artifacts and references
+
+- Linear: UNS-100 (parent), UNS-101 through UNS-108, UNS-109 (route consolidation)
+- PRs: #273, #274, #275, #276, #277, #278
+- Specs: `docs/specs/UNS-103-artist-page-rewrite.md`, `docs/specs/UNS-105-no-js-static-edge-function.md`, `docs/specs/UNS-108-artist-page-followups.md`, `docs/specs/UNS-109-artist-route-consolidation.md`
+- Related postmortems: `~/.openclaw/workspace/memory/postmortem-2026-06-07-pr256-merge-conflict.md` (different failure mode, but same theme: review processes need to catch structural problems, not just textual ones)

--- a/docs/specs/UNS-103-artist-page-rewrite.md
+++ b/docs/specs/UNS-103-artist-page-rewrite.md
@@ -1,0 +1,205 @@
+# UNS-103 — `<ArtistPage>` rewrite spec
+
+**Sub-task of:** UNS-100 (collapse the MPA↔SPA bifurcation for `/a/{slug}`)
+**Issue:** UNS-103, currently Backlog
+**Owner:** Daryl
+**Reviewer:** Dan
+**Coordinator:** Wayne
+**Status:** Blocked on PR #273 (UNS-102) merge
+
+## Goal
+
+Rewrite `apps/web/src/pages/ArtistPage.tsx` to use the new `/api/artist-page` endpoint (UNS-100a, PR #272, merged 2026-06-14) and the new `<RichArtistProfile>` component (UNS-100b, PR #273, in review). Drop the multi-branch `isClaimedArtist` ternary, the pre-generated JSON fallback, the dead search-bar branch, and the stale `useLocation` comment. After this lands, `<ArtistPage>` is a thin shell that fetches the payload and picks one of three components to render.
+
+## What changes in the file
+
+**Files:**
+- `apps/web/src/pages/ArtistPage.tsx` — rewrite
+- `apps/web/src/components/NotFoundCard.tsx` — new
+- `apps/web/src/components/LoadingProfile.tsx` — new (or inline if <50 lines)
+- `apps/web/src/components/UnclaimedQuietCard.tsx` — new
+- `apps/web/src/components/MacAppPromo.tsx` — new (extracted from `ArtistPage.tsx:154-245` for reuse in `<NotFoundCard>`)
+- `apps/web/src/components/RichArtistProfile.tsx` — small additions: `justClaimed`, `onSave`/`onUnsave`/`isSaved`/`disabledSave` props, save-button JSX, post-claim banner JSX
+- `apps/web/tests/unit/ArtistPage.test.tsx` — new (covers the three render branches + loading + not-found)
+
+**File size target:** `ArtistPage.tsx` <150 lines (currently 450).
+
+**Removed from `ArtistPage.tsx`:**
+- `isClaimedArtist = results.length === 1 && results[0].type === 'artist' && results[0].matchConfidence === 'claimed'` derivation (line 76) — replaced by `payload.profile?.verifiedAt` check.
+- Multi-branch JSX ternary: `isClaimedArtist ? (...) : isProfileRoute && results.length > 0 ? (...) : results.length > 0 ? (...) : !error ? (...) : null` (lines 317, 327, ~400) — replaced by a single `if/else` chain over `(isLoading, notFound, payload, payload.profile)`.
+- `/data/artists/{slug}.json` fetch (line 133) — `/api/artist-page` is the source of truth, no fallback.
+- `useSearchParams` / `searchParams` / `justClaimed` post-claim banner logic (lines 24, 257) — *migrate* the banner into `<RichArtistProfile>` and `<UnclaimedQuietCard>` via a `justClaimed` prop. (Brandon is still in the post-claim flow and this UX matters.)
+- `!isProfileRoute && !isClaimedArtist` branch showing the search bar (line 248) — **dead code**: `ArtistPage` is only mounted on `/a/:slug` and `/artist/:slug` per `main.tsx:72-73`, so `isProfileRoute` is always `true`. Remove the comment too.
+- `useLocation` comment block (lines 19-22) — the `useLocation` import was already dropped in #269, only the stale comment survives. Clean up.
+- `useAuth` / `handleSaveArtist` / `handleClaimShare` / `LoginInterstitial` — these still apply to the rich profile page. **Preserve**, wire to the new components via props or a thin context.
+- `SearchBar` import (line 4) — unused after the dead branch goes.
+- `ResultCard` import (line 5) — unused after the multi-branch render goes.
+- `navigate` and `handleSearch` (line 152) — `SearchBar` is gone, no more programmatic search from this page.
+- `macAppPromo` block (lines 154-245) — **drop entirely from `ArtistPage.tsx`**. Per Brandon (2026-06-15 15:16): the Mac app card is a search-results-page thing, doesn't belong on a clean profile. The `<NotFoundCard>` includes its own macAppPromo copy.
+- `analytics.trackArtistPageView` call (line 88) — preserve, fire on slug change.
+
+**No changes to these files:**
+- `apps/web/src/main.tsx` — routes stay the same
+- `apps/web/src/components/RichArtistProfile.tsx` — already ships the rich profile UI
+- `api/edge/claimed-artist-page.ts` — still serves as the no-JS / OG-preview path **until UNS-100d** (don't touch it in this PR)
+- `apps/web/vite.config.ts` — the `navigateFallbackDenylist` `/^\/a\//` entry stays until UNS-100d
+- `apps/web/src/types/artist-page.ts` — type is already correct
+- `apps/web/src/components/ClaimPage.tsx` — UNS-100f is a separate task (`window.location.href` → `navigate()`)
+
+## The new shape (sketch)
+
+```tsx
+export function ArtistPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [payload, setPayload] = useState<ArtistPagePayload | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchParams] = useSearchParams();
+  const justClaimed = searchParams.get('claimed') !== null;
+  const { session, isArtistSaved, saveArtist, removeSavedArtist, loadSavedArtists } = useAuth();
+
+  useEffect(() => {
+    if (session) loadSavedArtists();
+  }, [session]);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setNotFound(false);
+    setPayload(null);
+    fetch(`/api/artist-page?slug=${encodeURIComponent(slug)}`)
+      .then(r => r.ok ? r.json() : r.status === 404 ? null : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((data: ArtistPagePayload | null) => {
+        if (cancelled) return;
+        if (data === null) setNotFound(true);
+        else setPayload(data);
+      })
+      .catch(err => {
+        if (cancelled) return;
+        Sentry.captureException(err, { extra: { context: 'ArtistPage.fetchArtistPage', slug } });
+        setNotFound(true);
+      })
+      .finally(() => { if (!cancelled) setIsLoading(false); });
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  useEffect(() => {
+    if (slug) analytics.trackArtistPageView(slug);
+  }, [slug]);
+
+  // Update page title and meta tags from the payload's artist name
+  useEffect(() => {
+    if (payload?.artist.name) {
+      document.title = `${payload.artist.name} on Bandcamp & alternative platforms | Unstream`;
+      const metaDesc = document.querySelector('meta[name="description"]');
+      if (metaDesc) {
+        const desc = payload.profile?.bio
+          ? `${payload.artist.name} on Unstream — ${payload.profile.bio.slice(0, 160)}`
+          : `${payload.artist.name} is on Bandcamp and other alternative platforms. Find direct links and support them outside streaming.`;
+        metaDesc.setAttribute('content', desc);
+      }
+    }
+    return () => { document.title = 'Unstream - Support artists directly'; };
+  }, [payload?.artist.name, payload?.profile?.bio]);
+
+  if (isLoading) return <LoadingProfile />;
+  if (notFound || !payload) return <NotFoundCard slug={slug} />;
+  if (payload.profile?.verifiedAt) {
+    return <RichArtistProfile payload={payload} slug={slug!} justClaimed={justClaimed} />;
+  }
+  return <UnclaimedQuietCard payload={payload} slug={slug!} justClaimed={justClaimed} />;
+}
+```
+
+## Component specs
+
+### `<LoadingProfile>` (new)
+
+- Spinner + "Loading profile…" copy
+- Same visual treatment as the current `isLoading` branch (line ~298)
+- Can be a 10-line inline component if simpler than a separate file
+- **Test:** renders without throwing, has the spinner
+
+### `<NotFoundCard>` (new)
+
+- 404-style message: "We couldn't find that artist"
+- Link back to `/artists`
+- **Include the macAppPromo** (per Brandon 2026-06-15 15:16): the dead-end becomes a soft redirect to the Mac app / browser extension. Reuse the existing macAppPromo JSX (lines 154-245 of current `ArtistPage.tsx`) — copy into a new `<MacAppPromo>` component in `apps/web/src/components/MacAppPromo.tsx` and import in `<NotFoundCard>`.
+- Sentry should already have caught the API error in the parent `catch` (no need to re-capture here).
+- **Test:** renders the link to `/artists`, shows the slug in the message, renders the MacAppPromo
+
+### `<UnclaimedQuietCard>` (new)
+
+- Simplified `<RichArtistProfile>`:
+  - **Same:** hero (image, name, location), platform links, social links, "Powered by Unstream" footer
+  - **Different:** no bio, no featured embed, no verified badge, no payout annotations on platform links, no embed-widget section, no "Save" button hover state
+  - **Plus:** a soft inline nudge "Are you {Name}? [Claim this profile →]" linking to `/claim?slug={slug}`. This is the primary CTA for unclaimed profiles.
+- **Test:** renders name + platform links, hides bio/embed/verified-badge, shows claim nudge
+
+### `<RichArtistProfile>` (already exists, UNS-102)
+
+- Add a `justClaimed?: boolean` prop. When true, render a dismissible green banner above the hero: "🎉 You're verified! Welcome to Unstream." with a small ✕ to dismiss (local state).
+- Add `onSave?: () => void`, `onUnsave?: () => void`, `isSaved?: boolean`, and `disabledSave?: boolean` props so the parent (`ArtistPage`) wires the auth-aware save button from `useAuth()`. **Per Brandon (2026-06-15 15:16):** save button goes on the rich profile, same Save/Unsave UI as the unclaimed card. Keeps the component pure (no `useAuth` import inside).
+- Save button placement: in the hero, next to the artist name / verified badge row, right-aligned. (Top of the page, not bottom-of-card.)
+
+## State and side effects
+
+- **Loading skeleton** during API fetch (currently the page is a blank screen for ~1-2s)
+- **404** on API 404 (artist doesn't exist) or network error (caught + Sentry)
+- **Title + meta** updates from `payload.artist.name` and `payload.profile?.bio`
+- **Analytics** `trackArtistPageView(slug)` on slug change (preserve existing behavior)
+- **No Sentry.captureException** for the normal 404 case — only for actual network errors / 5xx
+- **No retry** — the user can refresh or click the back link
+
+## Out of scope (other UNS-100 sub-tasks)
+
+- UNS-100a (API contract `/api/artist-page`) — **Done**, PR #272
+- UNS-100b (`<RichArtistProfile>`) — **In review**, PR #273
+- UNS-100d (delete `claimed-artist-page` edge function + drop `/a/*` from `navigateFallbackDenylist`) — depends on this PR
+- UNS-100e (no-JS fallback) — depends on this PR
+- UNS-100f (`ClaimPage.tsx:299` `window.location.href` → `navigate()`) — separate PR
+
+## Definition of done
+
+- [ ] `ArtistPage.tsx` is <150 lines (currently 450)
+- [ ] `/a/{slug}` for a claimed artist → `<RichArtistProfile>` (rich layout, bio, embed, payout annotations, embed-widget section, verified badge, save button)
+- [ ] `/a/{slug}` for an unclaimed artist with a Wikidata record → `<UnclaimedQuietCard>` (name, image, platform links, claim nudge, **no** bio/embed/verified/payout-annotations)
+- [ ] `/a/{slug}` for a not-found slug → `<NotFoundCard>` with a link back to `/artists`
+- [ ] `/a/{slug}?claimed=1` shows the post-claim banner on the relevant render branch
+- [ ] No more `useLocation` import or comment block
+- [ ] No more pre-generated JSON fetch
+- [ ] No more `SearchBar` / `ResultCard` imports in this file
+- [ ] No more `isClaimedArtist` derivation
+- [ ] No more `useNavigate` / `handleSearch` (the search bar is gone)
+- [ ] No more dead `!isProfileRoute && !isClaimedArtist` branch
+- [ ] Page title and meta description use the payload
+- [ ] `analytics.trackArtistPageView` still fires on slug change
+- [ ] `npm run build` clean (tsc + vitest + vite + sitemap)
+- [ ] `npm run test:unit` 280+/280+ (262 + ~18 new for `ArtistPage.test.tsx`, `<UnclaimedQuietCard>`, `<NotFoundCard>`)
+- [ ] Manual test on Safari 26: `/artists` → click → `/a/{slug}` → back button → `/artists` (no MPA boundary, no bfcache bug) — UNS-99 regression check
+- [ ] Manual test: direct visit `/a/{slug}` for a claimed artist renders identically to the current edge function output — UNS-97 regression check
+- [ ] Dan's review APPROVE
+- [ ] Sub-task moved to "Done" with the PR link
+
+## Open questions for Brandon (block on answer before implementation)
+
+1. **Save button location.** Currently `<RichArtistProfile>` (UNS-102) has no save button. The unclaimed card has one. Should the rich profile get a save button too, or should the CTA on a claimed profile be different (e.g., follow / share)?
+   - **Answered (2026-06-15 15:16 EDT):** ✅ Add the save button to `<RichArtistProfile>`. Same Save/Unsave UI as the unclaimed card. Wire via `onSave` / `onUnsave` / `isSaved` prop trio (parent passes auth-aware values from `useAuth()`).
+2. **macAppPromo on profile pages.** Was this intentionally shown on `/a/{slug}`? The old code path was `!isProfileRoute && !isClaimedArtist` so it was hidden for claimed profiles. Now that `ArtistPage` is always a profile route, does the promo show, or is this an oversight to clean up?
+   - **Answered (2026-06-15 15:16 EDT):** ❌ Drop the Mac app card totally from the profile page. Remove the import, the JSX, and the related state. The macAppPromo was a search-results page thing; doesn't belong on a clean profile.
+3. **`<NotFoundCard>` chrome.** Should it be a minimal 404, or include the macAppPromo / search bar so the user has somewhere to go next?
+   - **Answered (2026-06-15 15:16 EDT):** Include the Mac app promo there. NotFoundCard is the user's "wrong turn" landing — give them a way to discover the Mac app / browser extension so the dead-end becomes a soft redirect to a real product.
+4. **Post-claim banner placement.** Confirm the banner should appear above the rich profile / quiet card hero, not as a toast at the bottom of the page.
+   - **Answered (2026-06-15 15:16 EDT):** ✅ Above the hero. Inline. Green. "🎉 You're verified! Welcome to Unstream." with ✕ dismiss.
+
+## Lane
+
+* **Implementation:** Daryl
+* **Review:** Dan
+* **Coordination:** Wayne
+* **Verification:** Brandon (manual Safari 26 testing on macOS Tahoe and iOS 26)
+
+## Why a separate spec doc from the issue body
+
+The Linear issue body has the high-level plan but is short on specifics: it doesn't pin the API endpoint to use, doesn't address the `justClaimed` banner migration, doesn't enumerate the components to create, and doesn't list the open questions. This spec doc is the implementation source of truth; the issue body stays as the user-facing summary.

--- a/docs/specs/UNS-105-no-js-static-edge-function.md
+++ b/docs/specs/UNS-105-no-js-static-edge-function.md
@@ -1,0 +1,154 @@
+# UNS-105 — No-JS accessibility fallback: static-HTML edge function for /a/*
+
+**Linear:** [UNS-105](https://linear.app/cultoflightbulbs/issue/UNS-105) (UNS-100e)
+**Spec body:** UNS-105 issue description (this doc is a working expansion for the implementer)
+**Parent:** UNS-100 (collapse the MPA↔SPA bifurcation for `/a/{slug}`)
+**Sibling:** UNS-104 (remove the old `claimed-artist-page` edge function — must ship with or after this)
+**Owner:** Daryl
+**Reviewer:** Dan
+**Coordinator:** Wayne
+**Status:** Ready for Daryl — pending Brandon's sign-off on the scope
+
+## Why this exists
+
+After UNS-100a/b/c landed and PR #275 cleaned up the navigation, the SPA is the *only* renderer for `/a/{slug}`. Without JavaScript, the user gets an empty `<div id="root"></div>`. That's a regression for users on slow networks, JS-disabled browsers, and crawlers that don't execute JS. Brandon's principle: Unstream is accessible to anybody, including when JavaScript is disabled.
+
+The existing `api/edge/claimed-artist-page.ts` is the *old* server-renderer that UNS-100 made redundant. It was *only* for claimed artists and it included a theme-toggle JS script + an auth localStorage reader — both of which fail silently without JS. We're keeping it for one more release to maintain coverage while the new function ships, then removing it in UNS-104.
+
+## What to build
+
+A new edge function `api/edge/artist-page-static.ts` that:
+- Runs on every `/a/*` request, **before** the SPA loads
+- Returns fully-rendered HTML for *both* claimed and unclaimed artists (so the SPA fallback is uniform regardless of state)
+- Has **zero JavaScript** in the response (no theme toggle, no auth localStorage reader, no analytics)
+- Includes OG/Twitter meta tags + JSON-LD structured data
+- Re-uses the existing platform/icon/payout data from `api/shared/platform-registry.ts`
+- Embeds the same `ALLOWED_EMBED_DOMAINS` allowlist for the featured-embed iframe (sandboxed, no JS execution)
+
+The new function replaces `claimed-artist-page.ts` for `/a/*` routing. After this ships, `claimed-artist-page.ts` is dead code (UNS-104 removes it).
+
+## What to change
+
+### 1. New edge function: `api/edge/artist-page-static.ts`
+
+**Modeled on the existing `claimed-artist-page.ts` (452 lines).** Key differences:
+
+| Aspect | `claimed-artist-page.ts` (old) | `artist-page-static.ts` (new) |
+|---|---|---|
+| Audience | Claimed artists only | Claimed + unclaimed (unified) |
+| Theme toggle | Inline JS `<script>` block | No JS; CSS prefers-color-scheme media query only |
+| Auth UI | Reads localStorage, shows email/sign-out | No auth UI; show generic "Login" link (always visible) |
+| Analytics | No tracking (it predated) | No tracking |
+| Featured embed | Raw HTML inline | Sandbox iframe: `<iframe src="..." sandbox="allow-scripts allow-same-origin">` (or whatever the existing allowlist requires — match the SPA's `<RichArtistProfile>` behavior) |
+| Embed domains | Inline HTML allowlist | Re-use `ALLOWED_EMBED_DOMAINS` from `api/functions/artist-profile.ts` |
+| Bandcamp Friday | Already uses `isBandcampFriday()` | Same |
+| OG meta + JSON-LD | Already has both | Keep both; extend to unclaimed too |
+
+**Data shape:** fetch from Supabase the same way `claimed-artist-page.ts` does. Add an unclaimed branch:
+- Unclaimed artist: `match_confidence !== 'claimed'` OR no `profile.verified_at`
+  - Render a simpler card (no bio, no featured embed, no "Verified" badge)
+  - Show platform links + social links same as claimed
+  - Add a "Claim this profile" CTA linking to `/claim?slug={slug}`
+  - JSON-LD should still be a `MusicGroup` (per MusicBrainz-style metadata) but without `sameAs` claims that are speculative
+
+**Routing priority (in `netlify.toml`):**
+```toml
+[[edge_functions]]
+path = "/a/*"
+function = "artist-page-static"
+```
+
+This must REPLACE the `claimed-artist-page` registration, not coexist. Otherwise `/a/{slug}` could match the new function but fall through to the old one in some edge cases.
+
+### 2. Remove the JS from the new function's response
+
+- Drop the theme-toggle `<script>` block
+- Drop the auth localStorage reader `<script>` block
+- Use a `<noscript>` block in the SPA's `index.html` (item 3 below) as a defensive fallback for the case where the edge function *also* doesn't run
+- Verify with `curl -s ... | grep -c '<script' | grep -q 0` — zero `<script` tags in the response
+
+### 3. SPA defensive `<noscript>` block in `apps/web/index.html`
+
+**The existing index.html already has a `<noscript>` block** (visible in the file at line 21+). Read the existing one first — don't add a duplicate. If the existing one already covers "browse the artist index" + "search for an artist", no change needed. If it doesn't mention those, extend it.
+
+**Defensive purpose:** if the edge function *somehow* doesn't run on a request (cache miss, deploy race, etc.), users with JS disabled get a fallback. The edge function is the primary defense; the `<noscript>` block is the belt-and-suspenders.
+
+### 4. Update `netlify.toml`
+
+Replace:
+```toml
+[[edge_functions]]
+path = "/a/*"
+function = "claimed-artist-page"
+```
+with:
+```toml
+[[edge_functions]]
+path = "/a/*"
+function = "artist-page-static"
+```
+
+### 5. Update `apps/web/vite.config.ts` — `navigateFallbackDenylist`
+
+The current denylist excludes `/a/*` and `/artist/*` from the service worker fallback (so the edge function handles them). The denylist for `/a/*` should STAY (otherwise the SW would serve the empty SPA shell for non-JS users). The denylist for `/artist/*` (the old `/artist/{slug}` redirect target) can be removed since `claimed-artist-page` was the only thing using it and the SPA doesn't need to fallback for it.
+
+After this change, the denylist should only contain `/a/*` (one entry).
+
+### 6. Update `unstream/CLAUDE.md` doc block
+
+List the new edge function in the "edge functions" section. Remove the `claimed-artist-page` entry (UNS-104 will delete the file, but the doc should be consistent now).
+
+## Important caveats
+
+1. **The existing `claimed-artist-page.ts` MUST stay in `netlify.toml` until the new function is verified live.** The new function `artist-page-static.ts` should be added to a *different* route first, OR the old one should be removed in the same PR that the new one lands. Two valid options:
+   - **Option A (cleaner):** Ship UNS-105 + UNS-104 in a single PR — add the new function, swap the route, delete the old file. Single deploy, no gap.
+   - **Option B (safer for staged deploys):** Ship UNS-105 only, add the new function on a *different* path (e.g., `/a-static/*` for testing), verify it works on production, then in a separate deploy swap the route + delete the old file.
+
+   **Default: Option A.** Same PR is fine because the deploy preview URL is the verification surface.
+
+2. **The featured embed iframe is the XSS surface.** Whitelist domains match the SPA's `ALLOWED_EMBED_DOMAINS`. Default sandbox: `sandbox="allow-scripts allow-same-origin"`. **Dan reviews this part specifically** — XSS is the failure mode that breaks accessibility worse than no-JS at all.
+
+3. **No JavaScript means no client-side error handling.** If Supabase is down, the edge function returns context.next() and the user gets the empty SPA shell. That's *worse* than the rich profile. Add a 5-second timeout to the Supabase fetch — fail fast, fall through to SPA. The SPA at least shows the `<NotFoundCard>` for not-found slugs.
+
+## Definition of done
+
+- [ ] `api/edge/artist-page-static.ts` deployed
+- [ ] `netlify.toml` registers the new edge function for `/a/*` (replaces `claimed-artist-page`)
+- [ ] `claimed-artist-page.ts` deleted (this is what couples UNS-105 + UNS-104)
+- [ ] `vite.config.ts` `navigateFallbackDenylist` only contains `/a/*` (not `/artist/*`)
+- [ ] `unstream/CLAUDE.md` edge functions list updated
+- [ ] SPA's `index.html` `<noscript>` block covers the "browse the artist index" + "search for an artist" links (read first, don't duplicate)
+- [ ] Build clean, tests pass
+- [ ] `curl -s 'https://deploy-preview-NNN--unstream.netlify.app/a/kid-lightbulbs' | grep -c '<script' | grep -q 0` — zero `<script` tags in the static response
+- [ ] `curl -s '.../a/kid-lightbulbs' | grep -q 'og:title'` — OG meta present
+- [ ] `curl -s '.../a/kid-lightbulbs' | grep -q '"@type":"MusicGroup"'` — JSON-LD present
+- [ ] XSS check on the embed iframe: only allowlisted domains can be embedded, iframe is sandboxed
+- [ ] Dan's review (XSS check + no-JS verification)
+- [ ] **Brandon's manual test on Safari 26 (deferred to UNS-107):** JS disabled → /a/{slug} → rich profile renders with all links working, embed iframe is sandboxed, no console errors. JS enabled → SPA still mounts and takes over.
+- [ ] PR reviewed by Dan
+- [ ] Sub-task moved to "Done" with the PR link
+- [ ] Parent UNS-100 can be moved to Done once all sub-tasks (UNS-104, UNS-105, UNS-106, UNS-107, UNS-108) are Done
+
+## Lane
+
+- **Implementation:** Daryl
+- **Review:** Dan (XSS check, no-JS verification, embed iframe sandbox)
+- **Manual no-JS test:** Brandon (deferred to UNS-107)
+- **Coordination:** Wayne
+- **Spec written by:** Wayne
+- **Approved by:** Brandon (pending)
+
+## Out of scope
+
+- Removing the service worker denylist entirely (that's a bigger discussion about PWA + accessibility tradeoffs)
+- Server-side rendering for the artist directory page (`/artists`) — that's a separate accessibility consideration
+- Caching the edge function response at the CDN layer — the data changes too frequently (claims, profile edits) and the latency is already low
+- A static-HTML version of the directory page (UNS-105 is only for `/a/*`)
+- Replacing `claimed-artist-page.ts` with anything other than `artist-page-static.ts` (no need for a third function)
+
+## Risks (worth flagging in the PR body)
+
+1. **No-JS users on slow networks** — the response is a single full HTML page (no chunked loading). For a rich profile with 10+ platform links, the page could be 50-100 KB. That's fine for 4G; could be slow on 2G. Acceptable trade-off.
+2. **Static HTML doesn't update without a deploy** — if Brandon changes the `<RichArtistProfile>` component (CSS, layout), the static HTML drifts. Mitigation: keep the static HTML rendering as a manual port of the React component, not auto-generated. Document the drift risk in the PR.
+3. **OG meta tag values** — the static HTML generates OG meta server-side. If the artist changes their bio, the OG description in the static HTML is stale until the next request. (Actually it's per-request, so this is fine — the edge function re-renders on every request.)
+4. **The featured embed iframe is the XSS surface.** This is the part Dan reviews. Mitigation: allowlist domains, sandbox attribute, no `allow-scripts` if we can avoid it.

--- a/docs/specs/UNS-108-artist-page-followups.md
+++ b/docs/specs/UNS-108-artist-page-followups.md
@@ -1,0 +1,116 @@
+# UNS-108 — `<ArtistPage>` follow-ups: back-link, bfcache, footer
+
+**Sub-task of:** UNS-100 (collapse the MPA↔SPA bifurcation for `/a/{slug}`)
+**Sibling:** UNS-103 (rewrite shipped for review, feedback from PR #274 deploy preview)
+**Owner:** Daryl
+**Reviewer:** Dan
+**Coordinator:** Wayne
+**Status:** Ready for Daryl
+
+## Context
+
+Brandon reviewed the deploy preview for PR #274 and flagged three things, all surfaced on the same render path (`/artists` → click → `/a/{slug}`). All three are visible on the **claimed** branch (`<RichArtistProfile>`), not the unclaimed branch, so the unclaimed cards are unaffected. Filed screenshot 2026-06-16 08:12 EDT.
+
+## Issue 1 — "Back to artists" link is awkward
+
+**Where:** `apps/web/src/pages/ArtistPage.tsx:99-110`
+
+The link is the first child of `<main className="px-4 pb-16">`. Header has `p-4` and `border-b`. The link has only `mb-4`, so it sits flush against the header border in the screenshot — the spacing reads as overlapping the header. The link also only makes sense as a workaround for the broken browser-back button (Issue 2). Once back works, the explicit link can be dropped.
+
+**Fix:**
+- **Remove** the `<Link to="/artists">...</Link>` from `ArtistPage.tsx` entirely.
+- The `<NotFoundCard>` keeps its own "Browse artists" link — that's still useful on a 404. No change there.
+
+## Issue 2 — Browser back button broken after `/artists` → `/a/{slug}`
+
+**Where:** `apps/web/src/pages/ArtistPage.tsx` (whole file) and `apps/web/src/components/Header.tsx`
+
+The directory page uses React Router `<Link to={`/a/${slug}`}>` so navigation is push-history. The back button should work natively. It doesn't, which means something on the artist page is breaking Safari 26's bfcache eligibility — when the back button restores a bfcached page, Safari falls back to a full reload, and *if the previous page's listener or fetch is still in flight* the back nav appears to "not work."
+
+The most likely culprits, in order:
+
+1. **`document.title` / `meta` mutation in `useEffect` cleanup.** The title effect (lines 73-87) does mutate the DOM and tries to clean up. Cleanup returns the title to a string — that part looks fine. But there's no `pageshow` handler, so on bfcache restore the cleanup may have already run, leaving a stale title until the next effect fires. **Verify with a manual test first**; if confirmed, gate the DOM mutation on a `pageshow` listener and use a ref to avoid the stale state on restore.
+2. **`loadSavedArtists` in `AuthContext` (line 41-44 in `AuthContext.tsx`) has no cleanup.** The `useEffect` in `ArtistPage` calls `loadSavedArtists()` on session change but doesn't abort an in-flight request when the component unmounts during the back-nav. If the auth context's `getSession()` or `waitForMagicLinkSession()` fetch is still pending when the user hits back, the artist page won't fully tear down. **Add an `AbortController` to the `useAuth` fetch on unmount.**
+3. **`Header.tsx` `useEffect` for `/api/admin/verify`** (lines 41-58 in Header.tsx) has no abort on unmount. If the admin is the visitor, the request can outlive the page. **Add `AbortController` here too.** Non-admins skip this branch (early return) so it's only a problem for admins browsing the artist page.
+
+**Fix in priority order:**
+1. Add `pageshow` handler in `ArtistPage` (and ideally globally in `App.tsx`) that detects `event.persisted === true` and skips the title/meta reset on bfcache restore. Pattern:
+   ```tsx
+   useEffect(() => {
+     function onPageShow(e: PageTransitionEvent) {
+       if (e.persisted) {
+         // bfcache restore — don't re-run title/meta mutation
+         return;
+       }
+     }
+     window.addEventListener('pageshow', onPageShow);
+     return () => window.removeEventListener('pageshow', onPageShow);
+   }, []);
+   ```
+2. Add `AbortController` to the `useAuth` session-init fetch and to the Header's admin-verify fetch so they cancel on unmount.
+3. **Verify on Safari 26** (Brandon's manual test setup) before declaring it fixed.
+
+**Important:** Do NOT switch to `<a href>` for the directory links. The whole point of UNS-99 was keeping the SPA navigation so bfcache can kick in. The bug is on the *destination* page, not the source.
+
+## Issue 3 — Remove "Powered by Unstream" footer blurb from `<RichArtistProfile>` and `<UnclaimedQuietCard>`
+
+**Where:**
+- `apps/web/src/components/RichArtistProfile.tsx:338-350`
+- `apps/web/src/components/UnclaimedQuietCard.tsx:182-194`
+
+Both render the same block at the bottom:
+
+```tsx
+<div className="py-6 px-4 text-center">
+  <a href="https://unstream.stream" className="text-text-primary no-underline font-bold text-lg">
+    Powered by Unstream
+  </a>
+  <p className="text-sm text-text-muted mt-1">
+    Find music on platforms that pay artists fairly.
+  </p>
+</div>
+```
+
+Brandon's call: now that the unified `<Header>` is rendered above, the footer blurb is redundant noise. Remove the whole block from both files.
+
+**Test impact:** Check `RichArtistProfile.test.tsx` and `UnclaimedQuietCard.test.tsx` for tests that assert the "Powered by Unstream" text or a related query. If any, update them to assert the blurb is absent.
+
+## Files to change
+
+- `apps/web/src/pages/ArtistPage.tsx` — remove "Back to artists" Link; add pageshow handler; verify AbortController for fetch
+- `apps/web/src/contexts/AuthContext.tsx` — add AbortController to the session-init fetch
+- `apps/web/src/components/Header.tsx` — add AbortController to the admin-verify fetch
+- `apps/web/src/components/RichArtistProfile.tsx` — remove the "Powered by Unstream" block
+- `apps/web/src/components/UnclaimedQuietCard.tsx` — remove the "Powered by Unstream" block
+- `apps/web/tests/unit/RichArtistProfile.test.tsx` — drop/update "Powered by Unstream" assertion if present
+- `apps/web/tests/unit/UnclaimedQuietCard.test.tsx` — drop/update "Powered by Unstream" assertion if present
+
+## Out of scope
+
+- Switching to `<a href>` for navigation (would break UNS-99, which was the original bfcache fix)
+- Touching `<NotFoundCard>`'s "Browse artists" link — that one is correct as-is
+- Touching `<Footer>` (the global footer) — separate concern from the per-page "Powered by Unstream" blurb
+- Header layout or visual changes — out of scope for this issue
+
+## Definition of done
+
+- [ ] "Back to artists" link removed from `ArtistPage.tsx`
+- [ ] `<NotFoundCard>` still has its "Browse artists" link (no change)
+- [ ] `pageshow` handler added to handle bfcache restore correctly
+- [ ] `AbortController` added to `useAuth` session-init fetch
+- [ ] `AbortController` added to `Header.tsx` admin-verify fetch
+- [ ] "Powered by Unstream" block removed from `<RichArtistProfile>`
+- [ ] "Powered by Unstream" block removed from `<UnclaimedQuietCard>`
+- [ ] Existing tests updated to match (or new tests for the removals)
+- [ ] `npm run build` clean, `npm test` green
+- [ ] **Brandon's manual test on Safari 26:** `/artists` → click → `/a/kid-lightbulbs` → browser back returns to `/artists` instantly, no MPA flash, title preserved
+- [ ] PR reviewed by Dan
+- [ ] Deploy preview confirmed working
+- [ ] Sub-task moved to "Done" with the PR link
+
+## Lane
+
+- **Implementation:** Daryl
+- **Review:** Dan
+- **Manual Safari 26 verification:** Brandon
+- **Coordination:** Wayne

--- a/docs/specs/UNS-109-artist-route-consolidation.md
+++ b/docs/specs/UNS-109-artist-route-consolidation.md
@@ -1,0 +1,215 @@
+# UNS-109 — Replace legacy `/artist/*` edge fn with `artist-page-static`; remove Login from static header
+
+**Linear:** [UNS-109](https://linear.app/cultoflightbulbs/issue/UNS-109)
+**Spec body:** UNS-109 issue description (this doc is the working expansion for the implementer)
+**Parent:** UNS-105 (the static edge function)
+**Closes the loop on:** UNS-104 (the `/artist/*` retirement open question) + the follow-up comment I posted on UNS-105 asking whether to retire `/artist/*`
+**Owner:** Daryl
+**Reviewer:** Brandon (via Claude Code — Dan review intentionally skipped this round)
+**Coordinator:** Wayne
+**Status:** Ready for Daryl
+
+## Why this exists
+
+Production smoke test of PR #277 surfaced two header issues on the static artist pages:
+
+1. **Auth-bar inconsistency on `/artist/{slug}`** — the legacy `artist-page` edge function renders a static "Login" link AND an inline-JS auth bar that unhides itself by reading `localStorage`. Logged-in users see *both at once*: a "Logged in as you@…" bar AND a "Login" link in the nav. Two competing header elements.
+2. **"Login" link is misleading on `/a/{slug}`** — `artist-page-static` always shows "Login", but per the public-page framing (these are artist flyers for external audiences, not in-app navigation), a Login affordance is wrong anyway. Anyone who needs the app uses the footer "Index" link or browser back.
+
+The root cause: **the SPA's auth-aware nav is for in-app navigation. Static artist pages are content, not app.** Mixing the two is the bug.
+
+### The fix in two sentences
+
+Swap the renderer behind `/artist/*` to use the same static edge function as `/a/*`, then delete the legacy `artist-page` edge function. URLs don't change (no SEO impact, no redirects), the renderer does.
+
+## What to build
+
+### 1. `netlify.toml` — repoint `/artist/*` to `artist-page-static`
+
+**One-line change at line 17.**
+
+```toml
+[[edge_functions]]
+path = "/artist/*"
+function = "artist-page-static"   # was: "artist-page"
+```
+
+**Important: do not delete the `[[edge_functions]]` block.** Keep the routing, just point it at the new function. URLs (`/artist/all-time-low`, etc.) stay the same — no 301s, no SEO migration, no broken external links.
+
+### 2. `api/edge/artist-page-static.ts` — remove the Login link from both header branches
+
+The header is identical structure in both the claimed and unclaimed branches:
+
+```ts
+<header class="site-header">
+  <a href="/" class="brand">${LOGO_SVG} Unstream</a>
+  <div class="nav-right">
+    <a href="/login" class="nav-link">Login</a>   // ← remove this line
+  </div>
+</header>
+```
+
+**Two changes (both occurrences):**
+
+- **Claimed branch** (around line 278): remove the `<a href="/login" class="nav-link">Login</a>` line.
+- **Unclaimed branch** (around line 381): same — remove the `<a href="/login" class="nav-link">Login</a>` line.
+
+**Also clean up:** once the Login link is gone, the `<div class="nav-right">` wrapper becomes an empty div. Remove the wrapper too in both branches. The header should simplify to:
+
+```ts
+<header class="site-header">
+  <a href="/" class="brand">${LOGO_SVG} Unstream</a>
+</header>
+```
+
+**Don't add anything else.** No Dashboard link, no auth-aware rendering, no Supabase cookie work. Per Brandon's framing, the static page is a content page; the footer already has Index/Roadmap/Support/Privacy/Donate for anyone who wants to navigate into the app.
+
+**Don't remove the existing CSS classes** (`.site-header`, `.brand`, `.nav-right`) — they're harmless and removing them isn't in scope. Just don't *use* `.nav-right` anymore. If you want to strip the unused class from the CSS, do it in a follow-up; not this PR.
+
+### 3. Delete `api/edge/artist-page.ts` (393 lines)
+
+The legacy edge function. After this change, nothing references it. Delete the file outright.
+
+**Why we can delete it safely:**
+- The new `artist-page-static` is a strict superset: it handles both claimed AND unclaimed artists (the old function only handled claimed), and the URL `/artist/*` is now routed to it.
+- All test coverage for the old function transfers to `artist-page-static` (which already shipped with 316/322 tests passing in #277).
+- The old function's only unique feature that `artist-page-static` lacks is the theme toggle and the auth localStorage reader — both removed by design (see "What we lose" below).
+
+**Sanity-check before deleting:** `grep -rn "artist-page\b" /Users/brandonlucasgreen/projects/unstream/ --include="*.ts" --include="*.toml" --include="*.md"` should return zero hits after this PR. Run it locally to confirm.
+
+### 4. `CLAUDE.md` — update the edge functions list
+
+There's a doc block in `CLAUDE.md` listing the edge functions. Find the line that mentions `artist-page` (the legacy one) and remove it. The `artist-page-static` entry should already be there from #277 — verify.
+
+## What we lose (and why that's fine)
+
+The legacy `artist-page.ts` has three things `artist-page-static` doesn't:
+
+| Legacy feature | Why we lose it | User impact |
+|---|---|---|
+| Theme toggle (JS-driven) | `artist-page-static` uses `prefers-color-scheme` CSS media query — same behavior, no JS | None. The page still respects dark/light mode at the OS level. Users who *manually* toggle can't on this page, but they're not going to since they're coming from a link share. |
+| Auth localStorage reader + auth-bar | Per Brandon's framing: public artist pages are content, not app | None for the public-page audience. In-app users navigate via SPA routes, which already use `useAuth()` correctly. |
+| `<div id="root">` mount point | The SPA doesn't hydrate from this page anyway | None. Static page renders fully without React. |
+
+## Routing priority — nothing else changes
+
+`netlify.toml` order matters. After this change:
+
+```toml
+[[edge_functions]]
+path = "/"
+function = "og-metadata"
+
+[[edge_functions]]
+path = "/artist/*"
+function = "artist-page-static"
+
+[[edge_functions]]
+path = "/a/*"
+function = "artist-page-static"
+
+[[edge_functions]]
+path = "/search"
+function = "noscript-search"
+
+[[edge_functions]]
+path = "/guides/*"
+function = "guide-page"
+```
+
+Both `/artist/*` and `/a/*` route to the same function. The URL still works, the SEO still works, the rendering is unified. Netlify edge function matching is path-based, so a request to `/artist/all-time-low` matches the `/artist/*` rule; a request to `/a/all-time-low` matches the `/a/*` rule. No overlap.
+
+## Why I'm not doing the Supabase-auth-cookie approach
+
+Three options considered for the "always shows Login" issue:
+
+| Option | Scope | Status |
+|---|---|---|
+| **A.** Add Supabase auth cookie + edge fn reads it | Big: client cookie writes, server session lookup, signing key management | Rejected for this workstream. The auth cookie is a product decision (do we want cookies at all? GDPR implications? UX of unexpected sign-in on shared computers?) and pairs naturally with future server-side auth work. |
+| **B.** Add a tiny inline JS snippet in `artist-page-static` that reads localStorage and swaps the Login link (mirrors what `/artist/*` does today) | Small | Rejected. UNS-105's spec explicitly forbids JS in the response ("zero JS, per Brandon's no-JS accessibility principle"). Adding JS to fix an auth-state display issue violates the spec. Also inherits the confusing "two header elements" UX. |
+| **C.** Remove the Login link entirely, leave the static page as content | Smallest | **Chosen.** Per Brandon's framing: public artist pages are content, not app. The footer already provides Index/Roadmap/Support/Privacy/Donate. Anyone who needs the app uses those. |
+
+## Acceptance criteria
+
+### Code
+
+- [ ] `netlify.toml:17` swapped from `function = "artist-page"` to `function = "artist-page-static"`
+- [ ] `api/edge/artist-page-static.ts` Login link removed in both claimed (~line 278) and unclaimed (~line 381) branches
+- [ ] `api/edge/artist-page-static.ts` empty `<div class="nav-right">` wrapper removed in both branches
+- [ ] `api/edge/artist-page.ts` deleted (393 lines)
+- [ ] `CLAUDE.md` edge functions list no longer mentions `artist-page` (legacy)
+- [ ] `grep -rn "artist-page\b" --include="*.ts" --include="*.toml" --include="*.md"` returns zero hits for the legacy reference (the `artist-page-static` references should remain)
+- [ ] Build clean
+- [ ] All unit tests pass (316/322 expected, same 6 search-accuracy flakes as main — no regressions)
+
+### Curl verification (deploy preview)
+
+```bash
+# 1. Same HTML structure on both URLs (modulo claimed/unclaimed differences)
+curl -s https://deploy-preview-NNN--unstream.netlify.app/artist/all-time-low -o /tmp/artist.html
+curl -s https://deploy-preview-NNN--unstream.netlify.app/a/all-time-low -o /tmp/a.html
+diff <(grep -v 'canonical\|og:url' /tmp/artist.html) <(grep -v 'canonical\|og:url' /tmp/a.html)
+# → should be empty or near-empty (differences limited to claimed/unclaimed markup)
+
+# 2. No "Login" or "Dashboard" affordances in static header
+for path in /a/all-time-low /artist/all-time-low; do
+  curl -s "https://deploy-preview-NNN--unstream.netlify.app${path}" | \
+    grep -iE 'login|sign.?in|dashboard|auth-bar' && echo "FAIL: ${path}" || echo "PASS: ${path}"
+done
+# → both should print PASS
+
+# 3. No executable <script> tags (only JSON-LD allowed)
+for path in /a/all-time-low /artist/all-time-low; do
+  count=$(curl -s "https://deploy-preview-NNN--unstream.netlify.app${path}" | \
+    grep -c '<script' | grep -v 'application/ld+json')
+  echo "${path}: ${count} executable scripts (must be 0)"
+done
+
+# 4. Footer still has Index/Roadmap/Support for in-app navigation
+curl -s https://deploy-preview-NNN--unstream.netlify.app/a/all-time-low | grep -E '/artists|/login|/privacy-policy'
+# → should still find /login and /artists in the footer (not the header)
+```
+
+### Browser smoke test
+
+| State | Step | Expected |
+|---|---|---|
+| Logged out | Direct visit `https://unstream.stream/a/all-time-low` | Brand on left, no Login link in header, footer has Index/Roadmap/etc. Click "Index" → SPA loads, SPA shows Login link in header |
+| Logged out | Direct visit `https://unstream.stream/artist/all-time-low` | Same as above |
+| Logged in | Direct visit `https://unstream.stream/a/all-time-low` | Brand on left, no Login link in header (this is the *fix* — no false "Login" affordance), footer has Index. Click "Index" → SPA loads, SPA shows email + Dashboard + Sign out |
+| Logged in | Direct visit `https://unstream.stream/artist/all-time-low` | Same as above |
+| Either | Direct visit a slug that doesn't exist (e.g. `/a/nonexistent-slug`) | Edge function returns `context.next()`, SPA shell renders (`<div id="root">` present). Same as before — no regression. |
+
+### Pre-merge checks
+
+- [ ] Pre-review protocol: `git fetch origin && git diff origin/main..HEAD --stat` — check for deletions in files modified in the last 7 days. Should be clean (we're deleting a legacy file, but it's in `api/edge/` which hasn't been touched recently).
+- [ ] Semantic-revert bot: should fire for `api/edge/artist-page.ts` deletion, since it was last modified recently. That's expected — confirm the deletion is intentional in the PR description.
+- [ ] Daryl runs `deslop` skill on the branch diff before opening the PR (AGENTS.md red line). Strip any AI-style noise from the diff.
+- [ ] Netlify deploy preview builds clean
+- [ ] All curl verifications pass
+- [ ] Manual browser smoke test on a claimed + unclaimed artist slug, both logged-in and logged-out
+
+### Post-merge
+
+- [ ] `data/shipped-features.json` entry added: `{ id: "UNS-109", title: "Unified /artist/* renderer + removed Login link from public artist pages", description: "...", date: "YYYY-MM-DD", announced: false }`
+- [ ] UNS-109 closed with PR link
+- [ ] Verify `https://unstream.stream/artist/all-time-low` in production after merge — should match `/a/all-time-low` structurally
+
+## Definition of done
+
+- [ ] All code/curl/browser criteria above checked off
+- [ ] PR opened with the 4 file changes listed
+- [ ] PR reviewed by Brandon (via Claude Code)
+- [ ] PR merged
+- [ ] Production smoke test confirms `/artist/*` and `/a/*` both render the new static header
+- [ ] `data/shipped-features.json` updated
+- [ ] UNS-109 closed
+
+## Out of scope (explicitly)
+
+- Supabase auth cookie (Option A above) — separate, larger piece of work
+- Adding any auth-aware rendering to static pages — explicitly rejected for this workstream
+- Changing URL structure (e.g. moving `/artist/*` to `/a/*` with redirects) — explicit decision to keep URLs
+- `<noscript>` block changes in `apps/web/index.html` — already covered by UNS-105
+- Removing unused CSS classes (`.nav-right`, etc.) — cleanup, not this PR
+- Any changes to `<RichArtistProfile>` or the SPA's auth-aware nav — those work correctly today, don't touch

--- a/docs/specs/UNS-109-artist-route-consolidation.md
+++ b/docs/specs/UNS-109-artist-route-consolidation.md
@@ -75,7 +75,7 @@ The legacy edge function. After this change, nothing references it. Delete the f
 - All test coverage for the old function transfers to `artist-page-static` (which already shipped with 316/322 tests passing in #277).
 - The old function's only unique feature that `artist-page-static` lacks is the theme toggle and the auth localStorage reader — both removed by design (see "What we lose" below).
 
-**Sanity-check before deleting:** `grep -rn "artist-page\b" /Users/brandonlucasgreen/projects/unstream/ --include="*.ts" --include="*.toml" --include="*.md"` should return zero hits after this PR. Run it locally to confirm.
+**Sanity-check before deleting:** `grep -rn "artist-page\b" --include="*.ts" --include="*.toml" --include="*.md"` should return zero hits after this PR. Run it locally to confirm.
 
 ### 4. `CLAUDE.md` — update the edge functions list
 


### PR DESCRIPTION
## Goal

Three documentation artifacts were written during the UNS-100 series but never committed:

- `docs/retros/UNS-100-bifurcation-retro.md` — the full retrospective covering the 2-month bug loop (UNS-70/71/73/94/97/99) and the structural fix
- `CLAUDE.md` — new Engineering principles bullet "One route, one renderer" with a reference to the retro
- `docs/specs/UNS-103, UNS-105, UNS-108, UNS-109` — the four spec docs that drove the implementation work

All sub-tasks these specs covered are merged (Done in Linear). Committing these together because they're a coherent unit: the rule references the retro, the retro references the specs.

## What changed (6 files, +788/-0)

- `CLAUDE.md` — +1 bullet under Engineering principles
- `docs/retros/UNS-100-bifurcation-retro.md` — new file (97 lines)
- `docs/specs/UNS-103-artist-page-rewrite.md` — new file (205 lines)
- `docs/specs/UNS-105-no-js-static-edge-function.md` — new file (154 lines)
- `docs/specs/UNS-108-artist-page-followups.md` — new file (116 lines)
- `docs/specs/UNS-109-artist-route-consolidation.md` — new file (215 lines)

## Why docs are committed after the code

These docs were written *during* the implementation work as part of the agent handoff (Wayne → Daryl). They were untracked after each PR landed because the focus was on shipping code, not on committing the supporting docs. After PR #278 merged and UNS-100 was closed, the docs were the only remaining artifact of the workstream.

## Rule added (CLAUDE.md)

```
- **One route, one renderer.** If a URL is server-rendered by an edge function, it is not also client-rendered by the SPA. Pick one. The "two renderers for one URL" pattern causes back-button / bfcache breakage and creates bug loops where every fix is a partial revert of the previous fix. See `docs/retros/UNS-100-bifurcation-retro.md` for the full lesson.
```

## Pre-review checks

- [x] Rebased onto origin/main (UNS-109 already merged)
- [x] No deletions in recently-modified files (docs-only change, no risk)
- [x] No AI noise / cargo-cult patterns / defensive checks (docs only)
- [x] Deslop pass: clean (project documentation, all load-bearing)

## Lane

- **Author:** Wayne
- **Review:** Brandon (via Claude Code per the 2026-06-17 reorg — Claude Code is now the external 3rd-party reviewer)