### PR TITLE
Fix Xcode Cloud build: commit Package.resolved

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/mac/Unstream.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/apps/mac/Unstream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/mac/Unstream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "ccc727310637079b7355ccf59e7d153c26677020c1a43e177b78cc9df7963c0f",
+  "pins" : [
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase/supabase-swift.git",
+      "state" : {
+        "revision" : "06ae7b34ec21406cbd3e643bee7a8a54206fa8f5",
+        "version" : "2.44.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
+        "version" : "1.10.1"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## Problem

Xcode Cloud Mac builds are failing:

> a resolved file is required when automatic dependency resolution is disabled and should be placed at `…/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`. Running resolver because the following dependencies were added: 'supabase-swift'

## Cause

The Mac app gained its **first SPM dependency** (`supabase-swift`) in the 3.2.0 release ([#303](https://github.com/brandonlucasgreen/unstream/pull/303)), which makes a `Package.resolved` lockfile necessary. Xcode Cloud builds with automatic dependency resolution disabled and require that lockfile to be committed.

But `apps/mac/Unstream.xcodeproj/project.xcworkspace/` was **never tracked in git** — so `Package.resolved` only ever existed locally. Every Xcode Cloud build since #303 has been missing it.

[#304](https://github.com/brandonlucasgreen/unstream/pull/304) didn't cause this — it was extension-only. It just happened to be the next push to `main`, which triggered the build that surfaced the pre-existing gap from #303.

## Fix

Commit the lockfile (pinning supabase-swift 2.44.1 + its transitive deps) and the standard `contents.xcworkspacedata`. `xcuserdata` remains gitignored, so no user-specific state is committed.

After merge, the Xcode Cloud build should resolve the exact pinned versions instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)