### PR TITLE
Switch site font from SN Pro to Stack Sans Headline

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -85,7 +85,7 @@ const CSS = `
     :root { --bg: #ffffff; --bg2: #f5f5f5; --text: #1a1a1a; --muted: #555; --border: #e0e0e0; --accent: #e55a2b; --footer-border: #e0e0e0; }
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'SN Pro', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
+  body { font-family: 'Stack Sans Headline', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
   a { color: inherit; }
   .container { max-width: 640px; margin: 0 auto; padding: 0 24px; width: 100%; }
   .page-content { position: relative; flex: 1; display: flex; flex-direction: column; }
@@ -271,7 +271,7 @@ export default async function handler(request: Request, context: Context) {
   ${imageUrl ? `<meta name="twitter:image" content="${escapeHtml(imageUrl)}">` : ''}
   <link rel="canonical" href="${pageUrl}">
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>
-  <link href="https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>${CSS}</style>
 </head>
 <body>
@@ -374,7 +374,7 @@ export default async function handler(request: Request, context: Context) {
   ${imageUrl ? `<meta name="twitter:image" content="${escapeHtml(imageUrl)}">` : ''}
   <link rel="canonical" href="${pageUrl}">
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>
-  <link href="https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>${CSS}</style>
 </head>
 <body>

--- a/api/edge/noscript-search.ts
+++ b/api/edge/noscript-search.ts
@@ -139,14 +139,14 @@ function renderPage(query: string, results: SearchResult[], error?: string): str
   <meta name="robots" content="noindex">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     :root { --bg: #0d0d0d; --bg2: #1a1a1a; --text: #f0f0f0; --muted: #999; --border: #2a2a2a; --accent: #ff6b35; --footer-border: #1a1a1a; }
     @media (prefers-color-scheme: light) {
       :root { --bg: #ffffff; --bg2: #f5f5f5; --text: #1a1a1a; --muted: #555; --border: #e0e0e0; --accent: #e55a2b; --footer-border: #e0e0e0; }
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: 'SN Pro', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; -webkit-font-smoothing: antialiased; }
+    body { font-family: 'Stack Sans Headline', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; -webkit-font-smoothing: antialiased; }
     a { color: inherit; }
     .container { max-width: 640px; margin: 0 auto; padding: 0 24px; width: 100%; }
 

--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -19,7 +19,7 @@ const CSS = `
     :root { --bg: #ffffff; --bg2: #f5f5f5; --text: #1a1a1a; --muted: #555; --border: #e0e0e0; --accent: #e55a2b; --footer-border: #e0e0e0; }
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'SN Pro', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
+  body { font-family: 'Stack Sans Headline', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
   a { color: inherit; }
   .container { max-width: 640px; margin: 0 auto; padding: 0 24px; width: 100%; }
   .page-content { position: relative; flex: 1; display: flex; flex-direction: column; }
@@ -151,7 +151,7 @@ export default async function handler(request: Request, context: Context) {
   <meta name="twitter:description" content="Artists saved by ${ownerName} on Unstream — platforms that pay artists fairly.">
   <link rel="canonical" href="${pageUrl}">
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>
-  <link href="https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>${CSS}</style>
 </head>
 <body>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:image" content="https://unstream.stream/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>
@@ -32,7 +32,7 @@
         .noscript-fallback {
           position: fixed; inset: 0; z-index: 9999;
           background: var(--ns-bg); color: var(--ns-text);
-          font-family: 'SN Pro', system-ui, sans-serif;
+          font-family: 'Stack Sans Headline', system-ui, sans-serif;
           display: flex; flex-direction: column; align-items: center;
           justify-content: center; padding: 24px; text-align: center;
         }

--- a/apps/web/public/widget.js
+++ b/apps/web/public/widget.js
@@ -95,8 +95,8 @@
 
     var style = document.createElement('style');
     style.textContent = [
-      '@import url("https://fonts.googleapis.com/css2?family=SN+Pro:wght@400;500;600&display=swap");',
-      '.uw-root { font-family: "SN Pro", system-ui, sans-serif; background: ' + bg + '; border: 1px solid ' + border + '; border-radius: 12px; padding: 16px; max-width: 380px; box-sizing: border-box; }',
+      '@import url("https://fonts.googleapis.com/css2?family=Stack+Sans+Headline:wght@400;500;600&display=swap");',
+      '.uw-root { font-family: "Stack Sans Headline", system-ui, sans-serif; background: ' + bg + '; border: 1px solid ' + border + '; border-radius: 12px; padding: 16px; max-width: 380px; box-sizing: border-box; }',
       '.uw-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; text-decoration: none; color: inherit; }',
       '.uw-img { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; background: ' + border + '; flex-shrink: 0; }',
       '.uw-name { font-size: 16px; font-weight: 600; color: ' + text + '; margin: 0; line-height: 1.3; }',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,8 +2,8 @@
 @plugin "@tailwindcss/typography";
 
 @theme {
-  --font-display: "SN Pro", system-ui, sans-serif;
-  --font-body: "SN Pro", system-ui, sans-serif;
+  --font-display: "Stack Sans Headline", system-ui, sans-serif;
+  --font-body: "Stack Sans Headline", system-ui, sans-serif;
   --font-mono: ui-monospace, monospace;
 
   --color-bg-primary: #0d0d0d;


### PR DESCRIPTION
## Summary
- Replaces "SN Pro" with "Stack Sans Headline" (Google Fonts, variable font by Koto/Dylan Young) as the site-wide typeface
- Updates the Google Fonts `<link>`/`@import` and `font-family` declarations everywhere they appear: `apps/web/index.html` (SPA + noscript fallback), `apps/web/src/index.css` (`--font-display`/`--font-body` theme vars), `apps/web/public/widget.js` (embeddable widget), and the SSR edge functions `api/edge/artist-page-static.ts`, `api/edge/u-handle.ts`, `api/edge/noscript-search.ts`
- Kept the same weight set (400/500/600/700) that was already loaded for SN Pro, matching the `font-normal`/`font-medium`/`font-semibold`/`font-bold` classes used across the app

## Test plan
- [x] `npm run build` (guides manifest, dispatch feed, `tsc -b`, API + web unit tests, `vite build`, sitemap) — all green
- [x] Confirmed no remaining "SN Pro" references anywhere in the repo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToWWDhTUUAQEgzdwXzDPxh)_