### PR TITLE
fix(UNS-149): baseline migration for pre-migration schema.sql state

### DIFF
--- a/supabase/migrations/20260331000000_baseline.sql
+++ b/supabase/migrations/20260331000000_baseline.sql
@@ -1,0 +1,131 @@
+-- Baseline migration: captures pre-migration schema.sql state
+-- so that fresh DBs (branch previews) built from migrations only
+-- match the prod DB that was originally set up via schema.sql.
+--
+-- Every statement is idempotent (IF NOT EXISTS / CREATE OR REPLACE /
+-- DROP ... IF EXISTS) so this is a no-op on prod where schema.sql
+-- was applied long ago.
+--
+-- Source: supabase/schema.sql (canonical baseline)
+
+-- ── Tables ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.artists (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  image_url text,
+  match_confidence text check (match_confidence in ('verified', 'unverified')),
+  source text not null default 'auto',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_enriched_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS public.artist_links (
+  id uuid primary key default gen_random_uuid(),
+  artist_id uuid not null references artists(id) on delete cascade,
+  platform text not null,
+  url text not null,
+  source text not null default 'search',
+  is_direct boolean not null default true,
+  latest_release jsonb,
+  display_order integer,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(artist_id, platform)
+);
+
+CREATE TABLE IF NOT EXISTS public.verification_requests (
+  id uuid primary key default gen_random_uuid(),
+  artist_id uuid not null references artists(id) on delete cascade,
+  user_id uuid not null,
+  email text not null,
+  message text not null,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected')),
+  created_at timestamptz not null default now(),
+  reviewed_at timestamptz,
+  reviewer_notes text,
+  ownership_verified_by uuid,
+  ownership_verified_at timestamptz
+);
+
+-- ── Indexes ─────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_artists_slug ON public.artists(slug);
+CREATE INDEX IF NOT EXISTS idx_artists_updated ON public.artists(updated_at);
+CREATE INDEX IF NOT EXISTS idx_artist_links_artist_id ON public.artist_links(artist_id);
+CREATE INDEX IF NOT EXISTS idx_verification_requests_artist_id ON public.verification_requests(artist_id);
+CREATE INDEX IF NOT EXISTS idx_verification_requests_status ON public.verification_requests(status);
+
+-- ── Function ────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.update_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Row Level Security ──────────────────────────────────────────────
+
+ALTER TABLE public.artists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.artist_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.verification_requests ENABLE ROW LEVEL SECURITY;
+
+-- ── Policies ────────────────────────────────────────────────────────
+
+-- artists
+DROP POLICY IF EXISTS "Public read access" ON public.artists;
+CREATE POLICY "Public read access" ON public.artists
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Service insert" ON public.artists;
+CREATE POLICY "Service insert" ON public.artists
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Service update" ON public.artists;
+CREATE POLICY "Service update" ON public.artists
+  FOR UPDATE USING (true);
+
+-- artist_links
+DROP POLICY IF EXISTS "Public read access" ON public.artist_links;
+CREATE POLICY "Public read access" ON public.artist_links
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Service insert" ON public.artist_links;
+CREATE POLICY "Service insert" ON public.artist_links
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Service update" ON public.artist_links;
+CREATE POLICY "Service update" ON public.artist_links
+  FOR UPDATE USING (true);
+
+DROP POLICY IF EXISTS "Service delete" ON public.artist_links;
+CREATE POLICY "Service delete" ON public.artist_links
+  FOR DELETE USING (true);
+
+-- verification_requests
+DROP POLICY IF EXISTS "Users can read own verification requests" ON public.verification_requests;
+CREATE POLICY "Users can read own verification requests"
+  ON public.verification_requests FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Service role full access" ON public.verification_requests;
+CREATE POLICY "Service role full access"
+  ON public.verification_requests FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+-- ── Triggers ────────────────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS artists_updated_at ON public.artists;
+CREATE TRIGGER artists_updated_at
+  BEFORE UPDATE ON public.artists
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+DROP TRIGGER IF EXISTS artist_links_updated_at ON public.artist_links;
+CREATE TRIGGER artist_links_updated_at
+  BEFORE UPDATE ON public.artist_links
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();

--- a/supabase/migrations/20260411000000_verification-requests.sql
+++ b/supabase/migrations/20260411000000_verification-requests.sql
@@ -15,21 +15,23 @@ CREATE TABLE IF NOT EXISTS verification_requests (
 );
 
 -- Index for looking up requests by artist
-CREATE INDEX idx_verification_requests_artist_id ON verification_requests(artist_id);
+CREATE INDEX IF NOT EXISTS idx_verification_requests_artist_id ON verification_requests(artist_id);
 
 -- Index for admin review queue (pending requests)
-CREATE INDEX idx_verification_requests_status ON verification_requests(status);
+CREATE INDEX IF NOT EXISTS idx_verification_requests_status ON verification_requests(status);
 
 -- Enable RLS
 ALTER TABLE verification_requests ENABLE ROW LEVEL SECURITY;
 
 -- Users can read their own requests
+DROP POLICY IF EXISTS "Users can read own verification requests" ON verification_requests;
 CREATE POLICY "Users can read own verification requests"
   ON verification_requests
   FOR SELECT
   USING (auth.uid() = user_id);
 
 -- Service role can do everything (Netlify functions use service key)
+DROP POLICY IF EXISTS "Service role full access" ON verification_requests;
 CREATE POLICY "Service role full access"
   ON verification_requests
   FOR ALL


### PR DESCRIPTION
## Summary

Round 1 (PR #297) patched one symptom — the missing `artists` table — but Claude's review identified three more gaps from the same root cause: the pre-migration `schema.sql` baseline was never captured as a migration.

### Root cause
Branch previews build from `supabase/migrations/` only. Several objects defined only in `schema.sql` were never in any migration:
- `artists` table (round 1 patched this)
- `artist_links` table (needed by `20260525110000_featured-embed.sql`)
- `update_updated_at()` function (needed by migration 002's `artist_profiles_updated_at` trigger)
- RLS + policies + triggers on `artists` and `artist_links`

### Fix
1. **New baseline migration** `20260331000000_baseline.sql` (runs before 002) capturing the full pre-migration `schema.sql` state:
   - `CREATE TABLE IF NOT EXISTS` for `artists`, `artist_links`, `verification_requests`
   - All indexes with `IF NOT EXISTS`
   - `CREATE OR REPLACE FUNCTION update_updated_at()`
   - All `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`
   - All policies using `DROP POLICY IF EXISTS ... ; CREATE POLICY ...` pattern
   - All triggers using `DROP TRIGGER IF EXISTS ... ; CREATE TRIGGER ...` pattern
   - Every statement idempotent → no-op on prod

2. **Reverted round-1 changes** — `CREATE TABLE artists` + indexes removed from both copies of migration 002. The baseline owns those now.

3. **Patched migration 006** (`verification-requests.sql`) — added `IF NOT EXISTS` to indexes and `DROP POLICY IF EXISTS` before `CREATE POLICY`, since the baseline now creates that table and 006's non-idempotent statements would fail on a fresh DB.

### Prod safety
- Baseline is fully idempotent (every statement guarded) → no-op on prod
- Migration 006 patches are also idempotent → no-op on prod (indexes/policies already exist, DROP IF EXISTS + CREATE is safe)
- No schema changes on prod; only affects fresh/preview DBs

### Checklist coverage
Every `CREATE TABLE` / `CREATE INDEX` / `CREATE FUNCTION` / `CREATE TRIGGER` / `CREATE POLICY` / `ENABLE ROW LEVEL SECURITY` from `schema.sql` that predates migration 002 is captured in the baseline. Items created by 002 itself (artist_profiles table, its indexes, RLS, policies, trigger) remain in 002.

### What to verify
- [ ] Supabase branch preview check passes (no 42P01, no `function does not exist`)
- [ ] `20260525110000_featured-embed.sql` applies cleanly (artist_links now exists)
- [ ] No regression on prod (baseline + 006 patches are no-ops)

Closes #297 (supersedes).
Refs UNS-149.