### PR TITLE
fix(supabase-migrate): add --include-all flag for out-of-order migration inserts

### DIFF
--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -50,4 +50,4 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase db push --linked --password "$SUPABASE_DB_PASSWORD"
+        run: supabase db push --linked --include-all --password "$SUPABASE_DB_PASSWORD"


### PR DESCRIPTION
## Problem

Run `28343571330` (Supabase auto-migrate workflow on the post-#298 push, 2026-06-29 01:47:15Z) **failed** with:

```
Found local migration files to be inserted before the last migration on remote database.
supabase/migrations/20260331000000_baseline.sql
Rerun the command with --include-all flag to apply these migrations
```

The baseline migration (`20260331000000_baseline.sql`) is correctly timestamped as the first migration in the canonical history, but its timestamp is technically earlier than the legacy migration set on prod. The Supabase CLI refuses to apply it because it would break the linear-migration-history invariant.

## Fix

Add `--include-all` to the `supabase db push` invocation. Tells the CLI: apply ALL local migrations, even if their timestamps are out of order.

```diff
-        run: supabase db push --linked --password "$SUPABASE_DB_PASSWORD"
+        run: supabase db push --linked --include-all --password "$SUPABASE_DB_PASSWORD"
```

## Risk profile

**Risk:** A future PR with a typo'd old timestamp would also be inserted out of order, breaking the linear-migration-history invariant.

**Mitigation:** The supabase CLI also checks for duplicate filenames; practical risk is low. PRs adding migrations should be small + reviewed (Daryl writes them, Claude Code reviews, Brandon merges).

**Alternative (more scoped):** Run `supabase migration repair --status applied --version 20260331000000` once on prod to mark the baseline as already in the ledger, then keep the workflow unchanged. This is the scoped fix but requires a one-time CLI invocation against prod with either `--linked` (needs `supabase link` config) or `--db-url` (needs the DB password). Going with the simpler `--include-all` per Brandon's call; can switch to the repair-once approach in a follow-up if the risk profile becomes uncomfortable.

## Verification

After merge, the next push to `main` that touches `supabase/migrations/**` should succeed in the workflow (instead of failing on the out-of-order error). Also, a `workflow_dispatch` after this merges will replay `20260331000000_baseline.sql` against prod (currently a no-op given prod schema is already consistent with the baseline per recent PostgREST probes).

## Files changed

- `.github/workflows/supabase-migrate.yml` — 1 line added (--include-all flag)

Wayne (cross-project orchestrator).