### PR TITLE
Stop a stale MusicBrainz link and a homonym from merging into one artist

### DIFF
--- a/api/functions/__tests__/bandcamp-identity-conflict.test.ts
+++ b/api/functions/__tests__/bandcamp-identity-conflict.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The bug this guards, reported by the artist Honeycrush:
+//
+//   /?q=honeycrush returned one result named "Honey Crush" whose Bandcamp button
+//   opened a Bandcamp *signup form*, mixed with the real Honeycrush's location,
+//   Instagram and Patreon.
+//
+// Three independent faults stacked up:
+//
+//   1. MusicBrainz lists https://honeyyycrush.bandcamp.com/ for the real artist. That
+//      subdomain was retired and now answers 303 -> bandcamp.com/signup?new_domain=…,
+//      but nothing ever fetched it, so the dead link shipped.
+//   2. The subdomain probe derived slug "honeycrush", which is a real and unrelated
+//      Orlando band literally named "Honey Crush". Name match and release count both
+//      pass — neither check can see it is someone else.
+//   3. MB's (dead) URL then overwrote the probe's (live) one, and MB's enrichment was
+//      grafted onto the homonym, producing one result assembled from two artists.
+
+import {
+  bandcampSubdomainOf,
+  bandcampSubdomainConflicts,
+  isBandcampSearchLink,
+} from '../search-utils';
+
+describe('bandcampSubdomainOf', () => {
+  it('extracts the subdomain from an artist URL', () => {
+    expect(bandcampSubdomainOf('https://honeycrushing.bandcamp.com/')).toBe('honeycrushing');
+    expect(bandcampSubdomainOf('https://honeyyycrush.bandcamp.com/music')).toBe('honeyyycrush');
+  });
+
+  it('lowercases so a casing difference is not read as a different account', () => {
+    expect(bandcampSubdomainOf('https://HoneyCrushing.bandcamp.com/')).toBe('honeycrushing');
+  });
+
+  it('returns null for non-Bandcamp and malformed URLs', () => {
+    expect(bandcampSubdomainOf('https://honeycrushing.com/')).toBeNull();
+    expect(bandcampSubdomainOf('https://bandcamp.com/search?q=honeycrush')).toBeNull();
+    expect(bandcampSubdomainOf('not a url')).toBeNull();
+    expect(bandcampSubdomainOf(null)).toBeNull();
+  });
+});
+
+describe('bandcampSubdomainConflicts', () => {
+  it('flags the Honeycrush case: MB names one account, the probe matched another', () => {
+    expect(
+      bandcampSubdomainConflicts('honeyyycrush', 'https://honeycrush.bandcamp.com/')
+    ).toBe(true);
+  });
+
+  it('does not flag the same account', () => {
+    expect(
+      bandcampSubdomainConflicts('honeycrushing', 'https://honeycrushing.bandcamp.com/')
+    ).toBe(false);
+  });
+
+  it('treats a missing side as absence, not conflict', () => {
+    // MB has no Bandcamp relation — the probe's find is all we have, and it stands.
+    expect(bandcampSubdomainConflicts(null, 'https://honeycrush.bandcamp.com/')).toBe(false);
+    // The probe found nothing — a search-link placeholder must not read as a rival account.
+    expect(bandcampSubdomainConflicts('honeyyycrush', undefined)).toBe(false);
+    expect(
+      bandcampSubdomainConflicts('honeyyycrush', 'https://bandcamp.com/search?q=honeycrush')
+    ).toBe(false);
+  });
+
+  it('ignores custom domains rather than guessing they are a different account', () => {
+    expect(bandcampSubdomainConflicts('honeyyycrush', 'https://honeycrushing.com/')).toBe(false);
+  });
+});
+
+describe('isBandcampSearchLink', () => {
+  it('recognises the placeholder that MB data is allowed to replace', () => {
+    expect(isBandcampSearchLink('https://bandcamp.com/search?q=honeycrush')).toBe(true);
+  });
+
+  it('does not treat a real artist page as replaceable', () => {
+    expect(isBandcampSearchLink('https://honeycrushing.bandcamp.com/')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkBandcampSubdomain — the retired-account check
+// ---------------------------------------------------------------------------
+
+// Redis is not available in tests; cacheGetOrFetch falls through to the fetch fn.
+vi.mock('../cache', () => ({
+  cacheGetOrFetch: async (_key: string, fetchFn: () => Promise<unknown>) => ({
+    data: await fetchFn(),
+    cached: false,
+  }),
+}));
+
+const { checkBandcampSubdomain } = await import('../../search/enrichment');
+
+function response(status: number, location?: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? location ?? null : null) },
+  } as unknown as Response;
+}
+
+describe('checkBandcampSubdomain', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls a retired subdomain dead', async () => {
+    // The exact response honeyyycrush.bandcamp.com gives today.
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      response(303, 'https://bandcamp.com/signup?new_domain=honeyyycrush')
+    );
+    await expect(checkBandcampSubdomain('https://honeyyycrush.bandcamp.com/')).resolves.toBe('dead');
+  });
+
+  it('calls a live subdomain live', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(response(200));
+    await expect(checkBandcampSubdomain('https://honeycrushing.bandcamp.com/')).resolves.toBe('live');
+  });
+
+  it('does not call an unrelated redirect dead', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      response(301, 'https://honeycrushing.bandcamp.com/music')
+    );
+    await expect(checkBandcampSubdomain('https://honeycrushing.bandcamp.com/')).resolves.toBe('live');
+  });
+
+  it('reports unknown when the check fails, never dead', async () => {
+    // The whole point of the tri-state: an outage must not strip good links off results.
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('network down'));
+    await expect(checkBandcampSubdomain('https://honeycrushing.bandcamp.com/')).resolves.toBe('unknown');
+
+    vi.mocked(globalThis.fetch).mockResolvedValue(response(429));
+    await expect(checkBandcampSubdomain('https://honeycrushing.bandcamp.com/')).resolves.toBe('unknown');
+  });
+
+  it('refuses a host outside the SSRF allowlist without fetching', async () => {
+    await expect(checkBandcampSubdomain('https://evil.example.com/')).resolves.toBe('unknown');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses HEAD and does not follow the redirect', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(response(200));
+    await checkBandcampSubdomain('https://honeycrushing.bandcamp.com/');
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(init).toMatchObject({ method: 'HEAD', redirect: 'manual' });
+  });
+});

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -30,6 +30,7 @@ import {
   parseLocationString,
   mergeLocations,
   fetchBandcampLocation,
+  checkBandcampSubdomain,
   fetchMirloLocation,
   enrichLocationFallback,
 } from '../search/enrichment';
@@ -146,7 +147,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     let wikipediaUrl: string | null = null;
     const socialLinks: SocialLink[] = [];
     const seenPlatforms = new Set<SocialPlatform>();
-    const platformUrls: string[] = [];
+    let platformUrls: string[] = [];
 
     let mbLocation: ArtistLocation | undefined;
     let hasPre2005Release = false;
@@ -286,7 +287,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     // Fetch additional social links from Discogs, official site, PeerTube, Wikipedia,
     // and platform locations (Bandcamp, Mirlo) in parallel.
     // Bandcamp location: prefers MB relation URL; falls back to live Bandcamp search by name.
-    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult, bandcampLocation, mirloLocation] = await Promise.all([
+    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult, bandcampLocation, mirloLocation, bandcampStatus] = await Promise.all([
       discogsUrl ? fetchDiscogsSocialLinks(discogsUrl) : Promise.resolve([]),
       officialUrl ? fetchOfficialSiteSocialLinks(officialUrl) : Promise.resolve({ socialLinks: [], linktreeUrl: null, discoveredPlatforms: [] }),
       searchPeerTubeChannels(artist.name),
@@ -304,7 +305,17 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
         return match?.location ? parseLocationString(match.location) : null;
       })(),
       fetchMirloLocation(mirloSlug),
+      mbBandcampUrl ? checkBandcampSubdomain(mbBandcampUrl) : Promise.resolve('unknown' as const),
     ]);
+
+    // Phase 1 strips retired subdomains at the same point; this is the Phase 2 path the
+    // client falls back to when server-side enrichment didn't land in time. Both have to
+    // do it, or the dead link simply arrives a second later. Only a confirmed 'dead' is
+    // dropped — 'unknown' keeps trusting MB, so a Bandcamp outage changes nothing.
+    if (mbBandcampUrl && bandcampStatus === 'dead') {
+      console.log(`[MusicBrainz] Dropping retired Bandcamp subdomain for "${artist.name}": ${mbBandcampUrl}`);
+      platformUrls = platformUrls.filter(u => u !== mbBandcampUrl);
+    }
 
     // Merge locations: MusicBrainz is authoritative; Bandcamp and Mirlo fill in missing fields
     const location = mergeLocations(mbLocation, bandcampLocation, mirloLocation);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -24,6 +24,9 @@ import {
   filterAndSort,
   applyMergeOverrides,
   displayNameFromSlug,
+  isBandcampSearchLink,
+  bandcampSubdomainOf,
+  bandcampSubdomainConflicts,
 } from './search-utils';
 
 // Import shared enrichment functions
@@ -41,6 +44,7 @@ import {
   parseLocationString,
   mergeLocations,
   fetchBandcampLocation,
+  checkBandcampSubdomain,
   fetchMirloLocation,
   enrichLocationFallback,
   fetchWikipediaSummary,
@@ -273,6 +277,15 @@ interface EnrichedMusicBrainzResult {
   officialUrl: string | null;
   discogsUrl: string | null;
   bandcampUrl: string | null;
+  /**
+   * The Bandcamp subdomain MusicBrainz says belongs to this artist, recorded even when
+   * the account behind it has been retired and `bandcampUrl` was therefore dropped.
+   *
+   * MB is authoritative about *which* account is the artist's, independent of whether
+   * that account still exists — so a probe hit on a different subdomain is evidence of
+   * a different artist, not a better link. See `bandcampSubdomainConflicts`.
+   */
+  bandcampSubdomain: string | null;
   qobuzUrl: string | null;
   hasPre2005Release: boolean;
   socialLinks: SocialLink[];
@@ -291,6 +304,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     officialUrl: null,
     discogsUrl: null,
     bandcampUrl: null,
+    bandcampSubdomain: null,
     qobuzUrl: null,
     hasPre2005Release: false,
     socialLinks: [],
@@ -370,7 +384,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     let wikipediaUrl: string | null = null;
     const socialLinks: SocialLink[] = [];
     const seenPlatforms = new Set<SocialPlatform>();
-    const platformUrls: string[] = [];
+    let platformUrls: string[] = [];
 
     let mbLocation: ArtistLocation | undefined;
 
@@ -518,14 +532,39 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
 
     // Fetch enrichment data in parallel
     const mirloSlug = artist.name.toLowerCase().replace(/\s+/g, '');
-    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult, bandcampLocation, mirloLocation] = await Promise.all([
+    const [discogsSocialLinks, officialSiteResult, peertubeLink, wikipediaResult, bandcampLocation, mirloLocation, bandcampStatus] = await Promise.all([
       discogsUrl ? fetchDiscogsSocialLinks(discogsUrl) : Promise.resolve([]),
       officialUrl ? fetchOfficialSiteSocialLinks(officialUrl) : Promise.resolve({ socialLinks: [], linktreeUrl: null, discoveredPlatforms: [] }),
       searchPeerTubeChannels(artist.name),
       wikipediaUrl ? fetchWikipediaSummary(wikipediaUrl) : Promise.resolve(null),
       bandcampUrl ? fetchBandcampLocation(bandcampUrl) : Promise.resolve(null),
       fetchMirloLocation(mirloSlug),
+      // Rides in this existing parallel block, so a confirmed-dead link costs no
+      // extra wall-clock — and only runs at all when MB actually has a Bandcamp rel.
+      bandcampUrl ? checkBandcampSubdomain(bandcampUrl) : Promise.resolve('unknown' as const),
     ]);
+
+    // Drop a retired subdomain here, at the single point where MB's Bandcamp link enters
+    // the pipeline, rather than at each of the four places that later read it. Only a
+    // confirmed 'dead' is dropped; 'unknown' keeps the old behaviour of trusting MB.
+    // Captured before the dead-link drop below: the identity claim outlives the account.
+    const mbClaimedBandcampUrl = bandcampUrl;
+
+    if (bandcampUrl && bandcampStatus === 'dead') {
+      console.log(`[MusicBrainz] Dropping retired Bandcamp subdomain for "${artist.name}": ${bandcampUrl}`);
+      platformUrls = platformUrls.filter(u => u !== bandcampUrl);
+      // MB is the only place this artist's Bandcamp account is recorded, and the record
+      // is stale. Worth knowing about: the fix is an edit upstream, not in our code.
+      const shouldCapture = await checkSentryDedup(`dead-bandcamp:${bandcampUrl}`, 7 * 24 * 60 * 60);
+      if (shouldCapture) {
+        Sentry.captureMessage('MusicBrainz Bandcamp relation points at a retired subdomain', {
+          level: 'info',
+          extra: { artist: artist.name, bandcampUrl, query },
+          tags: { platform: 'bandcamp' },
+        });
+      }
+      bandcampUrl = null;
+    }
 
     // Merge locations
     const location = mergeLocations(mbLocation, bandcampLocation, mirloLocation);
@@ -555,6 +594,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
       officialUrl,
       discogsUrl,
       bandcampUrl,
+      bandcampSubdomain: bandcampSubdomainOf(mbClaimedBandcampUrl),
       qobuzUrl,
       hasPre2005Release,
       socialLinks: allSocialLinks,
@@ -1283,7 +1323,17 @@ function applyEnrichmentToResults(
       resultNormalized === mbNormalized ||
       (resultNormalized.includes(mbNormalized) && mbNormalized.length > resultNormalized.length * 0.7) ||
       (mbNormalized.includes(resultNormalized) && resultNormalized.length > mbNormalized.length * 0.7);
-    if (isMatch) matchingIndices.push(i);
+    if (!isMatch) continue;
+
+    // Same name, different Bandcamp account — a homonym, not this artist. Enriching it
+    // would graft the MB artist's location, socials and Wikipedia entry onto a stranger.
+    const bandcampPlatform = result.platforms.find(p => p.sourceId === 'bandcamp');
+    if (bandcampSubdomainConflicts(mbData.bandcampSubdomain, bandcampPlatform?.url)) {
+      console.log(`[MusicBrainz] "${result.name}" is on a different Bandcamp account than MB lists for "${mbData.artistName}" — not enriching`);
+      continue;
+    }
+
+    matchingIndices.push(i);
   }
 
   // Disambiguate using MB platform URLs
@@ -1389,11 +1439,16 @@ function applyEnrichmentToResults(
     });
     if (bandcampUrl) {
       const existingBandcamp = newPlatforms.findIndex(p => p.sourceId === 'bandcamp');
-      if (existingBandcamp !== -1) {
-        newPlatforms[existingBandcamp] = { sourceId: 'bandcamp' as SourceId, url: bandcampUrl };
-      } else {
+      if (existingBandcamp === -1) {
         newPlatforms.push({ sourceId: 'bandcamp' as SourceId, url: bandcampUrl });
+      } else if (isBandcampSearchLink(newPlatforms[existingBandcamp].url)) {
+        // Only a "go search Bandcamp yourself" placeholder is worth replacing.
+        newPlatforms[existingBandcamp] = { sourceId: 'bandcamp' as SourceId, url: bandcampUrl };
       }
+      // Otherwise the existing link came from the probe, which fetched the page and
+      // verified the account's identity against the query. An MB relation is a stored
+      // string nobody re-checked. Overwriting the verified one with it was how a fan
+      // searching "Honeycrush" got sent to a Bandcamp signup form.
     }
 
     // Add Subvert URL from MB platform relations if available
@@ -1526,8 +1581,13 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   // are findable even when they're not on any of our indie platforms.
   if (mbData && mbData.artistName !== null) {
     const mbNorm = normalizeForComparison(mbData.artistName);
+    // A homonym on a different Bandcamp account does not count as covering this artist.
+    // Without that exclusion, refusing to enrich the impostor in Phase 2.1 would delete
+    // the real artist from the response entirely rather than listing them separately.
     const existingMatch = aggregated.some(r =>
-      r.type === 'artist' && normalizeForComparison(r.name) === mbNorm
+      r.type === 'artist' &&
+      normalizeForComparison(r.name) === mbNorm &&
+      !bandcampSubdomainConflicts(mbData.bandcampSubdomain, r.platforms.find(p => p.sourceId === 'bandcamp')?.url)
     );
     if (!existingMatch) {
       const mbPlatforms = [];

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -347,6 +347,61 @@ export function isSearchOnlyLink(p: { sourceId: SourceId; url: string }): boolea
   return false;
 }
 
+/**
+ * A "go search Bandcamp yourself" placeholder rather than a real artist page.
+ *
+ * Kept separate from `isSearchOnlyLink`, which drives sorting and filtering across the
+ * whole pipeline — Bandcamp is not a search-only platform, it just gets a search-link
+ * fallback when nothing resolved.
+ */
+export function isBandcampSearchLink(url: string): boolean {
+  return url.includes('bandcamp.com/search');
+}
+
+/**
+ * The subdomain of a `*.bandcamp.com` URL, or null for anything else.
+ *
+ * Custom domains deliberately return null: `artist.com` may well be a Bandcamp site,
+ * but we cannot tell from the URL, and guessing would make the identity comparison
+ * below produce false conflicts.
+ */
+export function bandcampSubdomainOf(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const { hostname } = new URL(url);
+    if (!hostname.endsWith('.bandcamp.com')) return null;
+    return hostname.slice(0, -'.bandcamp.com'.length).toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether MusicBrainz and the subdomain probe disagree about which Bandcamp account
+ * belongs to an artist.
+ *
+ * The probe matches on name, so a homonym passes it: searching "Honeycrush" accepts
+ * `honeycrush.bandcamp.com`, a real and unrelated Orlando band called "Honey Crush",
+ * because the names normalize identically and the account has releases. Both of the
+ * probe's checks did their job; neither can see that this is someone else.
+ *
+ * MusicBrainz can. When MB names a specific Bandcamp subdomain for the artist and the
+ * probe matched a different one, they are two different accounts, and the MB artist's
+ * location, socials and Wikipedia entry do not belong on the probe's result. This holds
+ * even when MB's own link is retired — the claim identifies the artist, the HTTP status
+ * only says whether the page still loads.
+ *
+ * Returns false unless both sides actually named a subdomain. Absence is not conflict.
+ */
+export function bandcampSubdomainConflicts(
+  mbSubdomain: string | null | undefined,
+  resultUrl: string | null | undefined,
+): boolean {
+  const probed = bandcampSubdomainOf(resultUrl);
+  if (!mbSubdomain || !probed) return false;
+  return mbSubdomain.toLowerCase() !== probed;
+}
+
 // Platforms where "no releases" is reliable evidence of a different artist
 export const RELIABLE_RELEASE_PLATFORMS = new Set(['bandcamp']);
 

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -1,6 +1,7 @@
 // Shared enrichment functions for MusicBrainz data extraction
 // These functions are used both by the MusicBrainz Netlify function and search-sources.ts
 
+import { cacheGetOrFetch } from '../functions/cache';
 import { isUrlHostnameAllowed } from '../functions/middleware';
 import { findBandcampArtist } from './bandcamp-probe';
 
@@ -460,6 +461,76 @@ export function mergeLocations(...sources: (ArtistLocation | null | undefined)[]
     if (!result.countryCode && src.countryCode) result.countryCode = src.countryCode;
   }
   return (result.city || result.country) ? result : undefined;
+}
+
+/**
+ * Whether a Bandcamp subdomain still hosts an account.
+ *
+ * `unknown` is a first-class answer, not a synonym for `live`. Callers must not
+ * treat it as either verdict — see the tri-state rule in CLAUDE.md.
+ */
+export type BandcampSubdomainStatus = 'live' | 'dead' | 'unknown';
+
+/** Retired subdomains stay retired; a live one rarely vanishes. Both are safe to hold for a week. */
+const SUBDOMAIN_STATUS_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Check whether a Bandcamp artist URL still resolves to a real account.
+ *
+ * A retired subdomain does not 404 — it answers `303` with
+ * `Location: https://bandcamp.com/signup?new_domain=<slug>`, so an unchecked link
+ * drops the fan on a signup form. MusicBrainz relations outlive the accounts they
+ * point at, which is exactly how the Honeycrush report happened: MB still lists
+ * `honeyyycrush.bandcamp.com`, retired some time ago.
+ *
+ * Only that one redirect counts as `dead`. A 200, any other redirect, a non-2xx, a
+ * timeout or a network error all return `live`/`unknown` and leave the link alone —
+ * a Bandcamp outage must degrade to "show the link anyway", never to stripping good
+ * links off every result.
+ *
+ * One HEAD, no body: measured at ~200ms for a dead subdomain and ~300-450ms for a live
+ * one. Verdicts are cached per URL (not per query) because this is a property of the
+ * subdomain; `unknown` is deliberately never cached.
+ */
+export async function checkBandcampSubdomain(
+  bandcampUrl: string,
+  timeoutMs = 2500,
+): Promise<BandcampSubdomainStatus> {
+  if (!isUrlHostnameAllowed(bandcampUrl)) return 'unknown';
+
+  const key = `bandcamp-subdomain:${bandcampUrl.replace(/\/+$/, '').toLowerCase()}`;
+  const { data } = await cacheGetOrFetch<BandcampSubdomainStatus>(
+    key,
+    async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await globalThis.fetch(bandcampUrl, {
+          method: 'HEAD',
+          redirect: 'manual',
+          signal: controller.signal,
+          headers: { 'User-Agent': 'Unstream/1.0 (+https://unstream.stream)' },
+        });
+        const location = response.headers.get('location') ?? '';
+        // The one signal that means "this account is gone".
+        if (location.startsWith('https://bandcamp.com/signup')) return 'dead';
+        // A 2xx, or a redirect to anywhere else on Bandcamp, means the account is there.
+        if (response.ok) return 'live';
+        if (response.status >= 300 && response.status < 400) return 'live';
+        // 429, 5xx, bot challenge: Bandcamp did not answer the question we asked.
+        return 'unknown';
+      } catch {
+        // Timeout or network error. We did not find out.
+        return 'unknown';
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+    SUBDOMAIN_STATUS_TTL_SECONDS,
+    status => status !== 'unknown',
+  );
+
+  return data;
 }
 
 // Fetch location from a Bandcamp artist profile page.


### PR DESCRIPTION
Reported by the artist Honeycrush: searching `honeycrush` returned a single result named "Honey Crush" whose Bandcamp button opened a **Bandcamp signup form**, mixed together with the real Honeycrush's location, Instagram and Patreon.

Not a regression from the probe-cache work in #328. Three independent faults stacked up.

## Root causes

**1. MusicBrainz has a stale Bandcamp relation.** MB artist `d4268f62…` ("Honeycrush", Brooklyn) lists `https://honeyyycrush.bandcamp.com/`. That subdomain was retired and now answers:

```
303 → https://bandcamp.com/signup?new_domain=honeyyycrush
```

Nothing ever fetched it, and MB's URL unconditionally overwrote the probe's, so the dead link shipped.

**2. A homonym passes the probe.** `bandcampSlugCandidates("honeycrush")` yields slug `honeycrush`, which is a real and unrelated Orlando band literally named "Honey Crush". Name match and release count both pass — neither check can see it's someone else. The true artist is at `honeycrushing`, a slug not derivable from the name.

| slug | name | location | releases |
|---|---|---|---|
| `honeycrush` | Honey Crush | Orlando, Florida | 1984, Trying |
| `honeycrushing` | Honeycrush | New York, New York | Man-Size, Dogwoods, Marigold, … |

**3. The two merged**, producing one result assembled from two artists plus a link belonging to neither live account.

## Fixes

**1. `checkBandcampSubdomain()`** — one `HEAD` with `redirect: 'manual'` before we trust an MB Bandcamp relation. Tri-state `'live' | 'dead' | 'unknown'`: only a redirect to `bandcamp.com/signup` counts as dead, while a 429, 5xx, timeout or network error returns `unknown` and leaves the link alone, so a Bandcamp outage can't strip good links off every result. Verdicts cache per-URL for a week; `unknown` is never cached.

Applied in **both** search functions — Phase 2 is the client's fallback path, so fixing only Phase 1 would let the dead link arrive a second later instead of not at all.

**2. An MB relation no longer overwrites a probe-verified URL.** The probe fetched the page and checked identity against the query; an MB relation is a stored string nobody re-checked. Only a `bandcamp.com/search` placeholder is still replaced.

**3. Subdomain-disagreement check.** MB is authoritative about *which* Bandcamp account belongs to an artist, and that claim survives the account being retired. MB says `honeyyycrush`, the probe matched `honeycrush` → different accounts → MB's enrichment no longer attaches. Phase 2.2's coverage check excludes conflicting homonyms too; otherwise rejecting the impostor would delete the real artist from the response instead of listing them separately.

### Two heuristics deliberately rejected

The obvious disambiguators both reject the **correct** artist, so they're not here:

- **Location.** MB says `Brooklyn`; the correct Bandcamp account says `New York, New York`. Same place, different strings. Country level is useless — the wrong artist is also `US`.
- **Release-title overlap.** MB knows one release group ("Unfold"); the correct account lists eight different titles. Zero overlap.

MB's coverage of small independent artists is thin, so "the reference source doesn't corroborate this" almost always means it doesn't know — absence treated as a negative, the same error class as `never cache uncertainty`. Hence an authoritative identity claim rather than attribute comparison.

## Performance

Roughly 0ms added on cache hits. On a cold miss: one bodyless `HEAD`, measured at ~200ms for a dead subdomain and ~275–450ms for a live one, running *inside* the existing parallel enrichment block that already budgets 4s — so `max(phase, 0.3s)`, not `phase + 0.3s`. Only fires when MB actually has a Bandcamp relation. Fixes 2 and 3 are pure logic, zero network.

## Testing

- 15 new tests in `api/functions/__tests__/bandcamp-identity-conflict.test.ts`. One caught a real bug during development — the first cut classified a 429 as `live`.
- `npm run build` green end to end. API 110/110, unit 380/380.
- `api/` isn't in the build's typecheck include, so `tsc` was run explicitly against each changed file and diffed against a stashed baseline: four pre-existing errors in `search-sources.ts`, unchanged, zero new. Lint: 78 pre-existing problems before and after, none from this branch.
- The pieces are verified; the assembled pipeline is not verified against production — worth a look at the deploy preview.

## Scope limit

Honeycrush is still not discoverable **by name** — `honeycrushing` can't be derived from "honeycrush". That needs the upstream MusicBrainz record corrected (the artist has been contacted) or a merge override, which has been applied. What this PR fixes is that the signup link is gone and the two artists no longer merge into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)