### PR TITLE
fix: saved artists UX bugs in Mac app and extension

### DIFF
--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -858,7 +858,7 @@ async function loadSavedArtists() {
     nameSpan.textContent = artistData.name || artist;
     nameSpan.addEventListener('click', () => {
       switchToTab('discover');
-      searchArtist(artist);
+      searchArtist(artistData.name || artist);
     });
     nameLocationWrap.appendChild(nameSpan);
 
@@ -881,43 +881,6 @@ async function loadSavedArtists() {
     header.appendChild(nameWrap);
     header.appendChild(removeBtn);
     card.appendChild(header);
-
-    // Platform links
-    if (platforms.length > 0) {
-      const platformsDiv = document.createElement('div');
-      platformsDiv.className = 'saved-artist-platforms';
-
-      // Filter to non-social, non-search platforms
-      const relevantPlatforms = platforms.filter(p =>
-        !isSocialSource(p.sourceId) && !isSearchOnlySource(p.sourceId, p.url)
-      );
-
-      // Deduplicate by sourceId
-      const seen = new Set();
-      const uniquePlatforms = relevantPlatforms.filter(p => {
-        if (seen.has(p.sourceId)) return false;
-        seen.add(p.sourceId);
-        return true;
-      });
-
-      uniquePlatforms.slice(0, 5).forEach(p => {
-        const config = SOURCE_CONFIG[p.sourceId] || { icon: '🔗', name: p.sourceId };
-        const link = document.createElement('a');
-        link.href = p.url;
-        link.target = '_blank';
-        link.className = 'platform-link';
-
-        const iconSpan = document.createElement('span');
-        iconSpan.className = 'platform-icon';
-        iconSpan.textContent = config.icon;
-
-        link.appendChild(iconSpan);
-        link.appendChild(document.createTextNode(config.name));
-        platformsDiv.appendChild(link);
-      });
-
-      card.appendChild(platformsDiv);
-    }
 
     // Social links
     if (socialLinks.length > 0) {

--- a/apps/mac/Unstream/Services/AuthService.swift
+++ b/apps/mac/Unstream/Services/AuthService.swift
@@ -21,6 +21,7 @@ class AuthService: ObservableObject {
 
     #if os(macOS)
     private var authPresentationAnchor: AuthPresentationAnchor?
+    private var pendingWebSession: ASWebAuthenticationSession?
     #endif
 
     private init() {
@@ -160,11 +161,26 @@ class AuthService: ObservableObject {
 
             #if os(macOS)
             webSession.presentationContextProvider = authPresentationAnchor
+            pendingWebSession = webSession
             #endif
 
             webSession.start()
         }
     }
+
+    #if os(macOS)
+    /// Cancels any in-flight ASWebAuthenticationSession and resets loading state.
+    /// Called when the popover closes so the sign-in sheet doesn't reopen locked.
+    func cancelPendingAuth() {
+        let session = pendingWebSession
+        pendingWebSession = nil
+        session?.cancel()
+        if isLoading {
+            isLoading = false
+            errorMessage = nil
+        }
+    }
+    #endif
 
     // MARK: - Deeplink handling
 

--- a/apps/mac/Unstream/Services/SavedArtistsSync.swift
+++ b/apps/mac/Unstream/Services/SavedArtistsSync.swift
@@ -239,7 +239,7 @@ struct SyncedArtist: Codable, Identifiable, Hashable {
     }
 
     var profileURL: URL? {
-        guard !slug.isEmpty else { return nil }
+        guard claimed == true, !slug.isEmpty else { return nil }
         return URL(string: "https://unstream.stream/a/\(slug)")
     }
 }

--- a/apps/mac/Unstream/UnstreamApp.swift
+++ b/apps/mac/Unstream/UnstreamApp.swift
@@ -299,6 +299,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         popover.contentSize = NSSize(width: 320, height: 480)
         popover.behavior = .transient
         popover.animates = true
+        popover.delegate = self
 
         // Create the SwiftUI content view with all the environment objects
         let container = AppStateContainer.shared
@@ -416,6 +417,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     // Prevent app reopen from creating duplicates
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         return false
+    }
+}
+
+// MARK: - Popover close notification
+
+extension Notification.Name {
+    static let popoverDidClose = Notification.Name("unstreamPopoverDidClose")
+}
+
+extension AppDelegate: NSPopoverDelegate {
+    func popoverDidClose(_ notification: Notification) {
+        AuthService.shared.cancelPendingAuth()
+        NotificationCenter.default.post(name: .popoverDidClose, object: nil)
     }
 }
 

--- a/apps/mac/Unstream/Views/Shared/SyncedArtistsView.swift
+++ b/apps/mac/Unstream/Views/Shared/SyncedArtistsView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct SyncedArtistsView: View {
     @ObservedObject var sync = SavedArtistsSync.shared
     @ObservedObject var auth = AuthService.shared
+    /// Called with the artist display name when an unclaimed artist row is tapped.
+    var onSearchArtist: ((String) -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -100,11 +102,11 @@ struct SyncedArtistsView: View {
             }
 
             ForEach(sync.syncedArtists) { artist in
-                SyncedArtistRow(artist: artist) {
-                    Task {
-                        await sync.removeArtist(slug: artist.displaySlug)
-                    }
-                }
+                SyncedArtistRow(
+                    artist: artist,
+                    onOpen: artist.claimed == true ? nil : { onSearchArtist?(artist.name) },
+                    onRemove: { Task { await sync.removeArtist(slug: artist.displaySlug) } }
+                )
             }
         }
     }
@@ -112,6 +114,7 @@ struct SyncedArtistsView: View {
 
 struct SyncedArtistRow: View {
     let artist: SyncedArtist
+    var onOpen: (() -> Void)? = nil
     let onRemove: () -> Void
 
     #if os(iOS)
@@ -156,16 +159,22 @@ struct SyncedArtistRow: View {
 
             Spacer()
 
-            // Open artist page
-            if let profileURL = artist.profileURL {
-                Button(action: { openURL(profileURL) }) {
+            // Open artist page (claimed) or search (unclaimed)
+            if artist.profileURL != nil || onOpen != nil {
+                Button(action: {
+                    if let onOpen {
+                        onOpen()
+                    } else if let profileURL = artist.profileURL {
+                        openURL(profileURL)
+                    }
+                }) {
                     Image(systemName: "arrow.up.right.square")
                         .font(.system(size: 12))
                         .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
                 #if os(macOS)
-                .help("Open artist page")
+                .help(artist.claimed == true ? "Open artist page" : "Search for artist")
                 #endif
             }
 

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -70,7 +70,12 @@ struct PopoverView: View {
                     if selectedTab == .supportList {
                         // Synced artists from server (if signed in)
                         if auth.isSignedIn {
-                            SyncedArtistsView()
+                            SyncedArtistsView(onSearchArtist: { name in
+                                appState.searchQuery = name
+                                appState.clearResults()
+                                Task { await appState.performSearch() }
+                                selectedTab = .search
+                            })
                                 .onAppear {
                                     startMenuPoll()
                                 }
@@ -228,8 +233,18 @@ struct PopoverView: View {
         .sheet(isPresented: $showSignIn) {
             SignInView()
         }
+        .onAppear {
+            // Reset sheet state on every open — NSPopover hides (not destroys) its content
+            // view, so onDisappear isn't reliable; onAppear fires on each show.
+            showSignIn = false
+        }
         .onDisappear {
             stopMenuPoll()
+            showSignIn = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .popoverDidClose)) { _ in
+            // NSPopoverDelegate fires this unconditionally when the popover closes.
+            showSignIn = false
         }
         .onChange(of: auth.isSignedIn) { signedIn in
             if !signedIn {


### PR DESCRIPTION
## Summary

- **Mac app — sign-in sheet locked state**: When a user opened the sign-in sheet and then clicked away to get their password, the popover closed but `showSignIn` stayed `true`. On reopen, SwiftUI tried to re-present the sheet and left the popover unresponsive. Fix uses `NSPopoverDelegate.popoverDidClose` to post a notification; `PopoverView` resets `showSignIn` via `onReceive` + `onAppear`. Also adds `AuthService.cancelPendingAuth()` to cancel any in-flight `ASWebAuthenticationSession` (which would have left `isLoading=true` and all buttons disabled).
- **Mac app — unclaimed artist open button opened a broken URL**: `profileURL` was building `unstream.stream/a/<slug>` for all artists, but platform slugs like `qobuz-robert-logan` aren't valid artist pages. Fix gates `profileURL` on `claimed == true`; unclaimed artists get an `onOpen` callback that triggers an in-app search by name and switches to the Search tab — matching web app behaviour.
- **Extension — unclaimed artist name click searched by slug**: `searchArtist(artist)` was called with the storage key (e.g. `qobuz-robert-logan`) instead of `artistData.name || artist`.
- **Extension — removed redundant "unstream" platform chip**: The chip under each saved artist card was unnecessary since clicking the artist name already loads results in-app.

## Test plan

- [ ] Mac app: open Saved Artists tab → click Sign In → click away to a password manager → reopen popover → popover is interactive, no locked state
- [ ] Mac app: sign in as info@kidlightbulbs.com → Saved Artists tab loads Robert Logan and others
- [ ] Mac app: click the open button on Robert Logan (unclaimed) → switches to Search tab and searches "Robert Logan"
- [ ] Mac app: click the open button on a Verified artist → opens `unstream.stream/a/<slug>` in browser
- [ ] Extension: saved artists list shows no "unstream" chip under each artist
- [ ] Extension: click an unclaimed artist name → searches by display name, not slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)