### PR TITLE
Source the artist photo from Bandcamp instead of Qobuz

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -212,6 +212,8 @@ export interface BandcampProbeRow {
   location: string | null;
   /** Normalized release titles from the probed /music page. */
   release_titles: string[] | null;
+  /** Artist photo from the probed page's og:image. */
+  image_url: string | null;
   checked_at: string;
 }
 
@@ -234,7 +236,7 @@ export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbe
   try {
     const { data, error } = await client
       .from('bandcamp_slug_probes')
-      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, release_titles, checked_at')
+      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, release_titles, image_url, checked_at')
       .eq('query_norm', queryNorm)
       .maybeSingle();
 

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -216,6 +216,25 @@ export function parseBandcampPageLocation(html: string): string | null {
   return raw.length > 0 && raw.length <= 120 ? raw : null;
 }
 
+/**
+ * Read the artist photo from a Bandcamp page's og:image.
+ *
+ * Verified band-level rather than album art: radiohead/music yields
+ * f4.bcbits.com/img/0040867508_23.jpg, which is exactly the image production already
+ * shows for Radiohead. Free — the probe has this HTML in hand.
+ *
+ * Matters because the artist image has been coming from the Qobuz match, and Qobuz's
+ * search path is robots-disallowed and being retired. Bandcamp is the replacement.
+ */
+export function parseBandcampImage(html: string): string | null {
+  const match = html.match(/<meta property="og:image" content="([^"]+)"/);
+  if (!match) return null;
+  const url = match[1].trim();
+  // Bandcamp uses blank.gif as a placeholder; treat it as no image.
+  if (!url.startsWith('https://') || url.includes('/blank.gif')) return null;
+  return url;
+}
+
 /** Parse Bandcamp /music page HTML to extract release titles */
 export function parseBandcampReleaseTitles(html: string): string[] {
   const root = parse(html);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -100,6 +100,9 @@ async function searchBandcamp(query: string): Promise<PlatformResult[]> {
     // that budget and starves the Qobuz ones — which drops the Qobuz link, and with
     // it the artist image.
     allReleaseTitles: match.releaseTitles.length > 0 ? match.releaseTitles : undefined,
+    // Artist photo. aggregateResults carries imageUrl from a PlatformResult, so this
+    // gives results a picture without depending on the Qobuz match.
+    imageUrl: match.imageUrl ?? undefined,
   }];
 }
 

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -30,6 +30,7 @@ import {
 import {
   isBandcampChallenge,
   parseBandcampBandIdentity,
+  parseBandcampImage,
   parseBandcampPageLocation,
   parseBandcampReleaseCounts,
   parseBandcampReleaseTitles,
@@ -71,6 +72,8 @@ export interface BandcampProbeResult {
    * more requests into that budget and starves the Qobuz ones.
    */
   releaseTitles?: string[];
+  /** Artist photo from the page's og:image. Replaces Qobuz as the image source. */
+  imageUrl?: string;
 }
 
 const DEFAULT_BUDGET_MS = 5000;
@@ -82,6 +85,7 @@ interface CandidateOutcome {
   counts: { albums: number; tracks: number };
   location?: string;
   releaseTitles?: string[];
+  imageUrl?: string;
   /** Bandcamp asked us to back off. Stop the whole round, don't try more candidates. */
   rateLimited?: boolean;
 }
@@ -146,7 +150,8 @@ async function probeCandidate(slug: string, timeoutMs: number): Promise<Candidat
   const counts = parseBandcampReleaseCounts(html);
   const location = parseBandcampPageLocation(html) ?? undefined;
   const releaseTitles = parseBandcampReleaseTitles(html);
-  return { verdict: 'accepted', identity, counts, location, releaseTitles };
+  const imageUrl = parseBandcampImage(html) ?? undefined;
+  return { verdict: 'accepted', identity, counts, location, releaseTitles, imageUrl };
 }
 
 /**
@@ -243,6 +248,7 @@ export async function probeBandcampArtist(
       matchedSlug: slug,
       location: outcome.location,
       releaseTitles: outcome.releaseTitles,
+      imageUrl: outcome.imageUrl,
     };
   }
 
@@ -260,6 +266,8 @@ export interface BandcampArtistMatch {
   location: string | null;
   /** Normalized release titles, so disambiguation need not refetch /music. */
   releaseTitles: string[];
+  /** Artist photo (og:image), or null when the page shows none. */
+  imageUrl: string | null;
 }
 
 /**
@@ -290,6 +298,7 @@ export async function findBandcampArtist(
           bandName: cached.band_name,
           location: cached.location,
           releaseTitles: cached.release_titles ?? [],
+          imageUrl: cached.image_url,
         }
       : null;
   }
@@ -310,6 +319,7 @@ export async function findBandcampArtist(
     verdict: result.verdict,
     location: result.location ?? null,
     release_titles: result.releaseTitles ?? null,
+    image_url: result.imageUrl ?? null,
   });
 
   return result.artistUrl
@@ -318,6 +328,7 @@ export async function findBandcampArtist(
         bandName: result.bandName ?? null,
         location: result.location ?? null,
         releaseTitles: result.releaseTitles ?? [],
+        imageUrl: result.imageUrl ?? null,
       }
     : null;
 }

--- a/apps/web/tests/unit/search-parsers.test.ts
+++ b/apps/web/tests/unit/search-parsers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isBandcampChallenge,
   parseBandcampBandIdentity,
+  parseBandcampImage,
   parseBandcampPageLocation,
   parseBandcampReleaseCounts,
   parseBandcampSearchResults,
@@ -177,6 +178,37 @@ describe('parseBandcampPageLocation', () => {
 
   it('returns null for an empty element', () => {
     expect(parseBandcampPageLocation('<p class="location">   </p>')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBandcampImage
+// ---------------------------------------------------------------------------
+
+describe('parseBandcampImage', () => {
+  it('reads the artist photo from og:image', () => {
+    const html = `<meta property="og:image" content="https://f4.bcbits.com/img/0040867508_23.jpg">`;
+    expect(parseBandcampImage(html)).toBe('https://f4.bcbits.com/img/0040867508_23.jpg');
+  });
+
+  it('returns null when there is no og:image', () => {
+    expect(parseBandcampImage('<html><body>no meta here</body></html>')).toBeNull();
+  });
+
+  it("treats Bandcamp's blank.gif placeholder as no image", () => {
+    // Otherwise every artist without a photo gets a 1x1 transparent gif as their avatar.
+    const html = `<meta property="og:image" content="https://f4.bcbits.com/img/blank.gif">`;
+    expect(parseBandcampImage(html)).toBeNull();
+  });
+
+  it('rejects a non-https value rather than emitting a mixed-content URL', () => {
+    const html = `<meta property="og:image" content="http://f4.bcbits.com/img/1.jpg">`;
+    expect(parseBandcampImage(html)).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    const html = `<meta property="og:image" content="  https://f4.bcbits.com/img/2.jpg  ">`;
+    expect(parseBandcampImage(html)).toBe('https://f4.bcbits.com/img/2.jpg');
   });
 });
 

--- a/docs/specs/qobuz-coverage-research.md
+++ b/docs/specs/qobuz-coverage-research.md
@@ -1,0 +1,178 @@
+# Qobuz Coverage: Research & Decision
+
+> Status: **Decided — retire dedicated Qobuz search** (26 July 2026). All findings below were
+> verified empirically against live Qobuz endpoints on that date. This is the companion to
+> `bandcamp-coverage-research.md`; the story rhymes, but the ending is different.
+
+## 1. How this surfaced
+
+Brandon reported that Anna von Hausswolff's card had gained a working Bandcamp link but lost her
+**artist photo** and **Qobuz link**. The report arrived minutes after a Bandcamp PR deployed, which
+sent the investigation down three wrong paths before the decisive test was run.
+
+That test — query artists nobody had searched that day — took ninety seconds:
+
+| Query | Qobuz link | Artist photo |
+|---|---|---|
+| Portishead | missing | missing |
+| Massive Attack | missing | missing |
+| Bonobo | missing | missing |
+| Four Tet | missing | missing |
+| Radiohead | **present** | **present** |
+
+**Qobuz was failing for every artist**, not one. Radiohead was the anomaly — almost certainly a
+stale successful cache entry. The problem was systemic, pre-existing, and unrelated to the Bandcamp
+work.
+
+Lesson recorded separately: establish blast radius before hypothesising cause. Timing coincidence is
+the weakest evidence of causation, and it is the evidence most available right after a deploy.
+
+## 2. What Qobuz's robots.txt permits
+
+`searchQobuz` fetched `https://www.qobuz.com/us-en/search/artists/{query}`. From
+`https://www.qobuz.com/robots.txt`:
+
+```
+User-agent: *
+...
+Disallow: /api.json/
+Disallow: /*/search/albums/
+Disallow: /*/search/tracks/
+Disallow: /*/search/labels/
+Disallow: /*/search/artists/     <-- exactly the path we were scraping
+Disallow: /player/
+Disallow: /v4/
+```
+
+So the search path was **never permitted**, exactly as with Bandcamp's `/search`. The block just
+started being enforced.
+
+Artist pages (`/us-en/interpreter/...`) are **not** disallowed.
+
+Worth noting Qobuz draws a thoughtful distinction the rest of the industry mostly doesn't —
+interactive assistants are welcome, training crawlers are not:
+
+```
+User-agent: ChatGPT-User
+User-agent: Perplexity-User
+User-agent: Claude-User
+Allow: /
+
+User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: anthropic-ai
+User-agent: CCBot
+User-agent: Google-Extended
+...
+Disallow: /
+```
+
+## 3. Why the Bandcamp playbook does not transfer
+
+The Bandcamp fix worked because artist URLs are **guessable**: `<slug>.bandcamp.com`. Qobuz URLs are
+not.
+
+```
+/us-en/interpreter/radiohead          -> HTTP 404
+/us-en/interpreter/radiohead/43840    -> HTTP 200
+/us-en/interpreter/portishead         -> HTTP 404
+```
+
+The numeric ID is required and cannot be derived from the artist name. **There is no probe fallback
+for Qobuz.**
+
+Other doors, all closed:
+
+| Route | Status |
+|---|---|
+| `/*/search/artists/` | `Disallow` |
+| `/api.json/` | `Disallow` |
+| `open.qobuz.com/artist/…` | separate host, `User-Agent: * / Disallow: /` |
+| `/us-en/interpreter/{slug}/{id}` | **permitted**, but needs an ID you cannot guess |
+
+Not a User-Agent issue either — an honest `Unstream/1.0` UA and a browser UA both return HTTP 200
+with identical bodies (256,384 vs 256,385 bytes, 3 interpreter links each) from a residential IP.
+The production failure is therefore most likely datacenter-IP enforcement, again mirroring Bandcamp.
+
+## 4. The permitted route: metadata sources
+
+Since the artist URL cannot be guessed, it has to come from somewhere that already knows it.
+
+**MusicBrainz `url-rels`** — robots-clean, already integrated, and restored by PR #318:
+
+```
+Radiohead   https://www.qobuz.com/us-en/interpreter/radiohead/43840
+Portishead  https://www.qobuz.com/us-en/interpreter/portishead/41259
+Aphex Twin  https://open.qobuz.com/artist/53267
+```
+
+3/3 on the mainstream artists checked. Note two URL shapes — `www.qobuz.com/us-en/interpreter/…`
+and `open.qobuz.com/artist/…` — so normalisation is needed, and the `open.` form points at a host
+whose robots.txt disallows crawling (fine as a *link*, not as something to fetch).
+
+**Wikidata** has two relevant properties:
+
+- `P7071` — Qobuz artist ID
+- `P11578` — Qobuz artist numeric ID
+
+Unstream already pulls from Wikidata for `data/artist-list.json`, so this is a natural second source.
+**Coverage is unmeasured** — a spot check on one entity did not find the property, though that entity
+may have been wrong. Worth measuring before relying on it.
+
+**Qobuz partner API** — `/api.json/` is robots-disallowed, but Qobuz runs a partner programme. Worth
+asking, same as for Bandcamp.
+
+## 5. Decision
+
+**Retire dedicated Qobuz search.** Rely on MusicBrainz (and possibly Wikidata) to supply Qobuz links
+where they exist.
+
+Brandon's reasoning, which is the deciding factor: *"most indie artists don't even know or care
+about Qobuz, it's really meant as a fallback for major artists who don't have music available on
+Bandcamp or elsewhere."*
+
+That makes the coverage profile of metadata sources — strong for well-known artists, thin for the
+indie long tail — a **good fit** rather than a compromise. MusicBrainz covered only ~8–9% of
+long-tail Bandcamp artists, but the long tail is not who Qobuz is for.
+
+### Consequences
+
+1. **The artist image needed a new source.** It came from the Qobuz match
+   (`result.imageUrl = qobuzData.imageUrl`), which is why no artist currently has a photo. Bandcamp
+   now supplies it from the `og:image` on the `/music` page the probe already fetches — verified
+   band-level, and it matches the image production already shows for Radiohead. **PR #325.**
+
+2. **The Qobuz validators become unnecessary and harmful.** `removeDeadQobuzLinks` and
+   `crossPlatformReleaseComparison` exist to check *name-matched guesses* from the search. Once
+   Qobuz links come only from MusicBrainz relations — authoritative by construction — those
+   validators have nothing legitimate to filter, and would delete good links for having no release
+   data behind them.
+
+   This also **moots PR #324**, which fixed those validators' timeout behaviour. It should be closed
+   rather than merged.
+
+3. **Qobuz becomes a mainstream-only platform** in results. That is the intended outcome, not a
+   regression.
+
+## 6. Related work from the same investigation
+
+Three real bugs were found and fixed while chasing this. None of them was the cause, and that is
+worth recording so the next person does not re-litigate them:
+
+| PR | Bug | Status |
+|---|---|---|
+| #322 | Bandcamp release fetches crowded the shared 4s budget | merged |
+| #323 | Failed platform searches cached for 30 min as "artist not on this platform" | merged |
+| #324 | Qobuz link deleted when its release lookup merely timed out | **close — mooted by this decision** |
+| #325 | Artist photo sourced from Bandcamp instead of Qobuz | open |
+
+## 7. Remaining work
+
+1. **Remove `searchQobuz`** and the fan-out entry, plus the now-dead validators and Qobuz release
+   fetchers. Depends on #325 landing first so photos survive.
+2. **Attach MusicBrainz's Qobuz URL as a platform.** It is currently used only for disambiguation
+   (`search-sources.ts` ~1617), never attached — so removing the search without this would drop
+   Qobuz entirely.
+3. **Measure Wikidata `P7071` coverage** against real search traffic before deciding whether to add
+   it as a second source.
+4. **Consider asking Qobuz** about sanctioned access, as with Bandcamp.

--- a/supabase/migrations/20260726220000_bandcamp-probe-image.sql
+++ b/supabase/migrations/20260726220000_bandcamp-probe-image.sql
@@ -1,0 +1,20 @@
+-- Migration 028: Cache the artist photo alongside each Bandcamp probe (UNS-152)
+--
+-- The artist image on a search result has been coming from the Qobuz match
+-- (`qobuzMatches` carries an imageUrl). Qobuz's search path turns out to be
+-- Disallow'ed in its robots.txt and is being retired, so results would otherwise lose
+-- their photos entirely.
+--
+-- Bandcamp is the replacement source: the /music page the probe already fetches carries
+-- the band photo in its og:image. Verified band-level rather than album art —
+-- radiohead/music yields f4.bcbits.com/img/0040867508_23.jpg, which is exactly the
+-- image production already displays for Radiohead.
+--
+-- Nullable: artists whose page shows no photo, and rows probed before this column
+-- existed. Callers treat NULL as "no image" rather than refetching.
+
+ALTER TABLE public.bandcamp_slug_probes
+  ADD COLUMN IF NOT EXISTS image_url TEXT;
+
+COMMENT ON COLUMN public.bandcamp_slug_probes.image_url IS
+  'Artist photo (og:image) from the probed /music page. Replaces Qobuz as the artist image source (UNS-152).';


### PR DESCRIPTION
Prerequisite for retiring the Qobuz search, and it fixes the missing-photo symptom on its own.

## Why

The artist image comes from the Qobuz match — `attachQobuzAndSearchLinks` does `result.imageUrl = qobuzData.imageUrl`. Since Qobuz currently returns nothing in production, **no artist has a photo right now**, and removing the Qobuz search would make that permanent.

## Fix

Bandcamp is the natural replacement, and it's free: the `/music` page the probe already fetches carries the band photo in its `og:image`.

Verified band-level rather than album art — `radiohead/music` yields `f4.bcbits.com/img/0040867508_23.jpg`, which is **exactly** the image production already displays for Radiohead.

```
Anna von Hausswolff    https://f4.bcbits.com/img/0006059542_23.jpg
Boy Harsher            https://f4.bcbits.com/img/0007772900_23.jpg
Low Hum                https://f4.bcbits.com/img/0034700558_23.jpg
```

`parseBandcampImage` rejects two things deliberately:
- Bandcamp's `blank.gif` placeholder — otherwise artists with no photo get a 1×1 transparent gif as their avatar
- any non-`https` value, to avoid emitting a mixed-content URL

Cached in migration `028` so a cache hit carries the image too.

## Verification

End to end with Qobuz forced to **403**:

```
imageUrl:  https://f4.bcbits.com/img/0006059542_23.jpg
platforms: ["bandcamp","ampwall","kofi","buymeacoffee"]
```

The photo no longer depends on Qobuz at all.

`tsc -b` clean · explicit strict `tsc` **zero new errors** (28 baseline, 28 after) · api tests **77/77** · unit tests **393/393** (5 new)

## Next

This unblocks retiring the Qobuz search, which is `Disallow`ed in Qobuz's `robots.txt` (`Disallow: /*/search/artists/`). That's a separate PR plus a research doc, per the plan agreed in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)