### PR TITLE
fix(UNS-135): shorten "Mark supported" label and render as toggle on Dashboard

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -430,7 +430,7 @@ export function DashboardPage() {
                                 <circle cx="12" cy="12" r="10" strokeWidth={2} />
                               </svg>
                             )}
-                            {artist.supported ? 'Supported ✓' : 'Mark supported'}
+                            {artist.supported ? 'Supported' : 'Support'}
                           </button>
                             <button
                             onClick={() => handleRemoveSavedArtist(artist.artistId)}


### PR DESCRIPTION
## Summary

One-line change: shortens the support toggle button label on the Dashboard saved-artists card.

- `'Mark supported'` → `'Support'` (inactive state)
- `'Supported ✓'` → `'Supported'` (active state)

The existing check-circle icon already conveys active state visually, making the `✓` redundant. The shorter label prevents the trash icon from wrapping to a second line on narrow cards.

**Interpretation:** (a) — the button was already a toggle (`handleToggleSupport` calls support/unsupport with optimistic update and rollback). Only the label was too long.

## Verify
- Load `/dashboard`, check saved artists section
- Confirm trash icon stays on same line as the support button
- Toggle support on/off, confirm API call + visual state change still works

## Risks
None. No logic, styling, or API changes — label text only.

Ref: [UNS-135](https://linear.app/cultoflightbulbs/issue/UNS-135/dashboard-layout-issue-with-saved-artists)