### PR TITLE
fix(UNS-149): migration 002 self-contained

### DIFF
--- a/supabase/migration-002-artist-profiles.sql
+++ b/supabase/migration-002-artist-profiles.sql
@@ -1,6 +1,22 @@
 -- Migration 002: Artist Profiles & Claim Flow
 -- Run this in your Supabase SQL editor after enabling Supabase Auth.
 
+-- Foundation: ensure the artists table exists (originally created via dashboard before migrations)
+CREATE TABLE IF NOT EXISTS public.artists (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  image_url text,
+  match_confidence text check (match_confidence in ('verified', 'unverified')),
+  source text not null default 'auto',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_enriched_at timestamptz
+);
+
+create index if not exists idx_artists_slug on public.artists(slug);
+create index if not exists idx_artists_updated on public.artists(updated_at);
+
 -- Update match_confidence to support 'claimed'
 alter table artists drop constraint if exists artists_match_confidence_check;
 alter table artists add constraint artists_match_confidence_check

--- a/supabase/migrations/20260401000000_artist-profiles.sql
+++ b/supabase/migrations/20260401000000_artist-profiles.sql
@@ -1,6 +1,22 @@
 -- Migration 002: Artist Profiles & Claim Flow
 -- Run this in your Supabase SQL editor after enabling Supabase Auth.
 
+-- Foundation: ensure the artists table exists (originally created via dashboard before migrations)
+CREATE TABLE IF NOT EXISTS public.artists (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  image_url text,
+  match_confidence text check (match_confidence in ('verified', 'unverified')),
+  source text not null default 'auto',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_enriched_at timestamptz
+);
+
+create index if not exists idx_artists_slug on public.artists(slug);
+create index if not exists idx_artists_updated on public.artists(updated_at);
+
 -- Update match_confidence to support 'claimed'
 alter table artists drop constraint if exists artists_match_confidence_check;
 alter table artists add constraint artists_match_confidence_check


### PR DESCRIPTION
## fix(UNS-149): migration 002 self-contained

Fixes UNS-149

### Problem

Every Supabase branch preview check on every PR was failing with:

```
ERROR: relation "artists" does not exist (SQLSTATE 42P01)
```

Migration 002 (`20260401000000_artist-profiles.sql`) opens with `ALTER TABLE artists` but the `artists` table was never created by any migration file — it only exists in `supabase/schema.sql` (a one-time dashboard snapshot from before migrations existed). On fresh branch preview DBs, `artists` doesn't exist, so the ALTER fails immediately.

### Fix

Added `CREATE TABLE IF NOT EXISTS public.artists (...)` at the top of migration 002 (both the timestamped and legacy copies), sourced verbatim from `supabase/schema.sql:12-24`. Also added the two indexes (`idx_artists_slug`, `idx_artists_updated`) with `IF NOT EXISTS` guards.

### Column list in the CREATE

```sql
id uuid primary key default gen_random_uuid(),
slug text unique not null,
name text not null,
image_url text,
match_confidence text check (match_confidence in ('verified', 'unverified')),
source text not null default 'auto',
created_at timestamptz not null default now(),
updated_at timestamptz not null default now(),
last_enriched_at timestamptz
```

This matches `schema.sql` exactly. The original CHECK constraint (`'verified' | 'unverified'`) is included because migration 002 immediately drops it and replaces it with the expanded version (`'verified' | 'unverified' | 'claimed'`).

### Idempotency

- **Fresh DB (branch preview):** CREATE runs → table exists → ALTER succeeds → rest of migration applies.
- **Existing DB (prod, post-ledger-repair):** `CREATE IF NOT EXISTS` is a no-op → ALTER succeeds → no behavior change.

### Files changed

- `supabase/migrations/20260401000000_artist-profiles.sql` — added CREATE TABLE + indexes at top
- `supabase/migration-002-artist-profiles.sql` — identical change (legacy copy kept in sync)