### PR TITLE
fix(UNS-110): add root vitest config for cwd-independent test resolution

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+// Root-level vitest config so `npx vitest` works from the repo root, not just
+// from apps/web/.  The src/ alias mirrors apps/web/vitest.config.ts so test
+// files importing "src/..." resolve correctly regardless of cwd.
+// Per UNS-110.
+export default defineConfig({
+  resolve: {
+    alias: {
+      src: resolve(__dirname, 'apps/web/src'),
+    },
+  },
+  test: {
+    testTimeout: 30000,
+    hookTimeout: 60000,
+    retry: 0,
+    include: ['apps/web/tests/**/*.test.ts', 'apps/web/tests/**/*.test.tsx'],
+    environment: 'node',
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    target: 'es2022',
+  },
+});


### PR DESCRIPTION
## Summary

Add a root-level `vitest.config.ts` so `npx vitest` resolves the `src/` alias correctly regardless of the current working directory. Previously, the alias only existed in `apps/web/vitest.config.ts`, meaning the 4 component test files that import from `src/...` would fail when vitest was run from the repo root.

**Option A** from [UNS-110](https://linear.app/unstream/issue/UNS-110) — smallest change, fixes 4 of 9 pre-existing test failures (the cwd-relative import pattern). The other 5 are live-API flakes (Option B, separate PR if pursued).

## Files changed

- `vitest.config.ts` (new) — root-level config mirroring `apps/web/vitest.config.ts` with `src` alias pointing to `apps/web/src` and include globs adjusted for repo-root perspective.

## Verify

- `npx vitest run apps/web/tests/unit/` from repo root → all 302 unit tests pass (4 previously failing files now pass)
- `cd apps/web && npx vitest run tests/unit/` → still passes (existing config unaffected)
- `npx tsc -b` in `apps/web/` → clean

## Risks

None. The new config is additive — it only affects test runs initiated from the repo root. The existing `apps/web/vitest.config.ts` is unchanged and still takes precedence when cwd is `apps/web/`.

Ref: UNS-110