### PR TITLE
Move download buttons above search bar on homepage

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -232,19 +232,19 @@ function App() {
       {/* Search section */}
       <main className="px-4 pb-16">
         <div className="max-w-4xl mx-auto">
+          {/* Download buttons — above search, hidden in PWA mode */}
+          {!isStandalone && (
+          <div className="mb-[30px]">
+            <DownloadGrid />
+          </div>
+          )}
+
           <SearchBar
             onSearch={handleSearch}
             isLoading={isLoading || isResolving}
             initialQuery={resolvedQuery}
             onReset={hasSearched ? handleGoHome : undefined}
           />
-
-          {/* Download buttons — below search, hidden in PWA mode */}
-          {!isStandalone && (
-          <div className="mt-[30px]">
-            <DownloadGrid />
-          </div>
-          )}
 
           {/* Resolving URL state */}
           {isResolving && (


### PR DESCRIPTION
## Summary
- Reorders the homepage hero: the app/extension download button grid now renders first, with the search bar below it (previously the reverse).
- Applies to both desktop and mobile layouts.

## Why
Requested layout change — download buttons should be the primary above-the-fold CTA, with search below.

## Test plan
- [x] Verified locally in the Browser preview at desktop width (1280px) and mobile width (375px) — matches the requested order
- [x] `npm run lint` — no new errors introduced (pre-existing lint errors are in unrelated test files)