### PR TITLE
feat(UNS-144): user profile improvements

### DIFF
--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -58,10 +58,10 @@ export default async function handler(request: Request, context: Context) {
     let savedArtists: any[];
 
     try {
-      // Look up the username row to check sharing flag + get user_id
+      // Look up the username row to check sharing flag + get user_id + location
       const { data: unameData } = await supabase
         .from('usernames')
-        .select('user_id, username, saved_artists_public')
+        .select('user_id, username, saved_artists_public, location')
         .eq('username', handle)
         .maybeSingle()
         .abortSignal(controller.signal);
@@ -102,6 +102,7 @@ export default async function handler(request: Request, context: Context) {
     clearTimeout(timeoutId);
 
     const ownerName = escapeHtml(usernameRow.username);
+    const ownerLocation = usernameRow.location ? escapeHtml(usernameRow.location) : null;
     const pageUrl = `https://unstream.stream/u/${handle}`;
 
     // Build artist cards HTML
@@ -161,7 +162,7 @@ export default async function handler(request: Request, context: Context) {
   <div class="page-content">
     <div class="container" style="padding-top:48px;padding-bottom:16px;text-align:center">
       <h1 style="font-size:24px;font-weight:700">${ownerName}'s saved artists</h1>
-      <p style="color:var(--muted);font-size:14px;margin-top:8px">A listener's saved artists on Unstream</p>
+      ${ownerLocation ? `<p style="color:var(--text);font-size:14px;margin-top:4px">${ownerLocation}</p>` : ''}
       <div data-share-mount style="margin-top:24px">
         <button class="copy-btn" id="copy-url-btn" data-url="${pageUrl}">
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>

--- a/api/functions/__tests__/me-location.test.ts
+++ b/api/functions/__tests__/me-location.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockFrom: vi.fn(),
+    mockCreateClient: vi.fn(() => ({
+      auth: {
+        getUser: vi.fn(),
+        signInWithPassword: vi.fn(),
+      },
+    })),
+    mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+    mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  };
+});
+
+vi.mock('../db', () => ({
+  getClient: () => ({
+    from: mocks.mockFrom,
+  }),
+}));
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mocks.mockCreateClient,
+}));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+
+import { handler } from '../me-location';
+
+describe('me-location handler', () => {
+  const validEvent = {
+    httpMethod: 'GET',
+    headers: { authorization: 'Bearer valid-token' },
+    body: null,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'test@example.com' } },
+          error: null,
+        }),
+        signInWithPassword: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ ...validEvent, headers: {} });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('GET returns location when set', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: { location: 'Brooklyn, NY' }, error: null })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe('Brooklyn, NY');
+  });
+
+  it('GET returns null location when not set', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: { location: null }, error: null })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe(null);
+  });
+
+  it('GET returns null location when no username row', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe(null);
+  });
+
+  it('POST updates location', async () => {
+    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({
+      update: vi.fn(() => ({ eq: updateFn })),
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: 'Paris, France' }),
+    });
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe('Paris, France');
+    expect(updateFn).toHaveBeenCalled();
+  });
+
+  it('POST trims whitespace', async () => {
+    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({
+      update: vi.fn(() => ({ eq: updateFn })),
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: '  Brooklyn, NY  ' }),
+    });
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe('Brooklyn, NY');
+  });
+
+  it('POST clears location when empty string', async () => {
+    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({
+      update: vi.fn(() => ({ eq: updateFn })),
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: '   ' }),
+    });
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe(null);
+  });
+
+  it('POST clears location when null', async () => {
+    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({
+      update: vi.fn(() => ({ eq: updateFn })),
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: null }),
+    });
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe(null);
+  });
+
+  it('POST rejects location over 100 chars', async () => {
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: 'x'.repeat(101) }),
+    });
+    expect(res!.statusCode).toBe(400);
+    expect(JSON.parse(res!.body).error).toContain('100 characters');
+  });
+
+  it('handles OPTIONS preflight', async () => {
+    const res = await handler({ ...validEvent, httpMethod: 'OPTIONS' });
+    expect(res!.statusCode).toBe(204);
+  });
+
+  it('returns 404 for non-GET/POST methods', async () => {
+    const res = await handler({ ...validEvent, httpMethod: 'DELETE' });
+    expect(res!.statusCode).toBe(404);
+  });
+});

--- a/api/functions/__tests__/me-location.test.ts
+++ b/api/functions/__tests__/me-location.test.ts
@@ -105,10 +105,10 @@ describe('me-location handler', () => {
     expect(JSON.parse(res!.body).location).toBe(null);
   });
 
-  it('POST updates location', async () => {
-    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+  it('POST upserts location for existing row', async () => {
+    const upsertFn = vi.fn(() => Promise.resolve({ error: null }));
     mocks.mockFrom.mockReturnValue({
-      update: vi.fn(() => ({ eq: updateFn })),
+      upsert: upsertFn,
     });
 
     const res = await handler({
@@ -118,13 +118,17 @@ describe('me-location handler', () => {
     });
     expect(res!.statusCode).toBe(200);
     expect(JSON.parse(res!.body).location).toBe('Paris, France');
-    expect(updateFn).toHaveBeenCalled();
+    expect(upsertFn).toHaveBeenCalled();
+    expect(upsertFn).toHaveBeenCalledWith(
+      { user_id: 'user-1', location: 'Paris, France' },
+      { onConflict: 'user_id' }
+    );
   });
 
   it('POST trims whitespace', async () => {
-    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    const upsertFn = vi.fn(() => Promise.resolve({ error: null }));
     mocks.mockFrom.mockReturnValue({
-      update: vi.fn(() => ({ eq: updateFn })),
+      upsert: upsertFn,
     });
 
     const res = await handler({
@@ -137,9 +141,9 @@ describe('me-location handler', () => {
   });
 
   it('POST clears location when empty string', async () => {
-    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+    const upsertFn = vi.fn(() => Promise.resolve({ error: null }));
     mocks.mockFrom.mockReturnValue({
-      update: vi.fn(() => ({ eq: updateFn })),
+      upsert: upsertFn,
     });
 
     const res = await handler({
@@ -151,10 +155,10 @@ describe('me-location handler', () => {
     expect(JSON.parse(res!.body).location).toBe(null);
   });
 
-  it('POST clears location when null', async () => {
-    const updateFn = vi.fn(() => Promise.resolve({ error: null }));
+  it('POST clears location when null (existing row)', async () => {
+    const upsertFn = vi.fn(() => Promise.resolve({ error: null }));
     mocks.mockFrom.mockReturnValue({
-      update: vi.fn(() => ({ eq: updateFn })),
+      upsert: upsertFn,
     });
 
     const res = await handler({
@@ -164,6 +168,10 @@ describe('me-location handler', () => {
     });
     expect(res!.statusCode).toBe(200);
     expect(JSON.parse(res!.body).location).toBe(null);
+    expect(upsertFn).toHaveBeenCalledWith(
+      { user_id: 'user-1', location: null },
+      { onConflict: 'user_id' }
+    );
   });
 
   it('POST rejects location over 100 chars', async () => {
@@ -184,5 +192,45 @@ describe('me-location handler', () => {
   it('returns 404 for non-GET/POST methods', async () => {
     const res = await handler({ ...validEvent, httpMethod: 'DELETE' });
     expect(res!.statusCode).toBe(404);
+  });
+
+  // Regression tests: users without a usernames row (UNS-144 round 2)
+  // The `usernames` table has `username` as NOT NULL, so upserting without it
+  // fails with Postgres error 23502. The handler must detect this and respond
+  // gracefully instead of returning a false success.
+
+  it('POST returns 400 when setting location without a username row (23502)', async () => {
+    const upsertFn = vi.fn(() => Promise.resolve({
+      error: { code: '23502', message: 'null value in column "username" violates not-null constraint' },
+    }));
+    mocks.mockFrom.mockReturnValue({
+      upsert: upsertFn,
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: 'Boston' }),
+    });
+    expect(res!.statusCode).toBe(400);
+    expect(JSON.parse(res!.body).error).toContain('username');
+  });
+
+  it('POST returns 200 when clearing location without a username row (23502)', async () => {
+    const upsertFn = vi.fn(() => Promise.resolve({
+      error: { code: '23502', message: 'null value in column "username" violates not-null constraint' },
+    }));
+    mocks.mockFrom.mockReturnValue({
+      upsert: upsertFn,
+    });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ location: null }),
+    });
+    // Location is already effectively null — desired state achieved.
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).location).toBe(null);
   });
 });

--- a/api/functions/__tests__/me-settings.test.ts
+++ b/api/functions/__tests__/me-settings.test.ts
@@ -72,7 +72,7 @@ describe('me-settings handler', () => {
     expect(res!.statusCode).toBe(401);
   });
 
-  it('returns settings with username, email, and hasPassword', async () => {
+  it('returns settings with username, location, email, and hasPassword', async () => {
     mocks.mockAuthAdmin.getUserById.mockResolvedValue({
       data: { user: { email: 'test@example.com', user_metadata: { has_password: true } } },
       error: null,
@@ -80,7 +80,7 @@ describe('me-settings handler', () => {
     mocks.mockFrom.mockReturnValue({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
-          maybeSingle: vi.fn(() => Promise.resolve({ data: { username: 'kidlightbulbs' }, error: null })),
+          maybeSingle: vi.fn(() => Promise.resolve({ data: { username: 'kidlightbulbs', location: 'Brooklyn, NY' }, error: null })),
         })),
       })),
     });
@@ -89,11 +89,12 @@ describe('me-settings handler', () => {
     expect(res!.statusCode).toBe(200);
     const body = JSON.parse(res!.body);
     expect(body.username).toBe('kidlightbulbs');
+    expect(body.location).toBe('Brooklyn, NY');
     expect(body.email).toBe('test@example.com');
     expect(body.hasPassword).toBe(true);
   });
 
-  it('returns null username when user has no username row', async () => {
+  it('returns null username and location when user has no username row', async () => {
     mocks.mockAuthAdmin.getUserById.mockResolvedValue({
       data: { user: { email: 'test@example.com', user_metadata: {} } },
       error: null,
@@ -110,6 +111,7 @@ describe('me-settings handler', () => {
     expect(res!.statusCode).toBe(200);
     const body = JSON.parse(res!.body);
     expect(body.username).toBe(null);
+    expect(body.location).toBe(null);
     expect(body.hasPassword).toBe(false);
   });
 

--- a/api/functions/__tests__/public-saved-artists.test.ts
+++ b/api/functions/__tests__/public-saved-artists.test.ts
@@ -63,7 +63,7 @@ describe('public-saved-artists handler', () => {
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
           maybeSingle: vi.fn(() => Promise.resolve({
-            data: { user_id: 'user-1', username: 'testuser', saved_artists_public: false },
+            data: { user_id: 'user-1', username: 'testuser', saved_artists_public: false, location: null },
             error: null,
           })),
         })),
@@ -78,7 +78,7 @@ describe('public-saved-artists handler', () => {
     // First call: usernames lookup
     // Second call: saved_artists lookup
     const maybeSingle = vi.fn(() => Promise.resolve({
-      data: { user_id: 'user-1', username: 'testuser', saved_artists_public: true },
+      data: { user_id: 'user-1', username: 'testuser', saved_artists_public: true, location: 'Brooklyn, NY' },
       error: null,
     }));
     const savedSelect = vi.fn(() => ({
@@ -119,6 +119,7 @@ describe('public-saved-artists handler', () => {
     expect(res!.statusCode).toBe(200);
     const body = JSON.parse(res!.body);
     expect(body.owner_display_name).toBe('testuser');
+    expect(body.owner_location).toBe('Brooklyn, NY');
     expect(body.saved_artists).toHaveLength(2);
     expect(body.saved_artists[0].slug).toBe('band-1');
     expect(body.saved_artists[0].supported).toBe(true);
@@ -135,7 +136,7 @@ describe('public-saved-artists handler', () => {
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
           maybeSingle: vi.fn(() => Promise.resolve({
-            data: { user_id: 'user-1', username: 'testuser', saved_artists_public: true },
+            data: { user_id: 'user-1', username: 'testuser', saved_artists_public: true, location: null },
             error: null,
           })),
         })),

--- a/api/functions/me-location.ts
+++ b/api/functions/me-location.ts
@@ -90,13 +90,20 @@ export async function handler(event: {
     // Allow null to clear the field
     if (raw === null) {
       try {
-        const { error: updateError } = await client
+        const { error: upsertError } = await client
           .from('usernames')
-          .update({ location: null })
-          .eq('user_id', user.userId);
+          .upsert(
+          { user_id: user.userId, location: null },
+          { onConflict: 'user_id' }
+        );
 
-        if (updateError) {
-          console.error('[me-location] Error clearing location:', updateError.message);
+        if (upsertError) {
+          // No usernames row exists — username column is NOT NULL, so insert fails.
+          // Location is already effectively null, so this is the desired state.
+          if (upsertError.code === '23502') {
+            return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ location: null }) };
+          }
+          console.error('[me-location] Error clearing location:', upsertError.message);
           return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update location' }) };
         }
 
@@ -114,13 +121,20 @@ export async function handler(event: {
     }
 
     try {
-      const { error: updateError } = await client
+      const { error: upsertError } = await client
         .from('usernames')
-        .update({ location: trimmed || null })
-        .eq('user_id', user.userId);
+        .upsert(
+          { user_id: user.userId, location: trimmed || null },
+          { onConflict: 'user_id' }
+        );
 
-      if (updateError) {
-        console.error('[me-location] Error updating location:', updateError.message);
+      if (upsertError) {
+        // No usernames row — username column is NOT NULL, so insert fails.
+        // User must set a username before they can set a location.
+        if (upsertError.code === '23502') {
+          return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Set a username before setting your location.' }) };
+        }
+        console.error('[me-location] Error updating location:', upsertError.message);
         return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update location' }) };
       }
 

--- a/api/functions/me-location.ts
+++ b/api/functions/me-location.ts
@@ -1,0 +1,139 @@
+// API endpoint: /api/me/location
+// GET  — returns the current user's location string (or null).
+// POST — validates and sets the user's location.
+// Body: { location: string | null }
+// Returns the new location on success, or a friendly error on failure.
+
+import { createClient } from '@supabase/supabase-js';
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+const MAX_LENGTH = 100;
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { userId: data.user.id, email: data.user.email || '' };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    try {
+      const { data: row, error } = await client
+        .from('usernames')
+        .select('location')
+        .eq('user_id', user.userId)
+        .maybeSingle();
+
+      if (error) {
+        console.error('[me-location] Error fetching location:', error.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load location' }) };
+      }
+
+      return {
+        statusCode: 200,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ location: row?.location ?? null }),
+      };
+    } catch (error) {
+      console.error('[me-location] GET error:', error);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+    }
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    const raw = body.location;
+    // Allow null to clear the field
+    if (raw === null) {
+      try {
+        const { error: updateError } = await client
+          .from('usernames')
+          .update({ location: null })
+          .eq('user_id', user.userId);
+
+        if (updateError) {
+          console.error('[me-location] Error clearing location:', updateError.message);
+          return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update location' }) };
+        }
+
+        return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ location: null }) };
+      } catch (error) {
+        console.error('[me-location] POST (null) error:', error);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+      }
+    }
+
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+
+    if (trimmed.length > MAX_LENGTH) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: `Location must be ${MAX_LENGTH} characters or fewer.` }) };
+    }
+
+    try {
+      const { error: updateError } = await client
+        .from('usernames')
+        .update({ location: trimmed || null })
+        .eq('user_id', user.userId);
+
+      if (updateError) {
+        console.error('[me-location] Error updating location:', updateError.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update location' }) };
+      }
+
+      return {
+        statusCode: 200,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ location: trimmed || null }),
+      };
+    } catch (error) {
+      console.error('[me-location] POST error:', error);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+    }
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/functions/me-settings.ts
+++ b/api/functions/me-settings.ts
@@ -59,10 +59,10 @@ export async function handler(event: {
   }
 
   try {
-    // Read username from public.usernames (PostgREST-accessible table)
+    // Read username + location from public.usernames (PostgREST-accessible table)
     const { data: usernameRow, error: usernameError } = await client
       .from('usernames')
-      .select('username')
+      .select('username, location')
       .eq('user_id', user.userId)
       .maybeSingle();
 
@@ -86,6 +86,7 @@ export async function handler(event: {
       headers: CORS_HEADERS,
       body: JSON.stringify({
         username: usernameRow?.username || null,
+        location: usernameRow?.location ?? null,
         email: authData.user.email || user.email,
         hasPassword,
       }),

--- a/api/functions/public-saved-artists.ts
+++ b/api/functions/public-saved-artists.ts
@@ -45,10 +45,10 @@ export async function handler(event: {
   }
 
   try {
-    // Look up the username row to get user_id + check sharing flag
+    // Look up the username row to get user_id + check sharing flag + location
     const { data: usernameRow, error: usernameError } = await client
       .from('usernames')
-      .select('user_id, username, saved_artists_public')
+      .select('user_id, username, saved_artists_public, location')
       .eq('username', handle)
       .maybeSingle();
 
@@ -69,6 +69,7 @@ export async function handler(event: {
 
     const userId = usernameRow.user_id;
     const ownerDisplayName = usernameRow.username;
+    const ownerLocation = usernameRow.location ?? null;
 
     // Fetch saved artists for this user (non-deleted only)
     const { data: saved, error: savedError } = await client
@@ -104,6 +105,7 @@ export async function handler(event: {
       headers: CORS_HEADERS,
       body: JSON.stringify({
         owner_display_name: ownerDisplayName,
+        owner_location: ownerLocation,
         saved_artists: savedArtists,
       }),
     };

--- a/apps/web/src/components/LocationField.tsx
+++ b/apps/web/src/components/LocationField.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+
+const MAX_LENGTH = 100;
+
+interface LocationFieldProps {
+  currentLocation: string | null;
+  accessToken: string;
+  onSaved: (location: string | null) => void;
+}
+
+export function LocationField({ currentLocation, accessToken, onSaved }: LocationFieldProps) {
+  const [location, setLocation] = useState(currentLocation || '');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const trimmed = location.trim();
+
+    if (trimmed.length > MAX_LENGTH) {
+      setError(`Location must be ${MAX_LENGTH} characters or fewer.`);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch('/api/me/location', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ location: trimmed || null }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || 'Failed to update location.');
+      } else {
+        setSuccess('Location saved.');
+        onSaved(data.location);
+      }
+    } catch {
+      setError('Network error. Please try again.');
+    }
+    setLoading(false);
+  }
+
+  const isUnchanged = location.trim() === (currentLocation || '').trim();
+
+  return (
+    <form onSubmit={handleSave} className="space-y-3">
+      <div>
+        <label htmlFor="location" className="block text-sm font-medium mb-1">
+          Location
+        </label>
+        <input
+          id="location"
+          type="text"
+          value={location}
+          onChange={e => { setLocation(e.target.value); setError(null); setSuccess(null); }}
+          placeholder="e.g. Brooklyn, NY"
+          maxLength={MAX_LENGTH}
+          autoComplete="off"
+          spellCheck={false}
+          className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+        />
+        <p className="text-xs text-text-muted mt-1">
+          Shown on your public profile if you enable sharing. Optional.
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-400">{error}</p>
+      )}
+
+      {success && !error && (
+        <p className="text-sm text-green-400">{success}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={loading || isUnchanged}
+        className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors disabled:opacity-50"
+      >
+        {loading ? 'Saving...' : 'Save location'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,7 +7,6 @@ import { Header } from '../components/Header';
 import { ArtistAnalytics } from '../components/ArtistAnalytics';
 import { Footer } from '../components/Footer';
 import { SearchBar } from '../components/SearchBar';
-import { SharingControls } from '../components/SharingControls';
 
 interface ClaimedProfile {
   id: string;
@@ -474,9 +473,6 @@ export function DashboardPage() {
               </>
             )}
           </section>
-
-          {/* Sharing Controls — below saved artists per spec */}
-          <SharingControls />
         </div>
       </main>
 

--- a/apps/web/src/pages/PublicSavedArtistsPage.tsx
+++ b/apps/web/src/pages/PublicSavedArtistsPage.tsx
@@ -12,6 +12,7 @@ interface SavedArtistPublic {
 
 interface PublicSharingData {
   owner_display_name: string;
+  owner_location: string | null;
   saved_artists: SavedArtistPublic[];
 }
 
@@ -97,7 +98,9 @@ export function PublicSavedArtistsPage() {
         <div className="max-w-2xl mx-auto">
           <div className="text-center mb-8">
             <h1 className="text-2xl font-bold">{data.owner_display_name}'s saved artists</h1>
-            <p className="text-text-muted text-sm mt-2">A listener's saved artists on Unstream</p>
+            {data.owner_location && (
+              <p className="text-text-primary text-sm mt-2">{data.owner_location}</p>
+            )}
             <button
               onClick={handleCopy}
               className={`mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -5,10 +5,13 @@ import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { UsernameField } from '../components/UsernameField';
+import { LocationField } from '../components/LocationField';
 import { PasswordChangeForm } from '../components/PasswordChangeForm';
+import { SharingControls } from '../components/SharingControls';
 
 interface Settings {
   username: string | null;
+  location: string | null;
   email: string;
   hasPassword: boolean;
 }
@@ -81,6 +84,17 @@ export function SettingsPage() {
               accessToken={session!.access_token}
               onSaved={(username) => setSettings(prev => prev ? { ...prev, username } : prev)}
             />
+            <LocationField
+              currentLocation={settings?.location ?? null}
+              accessToken={session!.access_token}
+              onSaved={(location) => setSettings(prev => prev ? { ...prev, location } : prev)}
+            />
+          </section>
+
+          {/* Sharing section */}
+          <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
+            <h2 className="text-lg font-semibold">Sharing</h2>
+            <SharingControls />
           </section>
 
           {/* Password section */}

--- a/netlify.toml
+++ b/netlify.toml
@@ -94,6 +94,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/me/location"
+  to = "/.netlify/functions/me-location"
+  status = 200
+
+[[redirects]]
   from = "/api/me/password"
   to = "/.netlify/functions/me-password"
   status = 200

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preview": "cd apps/web && npx vite preview",
     "sentry:sourcemaps": "bash scripts/sentry-sourcemaps.sh",
     "migrate:dry-run": "supabase db push --dry-run --project-ref bwogclqzpsbvqbyhhqbz",
-    "migrate:list": "supabase migration list --project-ref bwogclqzpsbvqbyhhqbz"}
+    "migrate:list": "supabase migration list --project-ref bwogclqzpsbvqbyhhqbz"
   },
   "dependencies": {
     "@sentry/node": "^10.56.0",

--- a/supabase/migrations/20260628200000_user-location.sql
+++ b/supabase/migrations/20260628200000_user-location.sql
@@ -1,0 +1,8 @@
+-- Migration 024: Add location column to public.usernames (UNS-144)
+-- Stores a free-text location string for display on public profiles.
+-- Nullable: users who never set a location have NULL (no empty placeholder on profile).
+
+ALTER TABLE public.usernames
+  ADD COLUMN IF NOT EXISTS location TEXT;
+
+COMMENT ON COLUMN public.usernames.location IS 'Free-text location string for public profile display (UNS-144).';


### PR DESCRIPTION
Fixes UNS-144

## Changes

### A. Settings page (`/settings`)
- **Location field**: new free-text input after the username field, capped at 100 chars, trims whitespace. Optional — clears to `null` when empty.
- **Sharing toggle moved**: the public/private toggle (`SharingControls`) has been moved from the Dashboard to a new "Sharing" section on the Settings page. Data path unchanged (`profiles.saved_artists_public` on `public.usernames`).

### B. Public profile (`/u/<handle>`)
- **Subheading removed**: the "a listener's saved artists on Unstream" subheading has been removed from both the edge function (SSR) and the React SPA.
- **Location rendered**: if the user has set a location, it displays below their name on the public profile. Empty/null locations show nothing (no placeholder).

### Migration
- `20260628200000_user-location.sql`: adds `location TEXT` column to `public.usernames` (nullable, no default).

### API
- New endpoint `/api/me/location` (GET + POST) for reading/writing the location field.
- `/api/me/settings` GET now includes `location` in the response.
- `/api/public/saved-artists/:handle` now includes `owner_location` in the response.

### Other
- Fixed pre-existing JSON syntax error in `package.json` (missing closing brace — was already broken on `main`).

## Verification
- `npx tsc -b` passes
- `npm run build` passes (full build + sitemap)
- `npx vitest run` — all 23 tests pass across me-settings, me-location, and public-saved-artists suites

## To verify after merge
- Supabase auto-migrate picks up the new column
- Settings page shows location field + sharing toggle
- Public profile shows location (when set) and no subheading
- Dashboard no longer shows sharing controls