### PR TITLE
fix(UNS-136): track web download events + mac search/click events in app_events

### DIFF
--- a/api/functions/analytics-app-event.ts
+++ b/api/functions/analytics-app-event.ts
@@ -21,6 +21,7 @@ const VALID_EVENT_TYPES = new Set([
   'extension_activated',
   'page_view',
   'release_alert',
+  'download',
 ]);
 
 const VALID_APPS = new Set(['web', 'extension', 'mac']);

--- a/apps/mac/Unstream/Models/AppState.swift
+++ b/apps/mac/Unstream/Models/AppState.swift
@@ -78,12 +78,14 @@ class AppState: ObservableObject {
         hasSearched = true
         isSearching = true
         searchError = nil
+        api.trackAppEvent(eventType: "search")
 
         do {
             // Phase 1: Get initial results — show them immediately
             let (results, hasPendingEnrichment) = try await api.searchArtist(query)
             searchResults = results
             isSearching = false
+            api.trackAppEvent(eventType: "search", context: ["has_results": results.count > 0, "result_count": results.count])
             trackSearchAppearances(results)
 
             // Phase 2: Enrich with MusicBrainz data in the background
@@ -146,11 +148,13 @@ class AppState: ObservableObject {
             do {
                 print("[AppState] Fetching platforms for: \(artist)")
                 // Phase 1: Get initial results — show them immediately
+                api.trackAppEvent(eventType: "search")
                 let (results, hasPendingEnrichment) = try await api.searchArtist(artist)
                 nowPlayingResults = results
                 lastFetchedArtist = artist
                 lastFetchTime = Date()
                 isLoadingNowPlaying = false
+                api.trackAppEvent(eventType: "search", context: ["has_results": results.count > 0, "result_count": results.count])
                 trackSearchAppearances(results)
                 print("[AppState] Got \(results.count) results for \(artist)")
                 if let callback = onArtistResultsReady {
@@ -184,10 +188,11 @@ class AppState: ObservableObject {
         }
     }
 
-    /// Track a platform link click for a claimed artist
+    /// Track a platform link click for a claimed artist + product analytics
     func trackLinkClick(artist: ArtistResult, platformId: String) {
         if let slug = artist.claimedSlug {
             api.trackAnalyticsEvent(slug: slug, metric: "click:\(platformId)")
         }
+        api.trackAppEvent(eventType: "platform_click", context: ["platform": platformId])
     }
 }

--- a/apps/mac/Unstream/UnstreamAPI.swift
+++ b/apps/mac/Unstream/UnstreamAPI.swift
@@ -160,6 +160,20 @@ actor UnstreamAPI {
         }
     }
 
+    /// Fire-and-forget product analytics event (app_events table).
+    /// Mirrors the web client's trackAppEvent — sends event_type + app + context.
+    nonisolated func trackAppEvent(eventType: String, context: [String: Any] = [:]) {
+        guard let url = URL(string: "\(baseURL)/analytics/app-event") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = ["event_type": eventType, "app": "mac", "context": context]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        Task.detached(priority: .utility) { [session] in
+            _ = try? await session.data(for: request)
+        }
+    }
+
     func cacheResults(query: String, results: [ArtistResult]) {
         cache[query.lowercased()] = (results, Date())
     }


### PR DESCRIPTION
## Root cause

Two issues found:

1. **Mac app never sent product analytics events.** `UnstreamAPI.trackAnalyticsEvent()` only posted to `/api/analytics/event` (artist-level, for claimed artist dashboards). It never called `/api/analytics/app-event` (product-level). All Mac searches and platform clicks were absent from `app_events` — the table the admin analytics dashboard queries.

2. **Web `download` event type was invalid.** `trackAppEvent('download', ...)` was called by all four download tracking methods, but `'download'` was not in `VALID_EVENT_TYPES` in `analytics-app-event.ts`. The function silently returned 204 without inserting. Download events from web were dropped.

## Changes

- **`api/functions/analytics-app-event.ts`**: Added `'download'` to `VALID_EVENT_TYPES`.
- **`apps/mac/Unstream/UnstreamAPI.swift`**: Added `trackAppEvent(eventType:context:)` — fire-and-forget POST to `/api/analytics/app-event` with `app: "mac"`. Mirrors the web client's `trackAppEvent` shape.
- **`apps/mac/Unstream/Models/AppState.swift`**: Wired `trackAppEvent("search")` into `performSearch()` (manual search) and `updateNowPlaying()` (now-playing auto-search), with completion events carrying `has_results` + `result_count`. Wired `trackAppEvent("platform_click")` into `trackLinkClick()`.

## Verification

- `npx tsc -b` — clean
- `npm run build` — 302 unit tests pass, Vite build succeeds
- `xcodebuild build` (macOS, Debug) — BUILD SUCCEEDED

## Files changed

3 files, +21 / -1 lines

## To verify end-to-end

1. Deploy to Netlify (main merge triggers deploy)
2. Open the Mac app, run a search
3. Check admin analytics dashboard — `mac` should show non-zero search count in "By app" table
4. Click a download button on the web app — `download` events should now appear in "Recent events`