### PR TITLE
Fix ReferenceError that has disabled MusicBrainz enrichment since March

### DIFF
--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -1,7 +1,7 @@
 // MusicBrainz enrichment server function
 // Imports shared functions from enrichment.ts, keeps Netlify handler here
 
-import { cacheGetOrFetch } from './cache';
+import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistEnrichment } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -585,7 +585,11 @@ export async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 400
 export async function fetchMirloLocation(artistSlug: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
   if (!artistSlug) return null;
   try {
-    const apiUrl = `https://api.mirlo.space/v1/artists?urlSlug=${encodeURIComponent(artistSlug)}`;
+    // Must be the by-slug endpoint. The list form (`/v1/artists?urlSlug=…`) silently
+    // IGNORES the filter and returns the first page of all artists, so reading
+    // results[0] handed every artist on the site the same location — "Holyoke, MA",
+    // whoever happens to be first. This endpoint 404s when the artist isn't on Mirlo.
+    const apiUrl = `https://api.mirlo.space/v1/artists/${encodeURIComponent(artistSlug)}`;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     const response = await globalThis.fetch(apiUrl, {
@@ -594,8 +598,10 @@ export async function fetchMirloLocation(artistSlug: string, timeoutMs = 4000): 
     });
     clearTimeout(timeout);
     if (!response.ok) return null;
-    const data = await response.json() as { results?: { location?: string }[] };
-    const raw = data.results?.[0]?.location;
+    const data = await response.json() as { result?: { urlSlug?: string; location?: string } };
+    // Belt and braces: only trust the location if the slug really came back to us.
+    if (!data.result || data.result.urlSlug !== artistSlug) return null;
+    const raw = data.result.location;
     if (raw) return parseLocationString(raw);
     return null;
   } catch {


### PR DESCRIPTION
## The bug

`api/functions/search-musicbrainz.ts` calls `artistCacheKey()` at line 372, but line 4 only imports `cacheGetOrFetch`:

```ts
import { cacheGetOrFetch } from './cache';   // artistCacheKey missing
...
const cacheKey = artistCacheKey('musicbrainz', normalizedQuery);   // ReferenceError
```

`artistCacheKey` is exported from `./cache` and has no local declaration, so this is a hard `ReferenceError` on every invocation, thrown before the handler does any work.

## Why nobody saw it

The failure is silent at every layer:

1. The handler's own `try/catch` swallows the ReferenceError and returns **HTTP 500 with a well-formed all-nulls payload** (`artistName: null`, `socialLinks: []`, …).
2. The web client does `if (!response.ok) return null` — with **no Sentry capture** on that branch (the capture only covers thrown network errors).

So Phase 2 enrichment just returns nothing, and nothing anywhere reports a problem.

## How long

Introduced **2026-03-14** in `7d83630` (the v2.0 repo reorg) — roughly **four months**. Everything Phase 2 provides has been dead that whole time: official site, Discogs, social links, Wikipedia, MusicBrainz location, and the MusicBrainz-derived Bandcamp URL.

## Verification

Invoked the real handler with `query=radiohead`:

**Before**
```
MusicBrainz endpoint error: ReferenceError: artistCacheKey is not defined
statusCode: 500
artistName: null | officialUrl: null | socialLinks: []
```

**After**
```
statusCode: 200
artistName: Radiohead | officialUrl: http://www.radiohead.com/
socialLinks: facebook, instagram, tiktok, youtube, bluesky
9 platform URLs found, including https://radiohead.bandcamp.com/
```

Worth noting that last line: the MusicBrainz route to Bandcamp links was working the whole time — it just never got to run.

`tsc -b` clean · api tests 69/69 · unit tests 359/359

## Follow-up worth doing

This is invisible to the build because `api/tsconfig.json` has `include` limited to six named files. Nothing else under `api/` — ~40 functions and all the search modules — is typechecked. Put this file in scope and `tsc` flags it immediately as `TS2304`. Widening that coverage would have caught this in March; I'd suggest it as its own PR since there are ~30 pre-existing errors to work through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)