### PR TITLE
feat(UNS-128): scheduled GC for saved_artists tombstones (pg_cron)

### DIFF
--- a/supabase/migration-018-saved-artists-tombstone-gc.sql
+++ b/supabase/migration-018-saved-artists-tombstone-gc.sql
@@ -1,0 +1,39 @@
+-- Migration 018: Scheduled GC for saved_artists tombstones (UNS-128)
+--
+-- Migration 017 added soft-delete (deleted, deleted_at columns) for cross-client
+-- sync tombstones. Without GC, these accumulate forever — every artist that any
+-- user ever unsaved would stay in the table. This migration adds a daily 3am UTC
+-- sweep that hard-deletes tombstones older than 30 days.
+--
+-- The 30-day window is generous: sync clients reconcile via tombstones on
+-- the next pull, and a 5-min force-pull acts as a backstop for long sessions.
+-- 30 days of buffer easily covers offline clients, slow networks, and any
+-- scheduling jitter.
+--
+-- Required: pg_cron extension must be enabled in the Supabase dashboard
+-- before this migration runs. UNS-132 tracks that step.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+CREATE OR REPLACE FUNCTION gc_saved_artists_tombstones()
+RETURNS void AS $$
+BEGIN
+  DELETE FROM saved_artists
+  WHERE deleted = true
+    AND deleted_at < now() - interval '30 days';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Idempotent: unschedule first so re-running the migration doesn't error.
+-- cron.job is the pg_cron catalog table.
+SELECT cron.unschedule('gc-saved_artists_tombstones')
+  WHERE EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'gc-saved_artists_tombstones'
+  );
+
+-- Schedule: 3am UTC daily. Low-traffic window; runs a single DELETE.
+SELECT cron.schedule(
+  'gc-saved_artists_tombstones',
+  '0 3 * * *',
+  $$SELECT gc_saved_artists_tombstones();$$
+);


### PR DESCRIPTION
## UNS-128: Scheduled GC for saved_artists tombstones

Adds `supabase/migration-018-saved-artists-tombstone-gc.sql` — a daily 3am UTC `pg_cron` job that hard-deletes `saved_artists` rows soft-deleted more than 30 days ago.

### Why
Migration 017 added tombstone columns (`deleted`, `deleted_at`) for cross-client sync. Without GC, tombstones accumulate forever. This migration handles cleanup with a generous 30-day retention window that covers offline clients, slow networks, and scheduling jitter.

### What's in the migration
- `CREATE EXTENSION IF NOT EXISTS pg_cron` — idempotent
- `gc_saved_artists_tombstones()` — plpgsql function that runs the DELETE
- `cron.unschedule` guarded by `WHERE EXISTS` — idempotent on re-run
- `cron.schedule` at `0 3 * * *` — daily 3am UTC

### Deploy prerequisite (Brandon)
**UNS-132** must be completed first: enable the `pg_cron` extension in the Supabase dashboard on staging, apply this migration, smoke test, then repeat on prod. UNS-128 stays open until the first nightly run completes successfully in prod (verified via `cron.job_run_details`).

### What's NOT in this PR
- No Mac/iOS app code changes
- No `schema.sql` updates (auto-generated by Supabase)
- No `data/shipped-features.json` changes (infrastructure, not user-facing)

Refs: UNS-128, UNS-132