### PR TITLE
Add temporary debug logging to linear-webhook

### DIFF
--- a/api/functions/linear-webhook.ts
+++ b/api/functions/linear-webhook.ts
@@ -54,6 +54,11 @@ export async function handler(event: {
 
   const signature = event.headers['linear-signature'];
   if (!signature || !isValidSignature(event.body, signature)) {
+    // TEMPORARY debug instrumentation — remove once the live-test issue is resolved.
+    Sentry.captureMessage('linear-webhook DEBUG: signature check failed', {
+      level: 'info',
+      extra: { hasSignatureHeader: !!signature, headerKeys: Object.keys(event.headers) },
+    });
     return { statusCode: 401, body: 'Invalid signature' };
   }
 
@@ -65,13 +70,28 @@ export async function handler(event: {
   }
 
   if (payload.webhookTimestamp && Math.abs(Date.now() - payload.webhookTimestamp) > MAX_TIMESTAMP_SKEW_MS) {
+    // TEMPORARY debug instrumentation — remove once the live-test issue is resolved.
+    Sentry.captureMessage('linear-webhook DEBUG: stale timestamp check failed', {
+      level: 'info',
+      extra: { webhookTimestamp: payload.webhookTimestamp, now: Date.now(), diffMs: Date.now() - payload.webhookTimestamp },
+    });
     return { statusCode: 401, body: 'Stale timestamp' };
   }
 
   if (payload.type !== 'Issue' || payload.action !== 'create') {
-    // Acknowledge other event types without acting on them.
+    // TEMPORARY debug instrumentation — remove once the live-test issue is resolved.
+    Sentry.captureMessage('linear-webhook DEBUG: event ignored', {
+      level: 'info',
+      extra: { type: payload.type, action: payload.action },
+    });
     return { statusCode: 200, body: 'Ignored' };
   }
+
+  // TEMPORARY debug instrumentation — remove once the live-test issue is resolved.
+  Sentry.captureMessage('linear-webhook DEBUG: dispatching to background function', {
+    level: 'info',
+    extra: { identifier: payload.data?.identifier, title: payload.data?.title },
+  });
 
   const siteUrl = process.env.URL || 'https://unstream.stream';
 


### PR DESCRIPTION
## Summary
Temporary diagnostic PR — UNS-157 test issue produced one 6.38ms invocation of `linear-webhook` with nothing downstream and nothing in Linear's own delivery-failure log, so we can't tell which check (signature, timestamp, or event-type filter) is rejecting the payload. Adds Sentry info-level breadcrumbs at each decision point (signature fail, stale-timestamp fail, event-ignored, dispatching) to pinpoint it on the next test issue.

**Remove this instrumentation once diagnosed** — not meant to be permanent.

## Test plan
- [x] `npm run typecheck:api` / `npm run test:api` pass
- [ ] Merge, redeploy, file another test issue, check Sentry for which breadcrumb fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)