### PR TITLE
Find Bandcamp artists by probing subdomains instead of the blocked search (UNS-152)

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -197,6 +197,86 @@ export async function getMergeOverrides(): Promise<MergeOverrideRow[]> {
   }
 }
 
+// --- Bandcamp slug-probe cache (UNS-152) ---
+
+export interface BandcampProbeRow {
+  query_norm: string;
+  artist_url: string | null;
+  band_name: string | null;
+  band_id: number | null;
+  album_count: number;
+  track_count: number;
+  matched_slug: string | null;
+  verdict: 'accepted' | 'absent' | 'rejected_empty' | 'rejected_name' | 'pending_review';
+  checked_at: string;
+}
+
+// Positives are stable — a Bandcamp URL rarely moves. Negatives expire, because
+// an artist who wasn't on Bandcamp in March may well be by September.
+const NEGATIVE_PROBE_TTL_DAYS = 30;
+
+/**
+ * Read a cached probe outcome. Returns null when there is no usable cache entry,
+ * which is the caller's signal to probe.
+ *
+ * A stale negative returns null (re-probe); an accepted result never expires.
+ * `pending_review` rows return as-is so an unverified account is neither
+ * surfaced nor endlessly re-probed while it waits on /admin/verify.
+ */
+export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbeRow | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data, error } = await client
+      .from('bandcamp_slug_probes')
+      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, checked_at')
+      .eq('query_norm', queryNorm)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[DB] Failed to read bandcamp probe cache:', error);
+      return null;
+    }
+    if (!data) return null;
+
+    const row = data as BandcampProbeRow;
+    if (row.verdict === 'accepted' || row.verdict === 'pending_review') return row;
+
+    const ageMs = Date.now() - new Date(row.checked_at).getTime();
+    if (ageMs > NEGATIVE_PROBE_TTL_DAYS * 24 * 60 * 60 * 1000) return null;
+    return row;
+  } catch (error) {
+    console.error('[DB] getBandcampProbe error:', error);
+    return null;
+  }
+}
+
+/**
+ * Persist a probe outcome, positive or negative.
+ *
+ * Callers must never pass an undecided outcome. A network error, timeout or bot
+ * challenge means we don't know — writing that as a negative would turn a
+ * transient outage into a permanent "this artist isn't on Bandcamp". The DB's
+ * own CHECK constraint has no 'undecided' value, so this is enforced twice.
+ */
+export async function putBandcampProbe(
+  row: Omit<BandcampProbeRow, 'checked_at'>,
+): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  try {
+    const { error } = await client
+      .from('bandcamp_slug_probes')
+      .upsert({ ...row, checked_at: new Date().toISOString() }, { onConflict: 'query_norm' });
+
+    if (error) console.error('[DB] Failed to write bandcamp probe cache:', error);
+  } catch (error) {
+    console.error('[DB] putBandcampProbe error:', error);
+  }
+}
+
 // --- Read Operations ---
 
 /**

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -292,12 +292,14 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       searchPeerTubeChannels(artist.name),
       wikipediaUrl ? fetchWikipediaSummary(wikipediaUrl) : Promise.resolve(null),
       (async () => {
-        // Try MB relation URL first; if absent or returns no location, search Bandcamp directly
+        // Try MB relation URL first; if absent or returns no location, probe Bandcamp directly.
+        // These three steps run sequentially, so keep the probe budget tight — location is
+        // best-effort enrichment and this whole lambda shares the function's 10s ceiling.
         if (mbBandcampUrl) {
           const loc = await fetchBandcampLocation(mbBandcampUrl);
           if (loc) return loc;
         }
-        const searchedUrl = await findBandcampArtistUrl(artist.name);
+        const searchedUrl = await findBandcampArtistUrl(artist.name, 2500);
         return searchedUrl ? fetchBandcampLocation(searchedUrl) : null;
       })(),
       fetchMirloLocation(mirloSlug),

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -28,11 +28,11 @@ import {
   searchPeerTubeChannels,
   parseLocationString,
   mergeLocations,
-  searchBandcampForArtistUrl,
   fetchBandcampLocation,
   fetchMirloLocation,
   enrichLocationFallback,
 } from '../search/enrichment';
+import { findBandcampArtistUrl } from '../search/bandcamp-probe';
 
 // Cache TTL for MusicBrainz lookups (30 minutes)
 const MUSICBRAINZ_CACHE_TTL = 30 * 60;
@@ -297,7 +297,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
           const loc = await fetchBandcampLocation(mbBandcampUrl);
           if (loc) return loc;
         }
-        const searchedUrl = await searchBandcampForArtistUrl(artist.name);
+        const searchedUrl = await findBandcampArtistUrl(artist.name);
         return searchedUrl ? fetchBandcampLocation(searchedUrl) : null;
       })(),
       fetchMirloLocation(mirloSlug),

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -146,6 +146,55 @@ export function parseQobuzSearchResults(html: string, query: string): [string, s
 // Bandcamp releases
 // ---------------------------------------------------------------------------
 
+/**
+ * Read a Bandcamp page's own claim about which band it belongs to.
+ *
+ * Every Bandcamp page carries `data-band="{"id":...,"name":"..."}"`. This is the
+ * authoritative identity check when probing a guessed subdomain — a slug
+ * existing does not mean it is the right artist. `thebeths.bandcamp.com`
+ * resolves but is an unrelated account named "no content".
+ */
+export function parseBandcampBandIdentity(html: string): { id: number; name: string } | null {
+  const match = html.match(/data-band="([^"]*)"/);
+  if (!match) return null;
+  try {
+    // The attribute value is HTML-escaped JSON.
+    const decoded = match[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&');
+    const parsed = JSON.parse(decoded) as { id?: unknown; name?: unknown };
+    if (typeof parsed.id !== 'number' || typeof parsed.name !== 'string') return null;
+    return { id: parsed.id, name: parsed.name };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count releases on a Bandcamp /music page, split by type.
+ *
+ * Zero albums AND zero tracks is the parked-squatter signature. Accounts at
+ * `beyonce`, `sufjan` and `jackwhite` all exist and all return a matching
+ * data-band name, but hold no releases — so a name check alone would surface
+ * them as genuine artist pages.
+ */
+export function parseBandcampReleaseCounts(html: string): { albums: number; tracks: number } {
+  const root = parse(html);
+  const albums = new Set<string>();
+  const tracks = new Set<string>();
+
+  for (const item of root.querySelectorAll('.music-grid-item')) {
+    // e.g. data-item-id="album-1507079760" / "track-526682361"
+    const id = item.getAttribute('data-item-id');
+    if (!id) continue;
+    if (id.startsWith('album-')) albums.add(id);
+    else if (id.startsWith('track-')) tracks.add(id);
+  }
+
+  return { albums: albums.size, tracks: tracks.size };
+}
+
 /** Parse Bandcamp /music page HTML to extract release titles */
 export function parseBandcampReleaseTitles(html: string): string[] {
   const root = parse(html);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -44,7 +44,6 @@ import {
   fetchLinktreeLinks,
   parseLocationString,
   mergeLocations,
-  searchBandcampForArtistUrl,
   fetchBandcampLocation,
   fetchMirloLocation,
   enrichLocationFallback,

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -231,6 +231,40 @@ export function normalizeForComparison(str: string): string {
   return normalizeAccents(str).toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+/**
+ * Candidate `<slug>.bandcamp.com` subdomains for an artist name, most likely first.
+ *
+ * Bandcamp's search page is blocked and robots-disallowed, so artist URLs are
+ * found by probing these candidates and verifying the resulting page. Measured
+ * recall against 3,018 known artists (docs/specs/bandcamp-coverage-research.md):
+ *
+ *   1 candidate  (base)          66.3%
+ *   2 candidates (+strip "the")  69.3%
+ *   3 candidates (+hyphenated)   71.1%
+ *
+ * The curve then flattens hard — eleven candidates reach only 74.8%, so probes
+ * 4+ cost 8x the requests for under four points. Three is the deliberate stop.
+ * (True recall is higher than these figures, ~80%, because Bandcamp itself
+ * redirects some alias slugs to the right artist.)
+ */
+export function bandcampSlugCandidates(name: string): string[] {
+  const base = normalizeForComparison(name);
+  const withoutThe = normalizeForComparison(name.replace(/^\s*the\s+/i, ''));
+  const hyphenated = normalizeAccents(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const candidates: string[] = [];
+  for (const candidate of [base, withoutThe, hyphenated]) {
+    // Bandcamp subdomains are at least 3 characters; skip empties and dupes.
+    if (candidate.length >= 3 && !candidates.includes(candidate)) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
 // Check if two names are similar enough to be considered a match
 // Returns true if names match closely (same name, or one contains the other)
 export function namesMatch(name1: string, name2: string): boolean {

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -215,15 +215,23 @@ export async function probeBandcampArtist(
  * cached too, so repeated searches for an artist who isn't on Bandcamp are free
  * after the first. Undecided outcomes are never cached, so a transient failure
  * doesn't become a permanent miss.
+ *
+ * `budgetMs` caps the whole probe round, not each request. Callers running inside
+ * a Netlify function's 10s ceiling should pass their own budget rather than take
+ * the default — measured latency is 270-980ms, but the cap is what bounds the bad
+ * case if Bandcamp is slow.
  */
-export async function findBandcampArtistUrl(query: string): Promise<string | null> {
+export async function findBandcampArtistUrl(
+  query: string,
+  budgetMs = DEFAULT_BUDGET_MS,
+): Promise<string | null> {
   const queryNorm = normalizeForComparison(query);
   if (!queryNorm) return null;
 
   const cached = await getBandcampProbe(queryNorm);
   if (cached) return cached.artist_url;
 
-  const result = await probeBandcampArtist(query);
+  const result = await probeBandcampArtist(query, budgetMs);
 
   // Don't know != not there. Leave the cache empty so we retry next time.
   if (result.verdict === 'undecided') return null;

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -1,0 +1,243 @@
+// Find a Bandcamp artist URL by probing candidate subdomains.
+//
+// bandcamp.com/search is behind a Fastly bot challenge and is Disallow'ed in
+// Bandcamp's robots.txt, so it cannot be used to look artists up. Instead we
+// derive candidate slugs from the artist name and ask <slug>.bandcamp.com/music
+// directly — a path robots.txt permits.
+//
+// One request per candidate answers everything we need:
+//   - HTTP 404                      -> no such account
+//   - data-band="{id,name}"         -> authoritative identity
+//   - .music-grid-item data-item-id -> album / track counts
+//
+// Both verification steps are load-bearing. A slug existing does not mean it is
+// the right artist (thebeths.bandcamp.com is an unrelated account named "no
+// content"), and a matching name does not mean it is a real presence — the
+// accounts at beyonce, sufjan and jackwhite all match by name and hold no
+// releases at all. The real Jack White is at officialjackwhite.
+//
+// See docs/specs/bandcamp-coverage-research.md for the measurements behind this.
+
+import { Sentry } from '../lib/sentry';
+import { getBandcampProbe, putBandcampProbe } from '../functions/db';
+import { isUrlHostnameAllowed } from '../functions/middleware';
+import { checkSentryDedup } from '../functions/ratelimit';
+import {
+  bandcampSlugCandidates,
+  namesMatch,
+  normalizeForComparison,
+} from '../functions/search-utils';
+import {
+  isBandcampChallenge,
+  parseBandcampBandIdentity,
+  parseBandcampReleaseCounts,
+} from '../functions/search-parsers';
+
+/**
+ * Outcome of probing for an artist.
+ *
+ * `undecided` means we could not find out — a network error, a timeout, or a bot
+ * challenge. It is deliberately NOT a value the cache accepts: caching it would
+ * turn a transient outage into a permanent "this artist isn't on Bandcamp".
+ */
+export type BandcampProbeVerdict =
+  | 'accepted'
+  | 'absent'
+  | 'rejected_empty'
+  | 'rejected_name'
+  | 'undecided';
+
+export interface BandcampProbeResult {
+  verdict: BandcampProbeVerdict;
+  /** Resolved artist URL. Non-null only when verdict is 'accepted'. */
+  artistUrl: string | null;
+  bandName?: string;
+  bandId?: number;
+  albumCount: number;
+  trackCount: number;
+  matchedSlug?: string;
+}
+
+const DEFAULT_BUDGET_MS = 5000;
+const MIN_REQUEST_MS = 1200;
+
+interface CandidateOutcome {
+  verdict: Exclude<BandcampProbeVerdict, 'absent'>;
+  identity?: { id: number; name: string };
+  counts: { albums: number; tracks: number };
+}
+
+/** Fetch and classify a single candidate slug. Returns null if the slug has no account. */
+async function probeCandidate(slug: string, timeoutMs: number): Promise<CandidateOutcome | null> {
+  const url = `https://${slug}.bandcamp.com/music`;
+
+  // Slugs come from normalizeForComparison / accent-stripping, so they contain
+  // only [a-z0-9-] and cannot alter the host. Validated anyway as defence in depth.
+  if (!isUrlHostnameAllowed(url)) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await globalThis.fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Unstream/1.0 (+https://unstream.stream)' },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  // No such account. This is a real answer, not a failure.
+  if (response.status === 404) return null;
+  if (!response.ok) return { verdict: 'undecided', counts: { albums: 0, tracks: 0 } };
+
+  const html = await response.text();
+
+  if (isBandcampChallenge(html)) {
+    const shouldCapture = await checkSentryDedup('uns152:bandcamp-music-challenge', 6 * 60 * 60);
+    if (shouldCapture) {
+      Sentry.captureMessage('Bandcamp /music blocked by bot challenge', {
+        level: 'warning',
+        extra: { url, responseBytes: html.length },
+        tags: { platform: 'bandcamp' },
+      });
+    }
+    return { verdict: 'undecided', counts: { albums: 0, tracks: 0 } };
+  }
+
+  const identity = parseBandcampBandIdentity(html);
+  // A 200 with no identity block isn't a page we understand; don't treat it as absent.
+  if (!identity) return { verdict: 'undecided', counts: { albums: 0, tracks: 0 } };
+
+  const counts = parseBandcampReleaseCounts(html);
+  return { verdict: 'accepted', identity, counts };
+}
+
+/**
+ * Probe up to three candidate slugs for `query` and return the first verified match.
+ *
+ * Stops at the first acceptance. If no candidate is accepted, reports the most
+ * informative rejection so the cache records *why* — and so an 'undecided' is
+ * never mistaken for a genuine miss.
+ */
+export async function probeBandcampArtist(
+  query: string,
+  budgetMs = DEFAULT_BUDGET_MS,
+): Promise<BandcampProbeResult> {
+  const candidates = bandcampSlugCandidates(query);
+  const empty = { albumCount: 0, trackCount: 0 };
+  if (candidates.length === 0) {
+    return { verdict: 'absent', artistUrl: null, ...empty };
+  }
+
+  const deadline = Date.now() + budgetMs;
+  // Rejections are remembered so a later 'absent' can't overwrite a more
+  // specific reason; 'undecided' outranks both so we never cache a false miss.
+  let fallback: BandcampProbeResult = { verdict: 'absent', artistUrl: null, ...empty };
+  let sawUndecided = false;
+
+  for (const slug of candidates) {
+    const remaining = deadline - Date.now();
+    if (remaining < MIN_REQUEST_MS) {
+      // Out of budget with candidates left — that's unknown, not a miss.
+      sawUndecided = true;
+      break;
+    }
+
+    let outcome: CandidateOutcome | null;
+    try {
+      outcome = await probeCandidate(slug, remaining);
+    } catch {
+      // Network error or abort. Unknown, not a miss.
+      sawUndecided = true;
+      continue;
+    }
+
+    if (outcome === null) continue; // 404 — try the next candidate
+
+    if (outcome.verdict === 'undecided' || !outcome.identity) {
+      sawUndecided = true;
+      continue;
+    }
+
+    const { identity, counts } = outcome;
+
+    if (!namesMatch(identity.name, query)) {
+      if (fallback.verdict === 'absent') {
+        fallback = {
+          verdict: 'rejected_name',
+          artistUrl: null,
+          bandName: identity.name,
+          bandId: identity.id,
+          albumCount: counts.albums,
+          trackCount: counts.tracks,
+          matchedSlug: slug,
+        };
+      }
+      continue;
+    }
+
+    // Name matches but the account holds nothing — a parked squatter.
+    if (counts.albums === 0 && counts.tracks === 0) {
+      fallback = {
+        verdict: 'rejected_empty',
+        artistUrl: null,
+        bandName: identity.name,
+        bandId: identity.id,
+        albumCount: 0,
+        trackCount: 0,
+        matchedSlug: slug,
+      };
+      continue;
+    }
+
+    return {
+      verdict: 'accepted',
+      artistUrl: `https://${slug}.bandcamp.com`,
+      bandName: identity.name,
+      bandId: identity.id,
+      albumCount: counts.albums,
+      trackCount: counts.tracks,
+      matchedSlug: slug,
+    };
+  }
+
+  if (sawUndecided && fallback.verdict === 'absent') {
+    return { verdict: 'undecided', artistUrl: null, ...empty };
+  }
+  return fallback;
+}
+
+/**
+ * Cached artist-URL lookup. Replaces the blocked bandcamp.com/search scrape.
+ *
+ * Every distinct query costs at most one round of probes, ever — negatives are
+ * cached too, so repeated searches for an artist who isn't on Bandcamp are free
+ * after the first. Undecided outcomes are never cached, so a transient failure
+ * doesn't become a permanent miss.
+ */
+export async function findBandcampArtistUrl(query: string): Promise<string | null> {
+  const queryNorm = normalizeForComparison(query);
+  if (!queryNorm) return null;
+
+  const cached = await getBandcampProbe(queryNorm);
+  if (cached) return cached.artist_url;
+
+  const result = await probeBandcampArtist(query);
+
+  // Don't know != not there. Leave the cache empty so we retry next time.
+  if (result.verdict === 'undecided') return null;
+
+  await putBandcampProbe({
+    query_norm: queryNorm,
+    artist_url: result.artistUrl,
+    band_name: result.bandName ?? null,
+    band_id: result.bandId ?? null,
+    album_count: result.albumCount,
+    track_count: result.trackCount,
+    matched_slug: result.matchedSlug ?? null,
+    verdict: result.verdict,
+  });
+
+  return result.artistUrl;
+}

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -538,7 +538,7 @@ export async function enrichLocationFallback(query: string): Promise<ArtistLocat
   const mirloSlug = query.toLowerCase().replace(/\s+/g, '');
   const FALLBACK_TIMEOUT = 3000;
 
-  const bandcampUrl = await findBandcampArtistUrl(query);
+  const bandcampUrl = await findBandcampArtistUrl(query, FALLBACK_TIMEOUT);
   const [bandcampLocation, mirloLocation] = await Promise.all([
     bandcampUrl ? fetchBandcampLocation(bandcampUrl, FALLBACK_TIMEOUT) : Promise.resolve(null),
     fetchMirloLocation(mirloSlug, FALLBACK_TIMEOUT),

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -1,12 +1,8 @@
 // Shared enrichment functions for MusicBrainz data extraction
 // These functions are used both by the MusicBrainz Netlify function and search-sources.ts
 
-import { Sentry } from '../lib/sentry';
-import { cacheGetOrFetch, artistCacheKey } from '../functions/cache';
-import { persistEnrichment } from '../functions/db';
 import { isUrlHostnameAllowed } from '../functions/middleware';
-import { checkSentryDedup } from '../functions/ratelimit';
-import { isBandcampChallenge } from '../functions/search-parsers';
+import { findBandcampArtistUrl } from './bandcamp-probe';
 
 // Social platform types
 export type SocialPlatform =
@@ -466,79 +462,6 @@ export function mergeLocations(...sources: (ArtistLocation | null | undefined)[]
   return (result.city || result.country) ? result : undefined;
 }
 
-// Search Bandcamp for an artist by name and return the first matching artist/label URL.
-// Mirrors the Phase 1 Bandcamp scrape but runs server-side within Phase 2 enrichment,
-// so no client-supplied URLs are involved.
-//
-// NOTE: bandcamp.com/search is behind a Fastly bot challenge and is `Disallow`ed in
-// Bandcamp's robots.txt, so this currently always returns null. It is superseded by the
-// slug-probe lookup — see docs/specs/bandcamp-coverage-research.md. Until that lands, the
-// challenge is detected and reported rather than being silently read as "not on Bandcamp".
-export async function searchBandcampForArtistUrl(artistName: string, timeoutMs = 4000): Promise<string | null> {
-  try {
-    const searchUrl = `https://bandcamp.com/search?q=${encodeURIComponent(artistName)}&item_type=b`;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const response = await globalThis.fetch(searchUrl, {
-      signal: controller.signal,
-      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
-    });
-    clearTimeout(timeout);
-    if (!response.ok) return null;
-    const html = await response.text();
-
-    // A challenge page arrives as HTTP 200, so it would otherwise parse to zero
-    // results and be mistaken for a genuine "no such artist" answer.
-    if (isBandcampChallenge(html)) {
-      const shouldCapture = await checkSentryDedup('uns152:bandcamp-search-challenge', 6 * 60 * 60);
-      if (shouldCapture) {
-        Sentry.captureMessage('Bandcamp search blocked by bot challenge', {
-          level: 'warning',
-          extra: {
-            searchUrl,
-            responseBytes: html.length,
-            note: 'HTTP 200 challenge page — results are unavailable, not empty. Superseded by slug-probe lookup.',
-          },
-          tags: { platform: 'bandcamp' },
-        });
-      }
-      return null;
-    }
-
-    // Parse the first artist/label result whose name closely matches the query
-    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
-    const normalizedQuery = normalize(artistName);
-
-    // Match searchresult blocks: extract itemtype, URL, and display name
-    const blockPattern = /<li[^>]+class="[^"]*searchresult[^"]*"[^>]*>([\s\S]*?)<\/li>/g;
-    let block: RegExpExecArray | null;
-    while ((block = blockPattern.exec(html)) !== null) {
-      const blockHtml = block[1];
-      const typeMatch = blockHtml.match(/class="[^"]*itemtype[^"]*"[^>]*>\s*([^<]+)\s*</);
-      const linkMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]+href="([^"?]+)/);
-      const nameMatch = blockHtml.match(/class="[^"]*heading[^"]*"[^>]*>\s*<a[^>]*>([^<]+)</);
-      if (!typeMatch || !linkMatch || !nameMatch) continue;
-
-      const itemType = typeMatch[1].trim().toLowerCase();
-      if (itemType !== 'artist' && itemType !== 'label') continue;
-
-      const name = nameMatch[1].trim();
-      const url = linkMatch[1];
-      const normalizedName = normalize(name);
-
-      // Accept if names are equal or one contains the other (handles minor punctuation differences)
-      if (normalizedName === normalizedQuery ||
-          normalizedName.includes(normalizedQuery) ||
-          normalizedQuery.includes(normalizedName)) {
-        return url;
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
 // Fetch location from a Bandcamp artist profile page.
 // Validated against the SSRF allowlist as defense-in-depth.
 export async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
@@ -615,7 +538,7 @@ export async function enrichLocationFallback(query: string): Promise<ArtistLocat
   const mirloSlug = query.toLowerCase().replace(/\s+/g, '');
   const FALLBACK_TIMEOUT = 3000;
 
-  const bandcampUrl = await searchBandcampForArtistUrl(query, FALLBACK_TIMEOUT);
+  const bandcampUrl = await findBandcampArtistUrl(query);
   const [bandcampLocation, mirloLocation] = await Promise.all([
     bandcampUrl ? fetchBandcampLocation(bandcampUrl, FALLBACK_TIMEOUT) : Promise.resolve(null),
     fetchMirloLocation(mirloSlug, FALLBACK_TIMEOUT),

--- a/apps/web/tests/unit/normalize.test.ts
+++ b/apps/web/tests/unit/normalize.test.ts
@@ -5,7 +5,51 @@ import {
   normalizeForComparison,
   namesMatch,
   textMatchScore,
+  bandcampSlugCandidates,
 } from '../../../../api/functions/search-utils';
+
+describe('bandcampSlugCandidates', () => {
+  it('generates base, strip-"the", and hyphenated variants in that order', () => {
+    // Order matters: recall is 66.3% / 69.3% / 71.1% cumulative, so the base
+    // slug must be probed first.
+    expect(bandcampSlugCandidates('The Beths')).toEqual(['thebeths', 'beths', 'the-beths']);
+  });
+
+  it('collapses duplicates when variants coincide', () => {
+    // No leading "the", single word -> base and strip-"the" are identical.
+    expect(bandcampSlugCandidates('Radiohead')).toEqual(['radiohead']);
+  });
+
+  it('stops at three candidates', () => {
+    expect(bandcampSlugCandidates('The Mountain Goats').length).toBeLessThanOrEqual(3);
+  });
+
+  it('normalizes accents so Björk reaches bjork', () => {
+    expect(bandcampSlugCandidates('Björk')).toEqual(['bjork']);
+  });
+
+  it('only strips a leading "the", not one mid-name', () => {
+    const candidates = bandcampSlugCandidates('Explosions in the Sky');
+    expect(candidates[0]).toBe('explosionsinthesky');
+    expect(candidates).not.toContain('explosionsinsky');
+  });
+
+  it('drops candidates under three characters', () => {
+    // Bandcamp subdomains are at least 3 chars, so a 2-char guess is wasted work.
+    expect(bandcampSlugCandidates('U2')).toEqual([]);
+  });
+
+  it('handles punctuation and ampersands without emitting empty segments', () => {
+    const candidates = bandcampSlugCandidates('King Gizzard & The Lizard Wizard');
+    expect(candidates[0]).toBe('kinggizzardthelizardwizard');
+    expect(candidates.every(c => !c.startsWith('-') && !c.endsWith('-'))).toBe(true);
+    expect(candidates.every(c => !c.includes('--'))).toBe(true);
+  });
+
+  it('returns nothing for input with no alphanumerics', () => {
+    expect(bandcampSlugCandidates('!!! ???')).toEqual([]);
+  });
+});
 
 describe('normalizeAccents', () => {
   it('removes accents from characters', () => {

--- a/apps/web/tests/unit/search-parsers.test.ts
+++ b/apps/web/tests/unit/search-parsers.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   isBandcampChallenge,
+  parseBandcampBandIdentity,
+  parseBandcampReleaseCounts,
   parseBandcampSearchResults,
   parseMirloArtistPage,
   parseQobuzSearchResults,
@@ -53,6 +55,89 @@ describe('isBandcampChallenge', () => {
     // (e.g. inside user-supplied bio text) from disabling a working scrape.
     const big = `<html><body>${'x'.repeat(30_000)}/_fs-ch-nope</body></html>`;
     expect(isBandcampChallenge(big)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBandcampBandIdentity
+// ---------------------------------------------------------------------------
+
+describe('parseBandcampBandIdentity', () => {
+  it('reads id and name from the HTML-escaped data-band attribute', () => {
+    const html = `<div data-band="{&quot;id&quot;:2295933907,&quot;name&quot;:&quot;Boy Harsher&quot;}"></div>`;
+    expect(parseBandcampBandIdentity(html)).toEqual({ id: 2295933907, name: 'Boy Harsher' });
+  });
+
+  it('surfaces a squatted account under its real name', () => {
+    // thebeths.bandcamp.com resolves, but belongs to an account called "no content".
+    // Returning the true name is what lets the caller reject it.
+    const html = `<div data-band="{&quot;id&quot;:3801769277,&quot;name&quot;:&quot;no content&quot;}"></div>`;
+    expect(parseBandcampBandIdentity(html)?.name).toBe('no content');
+  });
+
+  it('decodes escaped apostrophes and ampersands in names', () => {
+    const html = `<div data-band="{&quot;id&quot;:1,&quot;name&quot;:&quot;Sam &amp; Dave&#39;s Band&quot;}"></div>`;
+    expect(parseBandcampBandIdentity(html)?.name).toBe("Sam & Dave's Band");
+  });
+
+  it('returns null when the attribute is absent', () => {
+    expect(parseBandcampBandIdentity('<html><body>nothing here</body></html>')).toBeNull();
+  });
+
+  it('returns null on malformed JSON rather than throwing', () => {
+    expect(parseBandcampBandIdentity('<div data-band="{not json}"></div>')).toBeNull();
+  });
+
+  it('returns null when id or name has the wrong type', () => {
+    const badId = `<div data-band="{&quot;id&quot;:&quot;123&quot;,&quot;name&quot;:&quot;X&quot;}"></div>`;
+    const noName = `<div data-band="{&quot;id&quot;:123}"></div>`;
+    expect(parseBandcampBandIdentity(badId)).toBeNull();
+    expect(parseBandcampBandIdentity(noName)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBandcampReleaseCounts
+// ---------------------------------------------------------------------------
+
+describe('parseBandcampReleaseCounts', () => {
+  const musicPage = `
+    <ol class="music-grid">
+      <li class="music-grid-item" data-item-id="album-1507079760"><p class="title">GET MEAN</p></li>
+      <li class="music-grid-item" data-item-id="album-181024544"><p class="title">Careful</p></li>
+      <li class="music-grid-item" data-item-id="track-748933878"><p class="title">Jeans</p></li>
+    </ol>`;
+
+  it('counts albums and tracks separately', () => {
+    expect(parseBandcampReleaseCounts(musicPage)).toEqual({ albums: 2, tracks: 1 });
+  });
+
+  it('reports zero for a parked account with no releases', () => {
+    // The squatter signature: beyonce / sufjan / jackwhite all look like this.
+    expect(parseBandcampReleaseCounts('<ol class="music-grid"></ol>')).toEqual({ albums: 0, tracks: 0 });
+  });
+
+  it('deduplicates repeated item ids', () => {
+    const dupes = `
+      <li class="music-grid-item" data-item-id="album-1"></li>
+      <li class="music-grid-item" data-item-id="album-1"></li>`;
+    expect(parseBandcampReleaseCounts(dupes)).toEqual({ albums: 1, tracks: 0 });
+  });
+
+  it('ignores grid items with no data-item-id and unknown prefixes', () => {
+    const odd = `
+      <li class="music-grid-item"></li>
+      <li class="music-grid-item" data-item-id="merch-99"></li>
+      <li class="music-grid-item" data-item-id="album-7"></li>`;
+    expect(parseBandcampReleaseCounts(odd)).toEqual({ albums: 1, tracks: 0 });
+  });
+
+  it('ignores album links outside the music grid', () => {
+    // Artist pages link to albums in navigation and footers; only grid items count.
+    const withNav = `
+      <a href="/album/somewhere-else">nav link</a>
+      <li class="music-grid-item" data-item-id="album-7"></li>`;
+    expect(parseBandcampReleaseCounts(withNav)).toEqual({ albums: 1, tracks: 0 });
   });
 });
 

--- a/docs/specs/bandcamp-coverage-research.md
+++ b/docs/specs/bandcamp-coverage-research.md
@@ -360,6 +360,49 @@ And note what this implies for Layer B: **the index needs no verification at all
 indexes albums, so an empty squatter cannot appear in it, and its records are authoritative. The
 squatter problem is a Layer-A problem only.
 
+## 5c. Layer A verified against live Bandcamp (26 July)
+
+Running the shipped `probeBandcampArtist` against real Bandcamp, not a sample:
+
+| Query | Verdict | Albums/Tracks | Result |
+|---|---|---|---|
+| Boy Harsher | `accepted` | 15/1 | `boyharsher` |
+| Radiohead | `accepted` | 15/0 | `radiohead` |
+| Sufjan Stevens | `accepted` | 15/1 | `sufjanstevens` |
+| The Mountain Goats | `accepted` | 14/2 | `themountaingoats` |
+| Explosions in the Sky | `accepted` | 13/0 | `explosionsinthesky` |
+| Robyn Hitchcock | `accepted` | 16/0 | `robynhitchcock` |
+| Nirvana | `accepted` | 2/0 | `nirvana` |
+| **Beyonce** | `rejected_empty` | 0/0 | squatter caught |
+| **Jack White** | `rejected_empty` | 0/0 | squatter caught (real one is `officialjackwhite`) |
+| **Panda Bear** | `rejected_empty` | 0/0 | real one is `pandabearmusic` |
+| **Butcher Brown** | `rejected_empty` | 0/0 | real one is `butcherbrownmusic` |
+| **MESH** | `rejected_empty` | 0/0 | `mesh` is "M.E.S.H." with no releases; real one is `meshphilly` |
+| **The Beths** | `rejected_name` | 0/0 | `thebeths` is "no content" |
+| **King Gizzard & The Lizard Wizard** | `absent` | 0/0 | real one is the truncated `kinggizzard` |
+| zzzznotarealartist999 | `absent` | 0/0 | correct |
+
+Every failure mode declines cleanly. **No case returned a wrong URL** — the squatter gate and name
+check between them turn every near-miss into an honest "nothing here" rather than a bad link.
+
+### The §5a recall figures were an undercount
+
+Several artists whose base slug §5a scored as a *miss* are in fact accepted here: `shearling`
+(2 albums), `rezn` (3), `loathe` (6), `robynhitchcock` (16), `themountaingoats` (14),
+`sufjanstevens` (15). The reason: **many artists hold more than one real Bandcamp account** — a
+plain-name one and an `…official` / `…music` variant. §5a compared the generated slug against the
+single URL discover happened to return, so a valid non-empty alternative counted as a failure.
+
+This is the same effect as the 41.7% "mismatches that still resolved correctly" — not only
+redirects, but genuinely multiple valid presences. Real-world accept rate is therefore at the
+upper end of the 66–80% range, better for well-known artists.
+
+**One honest consequence:** where both exist, Layer A may return the *secondary* account —
+`shearling` (2 albums) rather than `shearlingofficial` (more). That's a valid page for the artist,
+not a wrong answer, but it isn't necessarily their canonical or most complete one. Layer B's index
+returns whatever discover considers canonical, which is another reason to check the index first and
+fall back to probing, exactly as §6.4 orders it.
+
 ## 6. Recommended architecture
 
 The shift is from **per-query live scrape** to **local index + live fallback**. This is faster and
@@ -443,10 +486,11 @@ Stating these plainly rather than discovering them later:
 
 - **Track-only artists are invisible to discover.** `include_result_types` accepts only `["a"]`.
   The subdomain probe is the only path to them.
-- **Label subdomains hide artists.** `mountaingoats.bandcamp.com` doesn't exist because The
-  Mountain Goats release on a label's subdomain. Discover surfaces these as the *label's*
-  `band_name`, so artist-level attribution needs `album_artist` (present in the payload) as a
-  secondary signal.
+- **Label subdomains hide artists.** Discover surfaces these as the *label's* `band_name`, so
+  artist-level attribution needs `album_artist` (present in the payload) as a secondary signal.
+  (Correction: an earlier draft used The Mountain Goats as the example. That was wrong — probing
+  the *base* slug `themountaingoats` finds them with 14 albums. The stripped-"the" variant
+  `mountaingoats` is what 404s. Verified 26 July.)
 - **Slug guessing has a real false-positive rate.** `thebeths` proves it. Name verification is
   mandatory, not optional.
 - **The cursor is opaque and undocumented.** It could change shape without notice. Checkpoint by

--- a/supabase/migrations/20260726120000_bandcamp-slug-probes.sql
+++ b/supabase/migrations/20260726120000_bandcamp-slug-probes.sql
@@ -1,0 +1,73 @@
+-- Migration 025: Bandcamp slug-probe cache (UNS-152)
+--
+-- bandcamp.com/search is behind a Fastly bot challenge and is Disallow'ed in
+-- Bandcamp's robots.txt, so artist URLs are now found by probing candidate
+-- subdomains (<slug>.bandcamp.com) derived from the search query and verifying
+-- the result. See docs/specs/bandcamp-coverage-research.md.
+--
+-- This table caches probe outcomes so each distinct query costs at most one
+-- round of probes, ever. Caching NEGATIVES matters as much as positives: without
+-- it, every search for an artist who simply isn't on Bandcamp re-probes on every
+-- single search, indefinitely.
+--
+-- No PII: `query_norm` is a normalized artist-name search term, not user data.
+-- Reads and writes go through the service-role client in Netlify functions, so
+-- RLS is enabled with no public policies (anon gets nothing; service role
+-- bypasses RLS).
+
+create table if not exists public.bandcamp_slug_probes (
+  -- Normalized search query (lowercased, punctuation stripped). Primary key:
+  -- lookups are always by query, and one row per query is exactly what we want.
+  query_norm    text primary key,
+
+  -- Resolved Bandcamp artist URL. NULL is meaningful — it is the cached
+  -- negative ("we looked, there is nothing to link to").
+  artist_url    text,
+
+  -- Verified identity from the page's data-band attribute, kept for auditing
+  -- why a decision was made and for the /admin/verify queue.
+  band_name     text,
+  band_id       bigint,
+
+  -- Release counts at probe time. 0 albums AND 0 tracks is the squatter
+  -- signature (e.g. beyonce/sufjan/jackwhite are parked, name-matching, empty).
+  album_count   int  not null default 0,
+  track_count   int  not null default 0,
+
+  -- Which slug candidate won, for tuning candidate ordering later.
+  matched_slug  text,
+
+  -- Outcome of the probe:
+  --   accepted        verified artist, artist_url is set
+  --   absent          no candidate slug resolved to an account
+  --   rejected_empty  account exists and name matches, but has no releases
+  --   rejected_name   account exists but data-band name did not match the query
+  --   pending_review  non-empty and name matches, but cross-source release
+  --                   matching contradicted it -- routed to /admin/verify
+  verdict       text not null check (verdict in (
+                  'accepted', 'absent', 'rejected_empty',
+                  'rejected_name', 'pending_review'
+                )),
+
+  checked_at    timestamptz not null default now()
+);
+
+-- Stale negatives should be re-probed periodically (an artist may join Bandcamp
+-- later); positives are stable. Supports "find rows to refresh" scans.
+create index if not exists idx_bandcamp_slug_probes_verdict_checked
+  on public.bandcamp_slug_probes (verdict, checked_at);
+
+-- Feeds the /admin/verify queue.
+create index if not exists idx_bandcamp_slug_probes_pending
+  on public.bandcamp_slug_probes (checked_at desc)
+  where verdict = 'pending_review';
+
+alter table public.bandcamp_slug_probes enable row level security;
+
+-- Intentionally no policies: this cache is server-only. The service-role client
+-- bypasses RLS; anon and authenticated clients get no access.
+
+comment on table public.bandcamp_slug_probes is
+  'Cache of Bandcamp subdomain probe outcomes, positive and negative (UNS-152). Server-only; no RLS policies by design.';
+comment on column public.bandcamp_slug_probes.artist_url is
+  'Resolved Bandcamp artist URL; NULL is the cached negative result.';


### PR DESCRIPTION
Layer A of the Bandcamp coverage work. Rebased onto main after #317 and #318 (both squash-merged, so this replays only the Layer A commit).

## Why

`bandcamp.com/search` is behind a Fastly bot challenge **and** `Disallow`ed in Bandcamp's `robots.txt`. It can't be used to look artists up. This replaces it with candidate-subdomain probing against `<slug>.bandcamp.com/music` — a path `robots.txt` permits.

## How

One request per candidate answers everything:

| Signal | Meaning |
|---|---|
| `HTTP 404` | no such account |
| `data-band="{id,name}"` | authoritative identity |
| `.music-grid-item` `data-item-id="album-…"/"track-…"` | album / track counts |

**Both verification steps are load-bearing:**

- A slug existing ≠ the right artist. `thebeths.bandcamp.com` resolves but belongs to an account named **"no content"**.
- A matching name ≠ a real presence. The accounts at `beyonce`, `sufjan` and `jackwhite` all match by name and hold **zero releases**. The real Jack White is at `officialjackwhite`.

Three candidates, in measured recall order over 3,018 known artists: base **66.3%**, +strip-"the" **69.3%**, +hyphenated **71.1%**. The curve then flattens — eleven candidates reach only 74.8% — so three is a deliberate stop. True rate is nearer **80%**, because many artists hold more than one valid account and Bandcamp redirects some alias slugs.

## Caching

New table `bandcamp_slug_probes`, **negatives included**. Without negative caching, every search for an artist who isn't on Bandcamp would re-probe forever. Positives never expire; negatives refresh after 30 days since an artist may join later.

Server-only: RLS enabled with **no policies by design** (service role bypasses, anon and authenticated get nothing).

## The `undecided` verdict

`probeBandcampArtist` returns a fifth verdict for a timeout, network error, or bot challenge. **The migration's CHECK constraint deliberately omits it**, so a transient failure can never be written as a cached negative — enforced in both `putBandcampProbe` and the schema.

This is the failure mode that caused the original coverage loss (a 200 challenge read as "not on Bandcamp") and the Mirlo bug in #318 ("no data" indistinguishable from "someone else's data"). Belt and braces this time.

## Verified against live Bandcamp

| Query | Verdict | Alb/Trk | Result |
|---|---|---|---|
| Boy Harsher | `accepted` | 15/1 | `boyharsher` |
| Radiohead | `accepted` | 15/0 | `radiohead` |
| Sufjan Stevens | `accepted` | 15/1 | `sufjanstevens` |
| The Mountain Goats | `accepted` | 14/2 | `themountaingoats` |
| Robyn Hitchcock | `accepted` | 16/0 | `robynhitchcock` |
| Beyonce | `rejected_empty` | 0/0 | squatter caught |
| Jack White | `rejected_empty` | 0/0 | squatter caught |
| Panda Bear / Butcher Brown / MESH | `rejected_empty` | 0/0 | real ones are `…music` / `meshphilly` |
| The Beths | `rejected_name` | 0/0 | `thebeths` is "no content" |
| King Gizzard & The Lizard Wizard | `absent` | 0/0 | real one is truncated `kinggizzard` |
| nonsense query | `absent` | 0/0 | correct |

**No case returned a wrong URL.** Every failure mode declines cleanly.

## Checks

- `tsc -b` clean
- Explicit strict `tsc` over all touched files + import graph: **zero new errors** (31 baseline on main, 31 with this branch). Necessary because `api/tsconfig.json` only covers six files — see #318's note.
- api tests **69/69**
- unit tests **378/378** (up from 359 — 19 new)

New unit tests cover `parseBandcampBandIdentity` (escaped JSON, the "no content" squatter case, malformed input, wrong types), `parseBandcampReleaseCounts` (album/track split, dedupe, grid-only scoping), and `bandcampSlugCandidates` (order, dedupe, accents, 3-char floor, mid-name "the").

## Migration

`20260726120000_bandcamp-slug-probes.sql` — auto-deploys on merge via the Supabase GitHub Action. `IF NOT EXISTS` guards throughout, RLS enabled, two indexes (one partial, for the future `/admin/verify` queue).

## Note on scope

Cross-source release matching as an ambiguity resolver (`pending_review` → `/admin/verify`) is **not** in this PR. The verdict value exists in the CHECK constraint so it doesn't need a second migration later, but nothing produces it yet. That's a follow-on after Layer B, per the agreed order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)