### PR TITLE
Replace blank loading screens with branded skeleton UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,8 @@ import { SearchBar } from './components/SearchBar';
 import { ResultCard } from './components/ResultCard';
 
 import { Header } from './components/Header';
+import { LoadingLabel, SkeletonScreen } from './components/Skeleton';
+import { SearchResultsSkeleton } from './components/LoadingSkeletons';
 import type { SearchResult } from './types';
 import { sources, sourceCategories, searchPlatforms, resolveArtistUrl, fetchMusicBrainzData, mergeWithMusicBrainzData } from './services/sources';
 import { analytics } from './services/analytics';
@@ -246,9 +248,8 @@ function App() {
 
           {/* Resolving URL state */}
           {isResolving && (
-            <div className="mt-8 flex flex-col items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent-secondary border-t-transparent mb-3"></div>
-              <p className="text-text-muted">Resolving artist from link...</p>
+            <div className="mt-8 flex items-center justify-center py-8">
+              <LoadingLabel>Resolving artist from link...</LoadingLabel>
             </div>
           )}
 
@@ -263,22 +264,19 @@ function App() {
           {hasSearched && !error && (
             <div className="mt-8">
               {isLoading ? (
-                <div className="flex flex-col items-center justify-center py-16">
-                  <div className="animate-spin rounded-full h-12 w-12 border-2 border-accent-primary border-t-transparent mb-4"></div>
-                  <p className="text-text-muted">Searching platforms...</p>
-                </div>
+                <SkeletonScreen label="Searching platforms">
+                  <div className="space-y-4">
+                    <LoadingLabel>Searching platforms...</LoadingLabel>
+                    <SearchResultsSkeleton />
+                  </div>
+                </SkeletonScreen>
               ) : results.length > 0 ? (
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
                     <p className="text-text-muted text-sm">
                       Found {results.length} result{results.length !== 1 ? 's' : ''}
                     </p>
-                    {isEnriching && (
-                      <div className="flex items-center gap-2 text-text-muted text-sm">
-                        <div className="w-3 h-3 border-2 border-accent-secondary border-t-transparent rounded-full animate-spin"></div>
-                        <span>Loading more sources...</span>
-                      </div>
-                    )}
+                    {isEnriching && <LoadingLabel>Loading more sources...</LoadingLabel>}
                   </div>
                   {results.map((result) => (
                     <ResultCard

--- a/apps/web/src/components/AppFallback.tsx
+++ b/apps/web/src/components/AppFallback.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from './Skeleton';
+import { PageSkeleton } from './PageSkeleton';
+import { ArticleListSkeleton } from './LoadingSkeletons';
+
+/** Shown while a lazily-loaded page chunk downloads. */
+export function AppLoadingFallback() {
+  return (
+    <PageSkeleton label="Loading page" maxWidth="max-w-4xl">
+      <div className="space-y-8">
+        <Skeleton className="h-7 w-48" />
+        <ArticleListSkeleton count={3} />
+      </div>
+    </PageSkeleton>
+  );
+}
+
+/**
+ * Shown when a render throws. This sits outside the router, so it can't use
+ * <Link> — a plain link back to the homepage is the way out.
+ */
+export function AppErrorFallback() {
+  return (
+    <div className="min-h-screen bg-bg-primary text-text-primary flex flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="font-display text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-text-muted max-w-md">
+        Unstream hit an unexpected error. Reloading usually clears it.
+      </p>
+      <a
+        href="/"
+        className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
+      >
+        Back to Unstream
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/ArtistAnalytics.tsx
+++ b/apps/web/src/components/ArtistAnalytics.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { sources } from '../services/sources';
+import { SkeletonScreen } from './Skeleton';
+import { StatTilesSkeleton } from './LoadingSkeletons';
 import type { SourceId } from '../types';
 
 type Period = '7d' | '30d' | '90d' | 'all';
@@ -65,7 +67,11 @@ export function ArtistAnalytics({ slug }: { slug: string }) {
         </select>
       </div>
 
-      {loading && <p className="text-xs text-text-muted">Loading...</p>}
+      {loading && (
+        <SkeletonScreen label="Loading analytics">
+          <StatTilesSkeleton />
+        </SkeletonScreen>
+      )}
       {error && <p className="text-xs text-red-400">{error}</p>}
 
       {data && !loading && (

--- a/apps/web/src/components/LoadingProfile.tsx
+++ b/apps/web/src/components/LoadingProfile.tsx
@@ -1,8 +1,10 @@
+import { SkeletonScreen } from './Skeleton';
+import { ArtistProfileSkeleton } from './LoadingSkeletons';
+
 export function LoadingProfile() {
   return (
-    <div className="flex flex-col items-center justify-center py-16">
-      <div className="animate-spin rounded-full h-12 w-12 border-2 border-accent-primary border-t-transparent mb-4" />
-      <p className="text-text-muted">Loading profile…</p>
-    </div>
+    <SkeletonScreen label="Loading profile">
+      <ArtistProfileSkeleton />
+    </SkeletonScreen>
   );
 }

--- a/apps/web/src/components/LoadingSkeletons.tsx
+++ b/apps/web/src/components/LoadingSkeletons.tsx
@@ -1,0 +1,188 @@
+/**
+ * Page-shaped loading skeletons.
+ *
+ * Each one mirrors the layout of the content it stands in for, so the page
+ * doesn't jump around when the real data lands. Built from the primitives in
+ * Skeleton.tsx.
+ */
+
+import { Skeleton, SkeletonCircle, SkeletonText } from './Skeleton';
+
+/** Search results — matches the ResultCard header, platform badges and actions. */
+export function SearchResultsSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className="result-card">
+          <div className="flex gap-4 p-4">
+            <Skeleton className="w-16 h-16 flex-shrink-0 rounded" />
+            <div className="flex-1 min-w-0 space-y-2">
+              <Skeleton className="h-4 w-16 rounded" />
+              <Skeleton className="h-5 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+          </div>
+          <div className="px-4 pb-4 flex flex-wrap gap-2">
+            {Array.from({ length: 4 - (i % 2) }, (_, j) => (
+              <Skeleton key={j} className="h-8 w-28 rounded" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Artist profile hero, bio and platform links. */
+export function ArtistProfileSkeleton() {
+  return (
+    <div>
+      <div className="pt-12 pb-8 flex flex-col items-center">
+        <SkeletonCircle className="w-32 h-32 mb-4" />
+        <Skeleton className="h-8 w-48 mb-3" />
+        <Skeleton className="h-3 w-32 mb-6" />
+        <SkeletonText lines={2} className="w-full max-w-md" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div key={i} className="source-card flex items-center gap-3">
+            <SkeletonCircle className="w-8 h-8 flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** One saved/claimed artist card, as shown on the dashboard. */
+function ArtistCardSkeleton() {
+  return (
+    <div className="p-4 rounded-lg bg-bg-secondary border border-border">
+      <div className="flex gap-4">
+        <SkeletonCircle className="w-16 h-16 flex-shrink-0" />
+        <div className="flex-1 min-w-0 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <div className="flex gap-2 pt-2">
+            <Skeleton className="h-8 w-16 rounded-lg" />
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** The signed-in dashboard: claimed profiles above a grid of saved artists. */
+export function DashboardSkeleton() {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-7 w-40" />
+
+      <section>
+        <Skeleton className="h-5 w-32 mb-4" />
+        <ArtistCardSkeleton />
+      </section>
+
+      <section>
+        <Skeleton className="h-5 w-36 mb-4" />
+        <Skeleton className="h-12 w-full rounded-lg mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <ArtistCardSkeleton key={i} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/** A compact list of artist rows — the directory and public saved-artist lists. */
+export function ArtistRowsSkeleton({ count = 8 }: { count?: number }) {
+  return (
+    <div className="grid gap-0.5">
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className="flex items-center gap-3 px-3.5 py-2.5">
+          <SkeletonCircle className="w-9 h-9 flex-shrink-0" />
+          <Skeleton className={`h-4 ${i % 3 === 0 ? 'w-40' : i % 3 === 1 ? 'w-28' : 'w-52'}`} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Cards in a vertical list — guides index and changelog entries. */
+export function ArticleListSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className="bg-surface-secondary rounded-xl p-6 border border-border space-y-3">
+          <Skeleton className="h-5 w-2/3" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Long-form article body. */
+export function ArticleSkeleton() {
+  return (
+    <div className="space-y-6">
+      <SkeletonText lines={4} />
+      <Skeleton className="h-5 w-1/3" />
+      <SkeletonText lines={5} />
+      <SkeletonText lines={3} />
+    </div>
+  );
+}
+
+/** Stacked form sections — settings, profile editing, admin queues. */
+export function FormSkeleton({ sections = 2, fields = 3 }: { sections?: number; fields?: number }) {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-7 w-40" />
+      {Array.from({ length: sections }, (_, i) => (
+        <section key={i} className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
+          <Skeleton className="h-5 w-32" />
+          {Array.from({ length: fields }, (_, j) => (
+            <div key={j} className="space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-10 w-full rounded-lg" />
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+/** Three stat tiles over a short bar breakdown — the analytics panels. */
+export function StatTilesSkeleton({ bars = 3 }: { bars?: number }) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-3 gap-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="p-2 rounded bg-bg-primary border border-border/50 flex flex-col items-center gap-1.5">
+            <Skeleton className="h-5 w-10" />
+            <Skeleton className="h-2.5 w-14" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-1.5">
+        {Array.from({ length: bars }, (_, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className={`h-4 flex-1 ${i === 0 ? '' : 'opacity-70'}`} />
+            <Skeleton className="h-3 w-8" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PageSkeleton.tsx
+++ b/apps/web/src/components/PageSkeleton.tsx
@@ -1,0 +1,30 @@
+import { Header } from './Header';
+import { Footer } from './Footer';
+import { SkeletonScreen } from './Skeleton';
+
+/**
+ * Full-page loading shell. Renders the real header and footer — they need no
+ * data — and puts a content skeleton where the page body will land, so a
+ * loading page still looks like the app instead of a blank screen.
+ */
+export function PageSkeleton({
+  label,
+  maxWidth = 'max-w-2xl',
+  children,
+}: {
+  label: string;
+  maxWidth?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-bg-primary text-text-primary flex flex-col">
+      <Header />
+      <main className="flex-1 p-6">
+        <div className={`${maxWidth} mx-auto`}>
+          <SkeletonScreen label={label}>{children}</SkeletonScreen>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/components/Skeleton.tsx
+++ b/apps/web/src/components/Skeleton.tsx
@@ -1,0 +1,70 @@
+/**
+ * Loading primitives shared by every skeleton screen.
+ *
+ * The visuals live in index.css (`.skeleton`, `.eq-bars`, `.skeleton-fade-in`)
+ * so they follow the theme tokens and respect prefers-reduced-motion.
+ */
+
+interface SkeletonProps {
+  className?: string;
+}
+
+/** A single shimmering placeholder block. Size it with Tailwind classes. */
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return <div className={`skeleton ${className}`} />;
+}
+
+/** A round placeholder, for avatars and artist photos. */
+export function SkeletonCircle({ className = '' }: SkeletonProps) {
+  return <div className={`skeleton rounded-full ${className}`} />;
+}
+
+/** A block of placeholder text lines. The last line is short, like real copy. */
+export function SkeletonText({ lines = 3, className = '' }: SkeletonProps & { lines?: number }) {
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton key={i} className={`h-3 ${i === lines - 1 ? 'w-2/3' : 'w-full'}`} />
+      ))}
+    </div>
+  );
+}
+
+/** Four bouncing bars in the Unstream accent colours. */
+export function EqualizerBars({ className = '' }: SkeletonProps) {
+  return (
+    <span className={`eq-bars ${className}`} aria-hidden="true">
+      <span />
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
+/** An inline "still working" line: equalizer bars plus a short message. */
+export function LoadingLabel({ children, className = '' }: SkeletonProps & { children: React.ReactNode }) {
+  return (
+    <p className={`flex items-center gap-2 text-text-muted text-sm ${className}`}>
+      <EqualizerBars />
+      <span>{children}</span>
+    </p>
+  );
+}
+
+/**
+ * Wraps a skeleton screen. Screen readers hear the label instead of walking
+ * through a pile of empty boxes, and the whole thing fades in together.
+ */
+export function SkeletonScreen({
+  label,
+  className = '',
+  children,
+}: SkeletonProps & { label: string; children: React.ReactNode }) {
+  return (
+    <div role="status" aria-busy="true" className={`skeleton-fade-in ${className}`}>
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -28,6 +28,15 @@
   --badge-dark-text: #999999;
 }
 
+/* Loading skeletons. The base sits a step lighter/darker than every card
+   surface so placeholder blocks stay visible inside cards, not just on the page
+   background. The sheen is the highlight that sweeps across them. */
+:root {
+  --skeleton-base: #2b2b2b;
+  --skeleton-sheen: rgba(255, 255, 255, 0.06);
+  --skeleton-sheen-accent: rgba(255, 107, 53, 0.16);
+}
+
 html[data-theme="light"] {
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f5f5f5;
@@ -45,6 +54,10 @@ html[data-theme="light"] {
   --color-surface-secondary: #f0f0f0;
 
   --badge-dark-text: #333333;
+
+  --skeleton-base: #e3e3e3;
+  --skeleton-sheen: rgba(255, 255, 255, 0.7);
+  --skeleton-sheen-accent: rgba(229, 90, 43, 0.11);
 }
 
 @layer base {
@@ -55,6 +68,76 @@ html[data-theme="light"] {
 }
 
 @layer components {
+  /* Loading skeleton block: a soft placeholder with a warm sweep across it. */
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    background: var(--skeleton-base);
+  }
+
+  .skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      var(--skeleton-sheen) 40%,
+      var(--skeleton-sheen-accent) 50%,
+      var(--skeleton-sheen) 60%,
+      transparent 100%
+    );
+    animation: skeleton-sweep 1.6s ease-in-out infinite;
+  }
+
+  @keyframes skeleton-sweep {
+    100% { transform: translateX(100%); }
+  }
+
+  /* Skeleton screens fade in after a beat so quick loads never flash a placeholder. */
+  .skeleton-fade-in {
+    animation: skeleton-fade-in 0.3s ease-out 0.12s both;
+  }
+
+  @keyframes skeleton-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  /* Equalizer bars — the Unstream "working on it" mark, in the accent colours. */
+  .eq-bars {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 0.875rem;
+  }
+
+  .eq-bars span {
+    width: 3px;
+    height: 100%;
+    border-radius: 2px;
+    transform-origin: bottom;
+    animation: eq-bounce 1s ease-in-out infinite;
+  }
+
+  .eq-bars span:nth-child(1) { background: var(--color-accent-primary); animation-delay: 0s; }
+  .eq-bars span:nth-child(2) { background: var(--color-accent-secondary); animation-delay: 0.15s; }
+  .eq-bars span:nth-child(3) { background: var(--color-accent-tertiary); animation-delay: 0.3s; }
+  .eq-bars span:nth-child(4) { background: var(--color-accent-primary); animation-delay: 0.45s; }
+
+  @keyframes eq-bounce {
+    0%, 100% { transform: scaleY(0.25); }
+    50% { transform: scaleY(1); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton::after { animation: none; opacity: 0.5; }
+    .skeleton-fade-in { animation: none; }
+    .eq-bars span { animation: none; transform: scaleY(0.6); }
+  }
+
   .search-input {
     @apply w-full bg-bg-secondary border border-border rounded-lg px-4 py-3 text-base text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary transition-colors;
   }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 import App from './App.tsx'
 import { ArtistPage } from './pages/ArtistPage.tsx'
+import { AppLoadingFallback, AppErrorFallback } from './components/AppFallback'
 
 initSentry()
 
@@ -42,33 +43,12 @@ function ArtistDashboardRedirect() {
   return <Navigate to="/dashboard" replace />
 }
 
-function LoadingFallback() {
-  return (
-    <div className="min-h-screen bg-bg-primary">
-      <div className="p-4 border-b border-border flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <div className="w-6 h-6 bg-surface-secondary rounded animate-pulse" />
-          <div className="w-20 h-5 bg-surface-secondary rounded animate-pulse" />
-        </div>
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-5 bg-surface-secondary rounded animate-pulse" />
-          <div className="w-8 h-8 bg-surface-secondary rounded-full animate-pulse" />
-        </div>
-      </div>
-      <div className="max-w-4xl mx-auto px-4 py-16">
-        <div className="w-48 h-6 bg-surface-secondary rounded animate-pulse mb-4" />
-        <div className="w-64 h-4 bg-surface-secondary rounded animate-pulse" />
-      </div>
-    </div>
-  )
-}
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Sentry.ErrorBoundary fallback={<LoadingFallback />}>
+    <Sentry.ErrorBoundary fallback={<AppErrorFallback />}>
       <AuthProvider>
         <BrowserRouter>
-          <Suspense fallback={<LoadingFallback />}>
+          <Suspense fallback={<AppLoadingFallback />}>
             <Routes>
               <Route path="/" element={<App />} />
               <Route path="/artist/:slug" element={<ArtistPage />} />

--- a/apps/web/src/pages/AdminAnalyticsPage.tsx
+++ b/apps/web/src/pages/AdminAnalyticsPage.tsx
@@ -4,6 +4,9 @@ import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { Skeleton } from '../components/Skeleton';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { StatTilesSkeleton } from '../components/LoadingSkeletons';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -288,9 +291,14 @@ export function AdminAnalyticsPage() {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-text-muted">Loading…</p>
-      </div>
+      <PageSkeleton label="Loading analytics" maxWidth="max-w-5xl">
+        <div className="space-y-8">
+          <Skeleton className="h-7 w-40" />
+          <StatTilesSkeleton bars={5} />
+          <Skeleton className="h-56 w-full rounded-lg" />
+          <StatTilesSkeleton bars={4} />
+        </div>
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/AdminVerifyPage.tsx
+++ b/apps/web/src/pages/AdminVerifyPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
+import { SkeletonScreen } from '../components/Skeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
 
 interface VerificationRequest {
   id: string;
@@ -132,9 +134,9 @@ export function AdminVerifyPage() {
           )}
 
           {loading ? (
-            <div className="flex items-center justify-center py-16">
-              <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent-primary border-t-transparent"></div>
-            </div>
+            <SkeletonScreen label="Loading verification requests">
+              <FormSkeleton sections={2} fields={2} />
+            </SkeletonScreen>
           ) : (
             <>
               {/* Pending requests */}

--- a/apps/web/src/pages/ArtistDashboardPage.tsx
+++ b/apps/web/src/pages/ArtistDashboardPage.tsx
@@ -7,6 +7,8 @@ import { Header } from '../components/Header';
 import { ArtistAnalytics } from '../components/ArtistAnalytics';
 import { PasswordSection } from '../components/PasswordSection';
 import { Footer } from '../components/Footer';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { DashboardSkeleton } from '../components/LoadingSkeletons';
 
 interface ClaimedProfile {
   id: string;
@@ -76,9 +78,9 @@ export function ArtistDashboardPage() {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading your profiles...</div>
-      </div>
+      <PageSkeleton label="Loading your profiles">
+        <DashboardSkeleton />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/ArtistDirectoryPage.tsx
+++ b/apps/web/src/pages/ArtistDirectoryPage.tsx
@@ -4,6 +4,8 @@ import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { Skeleton, SkeletonScreen } from '../components/Skeleton';
+import { ArtistRowsSkeleton } from '../components/LoadingSkeletons';
 
 interface DirectoryArtist {
   slug: string;
@@ -68,9 +70,15 @@ export function ArtistDirectoryPage() {
         </div>
 
         {loading ? (
-          <div className="flex-1 flex items-center justify-center">
-            <span className="text-text-muted">Loading...</span>
-          </div>
+          <SkeletonScreen label="Loading the artist index" className="max-w-3xl mx-auto w-full px-6 pb-12">
+            <div className="flex flex-wrap gap-1.5 justify-center mb-8">
+              {Array.from({ length: 12 }, (_, i) => (
+                <Skeleton key={i} className="w-8 h-8 rounded-lg" />
+              ))}
+            </div>
+            <Skeleton className="h-6 w-8 mb-3" />
+            <ArtistRowsSkeleton count={8} />
+          </SkeletonScreen>
         ) : (
           <>
             {/* Letter navigation */}

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -6,6 +6,8 @@ import { sources } from '../services/sources';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
 import type { SourceId } from '../types';
 
 interface LinkEntry {
@@ -357,9 +359,9 @@ export function ArtistEditPage() {
 
   if (form.loading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading...</div>
-      </div>
+      <PageSkeleton label="Loading artist profile">
+        <FormSkeleton sections={3} fields={2} />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/ChangelogPage.tsx
+++ b/apps/web/src/pages/ChangelogPage.tsx
@@ -3,6 +3,8 @@ import * as Sentry from '@sentry/react';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { Skeleton, SkeletonScreen } from '../components/Skeleton';
+import { ArticleListSkeleton } from '../components/LoadingSkeletons';
 
 interface ChangelogEntry {
   id: string;
@@ -67,7 +69,10 @@ export function ChangelogPage() {
       <main className="px-4 pb-16">
         <div className="max-w-2xl mx-auto">
           {loading ? (
-            <p className="text-text-muted text-center">Loading...</p>
+            <SkeletonScreen label="Loading the changelog">
+              <Skeleton className="h-3 w-28 mb-4" />
+              <ArticleListSkeleton count={3} />
+            </SkeletonScreen>
           ) : entries.length === 0 ? (
             <p className="text-text-muted text-center">Nothing here yet.</p>
           ) : (

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -7,6 +7,8 @@ import { Header } from '../components/Header';
 import { ArtistAnalytics } from '../components/ArtistAnalytics';
 import { Footer } from '../components/Footer';
 import { SearchBar } from '../components/SearchBar';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { DashboardSkeleton } from '../components/LoadingSkeletons';
 
 interface ClaimedProfile {
   id: string;
@@ -247,9 +249,9 @@ export function DashboardPage() {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading...</div>
-      </div>
+      <PageSkeleton label="Loading your dashboard" maxWidth="max-w-6xl">
+        <DashboardSkeleton />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/GuidePage.tsx
+++ b/apps/web/src/pages/GuidePage.tsx
@@ -6,6 +6,8 @@ import remarkGfm from 'remark-gfm';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { Skeleton, SkeletonScreen } from '../components/Skeleton';
+import { ArticleSkeleton } from '../components/LoadingSkeletons';
 
 interface GuideMeta {
   slug: string;
@@ -71,6 +73,12 @@ export function GuidePage() {
       <Header />
       <div className="pt-6 pb-8 px-4">
         <div className="max-w-4xl mx-auto text-center">
+          {!meta && (
+            <div className="flex flex-col items-center gap-3">
+              <Skeleton className="h-9 w-3/4 max-w-md" />
+              <Skeleton className="h-4 w-2/3 max-w-sm" />
+            </div>
+          )}
           {meta && (
             <>
               <h1 className="font-display text-3xl md:text-4xl font-semibold text-text-primary mb-2">
@@ -88,7 +96,9 @@ export function GuidePage() {
       <main className="px-4 pb-16">
         <div className="max-w-2xl mx-auto">
           {content === null ? (
-            <p className="text-text-muted text-center">Loading...</p>
+            <SkeletonScreen label="Loading guide">
+              <ArticleSkeleton />
+            </SkeletonScreen>
           ) : (
             <>
               {meta && (

--- a/apps/web/src/pages/GuidesIndexPage.tsx
+++ b/apps/web/src/pages/GuidesIndexPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { SkeletonScreen } from '../components/Skeleton';
+import { ArticleListSkeleton } from '../components/LoadingSkeletons';
 
 interface GuideEntry {
   slug: string;
@@ -58,7 +60,9 @@ export function GuidesIndexPage() {
       <main className="px-4 pb-16">
         <div className="max-w-3xl mx-auto">
           {loading ? (
-            <p className="text-text-muted text-center">Loading...</p>
+            <SkeletonScreen label="Loading guides">
+              <ArticleListSkeleton />
+            </SkeletonScreen>
           ) : guides.length === 0 ? (
             <p className="text-text-muted text-center">No guides yet. Check back soon.</p>
           ) : (

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '../contexts/AuthContext';
 
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
 
 type ViewMode = 'form' | 'magicLinkSent' | 'resetSent';
 
@@ -91,9 +93,9 @@ export function LoginPage() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading...</div>
-      </div>
+      <PageSkeleton label="Loading sign in" maxWidth="max-w-md">
+        <FormSkeleton sections={1} fields={2} />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/PublicSavedArtistsPage.tsx
+++ b/apps/web/src/pages/PublicSavedArtistsPage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { ArtistRowsSkeleton } from '../components/LoadingSkeletons';
+import { Skeleton } from '../components/Skeleton';
 
 interface SavedArtistPublic {
   slug: string;
@@ -62,9 +65,13 @@ export function PublicSavedArtistsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading…</div>
-      </div>
+      <PageSkeleton label="Loading saved artists">
+        <div className="flex flex-col items-center mb-8">
+          <Skeleton className="h-7 w-64 mb-3" />
+          <Skeleton className="h-9 w-36 rounded-lg" />
+        </div>
+        <ArtistRowsSkeleton count={6} />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -5,6 +5,8 @@ import { updatePassword } from '../services/auth';
 import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
 
 export function ResetPasswordPage() {
   const navigate = useNavigate();
@@ -47,9 +49,9 @@ export function ResetPasswordPage() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading...</div>
-      </div>
+      <PageSkeleton label="Loading password reset" maxWidth="max-w-md">
+        <FormSkeleton sections={1} fields={2} />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -8,6 +8,8 @@ import { UsernameField } from '../components/UsernameField';
 import { LocationField } from '../components/LocationField';
 import { PasswordChangeForm } from '../components/PasswordChangeForm';
 import { SharingControls } from '../components/SharingControls';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
 
 interface Settings {
   username: string | null;
@@ -53,9 +55,9 @@ export function SettingsPage() {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen bg-bg-primary flex items-center justify-center">
-        <div className="text-text-muted">Loading...</div>
-      </div>
+      <PageSkeleton label="Loading your settings">
+        <FormSkeleton sections={3} />
+      </PageSkeleton>
     );
   }
 

--- a/apps/web/tests/unit/Skeleton.test.tsx
+++ b/apps/web/tests/unit/Skeleton.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { Skeleton, SkeletonText, SkeletonScreen, EqualizerBars } from 'src/components/Skeleton';
+
+describe('Skeleton primitives', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a shimmer block that keeps the caller class names', () => {
+    const { container } = render(<Skeleton className="h-4 w-20" />);
+    const block = container.firstElementChild!;
+    expect(block.className).toContain('skeleton');
+    expect(block.className).toContain('h-4');
+  });
+
+  it('renders one line per requested line, with a short last line', () => {
+    const { container } = render(<SkeletonText lines={3} />);
+    const lines = container.querySelectorAll('.skeleton');
+    expect(lines).toHaveLength(3);
+    expect(lines[2].className).toContain('w-2/3');
+  });
+
+  it('hides the equalizer bars from assistive tech', () => {
+    const { container } = render(<EqualizerBars />);
+    expect(container.firstElementChild!.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('SkeletonScreen', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('announces the loading label and hides the placeholder shapes', () => {
+    const { container } = render(
+      <SkeletonScreen label="Loading your dashboard">
+        <Skeleton className="h-4" />
+      </SkeletonScreen>
+    );
+
+    const status = screen.getByRole('status');
+    expect(status.getAttribute('aria-busy')).toBe('true');
+    expect(screen.getByText('Loading your dashboard')).toBeTruthy();
+    expect(container.querySelector('[aria-hidden="true"] .skeleton')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Every loading state in the web app was either a bare "Loading..." string on
an otherwise empty page or a generic spinner. Signed-in pages were the worst:
the dashboard, settings and profile editor dropped the header and footer
entirely while they fetched, so the whole app disappeared for a beat.

Adds a small set of loading primitives and page-shaped skeletons built on
them, then wires them through every loading branch:

- Skeleton.tsx: shimmer block, circle, text lines, equalizer bars and an
  accessible SkeletonScreen wrapper.
- LoadingSkeletons.tsx: skeletons shaped like the content they stand in for
  (search results, artist profile, dashboard, artist rows, article list and
  body, forms, stat tiles).
- PageSkeleton.tsx: full-page shell that keeps the real header and footer, so
  a loading page still looks like Unstream.
- AppFallback.tsx: the router's Suspense fallback plus a real error fallback.
  The error boundary previously rendered the loading skeleton, which left
  users staring at a placeholder forever after a crash.

The shimmer sweeps a warm accent tint across each block and the equalizer
bars use the three accent colours, so the waiting state reads as ours rather
than as a generic grey pulse. Both are theme-aware and both stop under
prefers-reduced-motion. Skeleton screens fade in after 120ms so fast loads
never flash a placeholder.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BdfxTVsXrxVukhcMAgox5Y