### PR TITLE
Add "also available for" links under mobile download buttons

### DIFF
--- a/apps/web/src/components/DownloadGrid.tsx
+++ b/apps/web/src/components/DownloadGrid.tsx
@@ -258,6 +258,40 @@ export function DownloadGrid() {
         })}
       </div>
 
+      {/* Mobile only: link to the alternative download destinations shown on desktop */}
+      {!showAll && (
+        <p className="text-sm text-text-secondary text-center mt-3">
+          Also available for{' '}
+          <a
+            href="https://github.com/brandonlucasgreen/unstream/releases/latest"
+            className="text-accent-primary hover:underline"
+            onClick={() => analytics.trackDownload()}
+          >
+            macOS
+          </a>
+          ,{' '}
+          <a
+            href="https://chromewebstore.google.com/detail/unstream-support-music-di/ghoiopeidkganjdebkgkehaofnmjofkf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-primary hover:underline"
+            onClick={() => analytics.trackDownloadChrome()}
+          >
+            Chrome
+          </a>{' '}
+          and{' '}
+          <a
+            href="https://addons.mozilla.org/en-US/firefox/addon/unstream/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-primary hover:underline"
+            onClick={() => analytics.trackDownloadFirefox()}
+          >
+            Firefox
+          </a>
+        </p>
+      )}
+
       {/* iOS "Add to Home Screen" overlay */}
       {showIOSOverlay && (
         <div


### PR DESCRIPTION
Mobile web only shows the platform-relevant download buttons (e.g. iOS
"Add to Home Screen" + shortcut, or Android + browser extension), so
macOS/Chrome/Firefox weren't discoverable there. Add supporting text
under the buttons on mobile linking to each destination; desktop
already shows all four buttons and is untouched.