### PR TITLE
Add user-opted dynamic per-site playback detection (UNS-152)

### DIFF
--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -3,6 +3,7 @@
 
 import { ALLOWED_RELEASE_DOMAINS } from '../lib/constants.js';
 import { getStoredSession, handleMagicLinkCallback, getAccessToken, signOut } from '../lib/supabase.js';
+import { reconcileCustomSites } from '../lib/custom-sites.js';
 
 const API_BASE = 'https://unstream.stream/api';
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -364,6 +365,13 @@ async function restoreState() {
 restoreState();
 pruneStaleCache();
 setupReleaseAlerts();
+
+// Keep user-enabled custom sites (UNS-152) in sync across restarts: re-register
+// any missing content scripts and prune origins whose permission was revoked
+// out-of-band via browser settings.
+chrome.runtime.onInstalled.addListener(() => { reconcileCustomSites(); });
+chrome.runtime.onStartup.addListener(() => { reconcileCustomSites(); });
+reconcileCustomSites();
 
 // ========================================
 // Artist Detection Notification System

--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -45,7 +45,7 @@ function addNotifiedArtist(slug) {
 // Listen for messages from content scripts and popup
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'MUSIC_DETECTED') {
-    handleMusicDetection(message.data);
+    handleMusicDetection(message.data, sender.tab?.id);
   } else if (message.type === 'GET_CURRENT_ARTIST') {
     // If in-memory state was lost (service worker restart), restore from storage
     if (currentArtist === null) {
@@ -131,7 +131,7 @@ async function trackAppEvent(event_type, context = {}) {
 }
 
 // Handle music detection from content scripts
-async function handleMusicDetection(data) {
+async function handleMusicDetection(data, tabId) {
   const { artist, title, source } = data;
 
   if (!artist) return;
@@ -148,9 +148,10 @@ async function handleMusicDetection(data) {
   // Update badge to show music detected
   updateBadge('detecting');
 
-  // Store current artist info
+  // Store current artist info. tabId lets the popup verify a "fresh" track
+  // actually came from the tab it's currently looking at, not some other tab.
   await chrome.storage.local.set({
-    currentTrack: { artist, title, source, timestamp: now }
+    currentTrack: { artist, title, source, timestamp: now, tabId: tabId ?? null }
   });
 
   // Track extension activation with streaming service
@@ -371,6 +372,11 @@ setupReleaseAlerts();
 // out-of-band via browser settings.
 chrome.runtime.onInstalled.addListener(() => { reconcileCustomSites(); });
 chrome.runtime.onStartup.addListener(() => { reconcileCustomSites(); });
+// Also reconcile immediately when a permission is revoked (e.g. via the
+// browser's site/extension settings) instead of waiting for the next
+// install/startup, so a stale registration doesn't linger for the rest of
+// the browsing session.
+chrome.permissions.onRemoved.addListener(() => { reconcileCustomSites(); });
 reconcileCustomSites();
 
 // ========================================

--- a/apps/extension/content/generic.js
+++ b/apps/extension/content/generic.js
@@ -30,7 +30,33 @@
     'fairplayer.band': 'fairplayer'
   };
 
+  // Faircamp's built-in player doesn't implement the Media Session API, so the
+  // generic Media Session reader can't see it. Faircamp pages are identifiable
+  // by their generator meta tag and share a stable template across every
+  // self-hosted deployment, so we read the playing track straight from the DOM.
+  // This is platform-wide detection keyed on the template — not per-site
+  // scraping of an arbitrary hostname.
+  function isFaircampPage() {
+    const generator = document.querySelector('meta[name="generator"]');
+    return !!generator && /^Faircamp\b/i.test(generator.content || '');
+  }
+
+  const IS_FAIRCAMP = isFaircampPage();
+
+  function getFromFaircamp() {
+    const active = document.querySelector('.track.active.playing')
+      || document.querySelector('.track.active');
+    if (!active) return null;
+    const title = active.querySelector('.title')?.textContent?.trim();
+    // Prefer a per-track artist (compilations); fall back to the release artist.
+    const artist = (active.querySelector('.track_artists')?.textContent
+      || document.querySelector('.release_artists')?.textContent || '').trim();
+    if (!title || !artist) return null;
+    return { artist, title };
+  }
+
   function getSourceName() {
+    if (IS_FAIRCAMP) return 'faircamp';
     const hostname = window.location.hostname.toLowerCase();
     for (const [domain, source] of Object.entries(DOMAIN_SOURCE_MAP)) {
       if (hostname === domain || hostname.endsWith('.' + domain)) return source;
@@ -39,7 +65,7 @@
   }
 
   function getNowPlaying() {
-    return getFromMediaSession();
+    return getFromMediaSession() || (IS_FAIRCAMP ? getFromFaircamp() : null);
   }
 
   function isPlaying() {

--- a/apps/extension/lib/custom-sites.js
+++ b/apps/extension/lib/custom-sites.js
@@ -1,0 +1,178 @@
+// User-opted, per-site playback detection (UNS-152).
+//
+// Lets a user turn on the generic Media Session detector for the site in the
+// active tab without shipping a new store release for every new site. We request
+// the host permission for just that origin, then register the existing
+// common.js + generic.js content scripts there at runtime. Nothing here changes
+// detection logic — it only extends *where* the generic detector can run.
+
+// chrome.storage.local key holding the list of user-enabled origin patterns,
+// e.g. ["https://fairplayer.band/*", "https://someartist.com/*"].
+export const CUSTOM_SITES_KEY = 'customSites';
+
+// Sanity cap so storage and startup reconciliation stay bounded. Nobody is
+// expected to hit this — it just prevents unbounded growth.
+export const MAX_CUSTOM_SITES = 100;
+
+// The bundled scripts a dynamically-enabled site runs — the same generic
+// detector the static allowlist uses. We only ever register our own files.
+const CUSTOM_SITE_SCRIPTS = ['content/common.js', 'content/generic.js'];
+
+// Stable registration id per origin so we can update/remove it later.
+function registrationId(origin) {
+  return `generic:${origin}`;
+}
+
+// "https://fairplayer.band/*" from any URL on that origin.
+export function originPattern(url) {
+  return `${new URL(url).origin}/*`;
+}
+
+// Can we script this URL at all? Only http/https pages — chrome://, about:,
+// extension, and other privileged pages can't be scripted and would reject
+// permissions.request.
+export function isScriptableUrl(url) {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'https:' || protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+// Does `url` match a manifest match pattern like "https://*.bandcamp.com/*"?
+// Standard match-pattern semantics: scheme, host (with optional "*." prefix or
+// bare "*"), and a glob path.
+function matchesPattern(url, pattern) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const m = /^(\*|https?|file|ftp):\/\/(\*|(?:\*\.)?[^/*]+)(\/.*)$/.exec(pattern);
+  if (!m) return false;
+  const [, scheme, host, path] = m;
+
+  // Scheme
+  const urlScheme = parsed.protocol.slice(0, -1); // drop trailing ":"
+  if (scheme === '*') {
+    if (urlScheme !== 'http' && urlScheme !== 'https') return false;
+  } else if (scheme !== urlScheme) {
+    return false;
+  }
+
+  // Host
+  if (host === '*') {
+    // matches any host
+  } else if (host.startsWith('*.')) {
+    const base = host.slice(2);
+    if (parsed.hostname !== base && !parsed.hostname.endsWith('.' + base)) return false;
+  } else if (host !== parsed.hostname) {
+    return false;
+  }
+
+  // Path (glob against pathname + search)
+  const escaped = path.split('*').map(seg => seg.replace(/[.+?^${}()|[\]\\]/g, '\\$&')).join('.*');
+  return new RegExp('^' + escaped + '$').test(parsed.pathname + parsed.search);
+}
+
+// Is this URL already covered by a built-in (statically-declared) content
+// script? If so, detection is already active and we hide the Enable control.
+export function isBuiltInSite(url) {
+  const scripts = chrome.runtime.getManifest().content_scripts || [];
+  return scripts.some(s => (s.matches || []).some(p => matchesPattern(url, p)));
+}
+
+export async function getCustomSites() {
+  const { [CUSTOM_SITES_KEY]: sites = [] } = await chrome.storage.local.get(CUSTOM_SITES_KEY);
+  return sites;
+}
+
+// Register the generic detector for an origin, unless it's already registered.
+async function registerCustomSite(origin) {
+  const existing = await chrome.scripting.getRegisteredContentScripts({ ids: [registrationId(origin)] });
+  if (existing.length > 0) return;
+  await chrome.scripting.registerContentScripts([{
+    id: registrationId(origin),
+    matches: [origin],
+    js: CUSTOM_SITE_SCRIPTS,
+    runAt: 'document_idle',
+    persistAcrossSessions: true, // browser re-registers on startup automatically
+  }]);
+}
+
+// Enable detection for an origin: register the content script and record it in
+// our own list. The caller is responsible for requesting the host permission
+// (that must happen from a user gesture in the popup) before calling this.
+// Returns { ok } or { ok: false, reason: 'limit' } when the cap is reached.
+export async function enableSite(origin) {
+  const sites = await getCustomSites();
+  if (sites.includes(origin)) {
+    await registerCustomSite(origin); // ensure it's actually registered
+    return { ok: true };
+  }
+  if (sites.length >= MAX_CUSTOM_SITES) {
+    return { ok: false, reason: 'limit' };
+  }
+  await registerCustomSite(origin);
+  sites.push(origin);
+  await chrome.storage.local.set({ [CUSTOM_SITES_KEY]: sites });
+  return { ok: true };
+}
+
+// Disable detection for an origin: unregister the content script, revoke the
+// host permission, and prune it from our list.
+export async function disableSite(origin) {
+  try {
+    await chrome.scripting.unregisterContentScripts({ ids: [registrationId(origin)] });
+  } catch {
+    // Not registered — nothing to unregister.
+  }
+  await chrome.permissions.remove({ origins: [origin] });
+  const sites = (await getCustomSites()).filter(s => s !== origin);
+  await chrome.storage.local.set({ [CUSTOM_SITES_KEY]: sites });
+}
+
+// Reconcile stored origins, granted permissions, and live registrations so they
+// don't drift apart (e.g. the user revoked a permission via browser settings,
+// or a registration went missing). Run on install and browser startup.
+export async function reconcileCustomSites() {
+  const sites = await getCustomSites();
+  if (sites.length === 0) return;
+
+  const registered = await chrome.scripting.getRegisteredContentScripts();
+  const registeredIds = new Set(registered.map(s => s.id));
+
+  const survivors = [];
+  for (const origin of sites) {
+    const hasPermission = await chrome.permissions.contains({ origins: [origin] });
+
+    if (!hasPermission) {
+      // User revoked the permission out-of-band — drop the orphaned registration.
+      if (registeredIds.has(registrationId(origin))) {
+        try {
+          await chrome.scripting.unregisterContentScripts({ ids: [registrationId(origin)] });
+        } catch {
+          // ignore
+        }
+      }
+      continue; // prune from list
+    }
+
+    // Permission still granted — make sure the script is registered.
+    if (!registeredIds.has(registrationId(origin))) {
+      try {
+        await registerCustomSite(origin);
+      } catch {
+        // Registration failed; keep it in the list to retry next reconcile.
+      }
+    }
+    survivors.push(origin);
+  }
+
+  if (survivors.length !== sites.length) {
+    await chrome.storage.local.set({ [CUSTOM_SITES_KEY]: survivors });
+  }
+}

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -14,7 +14,7 @@
     }
   },
   "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free, open source, no tracking.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -98,8 +98,10 @@
     "activeTab",
     "alarms",
     "notifications",
-    "identity"
+    "identity",
+    "scripting"
   ],
+  "optional_permissions": ["https://*/*"],
   "host_permissions": [
     "https://unstream.stream/*",
     "https://unstream.dev/*",

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Unstream - Support Music Directly",
   "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free and open source.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -87,8 +87,10 @@
     "activeTab",
     "alarms",
     "notifications",
-    "identity"
+    "identity",
+    "scripting"
   ],
+  "optional_host_permissions": ["https://*/*"],
   "host_permissions": [
     "https://unstream.stream/*",
     "https://unstream.dev/*",

--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -343,6 +343,101 @@ body {
 }
 
 
+/* Detect on this site */
+.detect-card {
+  background: #374151;
+  border: 1px solid #4B5563;
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.detect-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #F9FAFB;
+  margin-bottom: 6px;
+}
+
+.detect-desc {
+  font-size: 13px;
+  color: #9CA3AF;
+  margin-bottom: 12px;
+}
+
+.detect-enable-btn {
+  width: 100%;
+  padding: 10px 12px;
+  background: #3B82F6;
+  border: none;
+  border-radius: 8px;
+  color: #F9FAFB;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.detect-enable-btn:hover {
+  background: #2563EB;
+}
+
+.detect-enable-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.detect-enable-btn.hidden {
+  display: none;
+}
+
+/* Custom Sites list */
+.custom-sites-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.custom-site-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #374151;
+  border-radius: 8px;
+}
+
+.custom-site-host {
+  font-size: 13px;
+  color: #E5E7EB;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.custom-site-remove {
+  background: none;
+  border: 1px solid #4B5563;
+  border-radius: 6px;
+  color: #9CA3AF;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 10px;
+  flex-shrink: 0;
+  transition: all 0.2s;
+}
+
+.custom-site-remove:hover {
+  background: #4B5563;
+  color: #EF4444;
+  border-color: #EF4444;
+}
+
+.no-custom-sites {
+  margin-bottom: 0;
+}
+
 /* New Releases */
 .new-releases {
   display: flex;

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -48,6 +48,15 @@
           </div>
         </section>
 
+        <!-- Detect on this site (shown on scriptable, non-allowlist sites) -->
+        <section id="detect-site-section" class="section hidden">
+          <div class="detect-card">
+            <div id="detect-title" class="detect-title"></div>
+            <p id="detect-desc" class="detect-desc"></p>
+            <button id="detect-enable-btn" class="detect-enable-btn hidden"></button>
+          </div>
+        </section>
+
         <!-- Results Section -->
         <section id="results-section" class="section hidden">
           <h2 class="section-title">Support this artist</h2>
@@ -163,6 +172,14 @@
             <input type="checkbox" id="artist-notifications-toggle" checked>
             <span class="toggle-switch"></span>
           </label>
+        </section>
+
+        <!-- Custom Sites -->
+        <section id="custom-sites-section" class="section">
+          <h2 class="section-title">Custom Sites</h2>
+          <p class="setting-description">Sites you've turned on playback detection for. Open Unstream on a site that plays music to add one.</p>
+          <div id="custom-sites-list" class="custom-sites-list"></div>
+          <p id="no-custom-sites" class="setting-description no-custom-sites">No custom sites yet.</p>
         </section>
 
         <!-- Release Alerts Settings -->

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -3,6 +3,15 @@
 import { isBandcampFriday } from '../lib/bandcamp-friday.js';
 import { ALLOWED_RELEASE_DOMAINS, SOURCE_CONFIG, PAYOUT_PERCENTAGES } from '../lib/constants.js';
 import { signInWithPassword, signInWithOtp, signOut, getStoredSession, getAccessToken, getDeviceId } from '../lib/supabase.js';
+import {
+  getCustomSites,
+  enableSite,
+  disableSite,
+  originPattern,
+  isScriptableUrl,
+  isBuiltInSite,
+  MAX_CUSTOM_SITES,
+} from '../lib/custom-sites.js';
 
 const API_BASE = 'https://unstream.stream/api';
 
@@ -39,6 +48,10 @@ const elements = {
   // Discover tab
   nowPlaying: document.getElementById('now-playing'),
   idleState: document.getElementById('idle-state'),
+  detectSiteSection: document.getElementById('detect-site-section'),
+  detectTitle: document.getElementById('detect-title'),
+  detectDesc: document.getElementById('detect-desc'),
+  detectEnableBtn: document.getElementById('detect-enable-btn'),
   resultsSection: document.getElementById('results-section'),
   resultsGrid: document.getElementById('results-grid'),
   socialSection: document.getElementById('social-section'),
@@ -76,6 +89,8 @@ const elements = {
   releaseAlertsSection: document.getElementById('release-alerts-section'),
   checkNowBtn: document.getElementById('check-now-btn'),
   lastCheckTime: document.getElementById('last-check-time'),
+  customSitesList: document.getElementById('custom-sites-list'),
+  noCustomSites: document.getElementById('no-custom-sites'),
 };
 
 // State
@@ -86,6 +101,11 @@ let currentSocialLinks = null;
 let currentLocation = null;
 let newReleases = [];
 let authSession = null; // null = unknown/loading, false = signed out, object = signed in
+
+// Active-tab origin the "Enable" button will request, captured up front so the
+// permission request runs directly inside the user's click (no await before it,
+// which would break the required user gesture). { origin, tabId } or null.
+let detectTarget = null;
 
 // Slug lookup cache: { artistName → slug }
 const SLUG_CACHE_KEY = 'artistSlugCache';
@@ -457,6 +477,141 @@ function formatLocation(location) {
   return '';
 }
 
+// ---- Custom Sites (user-opted per-site detection, UNS-152) ----
+
+async function getActiveTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab || null;
+}
+
+// Decide what (if anything) to show in the "detect on this site" card for the
+// active tab: an Enable prompt on unsupported sites, or a gentle "watching but
+// nothing detected yet" note on sites already enabled that aren't reporting.
+async function setupDetectionControl() {
+  detectTarget = null;
+  elements.detectSiteSection.classList.add('hidden');
+  elements.detectEnableBtn.classList.add('hidden');
+
+  const tab = await getActiveTab();
+  // Hide on privileged pages (chrome://, about:, extension pages) and on
+  // built-in allowlist sites where detection already runs.
+  if (!tab || !tab.url || !isScriptableUrl(tab.url) || isBuiltInSite(tab.url)) return;
+
+  const origin = originPattern(tab.url);
+  const host = new URL(tab.url).hostname;
+  const sites = await getCustomSites();
+
+  if (sites.includes(origin)) {
+    // Already enabled. If nothing is playing/detected, explain the idle state
+    // rather than silently showing nothing.
+    const { currentTrack } = await chrome.storage.local.get('currentTrack');
+    const hasFreshTrack = currentTrack && Date.now() - currentTrack.timestamp < 5 * 60 * 1000;
+    if (!hasFreshTrack) showDetectIdleNote();
+    return;
+  }
+
+  showDetectEnablePrompt(host, origin, tab.id, sites.length);
+}
+
+function showDetectEnablePrompt(host, origin, tabId, siteCount) {
+  elements.detectTitle.textContent = 'Detect music on this site?';
+
+  if (siteCount >= MAX_CUSTOM_SITES) {
+    elements.detectDesc.textContent = `You've reached the limit of ${MAX_CUSTOM_SITES} custom sites. Remove one in Settings to add another.`;
+    elements.detectEnableBtn.classList.add('hidden');
+  } else {
+    elements.detectDesc.textContent = "Unstream isn't watching this site yet. Turn on detection to find artists you're playing here.";
+    elements.detectEnableBtn.textContent = `Enable on ${host}`;
+    elements.detectEnableBtn.disabled = false;
+    elements.detectEnableBtn.classList.remove('hidden');
+    detectTarget = { origin, tabId };
+  }
+
+  elements.detectSiteSection.classList.remove('hidden');
+}
+
+function showDetectIdleNote() {
+  elements.detectTitle.textContent = 'Watching this site';
+  elements.detectDesc.textContent = "Unstream is watching this site but hasn't picked up any track info. This site may not share what's playing in a way Unstream can read.";
+  elements.detectEnableBtn.classList.add('hidden');
+  elements.detectSiteSection.classList.remove('hidden');
+}
+
+// Handle the Enable click. Requests the host permission FIRST (directly in the
+// user gesture), then registers and injects the generic detector.
+async function handleEnableSite() {
+  if (!detectTarget) return;
+  const { origin, tabId } = detectTarget;
+
+  const granted = await chrome.permissions.request({ origins: [origin] });
+  if (!granted) return; // user declined — leave everything untouched
+
+  elements.detectEnableBtn.disabled = true;
+
+  const result = await enableSite(origin);
+  if (!result.ok) {
+    // Hit the sanity cap — surface it and revoke the just-granted permission.
+    await chrome.permissions.remove({ origins: [origin] });
+    await setupDetectionControl();
+    return;
+  }
+
+  // Inject into the already-open tab so the user doesn't have to reload.
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content/common.js', 'content/generic.js'],
+    });
+  } catch {
+    // Some pages block injection; the persistent registration still applies on reload.
+  }
+
+  await setupDetectionControl();
+  await loadCustomSites();
+}
+
+// Render the managed list of enabled custom sites in Settings.
+async function loadCustomSites() {
+  const sites = await getCustomSites();
+
+  if (sites.length === 0) {
+    elements.customSitesList.replaceChildren();
+    elements.noCustomSites.style.display = 'block';
+    return;
+  }
+
+  elements.noCustomSites.style.display = 'none';
+
+  const fragment = document.createDocumentFragment();
+  for (const origin of sites) {
+    const item = document.createElement('div');
+    item.className = 'custom-site-item';
+
+    const hostSpan = document.createElement('span');
+    hostSpan.className = 'custom-site-host';
+    // Show the bare host (strip scheme and the trailing "/*").
+    hostSpan.textContent = origin.replace(/^https?:\/\//, '').replace(/\/\*$/, '');
+    hostSpan.title = origin;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'custom-site-remove';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => removeCustomSite(origin));
+
+    item.appendChild(hostSpan);
+    item.appendChild(removeBtn);
+    fragment.appendChild(item);
+  }
+
+  elements.customSitesList.replaceChildren(fragment);
+}
+
+async function removeCustomSite(origin) {
+  await disableSite(origin);
+  await loadCustomSites();
+  await setupDetectionControl();
+}
+
 // Initialize popup
 async function init() {
   // Initialize auth state
@@ -470,6 +625,10 @@ async function init() {
     await loadResults(currentTrack.artist);
     await loadEnrichment(currentTrack.artist);
   }
+
+  // Show per-site detection control for the active tab, and the managed list
+  await setupDetectionControl();
+  await loadCustomSites();
 
   // Load saved artists and releases
   await loadSavedArtists();
@@ -1197,6 +1356,9 @@ function setupEventListeners() {
 
   // Sync now button
   elements.syncNowBtn.addEventListener('click', syncSavedArtists);
+
+  // Enable per-site detection
+  elements.detectEnableBtn.addEventListener('click', handleEnableSite);
 }
 
 // Initialize

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -502,10 +502,24 @@ async function setupDetectionControl() {
   const sites = await getCustomSites();
 
   if (sites.includes(origin)) {
-    // Already enabled. If nothing is playing/detected, explain the idle state
-    // rather than silently showing nothing.
+    const hasPermission = await chrome.permissions.contains({ origins: [origin] });
+    if (!hasPermission) {
+      // Permission was revoked out-of-band (e.g. via the browser's own site
+      // settings) since we last reconciled — the stored entry is stale. Prune
+      // it and fall through to the enable prompt instead of claiming we're
+      // still watching.
+      await disableSite(origin);
+      showDetectEnablePrompt(host, origin, tab.id, sites.length - 1);
+      return;
+    }
+
+    // Already enabled. If nothing is playing/detected on THIS tab, explain the
+    // idle state rather than silently showing nothing (or showing it based on
+    // a track that was actually detected on some other tab).
     const { currentTrack } = await chrome.storage.local.get('currentTrack');
-    const hasFreshTrack = currentTrack && Date.now() - currentTrack.timestamp < 5 * 60 * 1000;
+    const hasFreshTrack = currentTrack
+      && currentTrack.tabId === tab.id
+      && Date.now() - currentTrack.timestamp < 5 * 60 * 1000;
     if (!hasFreshTrack) showDetectIdleNote();
     return;
   }


### PR DESCRIPTION
Implements [UNS-152](https://linear.app/unstream/issue/UNS-152) — the "Tier 3" per-site playback detection from the expansion discussion.

## What it does

A user on a music site that isn't in the curated allowlist (e.g. `fairplayer.band`, an artist's own site) can open the popup and click **Enable on {host}**. The browser shows its native per-origin permission prompt; on accept, the existing generic Media Session detector is registered for that origin and injected into the current tab immediately (no reload). The site is remembered and auto-registers on future visits, and can be removed from a managed list in Settings (which revokes the permission).

This scales coverage to the long tail of small/self-hosted players **without** a new store release per site and **without** broadening the install-time permission prompt.

## Changes

- **New `apps/extension/lib/custom-sites.js`** — single home for the logic, imported by both popup and service worker: `enableSite`/`disableSite`/`reconcileCustomSites`, a standard match-pattern matcher (`isBuiltInSite`, unit-checked against the real allowlist incl. `amazon.com/music/*`), and the `customSites` storage source of truth.
- **Popup** — Enable card on Discover (shown only on scriptable, non-allowlist, not-already-enabled sites), a gentle "watching but no track info" idle note, and a Custom Sites remove-list in Settings. A 100-site sanity cap is surfaced in the UI.
- **Service worker** — reconcile stored origins vs granted permissions vs live registrations on `onInstalled`/`onStartup`, pruning any site whose permission was revoked out-of-band via browser settings.
- **Manifests** — add `scripting` + optional broad-host pattern; bump to **2.5.0**.

## Note on one spec deviation

The spec put `scripting` in Firefox's `optional_permissions`. This PR puts `scripting` in the **required** `permissions` for *both* manifests, and keeps only the broad host pattern (`https://*/*`) optional. Rationale: if `scripting` were optional in Firefox, `chrome.scripting` would be undefined until granted, breaking startup reconciliation. `scripting` alone grants no host access, so it doesn't widen the install prompt. Per-origin host access remains fully opt-in and user-initiated.

Also: the Enable button captures the target origin up front so `permissions.request` runs directly in the click gesture with no preceding `await` (Firefox rejects otherwise).

## Testing

Static checks pass (JS syntax, JSON validity, match-pattern unit test). The extension isn't covered by `npm run lint` or the build pipeline, and the enable flow depends on native permission dialogs, so end-to-end testing is manual (load unpacked):

- **Chrome:** enable `fairplayer.band`, confirm the prompt names only that origin, confirm detection without reload, restart browser and confirm persistence, remove and confirm script + permission are gone.
- **Firefox:** repeat with the Firefox manifest (manifest swap per usual flow).
- **Reconciliation:** revoke the permission in browser settings, restart, confirm the orphaned registration is cleaned up and the site drops from the list.
- **Negative:** enable a site with no Media Session support → idle "no track info" note, no crash.
- **Allowlist/privileged:** confirm the Enable control is hidden on built-in sites and `chrome://`/`about:` pages.

Ships in a normal extension release (version bump + manual zip workflow for Chrome + Firefox). Independent of the fairplayer.band static-allowlist PR (#304).

🤖 Generated with [Claude Code](https://claude.com/claude-code)