### PR TITLE
Fix Qobuz link and artist photo vanishing from search results

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -210,6 +210,8 @@ export interface BandcampProbeRow {
   verdict: 'accepted' | 'absent' | 'rejected_empty' | 'rejected_name' | 'pending_review';
   /** Raw location string from the probed /music page, e.g. "Oxford, UK". */
   location: string | null;
+  /** Normalized release titles from the probed /music page. */
+  release_titles: string[] | null;
   checked_at: string;
 }
 
@@ -232,7 +234,7 @@ export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbe
   try {
     const { data, error } = await client
       .from('bandcamp_slug_probes')
-      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, checked_at')
+      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, release_titles, checked_at')
       .eq('query_norm', queryNorm)
       .maybeSingle();
 

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -88,6 +88,12 @@ async function searchBandcamp(query: string): Promise<PlatformResult[]> {
     name: match.bandName ?? query,
     type: 'artist',
     url: match.url,
+    // Carried from the /music page the probe already read. This must be populated:
+    // fetchReleasesForDisambiguation shares one 4s budget across all its release
+    // fetches, so a Bandcamp platform with no titles forces two more requests into
+    // that budget and starves the Qobuz ones — which drops the Qobuz link, and with
+    // it the artist image.
+    allReleaseTitles: match.releaseTitles.length > 0 ? match.releaseTitles : undefined,
   }];
 }
 
@@ -1333,7 +1339,11 @@ async function fetchReleasesForDisambiguation(aggregated: AggregatedResult[]): P
     const bc = result.platforms.find(p => p.sourceId === 'bandcamp');
     if (bc) {
       promises.push(getBandcampLatestRelease(bc.url).then(r => { if (r) bc.latestRelease = r; }));
-      promises.push(getBandcampReleaseTitles(bc.url).then(t => { if (t.length > 0) bc.allReleaseTitles = t; }));
+      // Skip when the probe already supplied titles. All of these fetches share one
+      // 4s race below, so redundant Bandcamp requests directly cost Qobuz its data.
+      if (!bc.allReleaseTitles || bc.allReleaseTitles.length === 0) {
+        promises.push(getBandcampReleaseTitles(bc.url).then(t => { if (t.length > 0) bc.allReleaseTitles = t; }));
+      }
     }
 
     const qz = result.platforms.find(p => p.sourceId === 'qobuz');

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -46,6 +46,10 @@ export interface PlatformResult {
   url: string;
   imageUrl?: string;
   latestRelease?: LatestRelease;
+  // Normalized release titles, when the source already had them in hand. Lets
+  // fetchReleasesForDisambiguation skip a refetch — that step shares one 4s budget
+  // across platforms, so a redundant request costs another platform its data.
+  allReleaseTitles?: string[];
 }
 
 export interface AggregatedResult {
@@ -413,7 +417,7 @@ export function aggregateResults(allResults: PlatformResult[], query?: string): 
       const existingPlatform = existing.platforms.find(p => p.sourceId === result.sourceId);
 
       if (!existingPlatform) {
-        existing.platforms.push({ sourceId: result.sourceId, url: result.url });
+        existing.platforms.push({ sourceId: result.sourceId, url: result.url, allReleaseTitles: result.allReleaseTitles });
       } else {
         // Same platform type — split if different URL (different artist on same platform)
         const existingPlatformId = extractPlatformIdentifier(existingPlatform.url, existingPlatform.sourceId);
@@ -426,7 +430,7 @@ export function aggregateResults(allResults: PlatformResult[], query?: string): 
               artist: result.artist,
               type: result.type,
               imageUrl: result.imageUrl,
-              platforms: [{ sourceId: result.sourceId, url: result.url }],
+              platforms: [{ sourceId: result.sourceId, url: result.url, allReleaseTitles: result.allReleaseTitles }],
             });
             console.log(`[Aggregation] Created separate entry for "${result.name}" - different ${result.sourceId} profile: ${platformId}`);
           }
@@ -440,7 +444,7 @@ export function aggregateResults(allResults: PlatformResult[], query?: string): 
         artist: result.artist,
         type: result.type,
         imageUrl: result.imageUrl,
-        platforms: [{ sourceId: result.sourceId, url: result.url }],
+        platforms: [{ sourceId: result.sourceId, url: result.url, allReleaseTitles: result.allReleaseTitles }],
       });
     }
   }

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -32,6 +32,7 @@ import {
   parseBandcampBandIdentity,
   parseBandcampPageLocation,
   parseBandcampReleaseCounts,
+  parseBandcampReleaseTitles,
 } from '../functions/search-parsers';
 
 /**
@@ -62,6 +63,14 @@ export interface BandcampProbeResult {
    * Free — the page is already in hand — so callers never need a second fetch just for it.
    */
   location?: string;
+  /**
+   * Normalized release titles from the same /music response.
+   *
+   * Also free, and load-bearing: disambiguation fetches Bandcamp and Qobuz release data
+   * inside one fixed 4s race, so a Bandcamp platform arriving without titles forces two
+   * more requests into that budget and starves the Qobuz ones.
+   */
+  releaseTitles?: string[];
 }
 
 const DEFAULT_BUDGET_MS = 5000;
@@ -72,6 +81,7 @@ interface CandidateOutcome {
   identity?: { id: number; name: string };
   counts: { albums: number; tracks: number };
   location?: string;
+  releaseTitles?: string[];
   /** Bandcamp asked us to back off. Stop the whole round, don't try more candidates. */
   rateLimited?: boolean;
 }
@@ -135,7 +145,8 @@ async function probeCandidate(slug: string, timeoutMs: number): Promise<Candidat
 
   const counts = parseBandcampReleaseCounts(html);
   const location = parseBandcampPageLocation(html) ?? undefined;
-  return { verdict: 'accepted', identity, counts, location };
+  const releaseTitles = parseBandcampReleaseTitles(html);
+  return { verdict: 'accepted', identity, counts, location, releaseTitles };
 }
 
 /**
@@ -231,6 +242,7 @@ export async function probeBandcampArtist(
       trackCount: counts.tracks,
       matchedSlug: slug,
       location: outcome.location,
+      releaseTitles: outcome.releaseTitles,
     };
   }
 
@@ -246,6 +258,8 @@ export interface BandcampArtistMatch {
   bandName: string | null;
   /** Raw location string as Bandcamp renders it, e.g. "Oxford, UK". */
   location: string | null;
+  /** Normalized release titles, so disambiguation need not refetch /music. */
+  releaseTitles: string[];
 }
 
 /**
@@ -271,7 +285,12 @@ export async function findBandcampArtist(
   const cached = await getBandcampProbe(queryNorm);
   if (cached) {
     return cached.artist_url
-      ? { url: cached.artist_url, bandName: cached.band_name, location: cached.location }
+      ? {
+          url: cached.artist_url,
+          bandName: cached.band_name,
+          location: cached.location,
+          releaseTitles: cached.release_titles ?? [],
+        }
       : null;
   }
 
@@ -290,10 +309,16 @@ export async function findBandcampArtist(
     matched_slug: result.matchedSlug ?? null,
     verdict: result.verdict,
     location: result.location ?? null,
+    release_titles: result.releaseTitles ?? null,
   });
 
   return result.artistUrl
-    ? { url: result.artistUrl, bandName: result.bandName ?? null, location: result.location ?? null }
+    ? {
+        url: result.artistUrl,
+        bandName: result.bandName ?? null,
+        location: result.location ?? null,
+        releaseTitles: result.releaseTitles ?? [],
+      }
     : null;
 }
 

--- a/supabase/migrations/20260726200000_bandcamp-probe-release-titles.sql
+++ b/supabase/migrations/20260726200000_bandcamp-probe-release-titles.sql
@@ -1,0 +1,21 @@
+-- Migration 027: Cache Bandcamp release titles alongside each probe (UNS-152)
+--
+-- The probe fetches <slug>.bandcamp.com/music, which is the same page
+-- getBandcampReleaseTitles fetches during disambiguation. Storing the titles here
+-- lets that step reuse them instead of re-requesting a page we already read.
+--
+-- This is not just a saving. fetchReleasesForDisambiguation runs all its release
+-- fetches inside a fixed 4s race, so once Phase 1 started returning Bandcamp results
+-- the extra Bandcamp requests crowded out the Qobuz ones. Qobuz then arrived with no
+-- release data, removeDeadQobuzLinks dropped it, and because Qobuz is where the
+-- artist image comes from, the artist photo disappeared with it.
+--
+-- Normalized titles (via normalizeForComparison) since every consumer compares them
+-- normalized. Nullable: absent for rows probed before this column existed, and the
+-- caller falls back to fetching in that case.
+
+ALTER TABLE public.bandcamp_slug_probes
+  ADD COLUMN IF NOT EXISTS release_titles TEXT[];
+
+COMMENT ON COLUMN public.bandcamp_slug_probes.release_titles IS
+  'Normalized release titles from the probed /music page, reused during disambiguation so Qobuz release fetches are not starved of the shared 4s budget (UNS-152).';


### PR DESCRIPTION
Regression from #320, reported in production for **Anna von Hausswolff**: her Bandcamp link resolves correctly now, but the Qobuz link and the artist photo both disappeared.

## One cause, two symptoms

`fetchReleasesForDisambiguation` runs *every* release fetch inside a single fixed race:

```ts
await Promise.race([
  Promise.allSettled(promises),
  new Promise(resolve => setTimeout(resolve, 4000)),
]);
```

Before #320, Phase 1 returned no Bandcamp results, so that 4s budget was spent on Qobuz. #320 started returning them — adding **two Bandcamp requests per result** — which crowded the Qobuz fetches out. Qobuz then arrived with no release data, `removeDeadQobuzLinks` dropped it as a dead link, and because **the artist image comes from the Qobuz match**, the photo went with it.

Confirmed against production before fixing:

```
result: name='Anna von Hausswolff'  imageUrl=None
platforms: bandcamp, ampwall, kofi, buymeacoffee, officialsite, discogs, instagram, youtube, facebook
           ^ no qobuz
```

And ruled out the obvious alternative — Qobuz *does* list her, and the names normalize identically on both sides, so matching was never the problem:

```
normalizeForComparison('Anna von Hausswolff') = annavonhausswolff
probe data-band name                          = "Anna von Hausswolff" -> annavonhausswolff
parseQobuzSearchResults                       = [["annavonhausswolff",
                                                  ".../interpreter/anna-von-hausswolff/1078840"]]
```

## Fix

The probe already fetches `<slug>.bandcamp.com/music` — **the same page `getBandcampReleaseTitles` was refetching**. So the titles now come back with the probe and are cached (migration 027), and disambiguation skips the Bandcamp title fetch when they're already there. That halves Bandcamp's share of the budget and leaves room for Qobuz.

`PlatformResult` gains `allReleaseTitles`, and `aggregateResults` carries it through — it previously copied only `sourceId` and `url`. I deliberately did **not** also start copying `latestRelease` there, since that would change existing merge behaviour.

## Two side benefits

Bandcamp now arrives *with* release titles, so:
- `crossPlatformReleaseComparison` can actually compare catalogues instead of `continue`-ing on empty titles
- `splitSuspiciousPlatforms` no longer treats Bandcamp as a release-less "suspicious" platform

Both were silently inert for Bandcamp since #320.

## Verification

Probe returns titles from the page it already read, no extra requests:

```
Anna von Hausswolff  accepted  10 albums  "Gothenburg, Sweden"  13 titles
Boy Harsher          accepted  15 albums  "Northampton, MA"     16 titles
```

`tsc -b` clean · explicit strict `tsc` **zero new errors** (28 baseline, 28 after — it caught the `PlatformResult` field error on the first attempt) · api tests **74/74** · unit tests **384/384**

Will confirm on the deploy preview that Qobuz and the photo return before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)