### PR TITLE
Stop caching MusicBrainz failures as "this artist has no links"

### DIFF
--- a/api/functions/__tests__/cache-should-cache.test.ts
+++ b/api/functions/__tests__/cache-should-cache.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// cacheGetOrFetch no-ops its Redis calls when Upstash is unconfigured, which is the
+// case here — so these tests exercise the shouldCache decision itself: does the
+// fetch get re-run, or was a failure remembered?
+
+import { cacheGetOrFetch } from '../cache';
+
+describe('cacheGetOrFetch shouldCache predicate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the fetched value whether or not it is cacheable', async () => {
+    const ok = await cacheGetOrFetch('t:ok', async () => ({ v: 1 }), 60, () => true);
+    expect(ok.data).toEqual({ v: 1 });
+    expect(ok.cached).toBe(false);
+
+    const notOk = await cacheGetOrFetch('t:notok', async () => null, 60, d => d !== null);
+    expect(notOk.data).toBeNull();
+    expect(notOk.cached).toBe(false);
+  });
+
+  it('calls the predicate with the fetched data exactly once', async () => {
+    const predicate = vi.fn((d: { v: number }) => d.v > 0);
+    await cacheGetOrFetch('t:pred', async () => ({ v: 7 }), 60, predicate);
+    expect(predicate).toHaveBeenCalledTimes(1);
+    expect(predicate).toHaveBeenCalledWith({ v: 7 });
+  });
+
+  it('treats an omitted predicate as "always cacheable" (existing callers unchanged)', async () => {
+    const result = await cacheGetOrFetch('t:default', async () => 'value', 60);
+    expect(result.data).toBe('value');
+    expect(result.cached).toBe(false);
+  });
+
+  it('re-runs the fetch on a later call when the value was not cacheable', async () => {
+    // The regression this guards: a MusicBrainz 503 was returned as a populated
+    // all-nulls result and cached for 30 minutes, so one hiccup made an artist
+    // look link-less until the TTL expired.
+    let attempts = 0;
+    const fetchFn = async () => {
+      attempts++;
+      return attempts === 1 ? null : { artistName: 'Radiohead' };
+    };
+    const first = await cacheGetOrFetch('t:recover', fetchFn, 60, d => d !== null);
+    const second = await cacheGetOrFetch('t:recover', fetchFn, 60, d => d !== null);
+
+    expect(first.data).toBeNull();
+    expect(second.data).toEqual({ artistName: 'Radiohead' });
+    expect(attempts).toBe(2);
+  });
+
+  it('propagates a throwing fetch rather than caching anything', async () => {
+    await expect(
+      cacheGetOrFetch('t:throw', async () => { throw new Error('boom'); }, 60, () => true),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/api/functions/cache.ts
+++ b/api/functions/cache.ts
@@ -63,11 +63,16 @@ export async function cacheSet<T>(key: string, value: T, ttlSeconds: number = DE
 /**
  * Helper: Get from cache or fetch from source
  * Handles the common pattern of cache-aside
+ *
+ * Pass `shouldCache` when the fetch can return a value meaning "the upstream did not
+ * answer" as opposed to "the upstream answered with nothing". Caching the former turns
+ * one transient failure into a full TTL of wrong answers for that key.
  */
 export async function cacheGetOrFetch<T>(
   key: string,
   fetchFn: () => Promise<T>,
-  ttlSeconds: number = DEFAULT_TTL
+  ttlSeconds: number = DEFAULT_TTL,
+  shouldCache?: (data: T) => boolean
 ): Promise<{ data: T; cached: boolean }> {
   // Try cache first
   const cached = await cacheGet<T>(key);
@@ -79,7 +84,9 @@ export async function cacheGetOrFetch<T>(
   const data = await fetchFn();
 
   // Cache for next time (don't await - fire and forget)
-  cacheSet(key, data, ttlSeconds).catch(() => {});
+  if (!shouldCache || shouldCache(data)) {
+    cacheSet(key, data, ttlSeconds).catch(() => {});
+  }
 
   return { data, cached: false };
 }

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -1,9 +1,10 @@
 // MusicBrainz enrichment server function
 // Imports shared functions from enrichment.ts, keeps Netlify handler here
 
+import { Sentry } from '../lib/sentry';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistEnrichment } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';
 import { normalizeAccents, normalizeSearchQuery } from './search-utils';
 
@@ -52,8 +53,14 @@ interface MusicBrainzSearchResponse {
   location?: ArtistLocation;
 }
 
-// Search MusicBrainz for artist info including official website, Discogs, social links, and release history
-async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchResponse> {
+// Search MusicBrainz for artist info including official website, Discogs, social links, and release history.
+//
+// Returns null when MusicBrainz itself did not answer (non-2xx). That is deliberately
+// distinct from "MusicBrainz has no such artist", which returns a populated empty
+// result: the caller must not cache the former. Caching an upstream failure turned a
+// single MusicBrainz hiccup into 30 minutes of "this artist has no links" for that
+// query — the same mistake as reading a bot-challenge page as "not on Bandcamp".
+async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchResponse | null> {
   const emptyResult: MusicBrainzSearchResponse = {
     query,
     artistName: null,
@@ -79,8 +86,9 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     });
 
     if (!response.ok) {
+      // Upstream did not answer — signal "unknown" so this is not cached.
       console.log('MusicBrainz artist search failed:', response.status);
-      return emptyResult;
+      return null;
     }
 
     const data = await response.json() as { artists?: { id: string; name: string; score: number }[] };
@@ -330,10 +338,29 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       location,
     };
   } catch (error: unknown) {
+    // A network error or timeout is also "we don't know" rather than "no such artist",
+    // so it must not be cached either.
     const err = error as { name?: string; message?: string };
     console.error('MusicBrainz search error:', err.name, err.message);
-    return emptyResult;
+    return null;
   }
+}
+
+/** Response shape used when MusicBrainz did not answer. Nothing is cached for it. */
+function unavailableResult(query: string): MusicBrainzSearchResponse {
+  return {
+    query,
+    artistName: null,
+    officialUrl: null,
+    discogsUrl: null,
+    hasPre2005Release: false,
+    socialLinks: [],
+    discoveredPlatforms: [],
+    platformUrls: [],
+    wikipediaSummary: null,
+    wikipediaUrl: null,
+    location: undefined,
+  };
 }
 
 // Netlify function handler
@@ -359,14 +386,37 @@ export async function handler(event: { queryStringParameters?: Record<string, st
 
     // Use Redis cache to avoid hitting MusicBrainz rate limits
     const cacheKey = artistCacheKey('musicbrainz', normalizedQuery);
-    const { data: result, cached } = await cacheGetOrFetch<MusicBrainzSearchResponse>(
+    const { data: result, cached } = await cacheGetOrFetch<MusicBrainzSearchResponse | null>(
       cacheKey,
       () => searchMusicBrainz(normalizedQuery),
-      MUSICBRAINZ_CACHE_TTL
+      MUSICBRAINZ_CACHE_TTL,
+      // null means MusicBrainz did not answer. Never cache that — otherwise one
+      // hiccup makes an artist look link-less for the full 30 minute TTL.
+      data => data !== null,
     );
 
     if (cached) {
       console.log(`[MusicBrainz] Cache hit for "${normalizedQuery}"`);
+    }
+
+    if (result === null) {
+      const shouldCapture = await checkSentryDedup('uns152:musicbrainz-unavailable', 30 * 60);
+      if (shouldCapture) {
+        Sentry.captureMessage('MusicBrainz did not answer; enrichment skipped', {
+          level: 'warning',
+          extra: { query: normalizedQuery, note: 'Result deliberately not cached.' },
+        });
+      }
+      return {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          // Do not let the CDN cache an unavailable upstream either.
+          'Cache-Control': 'no-store',
+        },
+        body: JSON.stringify(unavailableResult(query)),
+      };
     }
 
     // Persist enrichment to the artist database.


### PR DESCRIPTION
Found while verifying #320 in production.

## Symptom

`Radiohead` returned `artistName: null` on **four consecutive** requests, while `Aphex Twin`, `Big Thief` and `Explosions in the Sky` all returned full data — and the *identical* code returned Radiohead correctly when run locally.

The only meaningful difference between those two environments is Redis.

## Cause

`cacheGetOrFetch` caches whatever the fetch returns. `searchMusicBrainz` returned its populated all-nulls `emptyResult` when MusicBrainz answered non-2xx:

```ts
if (!response.ok) {
  console.log('MusicBrainz artist search failed:', response.status);
  return emptyResult;      // <- indistinguishable from "no such artist", and cached
}
```

`artistCacheKey` lowercases and trims, so every casing of a query shares one key. **One MusicBrainz hiccup made that artist look link-less for the full 30-minute TTL.**

This is the third instance of the same root pattern today:

| PR | Collapsed "source unavailable" into… |
|---|---|
| #317 | a bot-challenge page → "not on Bandcamp" |
| #318 | Mirlo's unfiltered list → "this artist's location" |
| **this** | a MusicBrainz 503 → "this artist has no links" — *and cached it* |

## Fix

- `searchMusicBrainz` returns `null` **only** for a non-answering upstream (non-2xx, or a thrown network error/timeout). The legitimate no-match paths — no results, low score, name mismatch — keep returning `emptyResult` with fallback location, and stay cacheable.
- `cacheGetOrFetch` gains an optional `shouldCache` predicate. Existing callers are unaffected (omitted predicate means "always cacheable").
- The unavailable response sends `Cache-Control: no-store`, so the CDN doesn't hold it for 5 minutes either, and reports to Sentry deduped at 30 minutes.

## Verification

Simulated an outage and recovery against the real handler:

```
1. MusicBrainz down      -> HTTP 200  Cache-Control: no-store              artist null
2. MusicBrainz recovered -> HTTP 200  Cache-Control: s-maxage=300, swr     artist "Radiohead"
   3 MusicBrainz fetch attempts — the failure was retried, not remembered.
```

`tsc -b` clean · explicit strict `tsc` **zero new errors** (28 baseline, 28 after) · api tests **74/74** (5 new, covering the predicate contract including the re-run-after-failure case) · unit tests **384/384**

🤖 Generated with [Claude Code](https://claude.com/claude-code)