### PR TITLE
Surface Bandcamp probe results in search, and cut enrichment latency

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -208,6 +208,8 @@ export interface BandcampProbeRow {
   track_count: number;
   matched_slug: string | null;
   verdict: 'accepted' | 'absent' | 'rejected_empty' | 'rejected_name' | 'pending_review';
+  /** Raw location string from the probed /music page, e.g. "Oxford, UK". */
+  location: string | null;
   checked_at: string;
 }
 
@@ -230,7 +232,7 @@ export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbe
   try {
     const { data, error } = await client
       .from('bandcamp_slug_probes')
-      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, checked_at')
+      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, checked_at')
       .eq('query_norm', queryNorm)
       .maybeSingle();
 

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -32,7 +32,7 @@ import {
   fetchMirloLocation,
   enrichLocationFallback,
 } from '../search/enrichment';
-import { findBandcampArtistUrl } from '../search/bandcamp-probe';
+import { findBandcampArtist } from '../search/bandcamp-probe';
 
 // Cache TTL for MusicBrainz lookups (30 minutes)
 const MUSICBRAINZ_CACHE_TTL = 30 * 60;
@@ -114,8 +114,11 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     // Wait 1.1 seconds to respect MusicBrainz rate limit (1 req/sec)
     await new Promise(resolve => setTimeout(resolve, 1100));
 
-    // Fetch artist details with URL relations
-    const artistUrl = `https://musicbrainz.org/ws/2/artist/${artist.id}?inc=url-rels&fmt=json`;
+    // Fetch URL relations AND release groups in a single lookup. These used to be two
+    // requests with a mandatory 1.1s gap between them; `inc=url-rels+release-groups`
+    // returns both, saving a round trip plus the gap (~1.6s measured). The release
+    // groups carry `first-release-date`, which is all the pre-2005 check needs.
+    const artistUrl = `https://musicbrainz.org/ws/2/artist/${artist.id}?inc=url-rels+release-groups&fmt=json`;
 
     const artistResponse = await globalThis.fetch(artistUrl, {
       headers: {
@@ -132,6 +135,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     const platformUrls: string[] = [];
 
     let mbLocation: ArtistLocation | undefined;
+    let hasPre2005Release = false;
 
     if (artistResponse.ok) {
       const artistData = await artistResponse.json() as {
@@ -140,7 +144,19 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
         country?: string;
         area?: { name: string; type?: string | null; 'iso-3166-1-codes'?: string[] };
         'begin-area'?: { name: string; type?: string | null };
+        // Present because of inc=release-groups; feeds the pre-2005 check below.
+        'release-groups'?: { 'first-release-date'?: string }[];
       };
+
+      // Hoopla/Freegal eligibility: any release group first issued before 2005.
+      for (const rg of artistData['release-groups'] || []) {
+        const firstReleaseDate = rg['first-release-date'];
+        if (!firstReleaseDate) continue;
+        if (parseInt(firstReleaseDate.substring(0, 4), 10) < 2005) {
+          hasPre2005Release = true;
+          break;
+        }
+      }
 
       // Parse location from area / begin-area fields.
       // MB area types: 'Country', 'Subdivision', 'City', 'Municipality', 'District', 'Island'.
@@ -242,36 +258,6 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       }
     }
 
-    // Wait again before next request
-    await new Promise(resolve => setTimeout(resolve, 1100));
-
-    // Check if artist has pre-2005 releases (for Hoopla/Freegal eligibility)
-    const releasesUrl = `https://musicbrainz.org/ws/2/release-group/?artist=${artist.id}&fmt=json&limit=20`;
-
-    const releasesResponse = await globalThis.fetch(releasesUrl, {
-      headers: {
-        'User-Agent': 'Unstream/1.0 (https://github.com/unstream - ethical music finder)',
-      },
-    });
-
-    let hasPre2005Release = false;
-
-    if (releasesResponse.ok) {
-      const releasesData = await releasesResponse.json() as { 'release-groups'?: { 'first-release-date'?: string }[] };
-      const releaseGroups = releasesData['release-groups'] || [];
-
-      for (const rg of releaseGroups) {
-        const firstReleaseDate = rg['first-release-date'];
-        if (firstReleaseDate) {
-          const year = parseInt(firstReleaseDate.substring(0, 4), 10);
-          if (year < 2005) {
-            hasPre2005Release = true;
-            break;
-          }
-        }
-      }
-    }
-
     // Derive Bandcamp URL from MB's own platform relations if available (most authoritative).
     // Falls back to a live Bandcamp search by the MB-confirmed artist name so we always
     // try to find location even when MB's Bandcamp link is absent or stale.
@@ -292,15 +278,16 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       searchPeerTubeChannels(artist.name),
       wikipediaUrl ? fetchWikipediaSummary(wikipediaUrl) : Promise.resolve(null),
       (async () => {
-        // Try MB relation URL first; if absent or returns no location, probe Bandcamp directly.
-        // These three steps run sequentially, so keep the probe budget tight — location is
-        // best-effort enrichment and this whole lambda shares the function's 10s ceiling.
+        // Prefer MusicBrainz's own relation URL, then fall back to the probe.
+        // The probe reads location out of the /music page it already fetched, so this
+        // is at most two sequential requests rather than three — the third fetch used
+        // to push the worst case past the function's 10s ceiling.
         if (mbBandcampUrl) {
           const loc = await fetchBandcampLocation(mbBandcampUrl);
           if (loc) return loc;
         }
-        const searchedUrl = await findBandcampArtistUrl(artist.name, 2500);
-        return searchedUrl ? fetchBandcampLocation(searchedUrl) : null;
+        const match = await findBandcampArtist(artist.name, 2500);
+        return match?.location ? parseLocationString(match.location) : null;
       })(),
       fetchMirloLocation(mirloSlug),
     ]);

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -195,6 +195,27 @@ export function parseBandcampReleaseCounts(html: string): { albums: number; trac
   return { albums: albums.size, tracks: tracks.size };
 }
 
+/**
+ * Read the raw location string from a Bandcamp page, e.g. "Northampton, Massachusetts".
+ *
+ * Artist and /music pages carry this in a `class="location"` element. Returned raw so
+ * the caller can run it through parseLocationString — this module stays I/O and
+ * dependency free.
+ *
+ * Worth having because the probe already fetches /music: pulling location from that
+ * same response saves a second round trip to a page we have in hand. Measured 89%
+ * hit rate (16/18 long-tail artists; both misses have no location in Bandcamp's own
+ * discover API either).
+ */
+export function parseBandcampPageLocation(html: string): string | null {
+  const match = html.match(
+    /<(?:p|div|span)[^>]+class="[^"]*\blocation\b[^"]*"[^>]*>([^<]+)<\/(?:p|div|span)>/,
+  );
+  if (!match) return null;
+  const raw = match[1].replace(/\s+/g, ' ').trim();
+  return raw.length > 0 && raw.length <= 120 ? raw : null;
+}
+
 /** Parse Bandcamp /music page HTML to extract release titles */
 export function parseBandcampReleaseTitles(html: string): string[] {
   const root = parse(html);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1,5 +1,6 @@
 import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
+import { findBandcampArtist } from '../search/bandcamp-probe';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
@@ -69,12 +70,25 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutM
 // Cache TTL for platform searches (30 minutes)
 const PLATFORM_CACHE_TTL = 30 * 60;
 
-// Search Bandcamp by scraping search results page (DISABLED)
-// Bandcamp's anti-bot protection blocks server-side scraping, returning
-// challenge pages or 403s. We now rely on MusicBrainz enrichment for direct
-// Bandcamp URLs, and the client-side search fallback for manual discovery.
+// Find the artist on Bandcamp by probing candidate subdomains.
+//
+// bandcamp.com/search is behind a bot challenge and is Disallow'ed in Bandcamp's
+// robots.txt, so this used to return [] and Phase 1 surfaced no Bandcamp results at
+// all — the only Bandcamp link came from a MusicBrainz relation, or a generic
+// "go search Bandcamp yourself" fallback added in attachQobuzAndSearchLinks.
+//
+// The probe covers roughly twice as many artists as MusicBrainz relations alone, and
+// its result is cached (negatives included), so a repeat query costs one DB read.
+// See docs/specs/bandcamp-coverage-research.md.
 async function searchBandcamp(query: string): Promise<PlatformResult[]> {
-  return [];
+  const match = await findBandcampArtist(query, 3000);
+  if (!match) return [];
+  return [{
+    sourceId: 'bandcamp',
+    name: match.bandName ?? query,
+    type: 'artist',
+    url: match.url,
+  }];
 }
 
 // Fetch latest release from a Bandcamp artist page, then get release date from album page
@@ -1681,7 +1695,8 @@ function applyEnrichmentToResults(
 
 async function searchAllPlatforms(query: string): Promise<{ results: AggregatedResult[]; enrichmentApplied: boolean }> {
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
-  const [bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
+  const [bandcampResults, bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, qobuzResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
+    searchBandcamp(query),
     searchBandwagon(query),
     searchMirlo(query),
     searchFaircamp(query),
@@ -1696,6 +1711,7 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
 
   // UC6: Capture partial platform failures for monitoring
   const platformSettledResults: [string, PromiseSettledResult<unknown>][] = [
+    ['bandcamp', bandcampResults],
     ['bandwagon', bandwagonResults],
     ['mirlo', mirloResults],
     ['faircamp', faircampResults],
@@ -1724,6 +1740,7 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   }
 
   const allResults: PlatformResult[] = [];
+  if (bandcampResults.status === 'fulfilled') allResults.push(...bandcampResults.value.filter(r => r.type === 'artist'));
   if (mirloResults.status === 'fulfilled') allResults.push(...mirloResults.value.filter(r => r.type === 'artist'));
 
   const nameOnlyMaps: [string, Map<string, string>][] = [

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -30,6 +30,7 @@ import {
 import {
   isBandcampChallenge,
   parseBandcampBandIdentity,
+  parseBandcampPageLocation,
   parseBandcampReleaseCounts,
 } from '../functions/search-parsers';
 
@@ -56,6 +57,11 @@ export interface BandcampProbeResult {
   albumCount: number;
   trackCount: number;
   matchedSlug?: string;
+  /**
+   * Raw location string from the same /music response, e.g. "Northampton, Massachusetts".
+   * Free — the page is already in hand — so callers never need a second fetch just for it.
+   */
+  location?: string;
 }
 
 const DEFAULT_BUDGET_MS = 5000;
@@ -65,6 +71,9 @@ interface CandidateOutcome {
   verdict: Exclude<BandcampProbeVerdict, 'absent'>;
   identity?: { id: number; name: string };
   counts: { albums: number; tracks: number };
+  location?: string;
+  /** Bandcamp asked us to back off. Stop the whole round, don't try more candidates. */
+  rateLimited?: boolean;
 }
 
 /** Fetch and classify a single candidate slug. Returns null if the slug has no account. */
@@ -89,6 +98,21 @@ async function probeCandidate(slug: string, timeoutMs: number): Promise<Candidat
 
   // No such account. This is a real answer, not a failure.
   if (response.status === 404) return null;
+
+  // Bandcamp does rate-limit, and firing the remaining candidates into an active
+  // 429 is both rude and pointless. Flag it so the caller abandons the round.
+  if (response.status === 429 || response.status === 503) {
+    const shouldCapture = await checkSentryDedup('uns152:bandcamp-rate-limited', 60 * 60);
+    if (shouldCapture) {
+      Sentry.captureMessage('Bandcamp rate-limited the probe', {
+        level: 'warning',
+        extra: { url, status: response.status, retryAfter: response.headers.get('retry-after') },
+        tags: { platform: 'bandcamp' },
+      });
+    }
+    return { verdict: 'undecided', counts: { albums: 0, tracks: 0 }, rateLimited: true };
+  }
+
   if (!response.ok) return { verdict: 'undecided', counts: { albums: 0, tracks: 0 } };
 
   const html = await response.text();
@@ -110,7 +134,8 @@ async function probeCandidate(slug: string, timeoutMs: number): Promise<Candidat
   if (!identity) return { verdict: 'undecided', counts: { albums: 0, tracks: 0 } };
 
   const counts = parseBandcampReleaseCounts(html);
-  return { verdict: 'accepted', identity, counts };
+  const location = parseBandcampPageLocation(html) ?? undefined;
+  return { verdict: 'accepted', identity, counts, location };
 }
 
 /**
@@ -154,6 +179,12 @@ export async function probeBandcampArtist(
     }
 
     if (outcome === null) continue; // 404 — try the next candidate
+
+    // Back off immediately rather than spending the remaining candidates on a
+    // service that has just told us to stop.
+    if (outcome.rateLimited) {
+      return { verdict: 'undecided', artistUrl: null, ...empty };
+    }
 
     if (outcome.verdict === 'undecided' || !outcome.identity) {
       sawUndecided = true;
@@ -199,6 +230,7 @@ export async function probeBandcampArtist(
       albumCount: counts.albums,
       trackCount: counts.tracks,
       matchedSlug: slug,
+      location: outcome.location,
     };
   }
 
@@ -208,8 +240,16 @@ export async function probeBandcampArtist(
   return fallback;
 }
 
+/** What a cached lookup yields for an artist that is on Bandcamp. */
+export interface BandcampArtistMatch {
+  url: string;
+  bandName: string | null;
+  /** Raw location string as Bandcamp renders it, e.g. "Oxford, UK". */
+  location: string | null;
+}
+
 /**
- * Cached artist-URL lookup. Replaces the blocked bandcamp.com/search scrape.
+ * Cached artist lookup. Replaces the blocked bandcamp.com/search scrape.
  *
  * Every distinct query costs at most one round of probes, ever — negatives are
  * cached too, so repeated searches for an artist who isn't on Bandcamp are free
@@ -221,15 +261,19 @@ export async function probeBandcampArtist(
  * the default — measured latency is 270-980ms, but the cap is what bounds the bad
  * case if Bandcamp is slow.
  */
-export async function findBandcampArtistUrl(
+export async function findBandcampArtist(
   query: string,
   budgetMs = DEFAULT_BUDGET_MS,
-): Promise<string | null> {
+): Promise<BandcampArtistMatch | null> {
   const queryNorm = normalizeForComparison(query);
   if (!queryNorm) return null;
 
   const cached = await getBandcampProbe(queryNorm);
-  if (cached) return cached.artist_url;
+  if (cached) {
+    return cached.artist_url
+      ? { url: cached.artist_url, bandName: cached.band_name, location: cached.location }
+      : null;
+  }
 
   const result = await probeBandcampArtist(query, budgetMs);
 
@@ -245,7 +289,18 @@ export async function findBandcampArtistUrl(
     track_count: result.trackCount,
     matched_slug: result.matchedSlug ?? null,
     verdict: result.verdict,
+    location: result.location ?? null,
   });
 
-  return result.artistUrl;
+  return result.artistUrl
+    ? { url: result.artistUrl, bandName: result.bandName ?? null, location: result.location ?? null }
+    : null;
+}
+
+/** Convenience wrapper for callers that only want the URL. */
+export async function findBandcampArtistUrl(
+  query: string,
+  budgetMs = DEFAULT_BUDGET_MS,
+): Promise<string | null> {
+  return (await findBandcampArtist(query, budgetMs))?.url ?? null;
 }

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -2,7 +2,7 @@
 // These functions are used both by the MusicBrainz Netlify function and search-sources.ts
 
 import { isUrlHostnameAllowed } from '../functions/middleware';
-import { findBandcampArtistUrl } from './bandcamp-probe';
+import { findBandcampArtist } from './bandcamp-probe';
 
 // Social platform types
 export type SocialPlatform =
@@ -464,7 +464,9 @@ export function mergeLocations(...sources: (ArtistLocation | null | undefined)[]
 
 // Fetch location from a Bandcamp artist profile page.
 // Validated against the SSRF allowlist as defense-in-depth.
-export async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 4000): Promise<ArtistLocation | null> {
+// Default cap of 2.5s: this is one page fetch, measured at ~670ms, and it sits on a
+// sequential path inside a function with a 10s ceiling.
+export async function fetchBandcampLocation(bandcampUrl: string, timeoutMs = 2500): Promise<ArtistLocation | null> {
   if (!isUrlHostnameAllowed(bandcampUrl)) return null;
   try {
     const controller = new AbortController();
@@ -533,16 +535,21 @@ export async function fetchMirloLocation(artistSlug: string, timeoutMs = 4000): 
 }
 
 // Fallback enrichment when MusicBrainz has no match: look up location via Bandcamp and Mirlo.
-// Uses shorter timeouts (3s each) so the total adds at most ~6s to the Phase 2 response time.
+// Both run in parallel with a 3s cap, so this adds at most ~3s to Phase 2 — the Bandcamp
+// side used to be two sequential requests, but the probe now reads location out of the
+// /music page it already fetched.
 export async function enrichLocationFallback(query: string): Promise<ArtistLocation | undefined> {
   const mirloSlug = query.toLowerCase().replace(/\s+/g, '');
   const FALLBACK_TIMEOUT = 3000;
 
-  const bandcampUrl = await findBandcampArtistUrl(query, FALLBACK_TIMEOUT);
-  const [bandcampLocation, mirloLocation] = await Promise.all([
-    bandcampUrl ? fetchBandcampLocation(bandcampUrl, FALLBACK_TIMEOUT) : Promise.resolve(null),
+  const [bandcampMatch, mirloLocation] = await Promise.all([
+    findBandcampArtist(query, FALLBACK_TIMEOUT),
     fetchMirloLocation(mirloSlug, FALLBACK_TIMEOUT),
   ]);
+
+  const bandcampLocation = bandcampMatch?.location
+    ? parseLocationString(bandcampMatch.location)
+    : null;
 
   return mergeLocations(bandcampLocation, mirloLocation);
 }

--- a/apps/web/tests/unit/search-parsers.test.ts
+++ b/apps/web/tests/unit/search-parsers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isBandcampChallenge,
   parseBandcampBandIdentity,
+  parseBandcampPageLocation,
   parseBandcampReleaseCounts,
   parseBandcampSearchResults,
   parseMirloArtistPage,
@@ -138,6 +139,44 @@ describe('parseBandcampReleaseCounts', () => {
       <a href="/album/somewhere-else">nav link</a>
       <li class="music-grid-item" data-item-id="album-7"></li>`;
     expect(parseBandcampReleaseCounts(withNav)).toEqual({ albums: 1, tracks: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBandcampPageLocation
+// ---------------------------------------------------------------------------
+
+describe('parseBandcampPageLocation', () => {
+  it('reads the location element from a band page', () => {
+    const html = `<div id="band-name-location">
+      <span class="title">Boy Harsher</span>
+      <span class="location secondaryText">Northampton, Massachusetts</span>
+    </div>`;
+    expect(parseBandcampPageLocation(html)).toBe('Northampton, Massachusetts');
+  });
+
+  it('collapses surrounding whitespace and newlines', () => {
+    const html = `<p class="location">\n   Oxford,    UK  \n</p>`;
+    expect(parseBandcampPageLocation(html)).toBe('Oxford, UK');
+  });
+
+  it('returns null when no location element is present', () => {
+    // Legitimate: some artists set no location, and Bandcamp's own discover API
+    // reports none for them either.
+    expect(parseBandcampPageLocation('<div class="title">Some Band</div>')).toBeNull();
+  });
+
+  it('ignores a class that merely contains "location" as a substring', () => {
+    expect(parseBandcampPageLocation('<p class="relocation-notice">moved</p>')).toBeNull();
+  });
+
+  it('rejects absurdly long matches rather than returning page junk', () => {
+    const html = `<p class="location">${'x'.repeat(200)}</p>`;
+    expect(parseBandcampPageLocation(html)).toBeNull();
+  });
+
+  it('returns null for an empty element', () => {
+    expect(parseBandcampPageLocation('<p class="location">   </p>')).toBeNull();
   });
 });
 

--- a/supabase/migrations/20260726180000_bandcamp-probe-location.sql
+++ b/supabase/migrations/20260726180000_bandcamp-probe-location.sql
@@ -1,0 +1,15 @@
+-- Migration 026: Cache the location string alongside each Bandcamp probe (UNS-152)
+--
+-- The probe fetches <slug>.bandcamp.com/music, and that same response already
+-- carries the artist's location in a class="location" element (~90% of the time).
+-- Storing it here means a cache hit yields the URL *and* the location, so the
+-- enrichment path no longer needs a second request to a page we already read.
+--
+-- Nullable: artists whose page shows no location keep NULL, which is also what
+-- Bandcamp's own discover API reports for them.
+
+ALTER TABLE public.bandcamp_slug_probes
+  ADD COLUMN IF NOT EXISTS location TEXT;
+
+COMMENT ON COLUMN public.bandcamp_slug_probes.location IS
+  'Raw location string from the probed /music page, e.g. "Oxford, UK". NULL when the page shows none (UNS-152).';


### PR DESCRIPTION
Two related things: the probe from #319 was finding Bandcamp URLs and throwing them away, and the enrichment path had a worst case well over its function ceiling.

## 1. The probe's results never reached users

#319 wired the probe only into the location path. Both callers did this:

```ts
const searchedUrl = await findBandcampArtistUrl(artist.name, 2500);
return searchedUrl ? fetchBandcampLocation(searchedUrl) : null;   // URL discarded
```

Meanwhile Phase 1's `searchBandcamp` still returned `[]` — dead code the compiler had been flagging as unused (`TS6133`). So the only Bandcamp link a user saw came from a MusicBrainz relation, or a generic `bandcamp.com/search?q=` fallback.

Measured over 100 artists:

| Source | Finds a Bandcamp URL |
|---|---|
| MusicBrainz relations | 9% |
| **The probe** | **19%** |
| Either | 21% |

So ~12 points of coverage were being computed and discarded.

`searchBandcamp` now calls the probe and joins the Phase 1 fan-out. Verified end to end:

```
"Boy Harsher"  -> https://boyharsher.bandcamp.com/   [DIRECT]
"Radiohead"    -> https://radiohead.bandcamp.com/    [DIRECT]
"Beyonce"      -> none                               (empty-catalogue gate rejects the squatter)
```

Also diffed `Beyonce`'s platform list against main to confirm no search-fallback link was lost: identical before and after.

## 2. Location now rides along, saving a request

The probe fetches `<slug>.bandcamp.com/music`, and that response already carries the location in a `class="location"` element — **89%** of the time (16/18 long-tail artists; both misses have no location in Bandcamp's own discover API either). Returning it removes a second fetch of a page already in hand.

Migration `026` caches it, so a cache hit yields URL *and* location together.

`findBandcampArtist` is the new cached entry point; `findBandcampArtistUrl` remains as a thin wrapper. Phase 1 uses the cached form deliberately — it's the hot path, and a repeat query should cost one DB read rather than three HTTP requests.

## 3. Latency

`/api/search/musicbrainz` ran **three sequential network phases**, worst case ~19.6s in a 10s function. Measured real latency was 3.9s, so this was tail risk — but a timeout there produces the same silent all-nulls 500 that hid #318's crash for four months.

- **Merged two MusicBrainz calls.** The `url-rels` lookup and the release-group browse were separate requests with a mandatory 1100ms gap. `inc=url-rels+release-groups` returns both. Cold-cache A/B on fresh artists: **2.11s → 0.51s**. Verified the combined response carries `first-release-date` on every release group (25/25), which is all the pre-2005 Hoopla/Freegal check reads.
- **Dropped the third sequential fetch** in the location lambda (see §2).
- **Back off on HTTP 429.** Bandcamp *does* rate-limit — I triggered it during measurement. A 429 was already classified as `undecided` (never cached as a negative), but the loop then tried the remaining candidates anyway. It now abandons the round and reports to Sentry. This matters more for Layer B's sweep than for search.
- **`fetchBandcampLocation` default 4000 → 2500ms** (measured ~670ms).

## Checks

- `tsc -b` clean
- Explicit strict `tsc` over every touched file + import graph: **zero new errors**, and it clears **3 pre-existing** ones (31 → 28), including the dead `searchBandcamp`. Needed because `api/tsconfig.json` still only covers six files.
- api tests **69/69** · unit tests **384/384** (6 new, covering `parseBandcampPageLocation`)

## Note

Migration `20260726180000_bandcamp-probe-location.sql` adds one nullable column and auto-deploys on merge. The `Supabase Preview` check will exercise it on the preview branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)