### PR TITLE
fix(UNS-133): start foreground poll on iOS Settings tab sign-in

### DIFF
--- a/apps/mac/Unstream/Views/iOS/iOSSettingsTab.swift
+++ b/apps/mac/Unstream/Views/iOS/iOSSettingsTab.swift
@@ -208,7 +208,10 @@ struct iOSSettingsTab: View {
                 stopForegroundPoll()
             }
             .onChange(of: auth.isSignedIn) { signedIn in
-                if !signedIn {
+                if signedIn {
+                    Task { await sync.pull() }
+                    startForegroundPoll()
+                } else {
                     stopForegroundPoll()
                 }
             }


### PR DESCRIPTION
## What

The iOS Settings tab's `onChange(of: auth.isSignedIn)` only handled sign-out. When a user opened Settings while signed out, then signed in via the sheet, the 60-second foreground poll never started — `onAppear` had already fired with `isSignedIn == false` and `onChange` only handled the false branch.

## Fix

Added the true branch to the existing `onChange` handler: on sign-in, pull sync data and start the foreground poll. The false branch (sign-out → stop poll) is unchanged.

```swift
.onChange(of: auth.isSignedIn) { signedIn in
    if signedIn {
        Task { await sync.pull() }
        startForegroundPoll()
    } else {
        stopForegroundPoll()
    }
}
```

## Scope

- `apps/mac/Unstream/Views/iOS/iOSSettingsTab.swift` — 1 file, +4/-1
- No pbxproj changes (file already in target)
- macOS PopoverView unaffected (uses a different mount pattern)

## Verification

No Xcode available in the build environment to compile iOS target. Visual diff only — the change mirrors the existing `onAppear` pattern exactly (`Task { await sync.pull() }` then `startForegroundPoll()`).

Closes UNS-133.