### PR TITLE
Fix Linear webhook registration script: require allPublicTeams when no team given

### DIFF
--- a/scripts/linear-register-webhook.ts
+++ b/scripts/linear-register-webhook.ts
@@ -3,7 +3,9 @@
 //   LINEAR_API_KEY=... npx tsx scripts/linear-register-webhook.ts
 //
 // Optional: LINEAR_TEAM_ID=... to scope the webhook to a single team
-// (omit to receive Issue events from every team in the workspace).
+// (omit to receive Issue events from every public team in the workspace —
+// Linear's webhookCreate mutation requires either a teamId or an explicit
+// allPublicTeams: true; there's no implicit "whole workspace" default).
 //
 // Requires a workspace-admin personal API key, or an OAuth app token with
 // the `admin` scope — per Linear's docs, only admins can create webhooks.
@@ -21,12 +23,14 @@ if (!LINEAR_API_KEY) {
 }
 
 async function registerWebhook() {
-  const input: { url: string; resourceTypes: string[]; teamId?: string } = {
+  const input: { url: string; resourceTypes: string[]; teamId?: string; allPublicTeams?: boolean } = {
     url: WEBHOOK_URL,
     resourceTypes: ['Issue'],
   };
   if (LINEAR_TEAM_ID) {
     input.teamId = LINEAR_TEAM_ID;
+  } else {
+    input.allPublicTeams = true;
   }
 
   const response = await fetch('https://api.linear.app/graphql', {


### PR DESCRIPTION
## Summary
- Linear's `webhookCreate` mutation rejects requests with neither `teamId` nor `allPublicTeams` set — there's no implicit "whole workspace" default, contrary to what the script's original comment assumed
- Fix: when `LINEAR_TEAM_ID` isn't provided, explicitly pass `allPublicTeams: true`

## Test plan
- [x] Script typechecks
- [ ] Re-run `npm run register:linear-webhook` after merge and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)