### PR TITLE
Add AgentMail inbound-email webhook to trigger Claude Code issue triage

### DIFF
--- a/api/functions/agentmail-triage-background.ts
+++ b/api/functions/agentmail-triage-background.ts
@@ -1,0 +1,105 @@
+// Netlify Background Function (the `-background` suffix makes it async).
+// Receives a message.received payload from agentmail-webhook, formats it into
+// the "Inbound support email triage" Claude Code trigger's prompt, and fires
+// that trigger via the Claude Code remote-trigger API.
+//
+// NOTE: the remote-trigger `run` endpoint's request body isn't publicly
+// documented. This sends the per-run prompt override in the same shape the
+// trigger's own stored job_config uses (job_config.ccr.events[].data.message).
+// Verify with one live test email after setting the env vars below — if the
+// shape is wrong, the run will still fire but with the trigger's static
+// default prompt instead of the email content.
+
+import { randomUUID } from 'crypto';
+import { Sentry } from '../lib/sentry';
+
+const CLAUDE_TRIGGER_ID = process.env.CLAUDE_TRIGGER_ID || '';
+const CLAUDE_TRIGGER_API_TOKEN = process.env.CLAUDE_TRIGGER_API_TOKEN || '';
+const TRIGGER_RUN_URL = `https://api.anthropic.com/v1/code/triggers/${CLAUDE_TRIGGER_ID}/run`;
+
+interface AgentMailMessage {
+  message_id?: string;
+  thread_id?: string;
+  inbox_id?: string;
+  from_?: string[];
+  to?: string[];
+  subject?: string;
+  text?: string;
+  html?: string;
+}
+
+function buildPrompt(message: AgentMailMessage): string {
+  const from = message.from_?.join(', ') || 'unknown sender';
+  const subject = message.subject || '(no subject)';
+  const body =
+    message.text ||
+    message.html ||
+    '(body omitted — the webhook payload exceeded 1MB; fetch the full message via the AgentMail API if needed)';
+
+  return `You just received an email from a user of Unstream.
+
+From: ${from}
+Subject: ${subject}
+Thread ID: ${message.thread_id || 'unknown'}
+
+Message body:
+${body}
+
+Review the issue reported and diagnose the issue. Review the codebase to gain context on the product and the potential cause of the issue.
+
+If the reported issue is a bug report and is feasible without further input, open a branch and attempt to fix the issue using codebase standards and best practices. Review the code to ensure the fix aligns with the product strategy and goals. Run all unit tests to ensure the fix does not break other product features. Then open a PR.
+
+If the reported issue requires further context or is a product improvement/change, summarize the issue and a potential solution, and raise any open questions required to solve the issue. Do so in a Claude Code session (don't post an issue comment). Brandon will sort out the open questions with you there.`;
+}
+
+export async function handler(event: { body: string | null }) {
+  if (!event.body) return { statusCode: 400 };
+
+  if (!CLAUDE_TRIGGER_ID || !CLAUDE_TRIGGER_API_TOKEN) {
+    Sentry.captureMessage('agentmail-triage-background: missing CLAUDE_TRIGGER_ID or CLAUDE_TRIGGER_API_TOKEN', {
+      level: 'error',
+    });
+    return { statusCode: 500 };
+  }
+
+  const message: AgentMailMessage = JSON.parse(event.body);
+
+  try {
+    const response = await fetch(TRIGGER_RUN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${CLAUDE_TRIGGER_API_TOKEN}`,
+      },
+      body: JSON.stringify({
+        job_config: {
+          ccr: {
+            events: [
+              {
+                data: {
+                  message: {
+                    content: buildPrompt(message),
+                    role: 'user',
+                    uuid: randomUUID(),
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Trigger run failed: ${response.status} ${await response.text()}`);
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { source: 'agentmail-triage-background' },
+      extra: { threadId: message.thread_id, messageId: message.message_id },
+    });
+    return { statusCode: 500 };
+  }
+
+  return { statusCode: 200 };
+}

--- a/api/functions/agentmail-webhook.ts
+++ b/api/functions/agentmail-webhook.ts
@@ -1,0 +1,75 @@
+// POST /api/agentmail-webhook
+// AgentMail inbound-email webhook — verifies the Svix signature and dispatches
+// message.received events to a background function for Claude Code triage.
+// See https://www.agentmail.to/docs/webhooks-overview
+
+import { Webhook } from 'svix';
+import { Sentry } from '../lib/sentry';
+
+const AGENTMAIL_WEBHOOK_SECRET = process.env.AGENTMAIL_WEBHOOK_SECRET || '';
+
+interface AgentMailWebhookPayload {
+  event_type: string;
+  event_id: string;
+  message?: {
+    message_id: string;
+    thread_id: string;
+    inbox_id: string;
+    from_: string[];
+    to?: string[];
+    subject?: string;
+    text?: string;
+    html?: string;
+  };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  if (!event.body) {
+    return { statusCode: 400, body: 'Missing body' };
+  }
+
+  if (!AGENTMAIL_WEBHOOK_SECRET) {
+    Sentry.captureMessage('agentmail-webhook: AGENTMAIL_WEBHOOK_SECRET not configured', { level: 'error' });
+    return { statusCode: 500, body: 'Not configured' };
+  }
+
+  const svixHeaders = {
+    'svix-id': event.headers['svix-id'] || '',
+    'svix-timestamp': event.headers['svix-timestamp'] || '',
+    'svix-signature': event.headers['svix-signature'] || '',
+  };
+
+  let payload: AgentMailWebhookPayload;
+  try {
+    const wh = new Webhook(AGENTMAIL_WEBHOOK_SECRET);
+    payload = wh.verify(event.body, svixHeaders) as AgentMailWebhookPayload;
+  } catch (_error) {
+    return { statusCode: 401, body: 'Invalid signature' };
+  }
+
+  if (payload.event_type !== 'message.received' || !payload.message) {
+    // Acknowledge other event types without acting on them.
+    return { statusCode: 200, body: 'Ignored' };
+  }
+
+  const siteUrl = process.env.URL || 'https://unstream.stream';
+
+  // Fire-and-forget dispatch — respond fast so AgentMail doesn't retry the delivery.
+  fetch(`${siteUrl}/.netlify/functions/agentmail-triage-background`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload.message),
+  }).catch((error) => {
+    Sentry.captureException(error, { tags: { source: 'agentmail-webhook' } });
+  });
+
+  return { statusCode: 200, body: 'OK' };
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -163,6 +163,11 @@
   to = "/.netlify/functions/discord-interaction"
   status = 200
 
+[[redirects]]
+  from = "/api/agentmail-webhook"
+  to = "/.netlify/functions/agentmail-webhook"
+  status = 200
+
 # V1 Public API routes
 [[redirects]]
   from = "/api/v1/search"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.11.0",
         "remark-gfm": "^4.0.1",
+        "svix": "^1.96.1",
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
@@ -2886,9 +2887,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2903,9 +2901,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2920,9 +2915,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2937,9 +2929,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2954,9 +2943,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2971,9 +2957,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2988,9 +2971,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3005,9 +2985,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3022,9 +2999,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3039,9 +3013,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3056,9 +3027,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3073,9 +3041,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3090,9 +3055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3606,6 +3568,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3826,9 +3794,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3846,9 +3811,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3866,9 +3828,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3886,9 +3845,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6229,6 +6185,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -7855,9 +7817,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7879,9 +7838,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7903,9 +7859,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7927,9 +7880,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10236,6 +10186,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -10438,6 +10398,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.96.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.96.1.tgz",
+      "integrity": "sha512-l+GyPS6gjL0okiXplLazEY2GbBsv1jZ4UIwtjp553YkDDv635xMKbM5sABpIdiWy1BYxgyV8M6tHeTwY0gyXlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:data": "tsx scripts/generate-artist-data.ts",
     "generate:social": "tsx scripts/generate-social-posts.ts",
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
+    "register:agentmail-webhook": "npx tsx scripts/agentmail-register-webhook.ts",
     "test:web": "cd apps/web && npx vitest run",
     "test:api": "npx vitest run api/functions/",
     "test": "npm run test:web && npm run test:api",
@@ -36,6 +37,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.11.0",
     "remark-gfm": "^4.0.1",
+    "svix": "^1.96.1",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/scripts/agentmail-register-webhook.ts
+++ b/scripts/agentmail-register-webhook.ts
@@ -1,0 +1,50 @@
+// One-time script to register the message.received webhook with AgentMail.
+// Run with:
+//   AGENTMAIL_API_KEY=... npx tsx scripts/agentmail-register-webhook.ts
+//
+// Optional: AGENTMAIL_INBOX_ID=... to scope the webhook to a single inbox
+// (omit to receive events from every inbox on the account).
+//
+// Prints the returned signing secret — set that as AGENTMAIL_WEBHOOK_SECRET
+// in Netlify (see api/functions/agentmail-webhook.ts).
+
+const AGENTMAIL_API_KEY = process.env.AGENTMAIL_API_KEY;
+const AGENTMAIL_INBOX_ID = process.env.AGENTMAIL_INBOX_ID;
+const WEBHOOK_URL = process.env.WEBHOOK_URL || 'https://unstream.stream/api/agentmail-webhook';
+
+if (!AGENTMAIL_API_KEY) {
+  console.error('Missing AGENTMAIL_API_KEY environment variable.');
+  process.exit(1);
+}
+
+async function registerWebhook() {
+  const body: { url: string; event_types: string[]; inbox_ids?: string[] } = {
+    url: WEBHOOK_URL,
+    event_types: ['message.received'],
+  };
+  if (AGENTMAIL_INBOX_ID) {
+    body.inbox_ids = [AGENTMAIL_INBOX_ID];
+  }
+
+  const response = await fetch('https://api.agentmail.to/v0/webhooks', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${AGENTMAIL_API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    console.error(`Failed to register webhook: ${response.status} ${response.statusText}`);
+    console.error(await response.text());
+    process.exit(1);
+  }
+
+  const data = await response.json();
+  console.log('Webhook registered:', JSON.stringify(data, null, 2));
+  console.log('\nSet this as AGENTMAIL_WEBHOOK_SECRET in Netlify:');
+  console.log(data.secret);
+}
+
+registerWebhook().catch(console.error);


### PR DESCRIPTION
## Summary
- New `agentmail-webhook.ts` Netlify function verifies AgentMail's Svix-signed `message.received` webhook and dispatches to a background function
- New `agentmail-triage-background.ts` fires the existing **"Inbound support email triage"** Claude Code remote trigger, injecting the email's from/subject/body as the run prompt
- New `scripts/agentmail-register-webhook.ts` (`npm run register:agentmail-webhook`) registers the webhook with AgentMail and prints the signing secret to set in Netlify
- Adds `svix` dependency for signature verification

## Setup required before this is live
Set in Netlify env vars:
- `AGENTMAIL_WEBHOOK_SECRET` — the `secret` printed by `npm run register:agentmail-webhook` (run with `AGENTMAIL_API_KEY=...` after this deploys)
- `CLAUDE_TRIGGER_ID` — `trig_01G1ZeKdfqtZCAXgkgPurkkc` (the already-existing "Inbound support email triage" trigger, now enabled)
- `CLAUDE_TRIGGER_API_TOKEN` — the trigger's own API token (visible once at creation; may need a fresh one issued for this trigger if the original wasn't saved)

## Known limitation
The remote-trigger `run` endpoint's per-run body override isn't publicly documented — `agentmail-triage-background.ts` sends the dynamic prompt in the same shape the trigger's stored `job_config.ccr.events` uses. This should be verified with one live test email before fully trusting it; if the shape is wrong, the trigger still fires but falls back to its generic default prompt (no email content).

## Test plan
- [x] `npm run typecheck:api` passes
- [x] `npm run test:api` passes (69/69)
- [ ] Run `npm run register:agentmail-webhook` with a real `AGENTMAIL_API_KEY` after deploy, set the returned secret + trigger env vars in Netlify
- [ ] Send a real test email to the AgentMail inbox and confirm a Claude Code session kicks off with the email content in the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)