### PR TITLE
UNS-112 follow-ups: Task polling, anon key hygiene, test SDKROOT, 401 handling, keychain logging (UNS-123/124/125/126/127)

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -635,8 +635,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = lol.bgreen.UnstreamTests;
 				PRODUCT_NAME = UnstreamTests;
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Unstream.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Unstream";
 			};
@@ -656,8 +656,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = lol.bgreen.UnstreamTests;
 				PRODUCT_NAME = UnstreamTests;
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Unstream.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Unstream";
 			};

--- a/apps/mac/Unstream/Info-iOS.plist
+++ b/apps/mac/Unstream/Info-iOS.plist
@@ -59,5 +59,7 @@
 	<string>Copyright 2025-2026 brandon lucas green</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM</string>
 </dict>
 </plist>

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -43,5 +43,7 @@
 	<string>Copyright 2025-2026 brandon lucas green</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM</string>
 </dict>
 </plist>

--- a/apps/mac/Unstream/Services/AuthService.swift
+++ b/apps/mac/Unstream/Services/AuthService.swift
@@ -11,9 +11,6 @@ class AuthService: ObservableObject {
 
     // Public anon key — safe to embed, RLS is the real gatekeeper.
     private let supabaseURL = URL(string: "https://bwogclqzpsbvqbyhhqbz.supabase.co")!
-    private var supabaseAnonKey: String {
-        Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String ?? ""
-    }
 
     let client: SupabaseClient
 

--- a/apps/mac/Unstream/Services/AuthService.swift
+++ b/apps/mac/Unstream/Services/AuthService.swift
@@ -11,7 +11,9 @@ class AuthService: ObservableObject {
 
     // Public anon key — safe to embed, RLS is the real gatekeeper.
     private let supabaseURL = URL(string: "https://bwogclqzpsbvqbyhhqbz.supabase.co")!
-    private let supabaseAnonKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM"
+    private var supabaseAnonKey: String {
+        Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String ?? ""
+    }
 
     let client: SupabaseClient
 
@@ -20,7 +22,8 @@ class AuthService: ObservableObject {
     @Published var errorMessage: String?
 
     private init() {
-        client = SupabaseClient(supabaseURL: supabaseURL, supabaseKey: supabaseAnonKey)
+        let anonKey = Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String ?? ""
+        client = SupabaseClient(supabaseURL: supabaseURL, supabaseKey: anonKey)
 
         Task {
             migrateOldKeychainTokens()

--- a/apps/mac/Unstream/Services/DeviceIDManager.swift
+++ b/apps/mac/Unstream/Services/DeviceIDManager.swift
@@ -12,7 +12,10 @@ enum DeviceIDManager {
             return existing
         }
         let new = UUID().uuidString
-        KeychainHelper.save(key: key, value: new)
+        let saved = KeychainHelper.save(key: key, value: new)
+        if !saved {
+            print("[DeviceID] Failed to persist device ID to keychain — will regenerate on next launch")
+        }
         return new
     }()
 }

--- a/apps/mac/Unstream/Services/SavedArtistsSync.swift
+++ b/apps/mac/Unstream/Services/SavedArtistsSync.swift
@@ -139,6 +139,8 @@ class SavedArtistsSync: ObservableObject {
                     }
                     // Refresh pull to get the server's authoritative version
                     await pull()
+                } else {
+                    syncError = "Couldn't save — try again"
                 }
             }
         } catch {
@@ -181,6 +183,8 @@ class SavedArtistsSync: ObservableObject {
                     }
                     // Remove from local list immediately
                     syncedArtists.removeAll { $0.slug == slug }
+                } else {
+                    syncError = "Couldn't remove — try again"
                 }
             }
         } catch {

--- a/apps/mac/Unstream/Services/SavedArtistsSync.swift
+++ b/apps/mac/Unstream/Services/SavedArtistsSync.swift
@@ -57,8 +57,17 @@ class SavedArtistsSync: ObservableObject {
         do {
             let (data, response) = try await session.data(for: request)
 
-            guard let http = response as? HTTPURLResponse,
-                  (200...299).contains(http.statusCode) else {
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 {
+                    syncError = "Session expired — sign in again"
+                    isSyncing = false
+                    return
+                } else if !(200...299).contains(http.statusCode) {
+                    syncError = "Couldn't sync — tap to retry"
+                    isSyncing = false
+                    return
+                }
+            } else {
                 isSyncing = false
                 return
             }
@@ -118,16 +127,19 @@ class SavedArtistsSync: ObservableObject {
 
         do {
             let (data, response) = try await session.data(for: request)
-            if let http = response as? HTTPURLResponse,
-               (200...299).contains(http.statusCode) {
-                // Update sync cursor from the server's authoritative time
-                // so subsequent incremental pulls don't miss this save.
-                if let responseBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let serverTime = responseBody["server_time"] as? String {
-                    lastSyncTime = serverTime
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 {
+                    syncError = "Session expired — sign in again"
+                } else if (200...299).contains(http.statusCode) {
+                    // Update sync cursor from the server's authoritative time
+                    // so subsequent incremental pulls don't miss this save.
+                    if let responseBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let serverTime = responseBody["server_time"] as? String {
+                        lastSyncTime = serverTime
+                    }
+                    // Refresh pull to get the server's authoritative version
+                    await pull()
                 }
-                // Refresh pull to get the server's authoritative version
-                await pull()
             }
         } catch {
             syncError = "Couldn't save — try again"
@@ -158,15 +170,18 @@ class SavedArtistsSync: ObservableObject {
 
         do {
             let (data, response) = try await session.data(for: request)
-            if let http = response as? HTTPURLResponse,
-               (200...299).contains(http.statusCode) {
-                // Update sync cursor from the server's authoritative time
-                if let responseBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let serverTime = responseBody["server_time"] as? String {
-                    lastSyncTime = serverTime
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 {
+                    syncError = "Session expired — sign in again"
+                } else if (200...299).contains(http.statusCode) {
+                    // Update sync cursor from the server's authoritative time
+                    if let responseBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let serverTime = responseBody["server_time"] as? String {
+                        lastSyncTime = serverTime
+                    }
+                    // Remove from local list immediately
+                    syncedArtists.removeAll { $0.slug == slug }
                 }
-                // Remove from local list immediately
-                syncedArtists.removeAll { $0.slug == slug }
             }
         } catch {
             syncError = "Couldn't remove — try again"

--- a/apps/mac/Unstream/Views/iOS/iOSSettingsTab.swift
+++ b/apps/mac/Unstream/Views/iOS/iOSSettingsTab.swift
@@ -7,8 +7,7 @@ struct iOSSettingsTab: View {
     @ObservedObject private var sync = SavedArtistsSync.shared
     @State private var notificationDenied = false
     @State private var showSignIn = false
-    @State private var foregroundPollTimer: Timer?
-    @State private var foregroundForcePullTimer: Timer?
+    @State private var pollTask: Task<Void, Never>?
 
     var body: some View {
         NavigationStack {
@@ -220,26 +219,21 @@ struct iOSSettingsTab: View {
 
     private func startForegroundPoll() {
         stopForegroundPoll()
-        foregroundPollTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
-            Task { @MainActor in
-                await sync.pull()
-            }
-        }
-        // Periodic force-pull every 5 minutes as a safety net for
-        // cross-device removals (tombstones cover the common case,
-        // but a full refresh catches any edge cases during long sessions).
-        foregroundForcePullTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
-            Task { @MainActor in
-                await sync.pull(force: true)
+        var iterationCount = 0
+        pollTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { break }
+                iterationCount += 1
+                let force = iterationCount % 5 == 0  // every 5th iteration = 5 minutes
+                await sync.pull(force: force)
             }
         }
     }
 
     private func stopForegroundPoll() {
-        foregroundPollTimer?.invalidate()
-        foregroundPollTimer = nil
-        foregroundForcePullTimer?.invalidate()
-        foregroundForcePullTimer = nil
+        pollTask?.cancel()
+        pollTask = nil
     }
 }
 #endif

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -13,8 +13,7 @@ struct PopoverView: View {
     @ObservedObject private var sync = SavedArtistsSync.shared
     @State private var selectedTab: PopoverTab = .search
     @State private var showSignIn = false
-    @State private var menuPollTimer: Timer?
-    @State private var menuForcePullTimer: Timer?
+    @State private var pollTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -243,26 +242,21 @@ struct PopoverView: View {
 
     private func startMenuPoll() {
         stopMenuPoll()
-        menuPollTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
-            Task { @MainActor in
-                await sync.pull()
-            }
-        }
-        // Periodic force-pull every 5 minutes as a safety net for
-        // cross-device removals (tombstones cover the common case,
-        // but a full refresh catches any edge cases during long sessions).
-        menuForcePullTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
-            Task { @MainActor in
-                await sync.pull(force: true)
+        var iterationCount = 0
+        pollTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { break }
+                iterationCount += 1
+                let force = iterationCount % 5 == 0  // every 5th iteration = 5 minutes
+                await sync.pull(force: force)
             }
         }
     }
 
     private func stopMenuPoll() {
-        menuPollTimer?.invalidate()
-        menuPollTimer = nil
-        menuForcePullTimer?.invalidate()
-        menuForcePullTimer = nil
+        pollTask?.cancel()
+        pollTask = nil
     }
 }
 


### PR DESCRIPTION
## Summary

Five independent follow-up fixes for the UNS-112 Mac/iOS sync feature, one commit per issue.

## Issues

- **Fixes UNS-127** — `DeviceIDManager`: log keychain write failure instead of silently ignoring the `Bool` return from `KeychainHelper.save`.
- **Fixes UNS-126** — `SavedArtistsSync`: surface 401 responses with "Session expired — sign in again" in `pull`, `saveArtist`, and `removeArtist`. Other non-200 errors get "Couldn't sync — tap to retry". No auto-sign-out (v1 just surfaces the message).
- **Fixes UNS-124** — Move Supabase anon key from a hardcoded Swift literal in `AuthService.swift` to `SUPABASE_ANON_KEY` in both `Info-iOS.plist` and `Info-macOS.plist`. The key is read via `Bundle.main.infoDictionary` at init time. Same key value, just sourced from the plist.
- **Fixes UNS-125** — Set `SDKROOT = macosx` and `SUPPORTED_PLATFORMS = macosx` for the `UnstreamTests` target (Debug + Release configs) in `project.pbxproj`. App target stays on `SDKROOT = auto`.
- **Fixes UNS-123** — Replace `Timer.scheduledTimer` with `Task { while !Task.isCancelled { try? await Task.sleep(for: .seconds(60)); … } }` in both `PopoverView.swift` (macOS) and `iOSSettingsTab.swift` (iOS). Combines the 60s poll and 5min force-pull into a single task with an iteration counter.

## Build & Test

- `xcodebuild build` — **SUCCEEDED** (platform=macOS, Debug, CODE_SIGNING_ALLOWED=NO)
- `xcodebuild test` — **SUCCEEDED** — 5/5 SavedArtistsSyncTests passed
- `plutil -lint` — both Info.plists and pbxproj OK
- `swiftc -parse` — all modified Swift files parse clean

## What to verify

- The anon key value in the Info.plists matches what was in AuthService.swift (read from disk, same value)
- 401 handling doesn't auto-sign-out — just sets `syncError` (per spec)
- Task polling cancels correctly when the view disappears or auth state changes
- UnstreamTests target builds for macOS only (not iOS simulator)

## Risks

- The `supabaseAnonKey` change from `let` to computed property required reading the key into a local in `init` (Swift requires all stored properties initialized before accessing `self` properties). Functionally identical.
- The Task-based poll uses `Task.sleep(for: .seconds(60))` which requires macOS 13.0+ / iOS 16.0+ — both within the deployment targets (macOS 13.0, iOS 17.0).
