### PR TITLE
feat(UNS-111): Extension auth + saved artists sync

### DIFF
--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -1,7 +1,8 @@
 // Unstream Chrome Extension - Service Worker
-// Handles API calls, caching, badge updates, and release alerts
+// Handles API calls, caching, badge updates, release alerts, and auth
 
 import { ALLOWED_RELEASE_DOMAINS } from '../lib/constants.js';
+import { getStoredSession, handleMagicLinkCallback, getAccessToken, signOut } from '../lib/supabase.js';
 
 const API_BASE = 'https://unstream.stream/api';
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -79,6 +80,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   } else if (message.type === 'DISMISS_RELEASE') {
     dismissRelease(message.releaseId).then(sendResponse);
+    return true;
+  } else if (message.type === 'AUTH_GET_SESSION') {
+    getStoredSession().then(session => sendResponse({ session })).catch(() => sendResponse({ session: null }));
+    return true;
+  } else if (message.type === 'AUTH_MAGIC_LINK_CALLBACK') {
+    handleMagicLinkCallback(message.url).then(session => sendResponse({ session })).catch(() => sendResponse({ session: null }));
+    return true;
+  } else if (message.type === 'AUTH_SIGN_OUT') {
+    signOut().then(() => sendResponse({ success: true })).catch(() => sendResponse({ success: true }));
+    return true;
+  } else if (message.type === 'AUTH_GET_TOKEN') {
+    getAccessToken().then(token => sendResponse({ token })).catch(() => sendResponse({ token: null }));
     return true;
   }
 });

--- a/apps/extension/lib/supabase.js
+++ b/apps/extension/lib/supabase.js
@@ -26,8 +26,8 @@ export async function getStoredSession() {
   const result = await chrome.storage.local.get(SESSION_KEY);
   const session = result[SESSION_KEY];
   if (!session || !session.access_token) return null;
-  // Check expiry (with 60s buffer)
-  if (session.expires_at && session.expires_at * 1000 < Date.now() - 60000) {
+  // Check expiry (refresh 60s before it actually expires)
+  if (session.expires_at && session.expires_at * 1000 < Date.now() + 60000) {
     // Token expired — try refresh
     const refreshed = await refreshSession(session);
     if (refreshed) return refreshed;

--- a/apps/extension/lib/supabase.js
+++ b/apps/extension/lib/supabase.js
@@ -1,0 +1,222 @@
+// Supabase auth client for the Unstream browser extension.
+// Implements the auth REST API directly (no SDK dependency) because
+// the extension has no build step and can't import @supabase/supabase-js.
+// Tokens are persisted to chrome.storage.local so users stay signed in
+// across browser restarts and service worker cold starts.
+
+const SUPABASE_URL = 'https://bwogclqzpsbvqbyhhqbz.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM';
+
+const AUTH_URL = `${SUPABASE_URL}/auth/v1`;
+
+function authHeaders(accessToken) {
+  const headers = {
+    'apikey': SUPABASE_ANON_KEY,
+    'Content-Type': 'application/json',
+  };
+  if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
+  return headers;
+}
+
+// ---- Session persistence ----
+
+const SESSION_KEY = 'unstream_auth_session';
+
+export async function getStoredSession() {
+  const result = await chrome.storage.local.get(SESSION_KEY);
+  const session = result[SESSION_KEY];
+  if (!session || !session.access_token) return null;
+  // Check expiry (with 60s buffer)
+  if (session.expires_at && session.expires_at * 1000 < Date.now() - 60000) {
+    // Token expired — try refresh
+    const refreshed = await refreshSession(session);
+    if (refreshed) return refreshed;
+    // Refresh failed — clear session
+    await clearSession();
+    return null;
+  }
+  return session;
+}
+
+async function storeSession(session) {
+  if (session) {
+    await chrome.storage.local.set({ [SESSION_KEY]: session });
+  } else {
+    await chrome.storage.local.remove(SESSION_KEY);
+  }
+}
+
+async function clearSession() {
+  await chrome.storage.local.remove(SESSION_KEY);
+}
+
+// ---- Auth API ----
+
+// Sign in with email + password
+export async function signInWithPassword(email, password) {
+  const response = await fetch(`${AUTH_URL}/token?grant_type=password`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ email, password }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    return { error: data.error_description || data.msg || data.message || 'Sign in failed' };
+  }
+
+  const session = {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: data.expires_at,
+    user: data.user,
+  };
+
+  await storeSession(session);
+  return { session };
+}
+
+// Send a magic link (OTP) to the user's email
+export async function signInWithOtp(email, redirectTo) {
+  const body = { email };
+  if (redirectTo) body.options = { emailRedirectTo: redirectTo };
+
+  const response = await fetch(`${AUTH_URL}/otp`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    return { error: data.error_description || data.msg || data.message || 'Failed to send magic link' };
+  }
+
+  return { success: true };
+}
+
+// Sign out — revoke the refresh token
+export async function signOut() {
+  const session = await getStoredSession();
+  if (session?.refresh_token) {
+    try {
+      await fetch(`${AUTH_URL}/logout`, {
+        method: 'POST',
+        headers: authHeaders(session.access_token),
+        body: JSON.stringify({ refresh_token: session.refresh_token }),
+      });
+    } catch {
+      // Best effort — if the network call fails, we still clear locally
+    }
+  }
+  await clearSession();
+}
+
+// Refresh an expired access token
+async function refreshSession(session) {
+  if (!session?.refresh_token) return null;
+
+  try {
+    const response = await fetch(`${AUTH_URL}/token?grant_type=refresh_token`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ refresh_token: session.refresh_token }),
+    });
+
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const newSession = {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+      expires_at: data.expires_at,
+      user: data.user,
+    };
+
+    await storeSession(newSession);
+    return newSession;
+  } catch {
+    return null;
+  }
+}
+
+// Get a valid access token (refreshing if needed)
+export async function getAccessToken() {
+  const session = await getStoredSession();
+  return session?.access_token || null;
+}
+
+// Get current user info from stored session
+export async function getCurrentUser() {
+  const session = await getStoredSession();
+  return session?.user || null;
+}
+
+// Handle magic link callback — extract tokens from URL hash/params
+// and store the session
+export async function handleMagicLinkCallback(url) {
+  try {
+    const parsed = new URL(url);
+    let accessToken, refreshToken, expiresIn, tokenType;
+
+    // Check hash fragment first (Supabase default)
+    const hash = parsed.hash.substring(1);
+    const hashParams = new URLSearchParams(hash);
+    accessToken = hashParams.get('access_token');
+    refreshToken = hashParams.get('refresh_token');
+    expiresIn = hashParams.get('expires_in');
+    tokenType = hashParams.get('token_type');
+
+    // Fallback to query params
+    if (!accessToken) {
+      accessToken = parsed.searchParams.get('access_token');
+      refreshToken = parsed.searchParams.get('refresh_token');
+      expiresIn = parsed.searchParams.get('expires_in');
+      tokenType = parsed.searchParams.get('token_type');
+    }
+
+    if (!accessToken) return null;
+
+    // Fetch user info with the access token
+    const userResponse = await fetch(`${AUTH_URL}/user`, {
+      headers: authHeaders(accessToken),
+    });
+
+    if (!userResponse.ok) return null;
+
+    const user = await userResponse.json();
+    const expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + parseInt(expiresIn, 10) : null;
+
+    const session = {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      expires_at: expiresAt,
+      user,
+    };
+
+    await storeSession(session);
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+// ---- Device ID ----
+
+const DEVICE_ID_KEY = 'unstream_device_id';
+let deviceIdCache = null;
+
+export async function getDeviceId() {
+  if (deviceIdCache) return deviceIdCache;
+  const result = await chrome.storage.local.get(DEVICE_ID_KEY);
+  if (result[DEVICE_ID_KEY]) {
+    deviceIdCache = result[DEVICE_ID_KEY];
+    return deviceIdCache;
+  }
+  const id = crypto.randomUUID();
+  await chrome.storage.local.set({ [DEVICE_ID_KEY]: id });
+  deviceIdCache = id;
+  return id;
+}

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -100,6 +100,7 @@
   ],
   "host_permissions": [
     "https://unstream.stream/*",
-    "https://unstream.dev/*"
+    "https://unstream.dev/*",
+    "https://*.supabase.co/*"
   ]
 }

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -95,7 +95,8 @@
     "storage",
     "activeTab",
     "alarms",
-    "notifications"
+    "notifications",
+    "identity"
   ],
   "host_permissions": [
     "https://unstream.stream/*",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -84,7 +84,8 @@
     "storage",
     "activeTab",
     "alarms",
-    "notifications"
+    "notifications",
+    "identity"
   ],
   "host_permissions": [
     "https://unstream.stream/*",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -89,6 +89,7 @@
   ],
   "host_permissions": [
     "https://unstream.stream/*",
-    "https://unstream.dev/*"
+    "https://unstream.dev/*",
+    "https://*.supabase.co/*"
   ]
 }

--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -457,9 +457,15 @@ body {
 
 .saved-artist-name-wrap {
   display: flex;
-  flex-direction: column;
+  align-items: center;
   min-width: 0;
   flex: 1;
+}
+
+.saved-artist-name-wrap .name-location {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .saved-artist-name {
@@ -471,6 +477,15 @@ body {
 
 .saved-artist-name:hover {
   color: #60A5FA;
+}
+
+.saved-artist-img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-right: 8px;
+  flex-shrink: 0;
 }
 
 .saved-artist-remove {
@@ -694,6 +709,165 @@ body {
   color: #9CA3AF;
   border-radius: 3px;
   vertical-align: middle;
+}
+
+/* Auth Form */
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.auth-input {
+  padding: 10px 12px;
+  background: #374151;
+  border: 1px solid #4B5563;
+  border-radius: 8px;
+  color: #F9FAFB;
+  font-size: 14px;
+}
+
+.auth-input::placeholder {
+  color: #6B7280;
+}
+
+.auth-input:focus {
+  outline: none;
+  border-color: #60A5FA;
+}
+
+.auth-submit {
+  padding: 10px 16px;
+  background: #3B82F6;
+  border: none;
+  border-radius: 8px;
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.auth-submit:hover {
+  background: #2563EB;
+}
+
+.auth-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-error {
+  font-size: 12px;
+  color: #EF4444;
+  text-align: center;
+}
+
+.auth-magic-link {
+  background: none;
+  border: none;
+  color: #60A5FA;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 0;
+  text-align: center;
+  width: 100%;
+}
+
+.auth-magic-link:hover {
+  color: #93BBFD;
+  text-decoration: underline;
+}
+
+.auth-magic-link:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.magic-link-sent {
+  text-align: center;
+  padding: 16px 0;
+  color: #9CA3AF;
+  font-size: 13px;
+}
+
+.magic-link-sent .empty-icon {
+  font-size: 28px;
+}
+
+.magic-link-sent p {
+  margin-top: 8px;
+}
+
+/* Auth bar (logged-in state) */
+.auth-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.auth-email-display {
+  font-size: 13px;
+  color: #9CA3AF;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.auth-sign-out {
+  background: none;
+  border: 1px solid #4B5563;
+  border-radius: 6px;
+  color: #9CA3AF;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 10px;
+  transition: all 0.2s;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.auth-sign-out:hover {
+  background: #374151;
+  color: #EF4444;
+  border-color: #EF4444;
+}
+
+/* Sync now button */
+.sync-now-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 16px;
+  background: #374151;
+  border: 1px solid #4B5563;
+  border-radius: 8px;
+  color: #F9FAFB;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: 12px;
+}
+
+.sync-now-btn:hover {
+  background: #4B5563;
+}
+
+.sync-now-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sync-now-btn.syncing {
+  background: #3B82F6;
+  border-color: #3B82F6;
 }
 
 /* Loading state */

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -101,6 +101,37 @@
 
       <!-- Saved Tab -->
       <div id="tab-saved" class="tab-panel">
+        <!-- Auth Section (shown when signed out) -->
+        <section id="auth-section" class="section hidden">
+          <h2 class="section-title">Log in to sync your saved artists</h2>
+          <form id="auth-form" class="auth-form">
+            <input type="email" id="auth-email" class="auth-input" placeholder="Email" required autocomplete="email">
+            <input type="password" id="auth-password" class="auth-input" placeholder="Password" autocomplete="current-password">
+            <button type="submit" id="auth-submit" class="auth-submit">Sign in</button>
+            <div id="auth-error" class="auth-error hidden"></div>
+          </form>
+          <button id="auth-magic-link" class="auth-magic-link">Send magic link instead</button>
+          <div id="magic-link-sent" class="magic-link-sent hidden">
+            <span class="empty-icon">📧</span>
+            <p>Check your email for a sign-in link.</p>
+          </div>
+        </section>
+
+        <!-- Logged-in indicator (shown when signed in) -->
+        <section id="auth-logged-in" class="section hidden">
+          <div class="auth-bar">
+            <span id="auth-email-display" class="auth-email-display"></span>
+            <button id="auth-sign-out" class="auth-sign-out">Sign out</button>
+          </div>
+          <button id="sync-now-btn" class="sync-now-btn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="23 4 23 10 17 10"></polyline>
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+            </svg>
+            Sync now
+          </button>
+        </section>
+
         <!-- New Releases Section -->
         <section id="releases-section" class="section hidden">
           <h2 class="section-title">

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -2,6 +2,9 @@
 
 import { isBandcampFriday } from '../lib/bandcamp-friday.js';
 import { ALLOWED_RELEASE_DOMAINS, SOURCE_CONFIG, PAYOUT_PERCENTAGES } from '../lib/constants.js';
+import { signInWithPassword, signInWithOtp, signOut, getStoredSession, getAccessToken, getDeviceId } from '../lib/supabase.js';
+
+const API_BASE = 'https://unstream.stream/api';
 
 function isAllowedReleaseUrl(url) {
   try {
@@ -50,6 +53,19 @@ const elements = {
   artistLocation: document.getElementById('artist-location'),
   trackTitle: document.getElementById('track-title'),
   sourceBadge: document.getElementById('source-badge'),
+  // Auth
+  authSection: document.getElementById('auth-section'),
+  authForm: document.getElementById('auth-form'),
+  authEmail: document.getElementById('auth-email'),
+  authPassword: document.getElementById('auth-password'),
+  authSubmit: document.getElementById('auth-submit'),
+  authError: document.getElementById('auth-error'),
+  authMagicLink: document.getElementById('auth-magic-link'),
+  magicLinkSent: document.getElementById('magic-link-sent'),
+  authLoggedIn: document.getElementById('auth-logged-in'),
+  authEmailDisplay: document.getElementById('auth-email-display'),
+  authSignOut: document.getElementById('auth-sign-out'),
+  syncNowBtn: document.getElementById('sync-now-btn'),
   // Saved tab
   releasesSection: document.getElementById('releases-section'),
   newReleases: document.getElementById('new-releases'),
@@ -68,6 +84,307 @@ let currentResults = null;
 let currentSocialLinks = null;
 let currentLocation = null;
 let newReleases = [];
+let authSession = null; // null = unknown/loading, false = signed out, object = signed in
+
+// ---- Auth ----
+
+async function initAuth() {
+  try {
+    const { session } = await chrome.runtime.sendMessage({ type: 'AUTH_GET_SESSION' });
+    if (session && session.user) {
+      authSession = session;
+      showLoggedInState(session.user);
+    } else {
+      authSession = false;
+      showLoggedOutState();
+    }
+  } catch {
+    // Service worker may be starting up — try reading from storage directly
+    try {
+      const session = await getStoredSession();
+      if (session && session.user) {
+        authSession = session;
+        showLoggedInState(session.user);
+      } else {
+        authSession = false;
+        showLoggedOutState();
+      }
+    } catch {
+      authSession = false;
+      showLoggedOutState();
+    }
+  }
+}
+
+function showLoggedInState(user) {
+  elements.authSection.classList.add('hidden');
+  elements.authLoggedIn.classList.remove('hidden');
+  elements.authEmailDisplay.textContent = user.email || 'Signed in';
+  elements.syncNowBtn.disabled = false;
+  elements.syncNowBtn.textContent = '';
+  // Rebuild the sync button content
+  elements.syncNowBtn.innerHTML = '';
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+  polyline.setAttribute('points', '23 4 23 10 17 10');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M20.49 15a9 9 0 1 1-2.12-9.36L23 10');
+  svg.appendChild(polyline);
+  svg.appendChild(path);
+  elements.syncNowBtn.appendChild(svg);
+  elements.syncNowBtn.appendChild(document.createTextNode(' Sync now'));
+  // Update save button to show sync state
+  updateSaveButton();
+}
+
+function showLoggedOutState() {
+  elements.authSection.classList.remove('hidden');
+  elements.authLoggedIn.classList.add('hidden');
+  elements.authForm.reset();
+  elements.authError.classList.add('hidden');
+  elements.magicLinkSent.classList.add('hidden');
+  elements.authSubmit.disabled = false;
+  elements.authMagicLink.disabled = false;
+}
+
+async function handleSignIn(e) {
+  e.preventDefault();
+  const email = elements.authEmail.value.trim();
+  const password = elements.authPassword.value;
+
+  if (!email) return;
+
+  elements.authSubmit.disabled = true;
+  elements.authError.classList.add('hidden');
+
+  if (password) {
+    // Password sign-in
+    const result = await signInWithPassword(email, password);
+    if (result.error) {
+      elements.authError.textContent = result.error;
+      elements.authError.classList.remove('hidden');
+      elements.authSubmit.disabled = false;
+      return;
+    }
+    authSession = result.session;
+    showLoggedInState(result.session.user);
+    // Trigger initial sync
+    syncSavedArtists();
+  } else {
+    // Magic link — redirect to OAuth flow
+    elements.authSubmit.disabled = false;
+    await handleMagicLink(email);
+  }
+}
+
+async function handleMagicLink(email) {
+  if (!email) return;
+
+  elements.authMagicLink.disabled = true;
+  elements.authError.classList.add('hidden');
+
+  // Send the magic link email — the user will click the link in their email
+  // which opens unstream.stream and establishes a session there.
+  // The extension picks up the session on next popup open.
+  const result = await signInWithOtp(email);
+
+  if (result.error) {
+    elements.authError.textContent = result.error;
+    elements.authError.classList.remove('hidden');
+    elements.authMagicLink.disabled = false;
+    return;
+  }
+
+  // Show "check your email" message
+  elements.magicLinkSent.classList.remove('hidden');
+  elements.authForm.classList.add('hidden');
+  elements.authMagicLink.classList.add('hidden');
+
+  elements.authMagicLink.disabled = false;
+}
+
+async function handleSignOut() {
+  await signOut();
+  authSession = false;
+  showLoggedOutState();
+  // Clear synced artists — keep only local-only saves
+  await clearSyncedArtists();
+  loadSavedArtists();
+}
+
+async function clearSyncedArtists() {
+  // Remove artists that came from server sync, keeping locally-saved ones
+  const { syncedArtistSlugs = [] } = await chrome.storage.local.get('syncedArtistSlugs');
+  if (syncedArtistSlugs.length === 0) return;
+
+  const { savedArtists = [], savedArtistsData = {} } = await chrome.storage.local.get(['savedArtists', 'savedArtistsData']);
+  const remaining = savedArtists.filter(name => !syncedArtistSlugs.includes(name));
+  const remainingData = {};
+  for (const name of remaining) {
+    if (savedArtistsData[name]) remainingData[name] = savedArtistsData[name];
+  }
+
+  await chrome.storage.local.set({ savedArtists: remaining, savedArtistsData: remainingData });
+  await chrome.storage.local.remove('syncedArtistSlugs');
+  await chrome.storage.local.remove('lastSyncTime');
+}
+
+// ---- Saved Artists Sync ----
+
+async function syncSavedArtists() {
+  if (!authSession) return;
+
+  elements.syncNowBtn.disabled = true;
+  elements.syncNowBtn.classList.add('syncing');
+  elements.syncNowBtn.textContent = 'Syncing...';
+
+  try {
+    const token = authSession.access_token || await getAccessToken();
+    if (!token) return;
+
+    const { lastSyncTime } = await chrome.storage.local.get('lastSyncTime');
+    const since = lastSyncTime || '1970-01-01T00:00:00Z';
+
+    const response = await fetch(`${API_BASE}/saved-artists/sync?since=${encodeURIComponent(since)}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      console.error('Sync failed:', response.status);
+      return;
+    }
+
+    const data = await response.json();
+    const serverArtists = data.artists || [];
+
+    if (serverArtists.length === 0 && !lastSyncTime) {
+      // First sync, no server artists — just save the sync timestamp
+      await chrome.storage.local.set({ lastSyncTime: data.server_time });
+      // Reset the sync button but don't reload the list (nothing changed)
+      return;
+    }
+
+    // Merge server artists into local state
+    const { savedArtists = [], savedArtistsData = {} } = await chrome.storage.local.get(['savedArtists', 'savedArtistsData']);
+    const syncedSlugs = [];
+
+    for (const artist of serverArtists) {
+      const slug = artist.slug || artist.artistId;
+      if (!slug) continue;
+
+      syncedSlugs.push(slug);
+
+      // Add to local list if not present
+      if (!savedArtists.includes(slug)) {
+        savedArtists.push(slug);
+      }
+
+      // Build artist data from server record
+      savedArtistsData[slug] = {
+        platforms: (artist.claimed && artist.slug) ? [{ sourceId: 'unstream', url: `https://unstream.stream/a/${artist.slug}` }] : [],
+        socialLinks: [],
+        location: null,
+        imageUrl: artist.imageUrl || null,
+        name: artist.name || slug,
+        slug: artist.slug || '',
+        claimed: artist.claimed || false,
+        supported: artist.supported || false,
+        lastModified: artist.lastModified || null,
+      };
+    }
+
+    await chrome.storage.local.set({
+      savedArtists,
+      savedArtistsData,
+      syncedArtistSlugs: syncedSlugs,
+      lastSyncTime: data.server_time,
+    });
+
+    // Reload the saved artists display
+    loadSavedArtists();
+  } catch (error) {
+    console.error('Sync error:', error);
+  } finally {
+    elements.syncNowBtn.disabled = false;
+    elements.syncNowBtn.classList.remove('syncing');
+    // Reset button content
+    elements.syncNowBtn.innerHTML = '';
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '14');
+    svg.setAttribute('height', '14');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    polyline.setAttribute('points', '23 4 23 10 17 10');
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M20.49 15a9 9 0 1 1-2.12-9.36L23 10');
+    svg.appendChild(polyline);
+    svg.appendChild(path);
+    elements.syncNowBtn.appendChild(svg);
+    elements.syncNowBtn.appendChild(document.createTextNode(' Sync now'));
+  }
+}
+
+// Save an artist to the server (when logged in)
+async function saveArtistToServer(artistName, artistData) {
+  if (!authSession) return;
+
+  const token = authSession.access_token || await getAccessToken();
+  if (!token) return;
+
+  const deviceId = await getDeviceId();
+
+  try {
+    await fetch(`${API_BASE}/saved-artists`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        artistId: artistName,
+        name: artistData.name || artistName,
+        imageUrl: artistData.imageUrl || null,
+        last_modified: new Date().toISOString(),
+        device_id: deviceId,
+      }),
+    });
+  } catch {
+    // Silent — local save is still preserved
+  }
+}
+
+// Remove an artist from the server (when logged in)
+async function removeArtistFromServer(artistName) {
+  if (!authSession) return;
+
+  const token = authSession.access_token || await getAccessToken();
+  if (!token) return;
+
+  try {
+    await fetch(`${API_BASE}/saved-artists`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        action: 'remove',
+        artistId: artistName,
+      }),
+    });
+  } catch {
+    // Silent — local removal is still preserved
+  }
+}
 
 // Format ArtistLocation object to "City, Country" string
 function formatLocation(location) {
@@ -81,6 +398,9 @@ function formatLocation(location) {
 
 // Initialize popup
 async function init() {
+  // Initialize auth state
+  await initAuth();
+
   // Get current track from storage
   const { currentTrack } = await chrome.storage.local.get('currentTrack');
 
@@ -356,6 +676,8 @@ async function toggleSaveArtist() {
   if (index >= 0) {
     savedArtists.splice(index, 1);
     delete savedArtistsData[currentArtist];
+    // Remove from server if logged in
+    removeArtistFromServer(currentArtist);
   } else {
     savedArtists.push(currentArtist);
     const artistData = { platforms: [], socialLinks: [], location: currentLocation || null };
@@ -377,6 +699,8 @@ async function toggleSaveArtist() {
     }
 
     savedArtistsData[currentArtist] = artistData;
+    // Save to server if logged in
+    saveArtistToServer(currentArtist, artistData);
   }
 
   await chrome.storage.local.set({ savedArtists, savedArtistsData });
@@ -409,6 +733,7 @@ async function loadSavedArtists() {
     const platforms = artistData.platforms || [];
     const socialLinks = artistData.socialLinks || [];
     const location = artistData.location || null;
+    const imageUrl = artistData.imageUrl || null;
 
     const card = document.createElement('div');
     card.className = 'saved-artist-card';
@@ -420,22 +745,38 @@ async function loadSavedArtists() {
     const nameWrap = document.createElement('div');
     nameWrap.className = 'saved-artist-name-wrap';
 
+    // Artist image (if available from server sync)
+    if (imageUrl) {
+      const img = document.createElement('img');
+      img.src = imageUrl;
+      img.alt = '';
+      img.className = 'saved-artist-img';
+      img.loading = 'lazy';
+      nameWrap.appendChild(img);
+    }
+
+    const nameLocationWrap = document.createElement('div');
+    nameLocationWrap.className = 'name-location';
+
     const nameSpan = document.createElement('span');
     nameSpan.className = 'saved-artist-name';
-    nameSpan.textContent = artist;
+    // Use the synced name if available, otherwise fall back to the key
+    nameSpan.textContent = artistData.name || artist;
     nameSpan.addEventListener('click', () => {
       switchToTab('discover');
       searchArtist(artist);
     });
-    nameWrap.appendChild(nameSpan);
+    nameLocationWrap.appendChild(nameSpan);
 
     const locationText = formatLocation(location);
     if (locationText) {
       const locationSpan = document.createElement('div');
       locationSpan.className = 'saved-artist-location';
       locationSpan.textContent = locationText;
-      nameWrap.appendChild(locationSpan);
+      nameLocationWrap.appendChild(locationSpan);
     }
+
+    nameWrap.appendChild(nameLocationWrap);
 
     const removeBtn = document.createElement('button');
     removeBtn.className = 'saved-artist-remove';
@@ -524,6 +865,8 @@ async function removeSavedArtist(artist) {
     savedArtists.splice(index, 1);
     delete savedArtistsData[artist];
     await chrome.storage.local.set({ savedArtists, savedArtistsData });
+    // Remove from server if logged in
+    removeArtistFromServer(artist);
     loadSavedArtists();
     updateSaveButton();
   }
@@ -782,6 +1125,22 @@ function setupEventListeners() {
     }
   });
 
+  // Auth form submission
+  elements.authForm.addEventListener('submit', handleSignIn);
+
+  // Magic link button
+  elements.authMagicLink.addEventListener('click', () => {
+    const email = elements.authEmail.value.trim();
+    if (email) {
+      handleMagicLink(email);
+    }
+  });
+
+  // Sign out button
+  elements.authSignOut.addEventListener('click', handleSignOut);
+
+  // Sync now button
+  elements.syncNowBtn.addEventListener('click', syncSavedArtists);
 }
 
 // Initialize

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -80,11 +80,67 @@ const elements = {
 
 // State
 let currentArtist = null;
+let currentArtistSlug = null; // resolved slug for current artist
 let currentResults = null;
 let currentSocialLinks = null;
 let currentLocation = null;
 let newReleases = [];
 let authSession = null; // null = unknown/loading, false = signed out, object = signed in
+
+// Slug lookup cache: { artistName → slug }
+const SLUG_CACHE_KEY = 'artistSlugCache';
+
+// Look up the canonical slug for an artist name via the search API.
+// This mirrors what the web app does (claimedSlug || result.id).
+// Results are cached in chrome.storage.local so we don't re-fetch on every save.
+async function lookupSlug(artistName) {
+  if (!artistName) return null;
+
+  // Check cache
+  const { [SLUG_CACHE_KEY]: slugCache = {} } = await chrome.storage.local.get(SLUG_CACHE_KEY);
+  const normalizedName = artistName.toLowerCase().trim();
+
+  if (slugCache[normalizedName]) {
+    return slugCache[normalizedName];
+  }
+
+  try {
+    const response = await chrome.runtime.sendMessage({
+      type: 'GET_RESULTS',
+      artist: artistName,
+    });
+
+    if (!response || response.error) return null;
+
+    const results = response.results || [];
+    // Find the best-matching artist result
+    const match = results.find(r =>
+      r.type === 'artist' && r.name && r.name.toLowerCase() === normalizedName
+    ) || results.find(r =>
+      r.type === 'artist' && r.name && r.name.toLowerCase().includes(normalizedName)
+    );
+
+    if (match) {
+      const slug = match.claimedSlug || match.id;
+      if (slug) {
+        // Persist to cache
+        slugCache[normalizedName] = slug;
+        await chrome.storage.local.set({ [SLUG_CACHE_KEY]: slugCache });
+        return slug;
+      }
+    }
+  } catch {
+    // Network error — fall back to slugifying locally
+  }
+
+  // Fallback: slugify the display name the same way the server does
+  const fallbackSlug = artistName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  if (fallbackSlug) {
+    slugCache[normalizedName] = fallbackSlug;
+    await chrome.storage.local.set({ [SLUG_CACHE_KEY]: slugCache });
+  }
+  return fallbackSlug || null;
+}
 
 // ---- Auth ----
 
@@ -271,7 +327,7 @@ async function syncSavedArtists() {
     }
 
     // Merge server artists into local state
-    const { savedArtists = [], savedArtistsData = {} } = await chrome.storage.local.get(['savedArtists', 'savedArtistsData']);
+    const { savedArtists = [], savedArtistsData = {}, syncedArtistSlugs: prevSynced = [] } = await chrome.storage.local.get(['savedArtists', 'savedArtistsData', 'syncedArtistSlugs']);
     const syncedSlugs = [];
 
     for (const artist of serverArtists) {
@@ -299,10 +355,13 @@ async function syncSavedArtists() {
       };
     }
 
+    // Union with previously synced slugs so incremental syncs don't lose history
+    const mergedSlugs = new Set([...prevSynced, ...syncedSlugs]);
+
     await chrome.storage.local.set({
       savedArtists,
       savedArtistsData,
-      syncedArtistSlugs: syncedSlugs,
+      syncedArtistSlugs: [...mergedSlugs],
       lastSyncTime: data.server_time,
     });
 
@@ -334,8 +393,9 @@ async function syncSavedArtists() {
 }
 
 // Save an artist to the server (when logged in)
-async function saveArtistToServer(artistName, artistData) {
-  if (!authSession) return;
+// artistSlug should be the canonical slug (from lookupSlug), not a display name
+async function saveArtistToServer(artistSlug, artistData) {
+  if (!authSession) return; // TODO: queue saves fired before initAuth completes
 
   const token = authSession.access_token || await getAccessToken();
   if (!token) return;
@@ -350,8 +410,8 @@ async function saveArtistToServer(artistName, artistData) {
         'Authorization': `Bearer ${token}`,
       },
       body: JSON.stringify({
-        artistId: artistName,
-        name: artistData.name || artistName,
+        artistId: artistSlug,
+        name: artistData.name || artistSlug,
         imageUrl: artistData.imageUrl || null,
         last_modified: new Date().toISOString(),
         device_id: deviceId,
@@ -363,7 +423,8 @@ async function saveArtistToServer(artistName, artistData) {
 }
 
 // Remove an artist from the server (when logged in)
-async function removeArtistFromServer(artistName) {
+// artistSlug should be the canonical slug
+async function removeArtistFromServer(artistSlug) {
   if (!authSession) return;
 
   const token = authSession.access_token || await getAccessToken();
@@ -378,7 +439,7 @@ async function removeArtistFromServer(artistName) {
       },
       body: JSON.stringify({
         action: 'remove',
-        artistId: artistName,
+        artistId: artistSlug,
       }),
     });
   } catch {
@@ -426,6 +487,7 @@ async function init() {
 // Show now playing
 function showNowPlaying(track) {
   currentArtist = track.artist;
+  currentArtistSlug = null; // will be resolved asynchronously
   currentLocation = null;
   elements.artistName.textContent = track.artist;
   elements.artistLocation.textContent = '';
@@ -437,11 +499,18 @@ function showNowPlaying(track) {
   elements.actionsSection.classList.remove('hidden');
 
   updateSaveButton();
+
+  // Resolve the canonical slug for this artist
+  lookupSlug(track.artist).then(slug => {
+    currentArtistSlug = slug;
+    updateSaveButton();
+  });
 }
 
 // Hide now playing
 function hideNowPlaying() {
   currentArtist = null;
+  currentArtistSlug = null;
   currentResults = null;
   currentLocation = null;
   elements.artistLocation.textContent = '';
@@ -649,7 +718,9 @@ async function updateSaveButton() {
   if (!currentArtist) return;
 
   const { savedArtists = [] } = await chrome.storage.local.get('savedArtists');
-  const isSaved = savedArtists.includes(currentArtist);
+  // Check by slug if resolved, otherwise fall back to display name
+  const key = currentArtistSlug || currentArtist;
+  const isSaved = savedArtists.includes(key) || savedArtists.includes(currentArtist);
 
   const starSpan = document.createElement('span');
   starSpan.className = 'star';
@@ -669,18 +740,33 @@ async function updateSaveButton() {
 async function toggleSaveArtist() {
   if (!currentArtist) return;
 
-  const { savedArtists = [] } = await chrome.storage.local.get('savedArtists');
-  const { savedArtistsData = {} } = await chrome.storage.local.get('savedArtistsData');
-  const index = savedArtists.indexOf(currentArtist);
+  // Resolve slug if not yet available
+  const slug = currentArtistSlug || await lookupSlug(currentArtist);
+  if (slug) currentArtistSlug = slug;
+
+  const key = slug || currentArtist; // use slug as canonical key, display name as fallback
+  const { savedArtists = [], savedArtistsData = {} } = await chrome.storage.local.get(['savedArtists', 'savedArtistsData']);
+
+  // Check both slug and display name for backward compat with pre-migration data
+  const existingIndex = savedArtists.indexOf(key);
+  const legacyIndex = key !== currentArtist ? savedArtists.indexOf(currentArtist) : -1;
+  const index = existingIndex !== -1 ? existingIndex : legacyIndex;
 
   if (index >= 0) {
+    const removedKey = savedArtists[index];
     savedArtists.splice(index, 1);
-    delete savedArtistsData[currentArtist];
+    delete savedArtistsData[removedKey];
     // Remove from server if logged in
-    removeArtistFromServer(currentArtist);
+    removeArtistFromServer(removedKey);
   } else {
-    savedArtists.push(currentArtist);
-    const artistData = { platforms: [], socialLinks: [], location: currentLocation || null };
+    savedArtists.push(key);
+    const artistData = {
+      platforms: [],
+      socialLinks: [],
+      location: currentLocation || null,
+      name: currentArtist, // preserve display name for rendering
+      slug: slug || '',
+    };
 
     // Save platforms
     if (currentResults && currentResults.length > 0) {
@@ -698,9 +784,15 @@ async function toggleSaveArtist() {
       artistData.socialLinks = currentSocialLinks;
     }
 
-    savedArtistsData[currentArtist] = artistData;
+    // Save image URL from the claimed/first result if available
+    const bestResult = currentResults && currentResults.find(r => r.type === 'artist');
+    if (bestResult && bestResult.imageUrl) {
+      artistData.imageUrl = bestResult.imageUrl;
+    }
+
+    savedArtistsData[key] = artistData;
     // Save to server if logged in
-    saveArtistToServer(currentArtist, artistData);
+    saveArtistToServer(key, artistData);
   }
 
   await chrome.storage.local.set({ savedArtists, savedArtistsData });
@@ -746,9 +838,11 @@ async function loadSavedArtists() {
     nameWrap.className = 'saved-artist-name-wrap';
 
     // Artist image (if available from server sync)
-    if (imageUrl) {
+    // Restrict to https:// only for defense-in-depth
+    const safeImageUrl = imageUrl && imageUrl.startsWith('https://') ? imageUrl : '';
+    if (safeImageUrl) {
       const img = document.createElement('img');
-      img.src = imageUrl;
+      img.src = safeImageUrl;
       img.alt = '';
       img.className = 'saved-artist-img';
       img.loading = 'lazy';


### PR DESCRIPTION
Fixes UNS-111

## What this does

Adds Supabase auth and saved artists sync to the Unstream browser extensions (Chrome + Firefox). This is Phase 2 of UNS-61 (cross-client auth), building on the server-side schema and sync API shipped in UNS-93.

### Changes

**New file: `apps/extension/lib/supabase.js`**
- Implements Supabase auth REST API directly (no SDK dependency — the extension has no build step, so we can't import @supabase/supabase-js)
- Session persistence in `chrome.storage.local` for service worker cold start resilience
- Functions: `signInWithPassword`, `signInWithOtp`, `signOut`, `getStoredSession`, `getAccessToken`, `handleMagicLinkCallback`, `getDeviceId`
- Stable per-installation device ID via `crypto.randomUUID()`

**Modified: `apps/extension/popup/popup.html`**
- Auth form (email + password) in the Saved tab, shown when signed out
- "Send magic link instead" button
- "Check your email" confirmation state after magic link sent
- Logged-in state: email display + sign out button + "Sync now" button

**Modified: `apps/extension/popup/popup.css`**
- Auth form styles (inputs, submit button, error message)
- Magic link styles
- Auth bar (logged-in email + sign out)
- Sync button styles
- Saved artist image (32px circular avatar)
- Name/location flex layout update

**Modified: `apps/extension/popup/popup.js`**
- Auth state management: `initAuth()`, `showLoggedInState()`, `showLoggedOutState()`
- Email+password sign-in via Supabase REST API
- Magic link email sending (shows confirmation, no redirect capture yet)
- Sign out clears synced artists, preserves local-only saves
- `syncSavedArtists()`: calls GET /api/saved-artists/sync?since=<timestamp>, merges server artists into local state
- `saveArtistToServer()`: POST /api/saved-artists with device_id and last_modified on every local save when logged in
- `removeArtistFromServer()`: POST /api/saved-artists with action=remove on every local unsave when logged in
- Saved artist cards now display image URLs and synced names from server data
- **NEW:** `lookupSlug()` resolves artist display names to canonical slugs via `/api/search/sources`, matching the web app's `claimedSlug || id` path. Results are cached in `chrome.storage.local`.
- **NEW:** All save/remove operations now use the resolved slug as the key, preventing duplicate rows across web and extension clients.

**Modified: `apps/extension/background/service-worker.js`**
- Message handlers: AUTH_GET_SESSION, AUTH_MAGIC_LINK_CALLBACK, AUTH_SIGN_OUT, AUTH_GET_TOKEN
- All delegate to `supabase.js` functions which read from chrome.storage.local

**Modified: `apps/extension/manifest.json` + `manifest-firefox.json`**
- Added `identity` permission for future magic link redirect support
- **NEW:** Added `https://*.supabase.co/*` to `host_permissions` so auth calls succeed without relying on permissive CORS.

## Security

- The Supabase anon key shipped in `supabase.js` is a **public** publishable key — this is expected and by design. All data protection is via Row-Level Security (RLS) on the `saved_artists` table, which scopes all operations by `auth.uid()` (see UNS-93 migration). No service-role key is present in the extension bundle.

## Known limitations

- **Magic link redirect capture not yet implemented.** The "Send magic link instead" button sends the OTP email, but the extension cannot capture the redirect because the extension's redirect URL (`https://<id>.chromiumapp.org/`) is not in the Supabase dashboard's allowed redirect URLs. Full magic link support requires adding the extension's redirect URL to the Supabase dashboard. Email+password auth works fully.
- **Cross-client deletions don't propagate.** When an artist is unsaved on the web app, the extension won't learn about the deletion until Phase 4 (realtime subscriptions) or a tombstone scheme is implemented. The incremental sync endpoint (`/api/saved-artists/sync?since=<cursor>`) only returns rows modified since the cursor — deleted rows simply disappear from the result set. This is a v1 limitation documented for future work.
- **No realtime subscriptions yet** (deferred to Phase 4 per UNS-61).

## Acceptance criteria status

- [x] Email + password sign-in works from the popup
- [ ] Magic link sign-in — sends email but does not capture redirect (requires Supabase dashboard config)
- [x] Saved tab shows previously-saved artists on first load after auth
- [x] Save/unsave from extension reflects in the web app on next sync (fixed: now uses canonical slug, same as web app)
- [x] Refresh the popup: state persists, no flicker to login form
- [x] Sign out clears local state and returns to login form
- [x] Service worker cold-start preserves session (fixed: token refresh now triggers 60s before expiry, not after)
- [ ] Firefox build parity — manifest updated but not tested on Firefox profile yet
- [x] npm run build passes
- [x] Deslop pass completed on branch diff

## What to verify

1. Load the extension in Chrome (chrome://extensions → developer mode → load unpacked → select apps/extension/)
2. Open the popup, go to Saved tab — should show login form
3. Sign in with email+password — should show "Logged in as <email>" and sync saved artists
4. Save an artist from Discover tab — should sync to server using the canonical slug (not display name)
5. Verify on the web app that the saved artist uses the slug key, not the display name
6. Close and reopen popup — session should persist
7. Sign out — should return to login form and clear synced artists
8. Test magic link button — should send email but note redirect capture limitation