### PR TITLE
docs(UNS-100): clarify bug-loop timeline in retro

### DIFF
--- a/docs/retros/UNS-100-bifurcation-retro.md
+++ b/docs/retros/UNS-100-bifurcation-retro.md
@@ -4,7 +4,7 @@
 **Linear:** UNS-100 (closed 2026-06-17)
 **Author:** Wayne
 **Reviewers:** Brandon
-**Severity:** Process lesson, not an incident. No production damage. But the symptom — a 2-month bug loop on a single route — was real.
+**Severity:** Process lesson, not an incident. No production damage. But the symptom — a recurring bug loop on a single route dating back to May 31, with the active fix cycle (UNS-100 series) running roughly 2026-06-13 → 2026-06-17 — was real.
 
 ## TL;DR
 
@@ -16,13 +16,13 @@
 
 | PR / issue | Date | What it tried to fix | What it actually did |
 |---|---|---|---|
-| UNS-94 (PR #264) | early 2026 | `<Link to>` everywhere — SPA wins on direct visits | SPA-internal navigation worked, but rich profile was still in edge function → conflict on `/a/{slug}` (claimed) |
+| UNS-94 (PR #264) | 2026-06-10 | `<Link to>` everywhere — SPA wins on direct visits | SPA-internal navigation worked, but rich profile was still in edge function → conflict on `/a/{slug}` (claimed) |
 | UNS-98 (PR #268, never merged) | 2026-06-14 | Drop `/artists` edge function | Would have left `/a/*` dual-rendered (claimed → edge fn, unclaimed → SPA) |
 | UNS-97 (PR #269) | 2026-06-14 | Drop `/artists` edge function (re-attempt) | Worked, but also reverted `<Link to>` back to `<a href>` → MPA↔SPA boundary restored, UNS-99 surfaced |
 | UNS-99 (PR #271, hotfix) | 2026-06-14 | Targeted revert of the `<a href>` reversion | SPA-internal click back button worked, but UNS-97 (claimed artists showing search-result card) was back |
-| UNS-71 (Done earlier) | 2026-Q1 | Same symptom: back button broken | Fixed in isolation, regressed |
-| UNS-70 (Done earlier) | 2026-Q1 | Same symptom: claimed artists showing search pages | Fixed in isolation, regressed |
-| UNS-73 (Done earlier) | 2026-Q1 | Slow render of static pages | Treated as performance; was actually the dual-renderer handoff cost |
+| UNS-71 (Done) | 2026-05-31 (PR #237) | Same symptom: back button broken | Fixed in isolation, regressed later when UNS-97 reverted the `<Link to>` |
+| UNS-70 (Done) | 2026-05-31 (PR #236) | Same symptom: claimed artists showing search pages | Fixed in isolation, regressed later when UNS-97 restored the dual-renderer |
+| UNS-73 (Done, no code change) | pre-2026-05-31 | Slow render of static pages | Closed as performance; the actual cause was the dual-renderer handoff cost |
 
 **Pattern:** every fix moved the line somewhere else. None of them fixed the bifurcation.
 


### PR DESCRIPTION
## Goal

Fix the imprecise timeline framing in the UNS-100 retro. The Severity line said "2-month bug loop" and the table used "2026-Q1" as a placeholder for UNS-70/71. Both were rough guesses that don't match the actual git/Linear record.

## What changed (1 file, +5/-5)

- `docs/retros/UNS-100-bifurcation-retro.md`:
  - Severity line: "2-month bug loop" → "recurring bug loop dating back to May 31, with the active fix cycle (UNS-100 series) running 2026-06-13 → 2026-06-17"
  - UNS-94: "early 2026" → "2026-06-10" (PR #264's actual date)
  - UNS-70/71: "2026-Q1" → "2026-05-31 (PRs #236, #237)" — the actual PR dates
  - UNS-73: "2026-Q1" → "pre-2026-05-31 (Done, no code change)" — closed as a perf ticket; the dual-renderer cause was real but never had a code attempt
  - Updated the "regressed" framing for UNS-70/71 to specify *what later change caused the regression* (UNS-97 reverting `<Link to>`)

## Why

- "2-month bug loop" suggests a team stuck for 2 months. Reality: 2 weeks of ping-pong + 4 days of active fix.
- "2026-Q1" was a placeholder guess on my part when writing the retro. Actual PRs landed May 31.
- The lesson (one route, one renderer) is unchanged. The framing is just more honest now.

## Pre-review checks

- [x] Docs-only
- [x] No deletions in recently-modified files
- [x] Rebased onto origin/main
- [x] No AI noise

## Lane

- **Author:** Wayne
- **Review:** Claude Code (per the 2026-06-17 reorg — Claude Code is the external 3rd-party reviewer on Unstream PRs)

Brandon caught the imprecision in Discord after #279 merged. Fixing the record before it calcifies.