### PR TITLE
Add fairplayer.band to extension playback detection

### DIFF
--- a/apps/extension/content/generic.js
+++ b/apps/extension/content/generic.js
@@ -26,7 +26,8 @@
     'gaana.com': 'gaana',
     'wynk.in': 'wynk',
     'boomplay.com': 'boomplay',
-    'resonate.is': 'resonate'
+    'resonate.is': 'resonate',
+    'fairplayer.band': 'fairplayer'
   };
 
   function getSourceName() {

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -85,7 +85,9 @@
         "https://gaana.com/*",
         "https://wynk.in/*",
         "https://www.boomplay.com/*",
-        "https://stream.resonate.coop/*"
+        "https://stream.resonate.coop/*",
+        "https://fairplayer.band/*",
+        "https://*.fairplayer.band/*"
       ],
       "js": ["content/common.js", "content/generic.js"],
       "run_at": "document_idle"

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -74,7 +74,9 @@
         "https://gaana.com/*",
         "https://wynk.in/*",
         "https://www.boomplay.com/*",
-        "https://stream.resonate.coop/*"
+        "https://stream.resonate.coop/*",
+        "https://fairplayer.band/*",
+        "https://*.fairplayer.band/*"
       ],
       "js": ["content/common.js", "content/generic.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
## What

Inject the generic Media Session content script on the Fairplayer web player (`fairplayer.band`) and map its hostname to the `fairplayer` source.

## Why

Fairplayer is a decentralized, artist-first music player — squarely in Unstream's wheelhouse. Its player already implements the Media Session API (`_setMediaSession()` in `apps/player/static/js/player.v2.js`, source at [codeberg.org/fairplayer/fairplayer](https://codeberg.org/fairplayer/fairplayer)), so no site-specific scraping is needed. The only reason detection didn't work was that `generic.js` is gated behind a hardcoded allowlist in the manifests and `fairplayer.band` wasn't on it.

## Changes (3 files)

- `content/generic.js` — add `'fairplayer.band': 'fairplayer'` to `DOMAIN_SOURCE_MAP` for correct source attribution.
- `manifest.json` + `manifest-firefox.json` — add `https://fairplayer.band/*` and `https://*.fairplayer.band/*` to the `generic.js` content-script `matches` (Chrome + Firefox kept in sync).

No new detection logic. Both manifests validated as JSON; `generic.js` passed a syntax check.

## Known dependency (does not block merge)

`getFromMediaSession()` in `common.js` requires **both** `title` and `artist` to be non-empty, or detection silently no-ops. Fairplayer sets `title`; the `artist` field needs confirmation on their side. Brandon is coordinating with the Fairplayer team. This change is safe to merge now — it activates automatically once Fairplayer exposes an artist value, with no further extension change required.

No version bump in this PR — the extension release (with version bump) is cut separately, and shipping naturally aligns with the artist-field confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)