### PR TITLE
fix(UNS-134): first-initial fallback when artist photo is missing on /a/{slug}

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -101,6 +101,9 @@ const CSS = `
   .site-header .nav-accent:hover { text-decoration: underline; }
   .claim-cta { display: inline-block; margin-top: 24px; padding: 10px 24px; border-radius: 12px; background: var(--accent); color: #fff; font-weight: 600; font-size: 15px; text-decoration: none; }
   .claim-cta:hover { opacity: 0.9; }
+  .avatar-wrap { width:128px;height:128px;border-radius:50%;border:2px solid var(--border);margin:0 auto 16px;display:flex;align-items:center;justify-content:center;overflow:hidden;background:var(--bg2) }
+  .avatar-wrap img { width:100%;height:100%;object-fit:cover }
+  .avatar-fallback { font-size:48px;font-weight:600;color:var(--muted) }
 `;
 
 export default async function handler(request: Request, context: Context) {
@@ -278,7 +281,10 @@ export default async function handler(request: Request, context: Context) {
 
   <div class="page-content">
     <div class="container" style="padding-top:48px;padding-bottom:32px;text-align:center">
-      ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" style="width:128px;height:128px;border-radius:50%;object-fit:cover;border:2px solid var(--border);margin-bottom:16px">` : ''}
+      <div class="avatar-wrap">
+        ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" onerror="this.style.display='none';this.parentElement.querySelector('.avatar-fallback').style.display='flex'">` : ''}
+        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${artist.name[0]?.toUpperCase() || '?'}</span>
+      </div>
       <div style="display:flex;align-items:center;justify-content:center;gap:8px">
         <h1 style="font-size:28px;font-weight:700">${artistName}</h1>
         <span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-size:12px;font-weight:500;background:rgba(255,107,53,0.15);color:var(--accent)">
@@ -378,7 +384,10 @@ export default async function handler(request: Request, context: Context) {
 
   <div class="page-content">
     <div class="container" style="padding-top:48px;padding-bottom:32px;text-align:center">
-      ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" style="width:128px;height:128px;border-radius:50%;object-fit:cover;border:2px solid var(--border);margin-bottom:16px">` : ''}
+      <div class="avatar-wrap">
+        ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" onerror="this.style.display='none';this.parentElement.querySelector('.avatar-fallback').style.display='flex'">` : ''}
+        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${artist.name[0]?.toUpperCase() || '?'}</span>
+      </div>
       <h1 style="font-size:28px;font-weight:700">${artistName}</h1>
       ${locationHtml}
     </div>

--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -283,7 +283,7 @@ export default async function handler(request: Request, context: Context) {
     <div class="container" style="padding-top:48px;padding-bottom:32px;text-align:center">
       <div class="avatar-wrap">
         ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" onerror="this.style.display='none';this.parentElement.querySelector('.avatar-fallback').style.display='flex'">` : ''}
-        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${artist.name[0]?.toUpperCase() || '?'}</span>
+        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${escapeHtml((artist.name[0] || '?').toUpperCase())}</span>
       </div>
       <div style="display:flex;align-items:center;justify-content:center;gap:8px">
         <h1 style="font-size:28px;font-weight:700">${artistName}</h1>
@@ -386,7 +386,7 @@ export default async function handler(request: Request, context: Context) {
     <div class="container" style="padding-top:48px;padding-bottom:32px;text-align:center">
       <div class="avatar-wrap">
         ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${artistName}" onerror="this.style.display='none';this.parentElement.querySelector('.avatar-fallback').style.display='flex'">` : ''}
-        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${artist.name[0]?.toUpperCase() || '?'}</span>
+        <span class="avatar-fallback" style="display:${imageUrl ? 'none' : 'flex'}">${escapeHtml((artist.name[0] || '?').toUpperCase())}</span>
       </div>
       <h1 style="font-size:28px;font-weight:700">${artistName}</h1>
       ${locationHtml}

--- a/apps/web/src/components/RichArtistProfile.tsx
+++ b/apps/web/src/components/RichArtistProfile.tsx
@@ -74,13 +74,19 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
 
       {/* Hero */}
       <div className="pt-12 pb-8 text-center">
-        {imageUrl && (
-          <img
-            src={imageUrl}
-            alt={artist.name}
-            className="w-32 h-32 rounded-full object-cover border-2 border-border mx-auto mb-4"
-          />
-        )}
+        <div className="w-32 h-32 rounded-full border-2 border-border mx-auto mb-4 flex items-center justify-center overflow-hidden bg-bg-secondary">
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt={artist.name}
+              className="w-full h-full object-cover rounded-full"
+              onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.querySelector('.fallback')?.classList.remove('hidden'); }}
+            />
+          )}
+          <span className={imageUrl ? 'hidden fallback' : ''} style={{ fontSize: '48px', fontWeight: 600, color: 'var(--text-muted)' }}>
+            {artist.name[0]?.toUpperCase() || '?'}
+          </span>
+        </div>
         <div className="flex items-center justify-center gap-2">
           <h1 className="font-display text-[28px] font-bold text-text-primary">
             {artist.name}

--- a/apps/web/src/components/UnclaimedQuietCard.tsx
+++ b/apps/web/src/components/UnclaimedQuietCard.tsx
@@ -56,13 +56,19 @@ export function UnclaimedQuietCard({ payload, slug, justClaimed, onSave, onUnsav
 
       {/* Hero */}
       <div className="pt-12 pb-8 text-center">
-        {imageUrl && (
-          <img
-            src={imageUrl}
-            alt={artist.name}
-            className="w-32 h-32 rounded-full object-cover border-2 border-border mx-auto mb-4"
-          />
-        )}
+        <div className="w-32 h-32 rounded-full border-2 border-border mx-auto mb-4 flex items-center justify-center overflow-hidden bg-bg-secondary">
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt={artist.name}
+              className="w-full h-full object-cover rounded-full"
+              onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.querySelector('.fallback')?.classList.remove('hidden'); }}
+            />
+          )}
+          <span className={imageUrl ? 'hidden fallback' : ''} style={{ fontSize: '48px', fontWeight: 600, color: 'var(--text-muted)' }}>
+            {artist.name[0]?.toUpperCase() || '?'}
+          </span>
+        </div>
         <div className="flex items-center justify-center gap-2">
           <h1 className="font-display text-[28px] font-bold text-text-primary">
             {artist.name}


### PR DESCRIPTION
Closes UNS-134.

## What changed
- **Edge function** (`api/edge/artist-page-static.ts`): replaced conditional `<img>` with an avatar wrapper div containing the image (with inline `onerror` fallback) plus a first-initial span. Applies to both claimed and unclaimed artist paths.
- **`RichArtistProfile.tsx`**: added `onError` handler + fallback initial, mirroring the pattern from `ArtistDirectoryPage`.
- **`UnclaimedQuietCard.tsx`**: same fix for consistency.

## What to verify
- Visit `/a/kingtriumph` (verified artist, no photo) — should show "K" initial in a circle, not a broken image
- Visit a verified artist page with a working image — image should render normally
- Visit an unclaimed artist page without an image — same initial fallback

## Risks
- The edge function uses an inline `onerror` attribute (progressive enhancement). Non-JS users with a broken image URL will still see a broken `<img>`. The no-image case (empty `imageUrl`) works fully without JS.
- The inline `onerror` is technically JS but not a `<script>` tag — consistent with the spec's intent (no script blocks, no analytics, no auth readers).