### PR TITLE
Fix silently-dropped background dispatch in agentmail-webhook

### DIFF
--- a/api/functions/agentmail-triage-background.ts
+++ b/api/functions/agentmail-triage-background.ts
@@ -21,7 +21,7 @@ interface AgentMailMessage {
   message_id?: string;
   thread_id?: string;
   inbox_id?: string;
-  from_?: string[];
+  from?: string;
   to?: string[];
   subject?: string;
   text?: string;
@@ -29,7 +29,7 @@ interface AgentMailMessage {
 }
 
 function buildPrompt(message: AgentMailMessage): string {
-  const from = message.from_?.join(', ') || 'unknown sender';
+  const from = message.from || 'unknown sender';
   const subject = message.subject || '(no subject)';
   const body =
     message.text ||

--- a/api/functions/agentmail-webhook.ts
+++ b/api/functions/agentmail-webhook.ts
@@ -15,7 +15,7 @@ interface AgentMailWebhookPayload {
     message_id: string;
     thread_id: string;
     inbox_id: string;
-    from_: string[];
+    from: string;
     to?: string[];
     subject?: string;
     text?: string;
@@ -62,14 +62,19 @@ export async function handler(event: {
 
   const siteUrl = process.env.URL || 'https://unstream.stream';
 
-  // Fire-and-forget dispatch — respond fast so AgentMail doesn't retry the delivery.
-  fetch(`${siteUrl}/.netlify/functions/agentmail-triage-background`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload.message),
-  }).catch((error) => {
+  // Await the dispatch call itself (not the background function's full run) —
+  // Netlify background functions accept the job and respond immediately, but an
+  // un-awaited fetch can be killed when this handler returns and Lambda freezes
+  // the execution environment, silently dropping the dispatch.
+  try {
+    await fetch(`${siteUrl}/.netlify/functions/agentmail-triage-background`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload.message),
+    });
+  } catch (error) {
     Sentry.captureException(error, { tags: { source: 'agentmail-webhook' } });
-  });
+  }
 
   return { statusCode: 200, body: 'OK' };
 }


### PR DESCRIPTION
## Summary
- Root cause of "AgentMail shows successful deliveries but no Claude Code runs ever fired": `agentmail-webhook.ts` dispatched to `agentmail-triage-background.ts` via an un-awaited fire-and-forget `fetch()`. Netlify Functions run on Lambda, which freezes the execution environment as soon as the handler returns — the in-flight fetch got killed before it ever reached the network, and its `.catch()` never got a chance to run either (hence: no downstream invocations, no Sentry errors, just silence)
- Fix: `await` the dispatch call. Netlify background functions accept the job and respond immediately, so this shouldn't meaningfully slow down the webhook response
- Also corrects the `from` field to match AgentMail's actual payload (`from: string`, not `from_: string[]` — verified against their docs' literal example JSON)

## Test plan
- [x] `npm run typecheck:api` passes
- [x] `npm run test:api` passes (69/69)
- [ ] Send a real test email to `claudelol@agentmail.to` after merge/deploy and confirm a Claude Code run actually appears on `claude.ai/code/routines` for "Inbound support email triage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)