### PR TITLE
Add Linear issue webhook to trigger Claude Code issue triage

### DIFF
--- a/api/functions/linear-triage-background.ts
+++ b/api/functions/linear-triage-background.ts
@@ -1,0 +1,115 @@
+// Netlify Background Function (the `-background` suffix makes it async).
+// Receives a new-Issue payload from linear-webhook, formats it into the
+// "Linear issue triage & delegation" Claude Code trigger's prompt, and fires
+// that trigger via the Claude Code remote-trigger API.
+//
+// NOTE: the remote-trigger `run` endpoint's request body isn't publicly
+// documented. This sends the per-run prompt override in the same shape the
+// trigger's own stored job_config uses (job_config.ccr.events[].data.message).
+// Verify with one live test issue after setting the env vars below — if the
+// shape is wrong, the run will still fire but with the trigger's static
+// default prompt instead of the issue content.
+
+import { randomUUID } from 'crypto';
+import { Sentry } from '../lib/sentry';
+
+const LINEAR_TRIGGER_ID = process.env.LINEAR_TRIGGER_ID || '';
+const LINEAR_TRIGGER_API_TOKEN = process.env.LINEAR_TRIGGER_API_TOKEN || '';
+const TRIGGER_RUN_URL = `https://api.anthropic.com/v1/code/triggers/${LINEAR_TRIGGER_ID}/run`;
+
+interface LinearIssueData {
+  id?: string;
+  identifier?: string;
+  title?: string;
+  description?: string;
+  priority?: number;
+  url?: string;
+  team?: { key?: string; name?: string };
+  state?: { name?: string };
+}
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'No priority',
+  1: 'Urgent',
+  2: 'High',
+  3: 'Medium',
+  4: 'Low',
+};
+
+function buildPrompt(issue: LinearIssueData): string {
+  const identifier = issue.identifier || issue.id || 'unknown';
+  const title = issue.title || '(no title)';
+  const team = issue.team?.name || issue.team?.key || 'unknown team';
+  const priority = PRIORITY_LABELS[issue.priority ?? -1] || 'unknown';
+  const state = issue.state?.name || 'unknown';
+  const description = issue.description || '(no description)';
+
+  return `A new Linear issue was created for Unstream.
+
+Issue: ${identifier} — ${title}
+Team: ${team}
+Priority: ${priority}
+State: ${state}
+Link: ${issue.url || 'unknown'}
+
+Description:
+${description}
+
+Review the issue reported and diagnose the issue. Review the codebase to gain context on the product and the potential cause of the issue.
+
+If the reported issue is a bug report and is feasible without further input, open a branch and attempt to fix the issue using codebase standards and best practices. Review the code to ensure the fix aligns with the product strategy and goals. Run all unit tests to ensure the fix does not break other product features. Then open a PR.
+
+If the reported issue requires further context or is a product improvement/change, summarize the issue and a potential solution, and raise any open questions required to solve the issue. Do so in a Claude Code session (don't post an issue comment). Brandon will sort out the open questions with you there.`;
+}
+
+export async function handler(event: { body: string | null }) {
+  if (!event.body) return { statusCode: 400 };
+
+  if (!LINEAR_TRIGGER_ID || !LINEAR_TRIGGER_API_TOKEN) {
+    Sentry.captureMessage('linear-triage-background: missing LINEAR_TRIGGER_ID or LINEAR_TRIGGER_API_TOKEN', {
+      level: 'error',
+    });
+    return { statusCode: 500 };
+  }
+
+  const issue: LinearIssueData = JSON.parse(event.body);
+
+  try {
+    const response = await fetch(TRIGGER_RUN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${LINEAR_TRIGGER_API_TOKEN}`,
+      },
+      body: JSON.stringify({
+        job_config: {
+          ccr: {
+            events: [
+              {
+                data: {
+                  message: {
+                    content: buildPrompt(issue),
+                    role: 'user',
+                    uuid: randomUUID(),
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Trigger run failed: ${response.status} ${await response.text()}`);
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { source: 'linear-triage-background' },
+      extra: { issueId: issue.id, identifier: issue.identifier },
+    });
+    return { statusCode: 500 };
+  }
+
+  return { statusCode: 200 };
+}

--- a/api/functions/linear-webhook.ts
+++ b/api/functions/linear-webhook.ts
@@ -1,0 +1,92 @@
+// POST /api/linear-webhook
+// Linear webhook — verifies the Linear-Signature HMAC, filters for new Issues,
+// and dispatches to a background function for Claude Code triage.
+// See https://linear.app/developers/webhooks
+
+import { createHmac, timingSafeEqual } from 'crypto';
+import { Sentry } from '../lib/sentry';
+
+const LINEAR_WEBHOOK_SECRET = process.env.LINEAR_WEBHOOK_SECRET || '';
+const MAX_TIMESTAMP_SKEW_MS = 60_000;
+
+interface LinearIssuePayload {
+  action: string;
+  type: string;
+  data: {
+    id: string;
+    identifier?: string;
+    title?: string;
+    description?: string;
+    priority?: number;
+    url?: string;
+    team?: { key?: string; name?: string };
+    state?: { name?: string };
+  };
+  url?: string;
+  webhookTimestamp?: number;
+}
+
+function isValidSignature(rawBody: string, signatureHeader: string): boolean {
+  const expected = createHmac('sha256', LINEAR_WEBHOOK_SECRET).update(rawBody).digest('hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const receivedBuf = Buffer.from(signatureHeader, 'hex');
+  if (expectedBuf.length !== receivedBuf.length) return false;
+  return timingSafeEqual(expectedBuf, receivedBuf);
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  if (!event.body) {
+    return { statusCode: 400, body: 'Missing body' };
+  }
+
+  if (!LINEAR_WEBHOOK_SECRET) {
+    Sentry.captureMessage('linear-webhook: LINEAR_WEBHOOK_SECRET not configured', { level: 'error' });
+    return { statusCode: 500, body: 'Not configured' };
+  }
+
+  const signature = event.headers['linear-signature'];
+  if (!signature || !isValidSignature(event.body, signature)) {
+    return { statusCode: 401, body: 'Invalid signature' };
+  }
+
+  let payload: LinearIssuePayload;
+  try {
+    payload = JSON.parse(event.body);
+  } catch (_error) {
+    return { statusCode: 400, body: 'Invalid JSON' };
+  }
+
+  if (payload.webhookTimestamp && Math.abs(Date.now() - payload.webhookTimestamp) > MAX_TIMESTAMP_SKEW_MS) {
+    return { statusCode: 401, body: 'Stale timestamp' };
+  }
+
+  if (payload.type !== 'Issue' || payload.action !== 'create') {
+    // Acknowledge other event types without acting on them.
+    return { statusCode: 200, body: 'Ignored' };
+  }
+
+  const siteUrl = process.env.URL || 'https://unstream.stream';
+
+  // Await the dispatch call itself (not the background function's full run) —
+  // an un-awaited fetch can be killed when this handler returns and Lambda
+  // freezes the execution environment, silently dropping the dispatch.
+  try {
+    await fetch(`${siteUrl}/.netlify/functions/linear-triage-background`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload.data),
+    });
+  } catch (error) {
+    Sentry.captureException(error, { tags: { source: 'linear-webhook' } });
+  }
+
+  return { statusCode: 200, body: 'OK' };
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -168,6 +168,11 @@
   to = "/.netlify/functions/agentmail-webhook"
   status = 200
 
+[[redirects]]
+  from = "/api/linear-webhook"
+  to = "/.netlify/functions/linear-webhook"
+  status = 200
+
 # V1 Public API routes
 [[redirects]]
   from = "/api/v1/search"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate:social": "tsx scripts/generate-social-posts.ts",
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
     "register:agentmail-webhook": "npx tsx scripts/agentmail-register-webhook.ts",
+    "register:linear-webhook": "npx tsx scripts/linear-register-webhook.ts",
     "test:web": "cd apps/web && npx vitest run",
     "test:api": "npx vitest run api/functions/",
     "test": "npm run test:web && npm run test:api",

--- a/scripts/linear-register-webhook.ts
+++ b/scripts/linear-register-webhook.ts
@@ -1,0 +1,65 @@
+// One-time script to register the Issue-create webhook with Linear.
+// Run with:
+//   LINEAR_API_KEY=... npx tsx scripts/linear-register-webhook.ts
+//
+// Optional: LINEAR_TEAM_ID=... to scope the webhook to a single team
+// (omit to receive Issue events from every team in the workspace).
+//
+// Requires a workspace-admin personal API key, or an OAuth app token with
+// the `admin` scope — per Linear's docs, only admins can create webhooks.
+//
+// Prints the returned signing secret — set that as LINEAR_WEBHOOK_SECRET
+// in Netlify (see api/functions/linear-webhook.ts).
+
+const LINEAR_API_KEY = process.env.LINEAR_API_KEY;
+const LINEAR_TEAM_ID = process.env.LINEAR_TEAM_ID;
+const WEBHOOK_URL = process.env.WEBHOOK_URL || 'https://unstream.stream/api/linear-webhook';
+
+if (!LINEAR_API_KEY) {
+  console.error('Missing LINEAR_API_KEY environment variable.');
+  process.exit(1);
+}
+
+async function registerWebhook() {
+  const input: { url: string; resourceTypes: string[]; teamId?: string } = {
+    url: WEBHOOK_URL,
+    resourceTypes: ['Issue'],
+  };
+  if (LINEAR_TEAM_ID) {
+    input.teamId = LINEAR_TEAM_ID;
+  }
+
+  const response = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: LINEAR_API_KEY,
+    },
+    body: JSON.stringify({
+      query: `
+        mutation WebhookCreate($input: WebhookCreateInput!) {
+          webhookCreate(input: $input) {
+            success
+            webhook { id url enabled secret resourceTypes }
+          }
+        }
+      `,
+      variables: { input },
+    }),
+  });
+
+  const result = await response.json();
+
+  if (!response.ok || result.errors) {
+    console.error(`Failed to register webhook: ${response.status}`);
+    console.error(JSON.stringify(result.errors || result, null, 2));
+    process.exit(1);
+  }
+
+  const webhook = result.data?.webhookCreate?.webhook;
+  console.log('Webhook registered:', JSON.stringify(webhook, null, 2));
+  console.log('\nSet this as LINEAR_WEBHOOK_SECRET in Netlify:');
+  console.log(webhook.secret);
+}
+
+registerWebhook().catch(console.error);


### PR DESCRIPTION
## Summary
- New `linear-webhook.ts` verifies Linear's `Linear-Signature` HMAC-SHA256 (timing-safe compare, plus a 60s timestamp-skew check against replay) and dispatches new `Issue` `create` events to a background function
- New `linear-triage-background.ts` formats the issue (identifier, title, team, priority, state, description, link) and fires a Claude Code remote trigger via its `run` endpoint, same pattern as the AgentMail integration (#307/#308)
- New `scripts/linear-register-webhook.ts` (`npm run register:linear-webhook`) uses Linear's `webhookCreate` GraphQL mutation to register the webhook and prints the signing secret. Requires a workspace-admin personal API key. Optionally scope to one team via `LINEAR_TEAM_ID`
- **Learned from PR #308**: the dispatch `fetch()` is `await`ed before returning — an un-awaited fetch can get silently killed when Netlify's Lambda-based runtime freezes the execution environment on handler return

## Design note
This is trigger-agnostic — it reads `LINEAR_TRIGGER_ID` / `LINEAR_TRIGGER_API_TOKEN` from env vars rather than hardcoding a trigger ID, since Brandon is creating a fresh Claude Code routine for this rather than reusing an existing one.

## Setup required before this is live
Set in Netlify:
- `LINEAR_WEBHOOK_SECRET` — from running `npm run register:linear-webhook` with a real `LINEAR_API_KEY`
- `LINEAR_TRIGGER_ID` / `LINEAR_TRIGGER_API_TOKEN` — from the new Claude Code routine once created

## Known limitation
Same caveat as #308's original: the remote-trigger `run` endpoint's per-run prompt-override body isn't publicly documented — this mirrors the same guessed shape already confirmed working for the AgentMail integration.

## Test plan
- [x] `npm run typecheck:api` passes
- [x] `npm run test:api` passes (69/69)
- [ ] Create the new Linear-issue Claude Code routine, set its ID/token as env vars
- [ ] Run `npm run register:linear-webhook`, set the returned secret
- [ ] Create a real test issue in Linear and confirm a Claude Code run fires with the issue content in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)