### PR TITLE
Stop a cached negative from hiding an artist whose name has punctuation

### DIFF
--- a/api/functions/__tests__/bandcamp-probe-cache-coverage.test.ts
+++ b/api/functions/__tests__/bandcamp-probe-cache-coverage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+// The bug this guards: `bandcamp_slug_probes.query_norm` is
+// normalizeForComparison(query), which strips punctuation — but punctuation is exactly
+// what produces the extra slug candidate. So "Morice" and "Mo-Rice" share one cache row
+// while probing different slugs:
+//
+//   "Morice"  -> candidates ['morice']              -> 404 -> verdict 'absent'
+//   "Mo-Rice" -> candidates ['morice', 'mo-rice']   -> 'mo-rice' is a live account
+//
+// Reusing the first row for the second query hid a real artist with 16 releases.
+// A negative is only reusable when it covers every candidate the query would try.
+
+import { negativeCoversCandidates } from '../db';
+import { bandcampSlugCandidates } from '../search-utils';
+
+describe('negativeCoversCandidates', () => {
+  it('reuses a negative that covers every candidate', () => {
+    expect(negativeCoversCandidates(['morice'], ['morice'])).toBe(true);
+    expect(negativeCoversCandidates(['morice', 'mo-rice'], ['morice', 'mo-rice'])).toBe(true);
+  });
+
+  it('reuses a negative that probed more than the query needs', () => {
+    expect(negativeCoversCandidates(['morice', 'mo-rice'], ['morice'])).toBe(true);
+  });
+
+  it('rejects a negative that never tried one of the candidates', () => {
+    // The actual Mo-Rice bug.
+    expect(negativeCoversCandidates(['morice'], ['morice', 'mo-rice'])).toBe(false);
+  });
+
+  it('rejects a legacy row with unknown coverage', () => {
+    // Pre-migration rows have NULL probed_slugs — unknown, so re-probe once.
+    expect(negativeCoversCandidates(null, ['morice'])).toBe(false);
+  });
+
+  it('rejects a row that recorded no attempts at all', () => {
+    expect(negativeCoversCandidates([], ['morice'])).toBe(false);
+  });
+
+  it('treats an empty candidate list as covered, so callers can opt out', () => {
+    expect(negativeCoversCandidates(null, [])).toBe(false);
+    expect(negativeCoversCandidates(['morice'], [])).toBe(true);
+  });
+});
+
+describe('the Mo-Rice collision, end to end through the candidate generator', () => {
+  it('gives the two spellings different candidate sets', () => {
+    expect(bandcampSlugCandidates('Morice')).toEqual(['morice']);
+    expect(bandcampSlugCandidates('Mo-Rice')).toEqual(['morice', 'mo-rice']);
+  });
+
+  it("does not let the misspelling's negative answer for the real name", () => {
+    const probedForMisspelling = bandcampSlugCandidates('Morice');
+    const neededForRealName = bandcampSlugCandidates('Mo-Rice');
+
+    expect(negativeCoversCandidates(probedForMisspelling, neededForRealName)).toBe(false);
+    // ...while the reverse direction is safe to reuse.
+    expect(negativeCoversCandidates(neededForRealName, probedForMisspelling)).toBe(true);
+  });
+
+  it('holds for other punctuated names, e.g. Ben-G!', () => {
+    expect(bandcampSlugCandidates('Ben-G!')).toEqual(['beng', 'ben-g']);
+    expect(negativeCoversCandidates(['beng'], bandcampSlugCandidates('Ben-G!'))).toBe(false);
+  });
+
+  it('leaves single-token names unaffected, so their cache still hits', () => {
+    const candidates = bandcampSlugCandidates('Radiohead');
+    expect(candidates).toEqual(['radiohead']);
+    expect(negativeCoversCandidates(['radiohead'], candidates)).toBe(true);
+  });
+});

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -214,6 +214,16 @@ export interface BandcampProbeRow {
   release_titles: string[] | null;
   /** Artist photo from the probed page's og:image. */
   image_url: string | null;
+  /**
+   * Slug candidates actually attempted in this probe round.
+   *
+   * `query_norm` strips punctuation, so "Morice" and "Mo-Rice" share one row —
+   * but they generate different candidate sets (['morice'] vs
+   * ['morice', 'mo-rice']). Without this, a negative recorded for the shorter
+   * set is wrongly reused for the longer one, hiding a real artist. NULL means a
+   * legacy row whose candidates are unknown.
+   */
+  probed_slugs: string[] | null;
   checked_at: string;
 }
 
@@ -222,21 +232,46 @@ export interface BandcampProbeRow {
 const NEGATIVE_PROBE_TTL_DAYS = 30;
 
 /**
+ * True when a cached negative may be reused for a query that would probe `candidates`.
+ *
+ * A negative only means "none of the slugs we tried resolved". It says nothing about a
+ * slug that was never tried — so it is reusable only if it covers every candidate the
+ * current query would attempt. This is what keeps "Morice" (candidates ['morice'])
+ * from answering for "Mo-Rice" (['morice', 'mo-rice']), which share a `query_norm`.
+ *
+ * A NULL `probed_slugs` is a pre-migration row: unknown coverage, so treat it as not
+ * covering anything and let it be re-probed once.
+ */
+export function negativeCoversCandidates(
+  probedSlugs: string[] | null,
+  candidates: string[],
+): boolean {
+  if (!probedSlugs) return false;
+  return candidates.every(c => probedSlugs.includes(c));
+}
+
+/**
  * Read a cached probe outcome. Returns null when there is no usable cache entry,
  * which is the caller's signal to probe.
  *
  * A stale negative returns null (re-probe); an accepted result never expires.
  * `pending_review` rows return as-is so an unverified account is neither
  * surfaced nor endlessly re-probed while it waits on /admin/verify.
+ *
+ * Pass `candidates` — the slugs this query would probe. A negative that does not
+ * cover all of them is treated as a miss; see negativeCoversCandidates.
  */
-export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbeRow | null> {
+export async function getBandcampProbe(
+  queryNorm: string,
+  candidates: string[] = [],
+): Promise<BandcampProbeRow | null> {
   const client = getClient();
   if (!client) return null;
 
   try {
     const { data, error } = await client
       .from('bandcamp_slug_probes')
-      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, release_titles, image_url, checked_at')
+      .select('query_norm, artist_url, band_name, band_id, album_count, track_count, matched_slug, verdict, location, release_titles, image_url, probed_slugs, checked_at')
       .eq('query_norm', queryNorm)
       .maybeSingle();
 
@@ -251,6 +286,13 @@ export async function getBandcampProbe(queryNorm: string): Promise<BandcampProbe
 
     const ageMs = Date.now() - new Date(row.checked_at).getTime();
     if (ageMs > NEGATIVE_PROBE_TTL_DAYS * 24 * 60 * 60 * 1000) return null;
+
+    // A negative from a narrower candidate set must not answer for a wider one.
+    if (candidates.length > 0 && !negativeCoversCandidates(row.probed_slugs, candidates)) {
+      console.log(`[DB] Re-probing "${queryNorm}": cached negative covered ${JSON.stringify(row.probed_slugs)}, query needs ${JSON.stringify(candidates)}`);
+      return null;
+    }
+
     return row;
   } catch (error) {
     console.error('[DB] getBandcampProbe error:', error);

--- a/api/search/bandcamp-probe.ts
+++ b/api/search/bandcamp-probe.ts
@@ -74,6 +74,15 @@ export interface BandcampProbeResult {
   releaseTitles?: string[];
   /** Artist photo from the page's og:image. Replaced Qobuz as the image source. */
   imageUrl?: string;
+  /**
+   * Slug candidates actually attempted, in order.
+   *
+   * Cached so a negative can be reused only for queries whose candidates it covers.
+   * `query_norm` strips punctuation, so "Morice" (['morice']) and "Mo-Rice"
+   * (['morice', 'mo-rice']) share a cache row — without this the first spelling's
+   * miss answers for the second and hides a real artist.
+   */
+  probedSlugs: string[];
 }
 
 const DEFAULT_BUDGET_MS = 5000;
@@ -168,14 +177,17 @@ export async function probeBandcampArtist(
   const candidates = bandcampSlugCandidates(query);
   const empty = { albumCount: 0, trackCount: 0 };
   if (candidates.length === 0) {
-    return { verdict: 'absent', artistUrl: null, ...empty };
+    return { verdict: 'absent', artistUrl: null, ...empty, probedSlugs: [] };
   }
 
   const deadline = Date.now() + budgetMs;
   // Rejections are remembered so a later 'absent' can't overwrite a more
   // specific reason; 'undecided' outranks both so we never cache a false miss.
-  let fallback: BandcampProbeResult = { verdict: 'absent', artistUrl: null, ...empty };
+  let fallback: BandcampProbeResult = { verdict: 'absent', artistUrl: null, ...empty, probedSlugs: [] };
   let sawUndecided = false;
+  // Only the slugs we really requested. A round cut short by budget or a 429 must not
+  // claim coverage it does not have.
+  const probedSlugs: string[] = [];
 
   for (const slug of candidates) {
     const remaining = deadline - Date.now();
@@ -186,6 +198,7 @@ export async function probeBandcampArtist(
     }
 
     let outcome: CandidateOutcome | null;
+    probedSlugs.push(slug);
     try {
       outcome = await probeCandidate(slug, remaining);
     } catch {
@@ -199,7 +212,7 @@ export async function probeBandcampArtist(
     // Back off immediately rather than spending the remaining candidates on a
     // service that has just told us to stop.
     if (outcome.rateLimited) {
-      return { verdict: 'undecided', artistUrl: null, ...empty };
+      return { verdict: 'undecided', artistUrl: null, ...empty, probedSlugs };
     }
 
     if (outcome.verdict === 'undecided' || !outcome.identity) {
@@ -219,6 +232,7 @@ export async function probeBandcampArtist(
           albumCount: counts.albums,
           trackCount: counts.tracks,
           matchedSlug: slug,
+          probedSlugs,
         };
       }
       continue;
@@ -234,6 +248,7 @@ export async function probeBandcampArtist(
         albumCount: 0,
         trackCount: 0,
         matchedSlug: slug,
+        probedSlugs,
       };
       continue;
     }
@@ -249,13 +264,14 @@ export async function probeBandcampArtist(
       location: outcome.location,
       releaseTitles: outcome.releaseTitles,
       imageUrl: outcome.imageUrl,
+      probedSlugs,
     };
   }
 
   if (sawUndecided && fallback.verdict === 'absent') {
-    return { verdict: 'undecided', artistUrl: null, ...empty };
+    return { verdict: 'undecided', artistUrl: null, ...empty, probedSlugs };
   }
-  return fallback;
+  return { ...fallback, probedSlugs };
 }
 
 /** What a cached lookup yields for an artist that is on Bandcamp. */
@@ -290,7 +306,10 @@ export async function findBandcampArtist(
   const queryNorm = normalizeForComparison(query);
   if (!queryNorm) return null;
 
-  const cached = await getBandcampProbe(queryNorm);
+  // The cache key drops punctuation, so it cannot distinguish "Morice" from
+  // "Mo-Rice" — but their candidate sets differ. Pass the candidates so a negative
+  // recorded for a narrower set is not reused for a wider one.
+  const cached = await getBandcampProbe(queryNorm, bandcampSlugCandidates(query));
   if (cached) {
     return cached.artist_url
       ? {
@@ -320,6 +339,7 @@ export async function findBandcampArtist(
     location: result.location ?? null,
     release_titles: result.releaseTitles ?? null,
     image_url: result.imageUrl ?? null,
+    probed_slugs: result.probedSlugs,
   });
 
   return result.artistUrl

--- a/supabase/migrations/20260727090000_bandcamp-probe-probed-slugs.sql
+++ b/supabase/migrations/20260727090000_bandcamp-probe-probed-slugs.sql
@@ -1,0 +1,28 @@
+-- Bandcamp probe cache: record which slug candidates were actually tried.
+--
+-- Fixes a cache collision. `query_norm` is normalizeForComparison(query), which
+-- strips punctuation -- but punctuation is exactly what generates the extra slug
+-- candidate in bandcampSlugCandidates:
+--
+--   "Morice"   -> query_norm 'morice' -> candidates ['morice']
+--   "Mo-Rice"  -> query_norm 'morice' -> candidates ['morice', 'mo-rice']
+--
+-- Both spellings share one row. A search for the misspelling probes only
+-- 'morice' (a 404), writes verdict 'absent', and every later search for the
+-- correct "Mo-Rice" reads that row and returns nothing -- without ever trying
+-- mo-rice.bandcamp.com, which is a live account with 16 releases.
+--
+-- Negatives already expire after 30 days, so this was never permanent. But any
+-- repeated search for the wrong spelling refreshes the row, which kept it alive
+-- indefinitely in practice: an integration-test fixture querying "Morice" was
+-- doing exactly that.
+--
+-- With the tried candidates recorded, a cached negative is only reused when it
+-- covers every candidate the current query would probe. Existing rows have NULL
+-- here, so their negatives are re-probed once and then self-heal.
+
+ALTER TABLE public.bandcamp_slug_probes
+  ADD COLUMN IF NOT EXISTS probed_slugs TEXT[];
+
+COMMENT ON COLUMN public.bandcamp_slug_probes.probed_slugs IS
+  'Slug candidates actually attempted during this probe round. A cached negative is only reused when it covers every candidate the current query would try; NULL means unknown (legacy row), so negatives are re-probed once.';


### PR DESCRIPTION
A cached negative was hiding a real artist whose name contains punctuation.

## The bug

`bandcamp_slug_probes.query_norm` is `normalizeForComparison(query)`, which strips punctuation. But punctuation is exactly what generates the extra slug candidate in `bandcampSlugCandidates`, so two spellings share one cache row while probing different slugs:

| Query | `query_norm` | Candidates |
|---|---|---|
| `"Morice"` | `morice` | `['morice']` — 404 |
| `"Mo-Rice"` | `morice` | `['morice', 'mo-rice']` — the 2nd is a live account, 16 releases |

A search for the misspelling probes only `morice`, gets a 404, and writes `verdict: 'absent'`. Every later search for the correct **Mo-Rice** reads that row and returns nothing — **without ever requesting `mo-rice.bandcamp.com`**.

Verified:

```
mo-rice.bandcamp.com/music  -> HTTP 200, data-band name "Mo-Rice", 16 releases
morice.bandcamp.com         -> HTTP 404
prod /api/search/sources?query=Mo-Rice  -> 0 results
```

The probe itself was never at fault — `bandcampSlugCandidates` already produces `mo-rice` as candidate 2. And the same code finds her **locally**, because there's no Supabase configured there so the cache no-ops. That gap is how this stayed hidden.

Negatives do expire after 30 days, so this was never strictly permanent. It was permanent *in practice*: any repeated search for the wrong spelling refreshes the row, and an integration-test fixture querying `"Morice"` had been doing exactly that on every run. The test was feeding the bug that made the test fail.

## The fix

Record which candidates a probe round actually attempted, and reuse a cached negative only when it covers every candidate the current query would try. A negative means *"none of the slugs we tried resolved"* — it says nothing about a slug that was never tried.

- Migration adds `probed_slugs text[]` (nullable, no backfill)
- `probeBandcampArtist` records slugs **as it attempts them**, so a round cut short by budget exhaustion or a 429 can't claim coverage it doesn't have
- `getBandcampProbe` takes the current candidates and treats an uncovered negative as a miss. `accepted` and `pending_review` rows are unaffected — we found someone, or we're deliberately holding for `/admin/verify`
- Legacy rows have `NULL` here, so their negatives are re-probed once and then self-heal. **No manual SQL needed** — the Mo-Rice row heals itself on the next search for her.

Re-probing is bounded: single-token names (`radiohead` → `['radiohead']`) are unaffected and keep hitting cache. Only multi-candidate queries re-probe, once each, on demand.

Generalises beyond Mo-Rice — `Ben-G!` has the identical shape (`beng` / `ben-g`) and is one of the standing integration-test failures.

## Verification

- `npm run build` green — 375 unit tests, 87 api tests (**10 new**, in `api/functions/__tests__/` so they run in the build)
- `api/` isn't covered by the build's typecheck, so `db.ts` and `bandcamp-probe.ts` were checked explicitly against a stashed baseline: **27 pre-existing errors, zero new, none in the touched files**
- The migration is `ADD COLUMN IF NOT EXISTS` + `COMMENT`, matching the three prior probe migrations. It auto-deploys via `.github/workflows/supabase-migrate.yml` on merge to `main`.

## Unrelated papercut spotted

`npm run migrate:dry-run` is broken and has been: it passes `--project-ref` to `supabase db push`, which doesn't accept that flag (it wants `--linked` or `--db-url`). CLAUDE.md documents this command, so it's worth a one-line fix at some point — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
