### PR TITLE
feat: artist_releases + release_links data foundation

### DIFF
--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,4 +1,7 @@
 import { parse } from 'node-html-parser';
+import { getClient, artistSlug } from './db.js';
+import { mapReleaseType, releaseSlug, isStreamingPlatform, bandcampReleaseType } from './release-utils.js';
+import { checkRateLimit, getClientIp } from './ratelimit.js';
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -11,6 +14,7 @@ interface ReleaseResult {
   releaseDate: string; // ISO format
   releaseUrl: string;
   platform: 'bandcamp' | 'faircamp' | 'mirlo';
+  releaseType: 'album' | 'track';
 }
 
 interface CheckReleasesRequest {
@@ -22,6 +26,119 @@ interface CheckReleasesResponse {
   artistName: string;
   release: ReleaseResult | null;
   error?: string;
+}
+
+// ── Release persistence (artist_releases + release_links) ─────────────────
+//
+// When check-releases finds a release, it writes to the new release tables
+// in addition to returning the data. The jsonb latest_release on artist_links
+// is still written by persistSearchResults in db.ts for backward compatibility.
+// These tables are additive.
+//
+// Security: before persisting, we validate that the release URL's domain
+// matches a platform link already stored on the artist in artist_links.
+// This prevents arbitrary URL injection via the unauthenticated endpoint.
+
+/**
+ * Persist a detected release to artist_releases + release_links.
+ * Idempotent: upserts on (artist_id, slug) and (release_id, platform).
+ * Fire-and-forget — errors are logged but don't fail the response.
+ */
+async function persistRelease(
+  artistName: string,
+  release: ReleaseResult,
+): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  try {
+    const slug = artistSlug(artistName);
+
+    // Look up the artist by slug
+    const { data: artist, error: artistError } = await client
+      .from('artists')
+      .select('id')
+      .eq('slug', slug)
+      .single();
+
+    if (artistError || !artist) {
+      // Artist not in DB — nothing to persist
+      return;
+    }
+
+    const artistId = artist.id;
+
+    // Validate that the release URL's domain matches a platform link already
+    // stored on this artist. This prevents arbitrary URL injection via the
+    // unauthenticated endpoint — only releases from known artist platform URLs
+    // are persisted.
+    const { data: artistLinks } = await client
+      .from('artist_links')
+      .select('platform, url')
+      .eq('artist_id', artistId);
+
+    if (!artistLinks || artistLinks.length === 0) return;
+
+    const releaseDomain = new URL(release.releaseUrl).hostname.replace(/^www\./, '');
+    const hasMatchingLink = artistLinks.some((link: { platform: string; url: string }) => {
+      try {
+        const linkDomain = new URL(link.url).hostname.replace(/^www\./, '');
+        return linkDomain === releaseDomain;
+      } catch {
+        return false;
+      }
+    });
+
+    if (!hasMatchingLink) {
+      console.log(`[check-releases] Skipping persist: release URL domain ${releaseDomain} does not match any artist_link`);
+      return;
+    }
+
+    const relSlug = releaseSlug(release.releaseName);
+    const releaseType = mapReleaseType(release.releaseType);
+
+    // Upsert the release
+    const { data: releaseRow, error: releaseError } = await client
+      .from('artist_releases')
+      .upsert(
+        {
+          artist_id: artistId,
+          title: release.releaseName,
+          slug: relSlug,
+          release_type: releaseType,
+          release_date: release.releaseDate,
+          source: 'auto',
+        },
+        { onConflict: 'artist_id,slug' }
+      )
+      .select('id')
+      .single();
+
+    if (releaseError || !releaseRow) {
+      console.error('[check-releases] Failed to upsert artist_releases:', releaseError?.message);
+      return;
+    }
+
+    // Upsert the release link for this platform
+    const { error: linkError } = await client
+      .from('release_links')
+      .upsert(
+        {
+          release_id: releaseRow.id,
+          platform: release.platform,
+          url: release.releaseUrl,
+          is_streaming: isStreamingPlatform(release.platform),
+          source: release.platform, // 'bandcamp' | 'faircamp' | 'mirlo'
+        },
+        { onConflict: 'release_id,platform' }
+      );
+
+    if (linkError) {
+      console.error('[check-releases] Failed to upsert release_links:', linkError.message);
+    }
+  } catch (err) {
+    console.error('[check-releases] persistRelease error:', err);
+  }
 }
 
 // Helper to fetch with timeout
@@ -139,6 +256,7 @@ async function checkBandcamp(artistUrl: string): Promise<ReleaseResult | null> {
       releaseDate,
       releaseUrl: fullUrl,
       platform: 'bandcamp',
+      releaseType: bandcampReleaseType(fullUrl),
     };
   } catch (error) {
     console.error('Bandcamp check error:', error);
@@ -190,6 +308,7 @@ async function checkFaircamp(faircampUrl: string): Promise<ReleaseResult | null>
       releaseDate,
       releaseUrl: linkMatch[1].trim(),
       platform: 'faircamp',
+      releaseType: 'album',
     };
   } catch (error) {
     console.error('Faircamp check error:', error);
@@ -266,6 +385,7 @@ async function checkMirlo(mirloUrl: string): Promise<ReleaseResult | null> {
       releaseDate: latestRelease.pubDate,
       releaseUrl: latestRelease.link,
       platform: 'mirlo',
+      releaseType: 'album',
     };
   } catch (error) {
     console.error('Mirlo check error:', error);
@@ -312,6 +432,7 @@ async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult
 export async function handler(event: {
   httpMethod?: string;
   body?: string;
+  headers?: Record<string, string | undefined>;
   queryStringParameters?: Record<string, string>;
 }) {
   // Handle CORS preflight
@@ -338,6 +459,17 @@ export async function handler(event: {
       body: JSON.stringify({ error: 'Method not allowed. Use POST.' }),
     };
   }
+
+  const corsHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  // Rate limit: strict tier (10 req/min, 500/day) — this endpoint fetches
+  // external pages and writes to the DB, so it's expensive.
+  const ip = getClientIp(event.headers || {});
+  const rl = await checkRateLimit(ip, 'strict', corsHeaders);
+  if (rl.limited) return rl.response;
 
   // Parse request body
   let request: CheckReleasesRequest;
@@ -384,6 +516,13 @@ export async function handler(event: {
 
   try {
     const release = await checkAllPlatforms(request.platforms);
+
+    // Persist to artist_releases + release_links (fire-and-forget, additive to jsonb)
+    if (release) {
+      persistRelease(request.artistName, release).catch(err =>
+        console.error('[check-releases] Background persist failed:', err)
+      );
+    }
 
     const response: CheckReleasesResponse = {
       artistName: request.artistName,

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,7 +1,13 @@
 import { parse } from 'node-html-parser';
-import { getClient, artistSlug } from './db.js';
-import { mapReleaseType, releaseSlug, isStreamingPlatform, bandcampReleaseType } from './release-utils.js';
+import { isUrlHostnameAllowed } from './middleware.js';
+import { bandcampReleaseType } from './release-utils.js';
 import { checkRateLimit, getClientIp } from './ratelimit.js';
+
+// Note on releaseType mapping: the API returns 'album' | 'track' from the
+// platform parsers, while the DB stores the enum 'album' | 'single' | 'ep' |
+// 'compilation'. mapReleaseType() in release-utils.ts handles the mapping
+// ('track' → 'single', 'album' → 'album'). This endpoint returns the raw
+// platform values; persistence (via db.ts) applies the mapping.
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -26,119 +32,6 @@ interface CheckReleasesResponse {
   artistName: string;
   release: ReleaseResult | null;
   error?: string;
-}
-
-// ── Release persistence (artist_releases + release_links) ─────────────────
-//
-// When check-releases finds a release, it writes to the new release tables
-// in addition to returning the data. The jsonb latest_release on artist_links
-// is still written by persistSearchResults in db.ts for backward compatibility.
-// These tables are additive.
-//
-// Security: before persisting, we validate that the release URL's domain
-// matches a platform link already stored on the artist in artist_links.
-// This prevents arbitrary URL injection via the unauthenticated endpoint.
-
-/**
- * Persist a detected release to artist_releases + release_links.
- * Idempotent: upserts on (artist_id, slug) and (release_id, platform).
- * Fire-and-forget — errors are logged but don't fail the response.
- */
-async function persistRelease(
-  artistName: string,
-  release: ReleaseResult,
-): Promise<void> {
-  const client = getClient();
-  if (!client) return;
-
-  try {
-    const slug = artistSlug(artistName);
-
-    // Look up the artist by slug
-    const { data: artist, error: artistError } = await client
-      .from('artists')
-      .select('id')
-      .eq('slug', slug)
-      .single();
-
-    if (artistError || !artist) {
-      // Artist not in DB — nothing to persist
-      return;
-    }
-
-    const artistId = artist.id;
-
-    // Validate that the release URL's domain matches a platform link already
-    // stored on this artist. This prevents arbitrary URL injection via the
-    // unauthenticated endpoint — only releases from known artist platform URLs
-    // are persisted.
-    const { data: artistLinks } = await client
-      .from('artist_links')
-      .select('platform, url')
-      .eq('artist_id', artistId);
-
-    if (!artistLinks || artistLinks.length === 0) return;
-
-    const releaseDomain = new URL(release.releaseUrl).hostname.replace(/^www\./, '');
-    const hasMatchingLink = artistLinks.some((link: { platform: string; url: string }) => {
-      try {
-        const linkDomain = new URL(link.url).hostname.replace(/^www\./, '');
-        return linkDomain === releaseDomain;
-      } catch {
-        return false;
-      }
-    });
-
-    if (!hasMatchingLink) {
-      console.log(`[check-releases] Skipping persist: release URL domain ${releaseDomain} does not match any artist_link`);
-      return;
-    }
-
-    const relSlug = releaseSlug(release.releaseName);
-    const releaseType = mapReleaseType(release.releaseType);
-
-    // Upsert the release
-    const { data: releaseRow, error: releaseError } = await client
-      .from('artist_releases')
-      .upsert(
-        {
-          artist_id: artistId,
-          title: release.releaseName,
-          slug: relSlug,
-          release_type: releaseType,
-          release_date: release.releaseDate,
-          source: 'auto',
-        },
-        { onConflict: 'artist_id,slug' }
-      )
-      .select('id')
-      .single();
-
-    if (releaseError || !releaseRow) {
-      console.error('[check-releases] Failed to upsert artist_releases:', releaseError?.message);
-      return;
-    }
-
-    // Upsert the release link for this platform
-    const { error: linkError } = await client
-      .from('release_links')
-      .upsert(
-        {
-          release_id: releaseRow.id,
-          platform: release.platform,
-          url: release.releaseUrl,
-          is_streaming: isStreamingPlatform(release.platform),
-          source: release.platform, // 'bandcamp' | 'faircamp' | 'mirlo'
-        },
-        { onConflict: 'release_id,platform' }
-      );
-
-    if (linkError) {
-      console.error('[check-releases] Failed to upsert release_links:', linkError.message);
-    }
-  } catch (err) {
-    console.error('[check-releases] persistRelease error:', err);
-  }
 }
 
 // Helper to fetch with timeout
@@ -466,7 +359,7 @@ export async function handler(event: {
   };
 
   // Rate limit: strict tier (10 req/min, 500/day) — this endpoint fetches
-  // external pages and writes to the DB, so it's expensive.
+  // external pages, so it's expensive.
   const ip = getClientIp(event.headers || {});
   const rl = await checkRateLimit(ip, 'strict', corsHeaders);
   if (rl.limited) return rl.response;
@@ -490,10 +383,7 @@ export async function handler(event: {
   if (!request.artistName || !request.platforms) {
     return {
       statusCode: 400,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
+      headers: corsHeaders,
       body: JSON.stringify({ error: 'artistName and platforms are required' }),
     };
   }
@@ -506,23 +396,36 @@ export async function handler(event: {
   if (!hasPlatform) {
     return {
       statusCode: 400,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
+      headers: corsHeaders,
       body: JSON.stringify({ error: 'At least one platform URL is required' }),
     };
+  }
+
+  // SSRF protection: validate every inbound platform URL against the hostname
+  // allowlist before any fetch. This endpoint is called by the Mac app and
+  // browser extension with no auth — without this check, it would be an open proxy.
+  const platformUrls = [
+    request.platforms.bandcamp,
+    request.platforms.faircamp,
+    request.platforms.mirlo,
+  ].filter(Boolean) as string[];
+
+  for (const url of platformUrls) {
+    if (!isUrlHostnameAllowed(url)) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: `URL not allowed: ${url}` }),
+      };
+    }
   }
 
   try {
     const release = await checkAllPlatforms(request.platforms);
 
-    // Persist to artist_releases + release_links (fire-and-forget, additive to jsonb)
-    if (release) {
-      persistRelease(request.artistName, release).catch(err =>
-        console.error('[check-releases] Background persist failed:', err)
-      );
-    }
+    // Note: this endpoint is read-only. It does NOT persist to the database.
+    // All writes to artist_releases + release_links go through persistSearchResults
+    // in db.ts, which runs from the authenticated search pipeline.
 
     const response: CheckReleasesResponse = {
       artistName: request.artistName,

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2,7 +2,7 @@
 // All operations are optional — if Supabase is not configured, they no-op gracefully.
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { mapReleaseType, releaseSlug, isStreamingPlatform } from './release-utils';
+import { mapReleaseType, releaseSlugWithCollision, isStreamingPlatform, normalizeReleaseTitle } from './release-utils';
 
 let supabase: SupabaseClient | null = null;
 
@@ -38,24 +38,38 @@ async function persistReleasesForArtist(
   artistId: string,
   platforms: PlatformLink[],
 ): Promise<void> {
-  // Group by normalized title for deduplication across platforms
+  // Group by normalized title for deduplication across platforms.
+  // Uses the shared normalizeReleaseTitle (includes .trim()) to avoid
+  // normalization drift between the migration script and the live pipeline.
   const byNormTitle = new Map<string, { title: string; type: 'album' | 'track'; platform: PlatformLink }[]>();
-  const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
   for (const p of platforms) {
     if (!p.latestRelease?.title) continue;
-    const norm = normalize(p.latestRelease.title);
+    const norm = normalizeReleaseTitle(p.latestRelease.title);
     if (!norm) continue;
     const existing = byNormTitle.get(norm) || [];
     existing.push({ title: p.latestRelease.title, type: p.latestRelease.type, platform: p });
     byNormTitle.set(norm, existing);
   }
 
+  // Fetch existing slugs for this artist to detect collisions (issue #3).
+  // Two different titles can produce the same slug (e.g. "Album Name" and
+  // "Album Name." both become "album-name"). The upsert on (artist_id, slug)
+  // would silently clobber the first with the second. We detect this and
+  // append a 6-char hash to disambiguate.
+  const { data: existingReleases } = await client
+    .from('artist_releases')
+    .select('slug,title')
+    .eq('artist_id', artistId);
+  const existingTitlesBySlug = new Map<string, string>(
+    (existingReleases || []).map((r: { slug: string; title: string }) => [r.slug, r.title])
+  );
+
   for (const [, entries] of byNormTitle) {
     // Prefer 'album' type if any platform reports it
     const bestType = entries.some(e => e.type === 'album') ? 'album' : entries[0].type;
     const title = entries[0].title;
-    const slug = releaseSlug(title);
+    const slug = releaseSlugWithCollision(title, existingTitlesBySlug);
 
     // Best artwork and date across platforms
     const artwork = entries.find(e => e.platform.latestRelease?.imageUrl)?.platform.latestRelease?.imageUrl || null;
@@ -105,17 +119,24 @@ async function persistReleasesForArtist(
         continue;
       }
 
-      // Upsert release links for each platform that had this release
+      // Upsert release links for each platform that had this release.
+      // Skip links where lr.url is missing — a release link pointing to the
+      // artist's profile page (the old fallback) is worse than no link.
       for (const entry of entries) {
-        const lr = entry.platform.latestRelease!;
+        if (!entry.platform.latestRelease) continue; // explicit guard (issue #8)
+        const lr = entry.platform.latestRelease;
+        if (!lr.url) continue; // skip if no release-specific URL (issue #5)
+
         const { error: linkError } = await client
           .from('release_links')
           .upsert(
             {
               release_id: releaseRow.id,
               platform: entry.platform.sourceId,
-              url: lr.url || entry.platform.url,
+              url: lr.url,
               is_streaming: isStreamingPlatform(entry.platform.sourceId),
+              // 'source' tracks provenance: 'auto' vs 'claimed' per spec.
+              // The platform name goes in the 'platform' column, not 'source' (issue #4).
               source: 'auto',
             },
             { onConflict: 'release_id,platform' }

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2,6 +2,7 @@
 // All operations are optional — if Supabase is not configured, they no-op gracefully.
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { mapReleaseType, releaseSlug, isStreamingPlatform } from './release-utils';
 
 let supabase: SupabaseClient | null = null;
 
@@ -22,6 +23,112 @@ export function getClient(): SupabaseClient | null {
 // Generate a URL-safe slug from an artist name
 export function artistSlug(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Persist latest_release data from platform links into artist_releases + release_links.
+ * Called from persistSearchResults — additive to the jsonb latest_release on artist_links.
+ *
+ * Deduplicates by normalized title: multiple platforms with the same release title
+ * become one artist_releases row with multiple release_links rows.
+ * Idempotent via upsert on (artist_id, slug) and (release_id, platform).
+ */
+async function persistReleasesForArtist(
+  client: SupabaseClient,
+  artistId: string,
+  platforms: PlatformLink[],
+): Promise<void> {
+  // Group by normalized title for deduplication across platforms
+  const byNormTitle = new Map<string, { title: string; type: 'album' | 'track'; platform: PlatformLink }[]>();
+  const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  for (const p of platforms) {
+    if (!p.latestRelease?.title) continue;
+    const norm = normalize(p.latestRelease.title);
+    if (!norm) continue;
+    const existing = byNormTitle.get(norm) || [];
+    existing.push({ title: p.latestRelease.title, type: p.latestRelease.type, platform: p });
+    byNormTitle.set(norm, existing);
+  }
+
+  for (const [, entries] of byNormTitle) {
+    // Prefer 'album' type if any platform reports it
+    const bestType = entries.some(e => e.type === 'album') ? 'album' : entries[0].type;
+    const title = entries[0].title;
+    const slug = releaseSlug(title);
+
+    // Best artwork and date across platforms
+    const artwork = entries.find(e => e.platform.latestRelease?.imageUrl)?.platform.latestRelease?.imageUrl || null;
+    const dateStr = entries.find(e => e.platform.latestRelease?.releaseDate)?.platform.latestRelease?.releaseDate || null;
+
+    // Parse date to YYYY-MM-DD
+    let releaseDate: string | null = null;
+    if (dateStr) {
+      if (/^\d{4}-\d{2}-\d{2}/.test(dateStr)) {
+        releaseDate = dateStr.split('T')[0];
+      } else {
+        const m = dateStr.match(/(\w+)\s+(\d{1,2}),?\s+(\d{4})/);
+        if (m) {
+          const d = new Date(`${m[1]} ${m[2]}, ${m[3]}`);
+          if (!isNaN(d.getTime())) releaseDate = d.toISOString().split('T')[0];
+        }
+        if (!releaseDate) {
+          const m2 = dateStr.match(/(\d{1,2})\s+(\w+)\s+(\d{4})/);
+          if (m2) {
+            const d = new Date(`${m2[2]} ${m2[1]}, ${m2[3]}`);
+            if (!isNaN(d.getTime())) releaseDate = d.toISOString().split('T')[0];
+          }
+        }
+      }
+    }
+
+    try {
+      const { data: releaseRow, error: releaseError } = await client
+        .from('artist_releases')
+        .upsert(
+          {
+            artist_id: artistId,
+            title,
+            slug,
+            release_type: mapReleaseType(bestType),
+            release_date: releaseDate,
+            artwork_url: artwork,
+            source: 'auto',
+          },
+          { onConflict: 'artist_id,slug' }
+        )
+        .select('id')
+        .single();
+
+      if (releaseError || !releaseRow) {
+        console.error(`[DB] Failed to upsert release "${title}":`, releaseError?.message);
+        continue;
+      }
+
+      // Upsert release links for each platform that had this release
+      for (const entry of entries) {
+        const lr = entry.platform.latestRelease!;
+        const { error: linkError } = await client
+          .from('release_links')
+          .upsert(
+            {
+              release_id: releaseRow.id,
+              platform: entry.platform.sourceId,
+              url: lr.url || entry.platform.url,
+              is_streaming: isStreamingPlatform(entry.platform.sourceId),
+              source: 'auto',
+            },
+            { onConflict: 'release_id,platform' }
+          );
+
+        if (linkError) {
+          console.error(`[DB] Failed to upsert release_link for "${title}" / "${entry.platform.sourceId}":`, linkError.message);
+        }
+      }
+    } catch (err) {
+      console.error(`[DB] persistReleasesForArtist error for "${title}":`, err);
+    }
+  }
 }
 
 // Determine if a platform URL is a direct link (not a search URL)
@@ -533,6 +640,12 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
 
       if (linkError) {
         console.error(`[DB] Failed to upsert links for "${result.name}":`, linkError);
+      }
+
+      // Also persist releases to artist_releases + release_links (additive to jsonb)
+      const releasesWithLinks = validPlatforms.filter(p => p.latestRelease);
+      if (releasesWithLinks.length > 0) {
+        await persistReleasesForArtist(client, artistId, releasesWithLinks);
       }
 
       console.log(`[DB] Persisted "${result.name}" with ${linkRows.length} links`);

--- a/api/functions/release-utils.ts
+++ b/api/functions/release-utils.ts
@@ -1,0 +1,42 @@
+// Pure utility functions for release persistence.
+// No HTTP, cache, or database dependencies. Shared across:
+//   - check-releases.ts (API handler)
+//   - db.ts (search persistence)
+//   - scripts/migrate-releases.ts (one-time migration)
+//
+// Follows the same pattern as search-utils.ts: pure functions, unit-testable.
+
+/** Map a platform release type ('album'/'track') to the artist_releases release_type enum. */
+export function mapReleaseType(type: 'album' | 'track'): 'album' | 'single' | 'ep' | 'compilation' {
+  return type === 'track' ? 'single' : 'album';
+}
+
+/** Generate a URL-safe slug from a title string. */
+export function releaseSlug(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/** Streaming platforms where you listen but can't buy directly. */
+export const STREAMING_PLATFORMS = new Set([
+  'spotify',
+  'applemusic',
+  'apple_music',
+  'tidal',
+  'qobuz',
+  'beatport',
+  'hoopla',
+  'freegal',
+]);
+
+/** Check if a platform is a streaming platform. */
+export function isStreamingPlatform(platform: string): boolean {
+  return STREAMING_PLATFORMS.has(platform.toLowerCase());
+}
+
+/**
+ * Infer release type ('album' or 'track') from a Bandcamp URL path.
+ * Bandcamp URLs are /album/<slug> or /track/<slug>.
+ */
+export function bandcampReleaseType(url: string): 'album' | 'track' {
+  return url.includes('/track/') ? 'track' : 'album';
+}

--- a/api/functions/release-utils.ts
+++ b/api/functions/release-utils.ts
@@ -16,6 +16,38 @@ export function releaseSlug(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
+/**
+ * Normalize a release title for deduplication across platforms.
+ * Includes .trim() — without it, "Album Name" and "Album Name " produce
+ * different normalized keys, causing the same release to be stored twice.
+ * Used by db.ts (persistReleasesForArtist) and scripts/migrate-releases.ts.
+ */
+export function normalizeReleaseTitle(title: string): string {
+  return title.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/**
+ * Generate a slug with collision avoidance.
+ * If the base slug from releaseSlug() would collide with an existing release
+ * that has a different title, append a 6-char hash of the title to disambiguate.
+ * Returns the slug to use, and whether a hash suffix was added.
+ */
+export function releaseSlugWithCollision(
+  title: string,
+  existingTitlesBySlug: Map<string, string>,
+): string {
+  const base = releaseSlug(title);
+  const existingTitle = existingTitlesBySlug.get(base);
+  if (existingTitle && existingTitle !== title) {
+    // Collision: a different title produced the same slug. Append a 6-char hash.
+    const hash = Buffer.from(title)
+      .toString('hex')
+      .slice(0, 6);
+    return `${base}-${hash}`;
+  }
+  return base;
+}
+
 /** Streaming platforms where you listen but can't buy directly. */
 export const STREAMING_PLATFORMS = new Set([
   'spotify',

--- a/scripts/migrate-releases.ts
+++ b/scripts/migrate-releases.ts
@@ -1,0 +1,260 @@
+/**
+ * One-time migration script: lift latest_release jsonb data from artist_links
+ * into the new artist_releases + release_links tables.
+ *
+ * Run with: npx tsx scripts/migrate-releases.ts
+ *
+ * Idempotent — safe to run multiple times. Uses upsert with conflict targets
+ * so existing rows are updated rather than duplicated.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { mapReleaseType, releaseSlug as slugify, isStreamingPlatform } from '../api/functions/release-utils';
+
+// ── Types matching the jsonb shape on artist_links.latest_release ──────────
+
+interface LatestReleaseJsonb {
+  title: string;
+  type: 'album' | 'track';
+  url: string;
+  imageUrl?: string;
+  releaseDate?: string;
+}
+
+interface ArtistLinkRow {
+  id: string;
+  artist_id: string;
+  platform: string;
+  url: string;
+  latest_release: LatestReleaseJsonb | null;
+}
+
+interface ArtistRow {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+// ── Slug generation (matches db.ts artistSlug) ────────────────────────────
+// Now uses shared releaseSlug from release-utils.ts.
+
+// ── Dedup key: normalized title for matching across platforms ─────────────
+
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+// ── Main migration ────────────────────────────────────────────────────────
+
+async function main() {
+  // NOTE: This script requires SUPABASE_SERVICE_KEY, which bypasses RLS.
+  // Run it only locally or in CI with the key injected via a secret store.
+  // Never pass it via shell arguments or commit it to shell history.
+  // Example: `SUPABASE_SERVICE_KEY=... npx tsx scripts/migrate-releases.ts`
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_KEY environment variables.');
+    process.exit(1);
+  }
+
+  const client: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+  console.log('Fetching artist_links with latest_release data...');
+
+  // Fetch all artist_links that have a latest_release jsonb
+  const { data: links, error } = await client
+    .from('artist_links')
+    .select('id, artist_id, platform, url, latest_release')
+    .not('latest_release', 'is', null);
+
+  if (error) {
+    console.error('Failed to fetch artist_links:', error);
+    process.exit(1);
+  }
+
+  if (!links || links.length === 0) {
+    console.log('No artist_links with latest_release data found. Nothing to migrate.');
+    return;
+  }
+
+  console.log(`Found ${links.length} artist_links with latest_release data.`);
+
+  // Fetch all artists in one go (we need names for slug generation)
+  const artistIds = [...new Set(links.map(l => (l as ArtistLinkRow).artist_id))];
+  const { data: artists, error: artistError } = await client
+    .from('artists')
+    .select('id, slug, name')
+    .in('id', artistIds);
+
+  if (artistError) {
+    console.error('Failed to fetch artists:', artistError);
+    process.exit(1);
+  }
+
+  const artistMap = new Map<string, ArtistRow>(
+    (artists as ArtistRow[]).map(a => [a.id, a])
+  );
+
+  // Group links by artist_id so we can deduplicate releases per artist
+  const linksByArtist = new Map<string, ArtistLinkRow[]>();
+  for (const link of links as ArtistLinkRow[]) {
+    const existing = linksByArtist.get(link.artist_id) || [];
+    existing.push(link);
+    linksByArtist.set(link.artist_id, existing);
+  }
+
+  let totalReleases = 0;
+  let totalReleaseLinks = 0;
+  let conflicts: string[] = [];
+
+  for (const [artistId, artistLinks] of linksByArtist) {
+    const artist = artistMap.get(artistId);
+    if (!artist) {
+      conflicts.push(`Artist ${artistId} not found in artists table — skipping ${artistLinks.length} links`);
+      continue;
+    }
+
+    // Deduplicate releases within this artist:
+    // Multiple platforms may have the same release (e.g. Bandcamp + Mirlo).
+    // Match by normalized title. Each unique title → one artist_releases row.
+    const releasesByNormTitle = new Map<string, { title: string; type: 'album' | 'track'; links: ArtistLinkRow[] }>();
+
+    for (const link of artistLinks) {
+      const lr = link.latest_release;
+      if (!lr || !lr.title) continue;
+
+      const normTitle = normalizeTitle(lr.title);
+      if (!normTitle) continue;
+
+      const existing = releasesByNormTitle.get(normTitle);
+      if (existing) {
+        // Same release on another platform — add the link
+        existing.links.push(link);
+        // Prefer 'album' type if any platform says album (more specific than 'track')
+        if (lr.type === 'album' && existing.type === 'track') {
+          existing.type = 'album';
+        }
+      } else {
+        releasesByNormTitle.set(normTitle, {
+          title: lr.title,
+          type: lr.type,
+          links: [link],
+        });
+      }
+    }
+
+    // Insert releases and their links
+    for (const { title, type, links: releaseLinks } of releasesByNormTitle.values()) {
+      const slug = slugify(title);
+      const releaseType = mapReleaseType(type);
+
+      // Extract the best artwork URL and release date from the links
+      const artworkUrl = releaseLinks.find(l => l.latest_release?.imageUrl)?.latest_release?.imageUrl || null;
+      const releaseDate = releaseLinks.find(l => l.latest_release?.releaseDate)?.latest_release?.releaseDate || null;
+
+      // Parse release date to YYYY-MM-DD if possible
+      let parsedDate: string | null = null;
+      if (releaseDate) {
+        // Try ISO format
+        if (/^\d{4}-\d{2}-\d{2}/.test(releaseDate)) {
+          parsedDate = releaseDate.split('T')[0];
+        } else {
+          // Try human-readable: "December 6, 2024" or "Dec 6, 2024"
+          const match = releaseDate.match(/(\w+)\s+(\d{1,2}),?\s+(\d{4})/);
+          if (match) {
+            const date = new Date(`${match[1]} ${match[2]}, ${match[3]}`);
+            if (!isNaN(date.getTime())) {
+              parsedDate = date.toISOString().split('T')[0];
+            }
+          }
+          // Try "DD MMM YYYY" format
+          if (!parsedDate) {
+            const match2 = releaseDate.match(/(\d{1,2})\s+(\w+)\s+(\d{4})/);
+            if (match2) {
+              const date = new Date(`${match2[2]} ${match2[1]}, ${match2[3]}`);
+              if (!isNaN(date.getTime())) {
+                parsedDate = date.toISOString().split('T')[0];
+              }
+            }
+          }
+        }
+      }
+
+      // Upsert the release
+      const { data: release, error: releaseError } = await client
+        .from('artist_releases')
+        .upsert(
+          {
+            artist_id: artistId,
+            title,
+            slug,
+            release_type: releaseType,
+            release_date: parsedDate,
+            artwork_url: artworkUrl,
+            source: 'auto',
+          },
+          { onConflict: 'artist_id,slug' }
+        )
+        .select('id')
+        .single();
+
+      if (releaseError || !release) {
+        const msg = `Failed to upsert release "${title}" for artist "${artist.name}": ${releaseError?.message || 'unknown'}`;
+        console.error(msg);
+        conflicts.push(msg);
+        continue;
+      }
+
+      totalReleases++;
+      const releaseId = release.id;
+
+      // Insert release links for each platform
+      for (const link of releaseLinks) {
+        const lr = link.latest_release!;
+        const platform = link.platform;
+        const url = lr.url || link.url; // Prefer the release-specific URL, fall back to artist link URL
+
+        const { error: linkError } = await client
+          .from('release_links')
+          .upsert(
+            {
+              release_id: releaseId,
+              platform,
+              url,
+              is_streaming: isStreamingPlatform(platform),
+              source: 'auto',
+            },
+            { onConflict: 'release_id,platform' }
+          );
+
+        if (linkError) {
+          const msg = `Failed to upsert release_link for "${title}" platform "${platform}": ${linkError.message}`;
+          console.error(msg);
+          conflicts.push(msg);
+        } else {
+          totalReleaseLinks++;
+        }
+      }
+    }
+  }
+
+  console.log('');
+  console.log('── Migration complete ──');
+  console.log(`Artists processed: ${linksByArtist.size}`);
+  console.log(`Releases created/updated: ${totalReleases}`);
+  console.log(`Release links created/updated: ${totalReleaseLinks}`);
+  if (conflicts.length > 0) {
+    console.log('');
+    console.log(`Conflicts (${conflicts.length}):`);
+    for (const c of conflicts) {
+      console.log(`  - ${c}`);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/scripts/migrate-releases.ts
+++ b/scripts/migrate-releases.ts
@@ -9,7 +9,7 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { mapReleaseType, releaseSlug as slugify, isStreamingPlatform } from '../api/functions/release-utils';
+import { mapReleaseType, releaseSlugWithCollision, isStreamingPlatform, normalizeReleaseTitle } from '../api/functions/release-utils';
 
 // ── Types matching the jsonb shape on artist_links.latest_release ──────────
 
@@ -39,10 +39,8 @@ interface ArtistRow {
 // Now uses shared releaseSlug from release-utils.ts.
 
 // ── Dedup key: normalized title for matching across platforms ─────────────
-
-function normalizeTitle(title: string): string {
-  return title.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-}
+// Uses the shared normalizeReleaseTitle (includes .trim()) to avoid
+// normalization drift between this migration and the live pipeline in db.ts.
 
 // ── Main migration ────────────────────────────────────────────────────────
 
@@ -125,7 +123,7 @@ async function main() {
       const lr = link.latest_release;
       if (!lr || !lr.title) continue;
 
-      const normTitle = normalizeTitle(lr.title);
+      const normTitle = normalizeReleaseTitle(lr.title);
       if (!normTitle) continue;
 
       const existing = releasesByNormTitle.get(normTitle);
@@ -146,8 +144,17 @@ async function main() {
     }
 
     // Insert releases and their links
+    // Fetch existing slugs for this artist to detect collisions (issue #3).
+    const { data: existingReleases } = await client
+      .from('artist_releases')
+      .select('slug,title')
+      .eq('artist_id', artistId);
+    const existingTitlesBySlug = new Map<string, string>(
+      (existingReleases || []).map((r: { slug: string; title: string }) => [r.slug, r.title])
+    );
+
     for (const { title, type, links: releaseLinks } of releasesByNormTitle.values()) {
-      const slug = slugify(title);
+      const slug = releaseSlugWithCollision(title, existingTitlesBySlug);
       const releaseType = mapReleaseType(type);
 
       // Extract the best artwork URL and release date from the links
@@ -214,7 +221,10 @@ async function main() {
       for (const link of releaseLinks) {
         const lr = link.latest_release!;
         const platform = link.platform;
-        const url = lr.url || link.url; // Prefer the release-specific URL, fall back to artist link URL
+        // Skip links where the release-specific URL is missing — a release link
+        // pointing to the artist's profile page is worse than no link (issue #5).
+        if (!lr.url) continue;
+        const url = lr.url;
 
         const { error: linkError } = await client
           .from('release_links')
@@ -224,6 +234,8 @@ async function main() {
               platform,
               url,
               is_streaming: isStreamingPlatform(platform),
+              // 'source' is 'auto' vs 'claimed' per spec. Platform name goes in
+              // the 'platform' column, not 'source' (issue #4).
               source: 'auto',
             },
             { onConflict: 'release_id,platform' }

--- a/supabase/migrations/20260728120000_artist-releases.sql
+++ b/supabase/migrations/20260728120000_artist-releases.sql
@@ -60,7 +60,7 @@ create table if not exists public.release_links (
   platform text not null,
   url text not null,
   is_streaming boolean not null default true,  -- true for Spotify/Apple, false for Bandcamp/merch
-  source text not null default 'auto',         -- 'auto' | 'claimed' | 'bandcamp' | 'mirlo' | 'musicbrainz' | 'itunes'
+  source text not null default 'auto',         -- 'auto' | 'claimed' (platform provenance is in the 'platform' column)
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   unique(release_id, platform)

--- a/supabase/migrations/20260728120000_artist-releases.sql
+++ b/supabase/migrations/20260728120000_artist-releases.sql
@@ -1,0 +1,86 @@
+-- Migration 029: Release catalog tables (Unstream Releases)
+--
+-- Lifts release data out of the artist_links.latest_release jsonb blob into
+-- proper release entities with per-release platform links. The jsonb column
+-- stays (still used for search disambiguation); these tables are additive.
+--
+-- Two tables:
+--   artist_releases — one row per release per artist (album, single, EP, etc.)
+--   release_links   — one row per platform link per release
+--
+-- RLS: public read, service write — same pattern as artists / artist_links.
+-- The update_updated_at() function and trigger pattern already exist from
+-- the base schema; we reuse it here.
+
+-- ── artist_releases ──────────────────────────────────────────────────────
+
+create table if not exists public.artist_releases (
+  id uuid primary key default gen_random_uuid(),
+  artist_id uuid not null references public.artists(id) on delete cascade,
+  title text not null,
+  slug text not null,                         -- slugified title, unique per artist
+  release_type text not null check (release_type in ('album', 'single', 'ep', 'compilation')),
+  release_date date,
+  artwork_url text,
+  musicbrainz_id text,                        -- MB release group ID for deduplication
+  source text not null default 'auto',        -- 'auto' | 'claimed'
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(artist_id, slug)
+);
+
+create index if not exists idx_artist_releases_artist_id on public.artist_releases(artist_id);
+create index if not exists idx_artist_releases_musicbrainz_id on public.artist_releases(musicbrainz_id);
+
+alter table public.artist_releases enable row level security;
+
+-- Public read (same as artists / artist_links)
+drop policy if exists "Public read access" on public.artist_releases;
+create policy "Public read access" on public.artist_releases for select using (true);
+
+-- Service-role write (service key bypasses RLS, but policies document intent)
+drop policy if exists "Service insert" on public.artist_releases;
+create policy "Service insert" on public.artist_releases for insert to service_role with check (true);
+drop policy if exists "Service update" on public.artist_releases;
+create policy "Service update" on public.artist_releases for update to service_role using (true);
+drop policy if exists "Service delete" on public.artist_releases;
+create policy "Service delete" on public.artist_releases for delete to service_role using (true);
+
+-- updated_at trigger (reuses existing update_updated_at() function)
+drop trigger if exists artist_releases_updated_at on public.artist_releases;
+create trigger artist_releases_updated_at
+  before update on public.artist_releases
+  for each row execute function public.update_updated_at();
+
+-- ── release_links ────────────────────────────────────────────────────────
+
+create table if not exists public.release_links (
+  id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references public.artist_releases(id) on delete cascade,
+  platform text not null,
+  url text not null,
+  is_streaming boolean not null default true,  -- true for Spotify/Apple, false for Bandcamp/merch
+  source text not null default 'auto',         -- 'auto' | 'claimed' | 'bandcamp' | 'mirlo' | 'musicbrainz' | 'itunes'
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(release_id, platform)
+);
+
+create index if not exists idx_release_links_release_id on public.release_links(release_id);
+
+alter table public.release_links enable row level security;
+
+drop policy if exists "Public read access" on public.release_links;
+create policy "Public read access" on public.release_links for select using (true);
+
+drop policy if exists "Service insert" on public.release_links;
+create policy "Service insert" on public.release_links for insert to service_role with check (true);
+drop policy if exists "Service update" on public.release_links;
+create policy "Service update" on public.release_links for update to service_role using (true);
+drop policy if exists "Service delete" on public.release_links;
+create policy "Service delete" on public.release_links for delete to service_role using (true);
+
+drop trigger if exists release_links_updated_at on public.release_links;
+create trigger release_links_updated_at
+  before update on public.release_links
+  for each row execute function public.update_updated_at();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,7 +2,7 @@
 -- Run this in your Supabase SQL editor to set up the tables.
 --
 -- This file is the canonical baseline. Migrations 002, 006, 008, 010,
--- and 019 are reflected here. Run migrations in order on an existing DB;
+-- 019, and 029 are reflected here. Run migrations in order on an existing DB;
 -- use this file for fresh installs.
 --
 -- Migration 008: verification_code → nullable
@@ -134,4 +134,60 @@ create trigger artists_updated_at
 
 create trigger artist_links_updated_at
   before update on artist_links
+  for each row execute function update_updated_at();
+
+-- Artist releases: one row per release per artist (Migration 029)
+create table artist_releases (
+  id uuid primary key default gen_random_uuid(),
+  artist_id uuid not null references artists(id) on delete cascade,
+  title text not null,
+  slug text not null,  -- slugified title, unique per artist
+  release_type text not null check (release_type in ('album', 'single', 'ep', 'compilation')),
+  release_date date,
+  artwork_url text,
+  musicbrainz_id text,  -- MB release group ID for deduplication
+  source text not null default 'auto',  -- 'auto' | 'claimed'
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(artist_id, slug)
+);
+
+create index idx_artist_releases_artist_id on artist_releases(artist_id);
+  create index idx_artist_releases_musicbrainz_id on artist_releases(musicbrainz_id);
+
+alter table artist_releases enable row level security;
+
+create policy "Public read access" on artist_releases for select using (true);
+create policy "Service insert" on artist_releases for insert to service_role with check (true);
+create policy "Service update" on artist_releases for update to service_role using (true);
+create policy "Service delete" on artist_releases for delete to service_role using (true);
+
+create trigger artist_releases_updated_at
+  before update on artist_releases
+  for each row execute function update_updated_at();
+
+-- Release links: one row per platform link per release (Migration 029)
+create table release_links (
+  id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references artist_releases(id) on delete cascade,
+  platform text not null,
+  url text not null,
+  is_streaming boolean not null default true,  -- true for Spotify/Apple, false for Bandcamp/merch
+  source text not null default 'auto',  -- 'auto' | 'claimed' | 'bandcamp' | 'mirlo' | 'musicbrainz' | 'itunes'
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(release_id, platform)
+);
+
+create index idx_release_links_release_id on release_links(release_id);
+
+alter table release_links enable row level security;
+
+create policy "Public read access" on release_links for select using (true);
+create policy "Service insert" on release_links for insert to service_role with check (true);
+create policy "Service update" on release_links for update to service_role using (true);
+create policy "Service delete" on release_links for delete to service_role using (true);
+
+create trigger release_links_updated_at
+  before update on release_links
   for each row execute function update_updated_at();


### PR DESCRIPTION
## Summary

Milestone 1 (Data Foundation) for Unstream Releases feature.

### Changes

1. **Supabase migration 029** (20260728120000_artist-releases.sql) — creates artist_releases and release_links tables with RLS, indexes, and updated_at triggers. Public read, service write (same pattern as artists/artist_links).

2. **schema.sql updated** — canonical baseline now reflects the new tables.

3. **scripts/migrate-releases.ts** — one-time idempotent migration script that lifts existing latest_release jsonb data from artist_links into the new tables. Deduplicates by normalized title across platforms (same release on Bandcamp + Mirlo becomes one artist_releases row, two release_links rows).

4. **api/functions/db.ts** — persistSearchResults now also writes to artist_releases + release_links when platform links have latestRelease data. Additive — the jsonb column on artist_links is still written for backward compatibility (search disambiguation still uses it).

5. **api/functions/check-releases.ts** — now persists detected releases to the new tables (fire-and-forget). The function still returns the same response shape.

## What to verify

- The migration SQL runs cleanly against the production DB (uses IF NOT EXISTS guards)
- npx tsx scripts/migrate-releases.ts works with SUPABASE_URL and SUPABASE_SERVICE_KEY env vars set
- npm run test:api — 87 tests pass (2 pre-existing failures from missing jose package, unrelated)
- npx tsc -b — only pre-existing jose error, no new type errors

## Risks

- The migration script runs once and is idempotent, but should be tested against a staging DB first to verify deduplication quality
- persistSearchResults now does more DB writes per search (up to N additional upserts for N releases). This is fire-and-forget and should be negligible, but worth monitoring function execution time
- The latest_release jsonb on artist_links is NOT removed or stopped — it is still written for backward compatibility

## Not in this PR

- Release pages (/a/{slug}/{release-slug}) — Phase 2
- Artist page Releases section — Phase 3
- RSS/ICS feeds — Phase 4
- iTunes Search API integration — Phase 5