### PR TITLE
Stop deleting Qobuz links when the release lookup merely timed out

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -21,6 +21,7 @@ import {
   createQobuzOnlyResults,
   preferBandcampFeaturedRelease,
   removeDeadQobuzLinks,
+  type AggregatedPlatform,
   crossPlatformReleaseComparison,
   deduplicateQobuzUrls,
   createOrphanedQobuzStandalones,
@@ -1368,8 +1369,18 @@ async function searchEven(query: string): Promise<Map<string, string>> {
 // Phase 3: Fetch releases & disambiguate
 // ---------------------------------------------------------------------------
 
-async function fetchReleasesForDisambiguation(aggregated: AggregatedResult[]): Promise<void> {
+/**
+ * Fetch release data used for disambiguation, bounded by one shared 4s race.
+ *
+ * Returns the platform entries whose release lookups actually finished. That set is what
+ * lets removeDeadQobuzLinks tell "Qobuz has no releases" apart from "Qobuz didn't answer
+ * in time" — losing this race must not look like an empty catalogue.
+ */
+async function fetchReleasesForDisambiguation(
+  aggregated: AggregatedResult[],
+): Promise<Set<AggregatedPlatform>> {
   const promises: Promise<void>[] = [];
+  const completed = new Set<AggregatedPlatform>();
 
   for (const result of aggregated) {
     if (result.type !== 'artist') continue;
@@ -1386,8 +1397,14 @@ async function fetchReleasesForDisambiguation(aggregated: AggregatedResult[]): P
 
     const qz = result.platforms.find(p => p.sourceId === 'qobuz');
     if (qz) {
-      promises.push(getQobuzLatestRelease(qz.url).then(r => { if (r) qz.latestRelease = r; }));
-      promises.push(getQobuzReleaseTitles(qz.url).then(t => { if (t.length > 0) qz.allReleaseTitles = t; }));
+      // Marked complete only once BOTH lookups settle. If just one came back empty we
+      // still don't know whether Qobuz has releases.
+      promises.push(
+        Promise.allSettled([
+          getQobuzLatestRelease(qz.url).then(r => { if (r) qz.latestRelease = r; }),
+          getQobuzReleaseTitles(qz.url).then(t => { if (t.length > 0) qz.allReleaseTitles = t; }),
+        ]).then(() => { completed.add(qz); }),
+      );
     }
   }
 
@@ -1395,6 +1412,8 @@ async function fetchReleasesForDisambiguation(aggregated: AggregatedResult[]): P
     Promise.allSettled(promises),
     new Promise(resolve => setTimeout(resolve, 4000)),
   ]);
+
+  return completed;
 }
 
 // ---------------------------------------------------------------------------
@@ -1884,9 +1903,9 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   }
 
   // Phase 3: Fetch releases, then disambiguate using release data
-  await fetchReleasesForDisambiguation(aggregated);
+  const releaseLookupsCompleted = await fetchReleasesForDisambiguation(aggregated);
   preferBandcampFeaturedRelease(aggregated);
-  removeDeadQobuzLinks(aggregated);
+  removeDeadQobuzLinks(aggregated, releaseLookupsCompleted);
   crossPlatformReleaseComparison(aggregated);
   deduplicateQobuzUrls(aggregated);
   createOrphanedQobuzStandalones(aggregated, qobuzMatches);

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -593,14 +593,39 @@ export function preferBandcampFeaturedRelease(aggregated: AggregatedResult[]): v
 }
 
 // Remove Qobuz platforms with no releases (dead/placeholder pages)
-export function removeDeadQobuzLinks(aggregated: AggregatedResult[]): void {
+/** One entry in an AggregatedResult's platform list. */
+export type AggregatedPlatform = AggregatedResult['platforms'][number];
+
+/**
+ * Drop Qobuz links that have no releases behind them — they are usually a name-only
+ * match on a different artist.
+ *
+ * `releaseLookupsCompleted` holds the platform entries whose release lookups actually
+ * finished. Pass it. Without it, a Qobuz link is deleted whenever its lookup merely
+ * *didn't finish*, which is not the same thing as Qobuz having nothing: those lookups
+ * share one fixed 4s race in fetchReleasesForDisambiguation, so any artist whose Qobuz
+ * pages are slow to answer loses its link — and with it the artist image, which comes
+ * from the Qobuz match. Absence of data is not evidence of absence.
+ */
+export function removeDeadQobuzLinks(
+  aggregated: AggregatedResult[],
+  releaseLookupsCompleted?: ReadonlySet<AggregatedPlatform>,
+): void {
   for (const result of aggregated) {
     if (result.overrideMerged) continue;
     result.platforms = result.platforms.filter(p => {
       if (p.sourceId !== 'qobuz') return true;
       const hasReleases = p.latestRelease || (p.allReleaseTitles && p.allReleaseTitles.length > 0);
-      if (!hasReleases) console.log(`[Cleanup] Removing dead Qobuz link for "${result.name}": ${p.url}`);
-      return hasReleases;
+      if (hasReleases) return true;
+
+      // No release data. Only conclude Qobuz has nothing if we finished looking.
+      if (releaseLookupsCompleted && !releaseLookupsCompleted.has(p)) {
+        console.log(`[Cleanup] Keeping Qobuz link for "${result.name}" — release lookup did not finish: ${p.url}`);
+        return true;
+      }
+
+      console.log(`[Cleanup] Removing dead Qobuz link for "${result.name}": ${p.url}`);
+      return false;
     });
   }
 }

--- a/apps/web/tests/unit/disambiguation.test.ts
+++ b/apps/web/tests/unit/disambiguation.test.ts
@@ -213,6 +213,55 @@ describe('removeDeadQobuzLinks', () => {
 
     expect(results[0].platforms).toHaveLength(1);
   });
+
+  it('keeps a release-less Qobuz link when its lookup never finished', () => {
+    // The regression this guards: release lookups share one fixed 4s race, so a slow
+    // Qobuz response left the link with no data and it was deleted as "dead" — taking
+    // the artist image with it, since that comes from the Qobuz match.
+    const results = [makeResult('Artist', [
+      { sourceId: 'bandcamp', url: 'https://a.bandcamp.com' },
+      { sourceId: 'qobuz', url: 'https://qobuz.com/1' },
+    ])];
+    const completed = new Set<never>(); // nothing finished
+
+    removeDeadQobuzLinks(results, completed);
+
+    expect(results[0].platforms.map(p => p.sourceId)).toEqual(['bandcamp', 'qobuz']);
+  });
+
+  it('still removes a release-less Qobuz link when its lookup DID finish', () => {
+    const results = [makeResult('Artist', [
+      { sourceId: 'bandcamp', url: 'https://a.bandcamp.com' },
+      { sourceId: 'qobuz', url: 'https://qobuz.com/1' },
+    ])];
+    const qobuzPlatform = results[0].platforms.find(p => p.sourceId === 'qobuz')!;
+
+    removeDeadQobuzLinks(results, new Set([qobuzPlatform]));
+
+    expect(results[0].platforms.map(p => p.sourceId)).toEqual(['bandcamp']);
+  });
+
+  it('keeps Qobuz with releases regardless of whether the lookup finished', () => {
+    const results = [makeResult('Artist', [
+      { sourceId: 'qobuz', url: 'https://qobuz.com/1', allReleaseTitles: ['album'] },
+    ])];
+
+    removeDeadQobuzLinks(results, new Set<never>());
+
+    expect(results[0].platforms).toHaveLength(1);
+  });
+
+  it('without the set, behaves exactly as before (deletes on missing data)', () => {
+    // Backward compatibility: existing callers that pass no set keep the old semantics.
+    const results = [makeResult('Artist', [
+      { sourceId: 'bandcamp', url: 'https://a.bandcamp.com' },
+      { sourceId: 'qobuz', url: 'https://qobuz.com/1' },
+    ])];
+
+    removeDeadQobuzLinks(results);
+
+    expect(results[0].platforms.map(p => p.sourceId)).toEqual(['bandcamp']);
+  });
 });
 
 describe('preferBandcampFeaturedRelease', () => {


### PR DESCRIPTION
This is the actual cause of the Anna von Hausswolff card — the fifth and last instance of one pattern found today.

## The bug

`removeDeadQobuzLinks` deletes any Qobuz link with no release data behind it. The reasoning is sound: a name-only match with no catalogue is probably a different artist.

Except the release data is fetched inside **one fixed 4s race shared by every platform**:

```ts
await Promise.race([
  Promise.allSettled(promises),
  new Promise(resolve => setTimeout(resolve, 4000)),
]);
```

So "no release data" also covers **"Qobuz didn't answer in time"**. Absence of data was being read as evidence of absence.

That explains the observed pattern precisely: Radiohead kept its Qobuz link and image (popular query, warm at Qobuz's edge, wins the race), while Boy Harsher, Aphex Twin, Big Thief and Anna von Hausswolff lost theirs. And because **the artist image comes from the Qobuz match**, the photo disappeared with the link.

## Why my earlier attempts missed it

- **#322** reduced contention for that budget (real improvement, wrong target) — the deletion still fired.
- **#323** stopped caching failed *searches* (real bug, also not this) — the Qobuz search was succeeding all along; it was the *release lookup* losing the race.

## Fix

`fetchReleasesForDisambiguation` now returns the platform entries whose release lookups actually settled. `removeDeadQobuzLinks` deletes only when the lookup **finished and genuinely found nothing**.

A Qobuz platform counts as checked only once **both** its lookups settle — one empty answer isn't enough to conclude anything.

The set is an optional parameter, so previous semantics are preserved for any caller that omits it, and the existing tests still assert that.

## Verification

Made Qobuz's interpreter pages take 6s so they lose the race:

```
[Cleanup] Keeping Qobuz link for "Anna von Hausswolff" — release lookup did not finish
platforms: ["qobuz","bandcamp","ampwall","kofi",...]   qobuz kept: YES   imageUrl: present
```

Under the old code that same run deleted the link and the image.

`tsc -b` clean · explicit strict `tsc` **zero new errors** (28 baseline, 28 after) · api tests **77/77** · unit tests **388/388** (4 new, covering lookup-didn't-finish, lookup-did-finish, has-releases, and the no-set backward-compatible path)

## Deliberate trade-off

When a lookup times out we now keep a Qobuz link that release verification might have rejected — i.e. potentially a name-only match on a different artist.

I think that's the lesser harm: every other platform is already kept on a name match alone, and the old behaviour was demonstrably hiding *correct* links for every artist whose Qobuz pages are slow. But it is a real trade, so worth your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)