### PR TITLE
Search: find artists from partial queries (Mirlo API, MB discovery, Bandcamp name feedback loop)

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -483,18 +483,30 @@ export async function findKnownArtistSlugsByName(term: string, limit = 6): Promi
 
   const { data, error } = await client
     .from('artists')
-    .select('slug, match_confidence')
+    .select('slug, name, match_confidence')
     .ilike('name', `%${cleaned}%`)
     .in('match_confidence', ['claimed', 'verified'])
-    .limit(limit * 2);
+    .limit(40);
 
   if (error) {
     console.error('[DB] findKnownArtistSlugsByName error:', error);
     return [];
   }
 
+  // Rank before capping — the query itself returns arbitrary rows, and for a
+  // common name fragment ("patrick") the artist someone is typing toward must
+  // not lose their slot to whichever rows Postgres happened to emit first.
+  const termLower = cleaned.toLowerCase();
   return (data ?? [])
-    .sort((a, b) => (a.match_confidence === 'claimed' ? 0 : 1) - (b.match_confidence === 'claimed' ? 0 : 1))
+    .sort((a, b) => {
+      const aClaimed = a.match_confidence === 'claimed' ? 0 : 1;
+      const bClaimed = b.match_confidence === 'claimed' ? 0 : 1;
+      if (aClaimed !== bClaimed) return aClaimed - bClaimed;
+      const aPrefix = a.name.toLowerCase().startsWith(termLower) ? 0 : 1;
+      const bPrefix = b.name.toLowerCase().startsWith(termLower) ? 0 : 1;
+      if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+      return a.name.length - b.name.length;
+    })
     .slice(0, limit)
     .map(r => r.slug)
     .filter(Boolean);
@@ -533,7 +545,12 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
         return;
       }
 
-      // Upsert artist — always store as unverified until claimed
+      // Upsert artist, keeping the pipeline's verdict. This used to hardcode
+      // 'unverified', which made the stored confidence meaningless — every
+      // non-claimed row was 'unverified' forever, so quality filters over the
+      // table (partial-name discovery, typeahead) could never distinguish a
+      // release-corroborated artist from name-match junk. Rows refresh on
+      // every search, so the stored verdict tracks the latest pipeline run.
       const { data: artist, error: artistError } = await client
         .from('artists')
         .upsert(
@@ -541,7 +558,7 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
             slug,
             name: result.name,
             image_url: result.imageUrl || null,
-            match_confidence: 'unverified',
+            match_confidence: result.matchConfidence === 'verified' ? 'verified' : 'unverified',
             source: 'auto',
             updated_at: new Date().toISOString(),
           },

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -330,7 +330,10 @@ export async function putBandcampProbe(
 /**
  * Look up an artist by slug. Returns null if not found or Supabase is not configured.
  */
-export async function getArtistBySlug(slug: string): Promise<ArtistResult | null> {
+export async function getArtistBySlug(
+  slug: string,
+  opts?: { allowStale?: boolean },
+): Promise<ArtistResult | null> {
   const client = getClient();
   if (!client) return null;
 
@@ -376,8 +379,11 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
 
     const row = artist as ArtistRow;
 
-    // Claimed artists are always fresh; auto-discovered artists expire
-    if (row.match_confidence !== 'claimed') {
+    // Claimed artists are always fresh; auto-discovered artists expire.
+    // allowStale skips the expiry: the partial-name discovery channel would
+    // rather show a known artist with slightly old links than hide them —
+    // platform URLs are stable, and an exact search refreshes the row anyway.
+    if (row.match_confidence !== 'claimed' && !opts?.allowStale) {
       const updatedAt = new Date(row.updated_at).getTime();
       const now = Date.now();
       if (now - updatedAt > FRESHNESS_TTL_MS) {
@@ -454,14 +460,19 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */
 /**
- * Slugs of claimed artists whose display name contains the term.
+ * Slugs of artists Unstream already knows whose display name contains the term.
  *
- * The search handler's exact-slug lookup can only find a claimed profile when
- * the query IS the artist's name — a partial query like "lightbulbs" never
- * resolves the slug "kid-lightbulbs", so the artist's own curated page lost to
- * a generic scraped result. This is the name-contains channel that fixes that.
+ * The search handler's exact-slug lookup can only find an artist when the
+ * query IS their name — a partial query like "lightbulbs" never resolves the
+ * slug "kid-lightbulbs", and "patrick" never resolves "patrick-hardy" even
+ * though a past exact search persisted his full result. This is the
+ * name-contains channel that makes the accumulated artists table searchable.
+ *
+ * Claimed profiles come first (they replace generic results downstream), then
+ * verified rows. 'unverified' rows are deliberately excluded — that's where
+ * junk from name-only matches accumulates.
  */
-export async function findClaimedArtistSlugsByName(term: string, limit = 5): Promise<string[]> {
+export async function findKnownArtistSlugsByName(term: string, limit = 6): Promise<string[]> {
   const client = getClient();
   if (!client) return [];
 
@@ -472,17 +483,21 @@ export async function findClaimedArtistSlugsByName(term: string, limit = 5): Pro
 
   const { data, error } = await client
     .from('artists')
-    .select('slug')
+    .select('slug, match_confidence')
     .ilike('name', `%${cleaned}%`)
-    .eq('match_confidence', 'claimed')
-    .limit(limit);
+    .in('match_confidence', ['claimed', 'verified'])
+    .limit(limit * 2);
 
   if (error) {
-    console.error('[DB] findClaimedArtistSlugsByName error:', error);
+    console.error('[DB] findKnownArtistSlugsByName error:', error);
     return [];
   }
 
-  return (data ?? []).map(r => r.slug).filter(Boolean);
+  return (data ?? [])
+    .sort((a, b) => (a.match_confidence === 'claimed' ? 0 : 1) - (b.match_confidence === 'claimed' ? 0 : 1))
+    .slice(0, limit)
+    .map(r => r.slug)
+    .filter(Boolean);
 }
 
 export async function persistSearchResults(results: ArtistResult[]): Promise<void> {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -453,6 +453,38 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
  * Persist artist search results to the database.
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */
+/**
+ * Slugs of claimed artists whose display name contains the term.
+ *
+ * The search handler's exact-slug lookup can only find a claimed profile when
+ * the query IS the artist's name — a partial query like "lightbulbs" never
+ * resolves the slug "kid-lightbulbs", so the artist's own curated page lost to
+ * a generic scraped result. This is the name-contains channel that fixes that.
+ */
+export async function findClaimedArtistSlugsByName(term: string, limit = 5): Promise<string[]> {
+  const client = getClient();
+  if (!client) return [];
+
+  // Strip ILIKE wildcards so user input can't change the match shape
+  // (same reasoning as the slug guard in getArtistBySlug).
+  const cleaned = term.replace(/[%_,()]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (cleaned.length < 2) return [];
+
+  const { data, error } = await client
+    .from('artists')
+    .select('slug')
+    .ilike('name', `%${cleaned}%`)
+    .eq('match_confidence', 'claimed')
+    .limit(limit);
+
+  if (error) {
+    console.error('[DB] findClaimedArtistSlugsByName error:', error);
+    return [];
+  }
+
+  return (data ?? []).map(r => r.slug).filter(Boolean);
+}
+
 export async function persistSearchResults(results: ArtistResult[]): Promise<void> {
   const client = getClient();
   if (!client) return;

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -85,6 +85,51 @@ export function parseBandcampSearchResults(html: string, query: string): Platfor
 // Mirlo
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse Mirlo's artist search API response (`api.mirlo.space/v1/artists?name=`).
+ *
+ * Mirlo's `name` filter is a loose substring match over more than the visible
+ * name (searching "the" returns "Other Nothing"), so results are re-checked
+ * here: keep an artist only when their name contains the query or the query
+ * contains their name. This is what makes partial searches work — "argent"
+ * keeps "The Argent Grub" — while unrelated fuzz is dropped.
+ */
+export function parseMirloArtistSearch(data: unknown, query: string): PlatformResult[] {
+  const results: PlatformResult[] = [];
+  const queryNorm = normalizeForComparison(query);
+  if (!queryNorm) return results;
+
+  const artists = (data as { results?: unknown[] } | null)?.results;
+  if (!Array.isArray(artists)) return results;
+
+  for (const entry of artists) {
+    const artist = entry as {
+      name?: unknown;
+      urlSlug?: unknown;
+      enabled?: unknown;
+      deletedAt?: unknown;
+    };
+    if (typeof artist.name !== 'string' || typeof artist.urlSlug !== 'string') continue;
+    if (artist.enabled === false || artist.deletedAt) continue;
+    // The slug becomes a URL path segment; anything else is malformed data.
+    if (!/^[a-z0-9._-]+$/i.test(artist.urlSlug)) continue;
+
+    const nameNorm = normalizeForComparison(artist.name);
+    if (!nameNorm) continue;
+    if (!nameNorm.includes(queryNorm) && !queryNorm.includes(nameNorm)) continue;
+
+    results.push({
+      sourceId: 'mirlo',
+      name: artist.name,
+      type: 'artist',
+      url: `https://mirlo.space/${artist.urlSlug}`,
+    });
+    if (results.length >= 5) break;
+  }
+
+  return results;
+}
+
 /** Parse a Mirlo artist page HTML to determine if the artist exists */
 export function parseMirloArtistPage(html: string, normalizedQuery: string, artistUrl: string): PlatformResult | null {
   const ogTitleMatch = html.match(/<meta property="og:title" content="([^"]+)"/);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -5,15 +5,19 @@ import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
+import { parseMirloArtistSearch } from './search-parsers';
 import {
   type SourceId,
   type LatestRelease,
   type PlatformResult,
   type AggregatedResult,
   type SearchResponse,
+  type NameOnlyEntry,
   normalizeSearchQuery,
   normalizeForComparison,
-  namesMatch,
+  namesEqualIgnoringArticles,
+  looksLikeOpaqueId,
+  collectMbSuggestions,
   CURATED_PLATFORMS,
   collectReleaseTitles,
   aggregateResults,
@@ -99,6 +103,57 @@ async function searchBandcamp(query: string): Promise<PlatformResult[]> {
     // what gives results a picture (Bandcamp replaced Qobuz as the image source in #325).
     imageUrl: match.imageUrl ?? undefined,
   }];
+}
+
+// How many discovered artist names get a Bandcamp probe per search. Each probe is
+// up to three requests once, then cached in Supabase, so this bounds the cold case.
+const MAX_CANDIDATE_PROBES = 3;
+
+// Probe Bandcamp for artist names *other platforms* discovered.
+//
+// searchBandcamp derives its slugs from the query spelling, so it structurally
+// cannot find an artist whose name merely contains the query: "argent" never
+// probes theargentgrub.bandcamp.com. But when Mirlo, Bandwagon, or MusicBrainz
+// report an artist named "The Argent Grub", probing *that name* finds the account.
+// The probe's own identity + release checks still apply, so a candidate name can
+// only ever attach a Bandcamp page that verifiably belongs to it.
+async function probeBandcampForCandidates(
+  query: string,
+  candidateNames: string[],
+  existingBandcampUrls: Set<string>,
+): Promise<PlatformResult[]> {
+  const queryNorm = normalizeForComparison(query);
+  const toProbe: string[] = [];
+  const seen = new Set<string>();
+  for (const name of candidateNames) {
+    const norm = normalizeForComparison(name);
+    // The query itself was already probed by searchBandcamp.
+    if (!norm || norm === queryNorm || seen.has(norm)) continue;
+    seen.add(norm);
+    toProbe.push(name);
+    if (toProbe.length >= MAX_CANDIDATE_PROBES) break;
+  }
+  if (toProbe.length === 0) return [];
+
+  const probes = await Promise.allSettled(toProbe.map(name => findBandcampArtist(name, 2500)));
+
+  const results: PlatformResult[] = [];
+  const seenUrls = new Set(existingBandcampUrls);
+  for (const probe of probes) {
+    if (probe.status !== 'fulfilled' || !probe.value) continue;
+    const match = probe.value;
+    if (!match.bandName || seenUrls.has(match.url)) continue;
+    seenUrls.add(match.url);
+    results.push({
+      sourceId: 'bandcamp',
+      name: match.bandName,
+      type: 'artist',
+      url: match.url,
+      allReleaseTitles: match.releaseTitles.length > 0 ? match.releaseTitles : undefined,
+      imageUrl: match.imageUrl ?? undefined,
+    });
+  }
+  return results;
 }
 
 // Fetch latest release from a Bandcamp artist page, then get release date from album page
@@ -218,8 +273,8 @@ async function getBandcampReleaseTitles(artistUrl: string): Promise<string[]> {
 }
 
 // Search Bandwagon for artists by scraping search results
-async function searchBandwagon(query: string): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
+async function searchBandwagon(query: string): Promise<Map<string, NameOnlyEntry>> {
+  const results = new Map<string, NameOnlyEntry>();
   const searchUrl = `https://bandwagon.fm/artists?q=${encodeURIComponent(query)}`;
 
   try {
@@ -251,7 +306,9 @@ async function searchBandwagon(query: string): Promise<Map<string, string>> {
             normalizedName.includes(queryNormalized) ||
             queryNormalized.includes(normalizedName)) {
           if (!results.has(normalizedName)) {
-            results.set(normalizedName, href);
+            // Keep the artist's real name: Bandwagon URLs can be opaque account
+            // ids (bandwagon.fm/@695d15c1...), so the slug is not a display name.
+            results.set(normalizedName, { url: href, displayName: name });
           }
           if (results.size >= 10) break;
         }
@@ -294,6 +351,12 @@ interface EnrichedMusicBrainzResult {
   wikipediaSummary: string | null;
   wikipediaUrl: string | null;
   location: ArtistLocation | undefined;
+  /**
+   * Partial-match artist names from MB's ranked search results (beyond the top
+   * hit), e.g. "Goodnight Argent" for the query "argent". Discovery candidates
+   * only — they are verified against Bandcamp before becoming results.
+   */
+  suggestedNames: string[];
 }
 
 // Search MusicBrainz with full enrichment - fetches social links, location, Wikipedia, etc.
@@ -313,11 +376,14 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     wikipediaSummary: null,
     wikipediaUrl: null,
     location: undefined,
+    suggestedNames: [],
   };
 
   try {
-    // Search for artist
-    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=1`;
+    // Search for artist. MB is Lucene-backed and its ranked list is the one real
+    // search engine in the fan-out: the top hit drives enrichment (strict gates
+    // below), the rest become discovery candidates via collectMbSuggestions.
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=5`;
 
     const response = await globalThis.fetch(searchUrl, {
       headers: {
@@ -339,10 +405,16 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     }
 
     const artist = artists[0];
-    // Only consider exact/near-exact matches
+    // Only consider exact/near-exact matches for enrichment. Lower-scored hits are
+    // still worth reporting as discovery candidates — they just don't get to claim
+    // the MB identity (official site, socials, location) for themselves.
     if (artist.score < 95) {
       console.log(`[MusicBrainz] Low confidence match for "${query}" (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
-      return { ...emptyResult, location: await enrichLocationFallback(query) };
+      return {
+        ...emptyResult,
+        suggestedNames: collectMbSuggestions(artists, query),
+        location: await enrichLocationFallback(query),
+      };
     }
 
     // Verify the returned artist name actually matches the query.
@@ -361,7 +433,11 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
 
     if (!isNameMatch) {
       console.log(`[MusicBrainz] Skipping "${artist.name}" - doesn't match query "${query}", falling back to Bandcamp/Mirlo location`);
-      return { ...emptyResult, location: await enrichLocationFallback(query) };
+      return {
+        ...emptyResult,
+        suggestedNames: collectMbSuggestions(artists, query),
+        location: await enrichLocationFallback(query),
+      };
     }
 
     // Wait 1.1 seconds to respect MusicBrainz rate limit
@@ -603,6 +679,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
       wikipediaSummary: wikipediaResult?.extract || null,
       wikipediaUrl: wikipediaResult?.pageUrl || wikipediaUrl,
       location,
+      suggestedNames: collectMbSuggestions(artists, query, artist.name),
     };
   } catch (error: unknown) {
     const err = error as { name?: string; message?: string };
@@ -611,46 +688,55 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
   }
 }
 
-// Search Mirlo by checking if artist page exists
+// Search Mirlo through its public artist search API.
+//
+// This used to be a bare probe of mirlo.space/<query-with-spaces-removed>, which
+// could only find an artist whose URL slug happened to equal the query spelling —
+// partial queries and differently-slugged artists were invisible. The API matches
+// server-side (loosely; parseMirloArtistSearch re-filters), so "argent" now finds
+// "The Argent Grub" at mirlo.space/the-argent-grub.
 async function searchMirlo(query: string): Promise<PlatformResult[]> {
-  const results: PlatformResult[] = [];
-  const normalizedQuery = query.toLowerCase().replace(/\s+/g, '');
-  const artistUrl = `https://mirlo.space/${normalizedQuery}`;
+  const cacheKey = artistCacheKey('mirlo', query);
+  // Set when the upstream did not answer. A failure must not be cached as
+  // "this artist isn't on mirlo" -- see the shouldCache predicate below.
+  let fetchFailed = false;
 
-  try {
-    const response = await fetchWithTimeout(artistUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    }, 3000);
+  const { data } = await cacheGetOrFetch<PlatformResult[]>(
+    cacheKey,
+    async () => {
+      try {
+        const response = await fetchWithTimeout(
+          `https://api.mirlo.space/v1/artists?name=${encodeURIComponent(query)}`,
+          {
+            headers: {
+              'User-Agent': 'Unstream/1.0 (+https://unstream.stream)',
+              'Accept': 'application/json',
+            },
+          },
+          3000,
+        );
 
-    if (!response.ok) return results;
+        if (!response.ok) { fetchFailed = true; return []; }
 
-    const html = await response.text();
-    const ogTitleMatch = html.match(/<meta property="og:title" content="([^"]+)"/);
-    if (ogTitleMatch) {
-      const ogTitle = ogTitleMatch[1].toLowerCase();
-      if (ogTitle !== 'mirlo' && ogTitle.includes(normalizedQuery.substring(0, 4))) {
-        const ogImageMatch = html.match(/<meta property="og:image" content="([^"]+)"/);
-        const imageUrl = ogImageMatch ? ogImageMatch[1] : undefined;
-
-        results.push({
-          sourceId: 'mirlo',
-          name: ogTitleMatch[1],
-          type: 'artist',
-          url: artistUrl,
-          imageUrl,
-        });
+        const json = await response.json();
+        return parseMirloArtistSearch(json, query);
+      } catch (error: unknown) {
+        const err = error as { name?: string; message?: string };
+        fetchFailed = true;
+        if (err.name !== 'AbortError') {
+          console.error('Mirlo search error:', err.message);
+        }
+        return [];
       }
-    }
-  } catch (error: unknown) {
-    const err = error as { name?: string; message?: string };
-    if (err.name !== 'AbortError') {
-      console.error('Mirlo search error:', err.message);
-    }
-  }
+    },
+    PLATFORM_CACHE_TTL,
+    // A failed fetch must not be cached as "artist not on this platform"...
+    () => !fetchFailed,
+    // ...but remember it briefly so an outage doesn't cost every search the timeout.
+    PLATFORM_FAILURE_CACHE_TTL,
+  );
 
-  return results;
+  return data;
 }
 
 // Faircamp webring directory cache
@@ -679,8 +765,8 @@ async function getFaircampDirectory(): Promise<Record<string, { title: string; a
   }
 }
 
-async function searchFaircamp(query: string): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
+async function searchFaircamp(query: string): Promise<Map<string, NameOnlyEntry>> {
+  const results = new Map<string, NameOnlyEntry>();
   const queryLower = query.toLowerCase();
 
   try {
@@ -690,7 +776,7 @@ async function searchFaircamp(query: string): Promise<Map<string, string>> {
       for (const artist of info.artists || []) {
         if (artist.toLowerCase().includes(queryLower) || queryLower.includes(artist.toLowerCase())) {
           const normalizedArtist = artist.toLowerCase().replace(/[^a-z0-9]/g, '');
-          results.set(normalizedArtist, `https://${domain}`);
+          results.set(normalizedArtist, { url: `https://${domain}`, displayName: artist });
         }
       }
       if (results.size >= 10) break;
@@ -800,8 +886,8 @@ async function getJamcoopDirectory(): Promise<Map<string, { name: string; url: s
   }
 }
 
-async function searchJamcoop(query: string): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
+async function searchJamcoop(query: string): Promise<Map<string, NameOnlyEntry>> {
+  const results = new Map<string, NameOnlyEntry>();
   const queryNormalized = normalizeForComparison(query);
 
   try {
@@ -812,7 +898,7 @@ async function searchJamcoop(query: string): Promise<Map<string, string>> {
       if (normalizedName === queryNormalized ||
           normalizedName.includes(queryNormalized) ||
           queryNormalized.includes(normalizedName)) {
-        results.set(normalizedName, artist.url);
+        results.set(normalizedName, { url: artist.url, displayName: artist.name });
       }
       if (results.size >= 10) break;
     }
@@ -824,16 +910,16 @@ async function searchJamcoop(query: string): Promise<Map<string, string>> {
   return results;
 }
 
-async function searchPatreon(query: string): Promise<Map<string, string>> {
+async function searchPatreon(query: string): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('patreon', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on patreon" -- see the shouldCache predicate below.
   let fetchFailed = false;
 
-  const { data } = await cacheGetOrFetch<[string, string][]>(
+  const { data } = await cacheGetOrFetch<[string, NameOnlyEntry | string][]>(
     cacheKey,
     async () => {
-      const results: [string, string][] = [];
+      const results: [string, NameOnlyEntry][] = [];
       const seen = new Set<string>();
 
       try {
@@ -868,14 +954,14 @@ async function searchPatreon(query: string): Promise<Map<string, string>> {
               const normalizedName = normalizeForComparison(creatorName);
               if (!seen.has(normalizedName)) {
                 seen.add(normalizedName);
-                results.push([normalizedName, url]);
+                results.push([normalizedName, { url, displayName: creatorName }]);
               }
               const urlSlug = url.split('/').pop();
               if (urlSlug) {
                 const normalizedSlug = normalizeForComparison(urlSlug);
                 if (!seen.has(normalizedSlug)) {
                   seen.add(normalizedSlug);
-                  results.push([normalizedSlug, url]);
+                  results.push([normalizedSlug, { url, displayName: creatorName }]);
                 }
               }
             }
@@ -899,7 +985,16 @@ async function searchPatreon(query: string): Promise<Map<string, string>> {
     PLATFORM_FAILURE_CACHE_TTL,
   );
 
-  return new Map(data);
+  return coerceNameOnlyCache(data);
+}
+
+// Cache entries written before display names were carried hold a bare URL string.
+// Coerce them so a deploy doesn't invalidate every warm entry; the string form
+// ages out with the 30-minute platform TTL.
+function coerceNameOnlyCache(data: [string, NameOnlyEntry | string][]): Map<string, NameOnlyEntry> {
+  return new Map(data.map(([name, entry]) =>
+    [name, typeof entry === 'string' ? { url: entry } : entry] as [string, NameOnlyEntry]
+  ));
 }
 
 // Search Ampwall with Redis caching to minimize API load
@@ -949,16 +1044,16 @@ async function searchAmpwall(query: string): Promise<Map<string, string>> {
 }
 
 // Search Beatport via __NEXT_DATA__ JSON embedded in search page
-async function searchBeatport(query: string): Promise<Map<string, string>> {
+async function searchBeatport(query: string): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('beatport', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on beatport" -- see the shouldCache predicate below.
   let fetchFailed = false;
 
-  const { data } = await cacheGetOrFetch<[string, string][]>(
+  const { data } = await cacheGetOrFetch<[string, NameOnlyEntry | string][]>(
     cacheKey,
     async () => {
-      const results: [string, string][] = [];
+      const results: [string, NameOnlyEntry][] = [];
 
       try {
         const searchUrl = `https://www.beatport.com/search?q=${encodeURIComponent(query)}`;
@@ -1005,7 +1100,10 @@ async function searchBeatport(query: string): Promise<Map<string, string>> {
           if (isMatch && !seen.has(normalizedName)) {
             seen.add(normalizedName);
             const slug = artist_name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-            results.push([normalizedName, `https://www.beatport.com/artist/${slug}/${artist_id}`]);
+            results.push([normalizedName, {
+              url: `https://www.beatport.com/artist/${slug}/${artist_id}`,
+              displayName: artist_name,
+            }]);
           }
         }
       } catch (error: unknown) {
@@ -1025,20 +1123,20 @@ async function searchBeatport(query: string): Promise<Map<string, string>> {
     PLATFORM_FAILURE_CACHE_TTL,
   );
 
-  return new Map(data);
+  return coerceNameOnlyCache(data);
 }
 
 // Search EVEN via Algolia API (direct-to-fan marketplace)
-async function searchEven(query: string): Promise<Map<string, string>> {
+async function searchEven(query: string): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('even', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on even" -- see the shouldCache predicate below.
   let fetchFailed = false;
 
-  const { data } = await cacheGetOrFetch<[string, string][]>(
+  const { data } = await cacheGetOrFetch<[string, NameOnlyEntry | string][]>(
     cacheKey,
     async () => {
-      const results: [string, string][] = [];
+      const results: [string, NameOnlyEntry][] = [];
 
       try {
         const algoliaAppId = process.env.ALGOLIA_APP_ID || 'S64VD9CU46';
@@ -1078,7 +1176,7 @@ async function searchEven(query: string): Promise<Map<string, string>> {
 
           if (isMatch && !seen.has(normalizedName)) {
             seen.add(normalizedName);
-            results.push([normalizedName, `https://even.biz/artists/${slug}`]);
+            results.push([normalizedName, { url: `https://even.biz/artists/${slug}`, displayName: name }]);
           }
         }
       } catch (error: unknown) {
@@ -1098,7 +1196,7 @@ async function searchEven(query: string): Promise<Map<string, string>> {
     PLATFORM_FAILURE_CACHE_TTL,
   );
 
-  return new Map(data);
+  return coerceNameOnlyCache(data);
 }
 
 // ---------------------------------------------------------------------------
@@ -1139,7 +1237,7 @@ async function fetchReleasesForDisambiguation(
 
 async function attachNameOnlyPlatforms(
   merged: AggregatedResult[],
-  nameOnlyMaps: [string, Map<string, string>][],
+  nameOnlyMaps: [string, Map<string, NameOnlyEntry>][],
 ): Promise<void> {
   // Step 1: Group all name-only platform matches by normalized artist name.
   // This ensures Faircamp + Jamcoop + Bandwagon for the same artist travel together.
@@ -1147,15 +1245,19 @@ async function attachNameOnlyPlatforms(
   const groupedByName = new Map<string, { sourceId: string; url: string }[]>();
   const displayNames = new Map<string, string>(); // normalizedName -> best display name
   for (const [platformId, matchMap] of nameOnlyMaps) {
-    for (const [normalizedName, platformUrl] of matchMap) {
+    for (const [normalizedName, entry] of matchMap) {
       if (!groupedByName.has(normalizedName)) groupedByName.set(normalizedName, []);
-      groupedByName.get(normalizedName)!.push({ sourceId: platformId, url: platformUrl });
-      // Try to extract a display name from the URL path
-      if (!displayNames.has(normalizedName)) {
+      groupedByName.get(normalizedName)!.push({ sourceId: platformId, url: entry.url });
+      // Prefer the name the platform actually displayed; reconstruct from the URL
+      // slug only as a fallback, and never from an opaque account id — that's how
+      // "@695d15c12f0f56fdced0a5e6" once shipped as a result name.
+      if (entry.displayName) {
+        displayNames.set(normalizedName, entry.displayName);
+      } else if (!displayNames.has(normalizedName)) {
         try {
-          const urlObj = new URL(platformUrl);
+          const urlObj = new URL(entry.url);
           const slug = urlObj.pathname.split('/').filter(Boolean).pop() || '';
-          if (slug) {
+          if (slug && !looksLikeOpaqueId(slug)) {
             displayNames.set(normalizedName, displayNameFromSlug(slug));
           }
         } catch { /* ignore */ }
@@ -1165,9 +1267,21 @@ async function attachNameOnlyPlatforms(
 
   // Step 2: For each artist name group, attach or create a new result
   for (const [normalizedName, platforms] of groupedByName) {
-    const matching = merged.filter(
+    let matching = merged.filter(
       r => r.type === 'artist' && normalizeForComparison(r.name) === normalizedName
     );
+    // No exact-name result: platforms disagree about leading articles often enough
+    // ("Argent Grub" on Bandwagon, "The Argent Grub" on Bandcamp) that a hit is
+    // also accepted when the names differ only by one. Anything looser than that
+    // (substring, prefix) would attach one artist's links to another.
+    if (matching.length === 0) {
+      const displayName = displayNames.get(normalizedName);
+      if (displayName) {
+        matching = merged.filter(
+          r => r.type === 'artist' && namesEqualIgnoringArticles(r.name, displayName)
+        );
+      }
+    }
 
     // Filter out platforms already present on any matching result
     const toAttach = platforms.filter(
@@ -1552,7 +1666,7 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   if (bandcampResults.status === 'fulfilled') allResults.push(...bandcampResults.value.filter(r => r.type === 'artist'));
   if (mirloResults.status === 'fulfilled') allResults.push(...mirloResults.value.filter(r => r.type === 'artist'));
 
-  const nameOnlyMaps: [string, Map<string, string>][] = [
+  const nameOnlyMaps: [string, Map<string, NameOnlyEntry>][] = [
     ['bandwagon', bandwagonResults.status === 'fulfilled' ? bandwagonResults.value : new Map()],
     ['faircamp', faircampResults.status === 'fulfilled' ? faircampResults.value : new Map()],
     ['jamcoop', jamcoopResults.status === 'fulfilled' ? jamcoopResults.value : new Map()],
@@ -1563,6 +1677,27 @@ async function searchAllPlatforms(query: string): Promise<{ results: AggregatedR
   const ampwallMatches = ampwallResults.status === 'fulfilled' ? ampwallResults.value : new Map<string, string>();
 
   const mbData = musicbrainzResult.status === 'fulfilled' ? musicbrainzResult.value : null;
+
+  // Phase 1.5: Probe Bandcamp for artist names the fan-out discovered.
+  // Candidate order encodes trust: Mirlo and Bandwagon hits are confirmed platform
+  // presences; MB suggestions are name-similarity only. Only the first
+  // MAX_CANDIDATE_PROBES distinct names are probed.
+  const candidateNames: string[] = [];
+  if (mirloResults.status === 'fulfilled') {
+    candidateNames.push(...mirloResults.value.map(r => r.name));
+  }
+  if (bandwagonResults.status === 'fulfilled') {
+    for (const entry of bandwagonResults.value.values()) {
+      if (entry.displayName) candidateNames.push(entry.displayName);
+    }
+  }
+  if (mbData) candidateNames.push(...mbData.suggestedNames);
+
+  const existingBandcampUrls = new Set(
+    (bandcampResults.status === 'fulfilled' ? bandcampResults.value : []).map(r => r.url)
+  );
+  const discoveredBandcamp = await probeBandcampForCandidates(query, candidateNames, existingBandcampUrls);
+  allResults.push(...discoveredBandcamp);
 
   const aggregated = aggregateResults(allResults, query);
 

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { findBandcampArtist } from '../search/bandcamp-probe';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
-import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides } from './db';
+import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, findClaimedArtistSlugsByName } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
 import { parseMirloArtistSearch } from './search-parsers';
@@ -27,6 +27,7 @@ import {
   mergeByReleaseOverlap,
   filterAndSort,
   applyMergeOverrides,
+  mergeClaimedIntoResults,
   displayNameFromSlug,
   isBandcampSearchLink,
   bandcampSubdomainOf,
@@ -1844,6 +1845,30 @@ async function searchBandcampForAlbum(artistUrl: string, albumTitle: string): Pr
   }
 }
 
+// Shape a DB claimed-artist row into a result card. Null unless the artist is
+// actually claimed — an auto-discovered row must not masquerade as a profile.
+function toClaimedResult(
+  dbArtist: Awaited<ReturnType<typeof getArtistBySlug>>,
+  slug: string,
+): AggregatedResult | null {
+  if (!dbArtist || dbArtist.matchConfidence !== 'claimed') return null;
+  return {
+    id: `claimed-${slug}`,
+    name: dbArtist.name,
+    type: 'artist' as const,
+    imageUrl: dbArtist.profile?.customImageUrl || dbArtist.imageUrl,
+    platforms: dbArtist.platforms.map(p => ({
+      sourceId: p.sourceId as SourceId,
+      url: p.url,
+      displayName: p.displayName,
+      latestRelease: p.latestRelease,
+    })),
+    matchConfidence: 'claimed' as const,
+    claimedSlug: slug,
+    ...(dbArtist.location ? { location: dbArtist.location } : {}),
+  };
+}
+
 // Netlify function handler
 export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string> }) {
   const corsHeaders = { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' };
@@ -1871,36 +1896,36 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     // Normalize the query to handle accented characters (e.g., "Tanerélle" -> "Tanerelle")
     const normalizedQuery = normalizeSearchQuery(query);
 
-    // Check if there's a claimed artist in the DB matching this query.
-    // The lookup runs concurrently with the platform fan-out below — it's a
-    // Supabase read that used to add its round-trips ahead of the search.
+    // Claimed artists are looked up two ways, both concurrent with the platform
+    // fan-out: by exact slug of the query (covers queries that ARE the artist's
+    // name, including slug-ish spellings), and by name-contains (covers partial
+    // queries — "lightbulbs" must find the claimed kid-lightbulbs profile, not
+    // lose to a generic scraped card).
     const slug = artistSlug(normalizedQuery);
-    const claimedPromise: Promise<AggregatedResult | null> = getArtistBySlug(slug)
-      .then(dbArtist => {
-        if (!dbArtist || dbArtist.matchConfidence !== 'claimed') return null;
-        return {
-          id: `claimed-${slug}`,
-          name: dbArtist.name,
-          type: 'artist' as const,
-          imageUrl: dbArtist.profile?.customImageUrl || dbArtist.imageUrl,
-          platforms: dbArtist.platforms.map(p => ({
-            sourceId: p.sourceId as SourceId,
-            url: p.url,
-            displayName: p.displayName,
-            latestRelease: p.latestRelease,
-          })),
-          matchConfidence: 'claimed' as const,
-          claimedSlug: slug,
-          ...(dbArtist.location ? { location: dbArtist.location } : {}),
-        };
-      })
+    const claimedExactPromise: Promise<AggregatedResult | null> = getArtistBySlug(slug)
+      .then(dbArtist => toClaimedResult(dbArtist, slug))
       .catch(err => {
         console.error('[DB] Claimed artist lookup failed:', err);
         return null;
       });
+    const claimedByNamePromise: Promise<AggregatedResult[]> = findClaimedArtistSlugsByName(normalizedQuery)
+      .then(slugs => Promise.all(
+        slugs.map(s =>
+          getArtistBySlug(s)
+            .then(dbArtist => toClaimedResult(dbArtist, s))
+            .catch(() => null)
+        )
+      ))
+      .then(list => list.filter((r): r is AggregatedResult => r !== null))
+      .catch(err => {
+        console.error('[DB] Claimed artist name search failed:', err);
+        return [];
+      });
 
     const searchResult = await searchAllPlatforms(normalizedQuery);
-    const claimedResult = await claimedPromise;
+    const claimedExact = await claimedExactPromise;
+    const claimedByName = await claimedByNamePromise;
+    const claimedArtists = claimedExact ? [claimedExact, ...claimedByName] : claimedByName;
     const results = searchResult.results;
 
     // UC5: Capture zero-result searches for monitoring (volume signal for coverage gaps)
@@ -1918,24 +1943,20 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       }
     }
 
-    // If we have a claimed artist, put it first and remove any duplicate from live results
-    if (claimedResult) {
-      const claimedName = normalizeForComparison(claimedResult.name);
-      const filtered = results.filter(r => normalizeForComparison(r.name) !== claimedName);
-      results.length = 0;
-      results.push(claimedResult, ...filtered);
-    }
+    // Fold claimed profiles in: replace generic same-name results in place,
+    // lead with an exact query match, append the rest.
+    const finalResults = mergeClaimedIntoResults(results, claimedArtists, normalizedQuery);
 
     // Persist artist results to the database (skip claimed results, they're already in DB)
     try {
-      await persistSearchResults(results.filter(r => r.matchConfidence !== 'claimed'));
+      await persistSearchResults(finalResults.filter(r => r.matchConfidence !== 'claimed'));
     } catch (err) {
       console.error('[DB] Background persist failed:', err);
     }
 
     const response: SearchResponse = {
       query, // Return original query for display
-      results,
+      results: finalResults,
       // Signal client whether enrichment is still pending (true = MB enrichment failed/timed out,
       // client should call /api/search/musicbrainz as fallback; false = enrichment was applied server-side)
       hasPendingEnrichment: !searchResult.enrichmentApplied,

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { findBandcampArtist } from '../search/bandcamp-probe';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
-import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, findClaimedArtistSlugsByName } from './db';
+import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, findKnownArtistSlugsByName } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
 import { parseMirloArtistSearch } from './search-parsers';
@@ -27,7 +27,7 @@ import {
   mergeByReleaseOverlap,
   filterAndSort,
   applyMergeOverrides,
-  mergeClaimedIntoResults,
+  mergeStoredArtistsIntoResults,
   displayNameFromSlug,
   isBandcampSearchLink,
   bandcampSubdomainOf,
@@ -1845,15 +1845,22 @@ async function searchBandcampForAlbum(artistUrl: string, albumTitle: string): Pr
   }
 }
 
-// Shape a DB claimed-artist row into a result card. Null unless the artist is
-// actually claimed — an auto-discovered row must not masquerade as a profile.
-function toClaimedResult(
+// Shape a DB artist row into a result card. Claimed rows become full profile
+// cards (custom image, /a/ page link); verified rows become plain result cards
+// with the links a past search persisted. Unverified rows are rejected — that
+// confidence level is where junk from name-only matches accumulates.
+function toStoredResult(
   dbArtist: Awaited<ReturnType<typeof getArtistBySlug>>,
   slug: string,
 ): AggregatedResult | null {
-  if (!dbArtist || dbArtist.matchConfidence !== 'claimed') return null;
+  if (!dbArtist) return null;
+  const claimed = dbArtist.matchConfidence === 'claimed';
+  if (!claimed && dbArtist.matchConfidence !== 'verified') return null;
   return {
-    id: `claimed-${slug}`,
+    // The known- prefix marks a card served from the DB rather than resolved
+    // live; the persist step skips these so re-serving stored data can't
+    // refresh updated_at and mask genuine staleness.
+    id: claimed ? `claimed-${slug}` : `known-${slug}`,
     name: dbArtist.name,
     type: 'artist' as const,
     imageUrl: dbArtist.profile?.customImageUrl || dbArtist.imageUrl,
@@ -1863,8 +1870,8 @@ function toClaimedResult(
       displayName: p.displayName,
       latestRelease: p.latestRelease,
     })),
-    matchConfidence: 'claimed' as const,
-    claimedSlug: slug,
+    matchConfidence: claimed ? ('claimed' as const) : ('verified' as const),
+    ...(claimed ? { claimedSlug: slug } : {}),
     ...(dbArtist.location ? { location: dbArtist.location } : {}),
   };
 }
@@ -1896,36 +1903,37 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     // Normalize the query to handle accented characters (e.g., "Tanerélle" -> "Tanerelle")
     const normalizedQuery = normalizeSearchQuery(query);
 
-    // Claimed artists are looked up two ways, both concurrent with the platform
-    // fan-out: by exact slug of the query (covers queries that ARE the artist's
-    // name, including slug-ish spellings), and by name-contains (covers partial
-    // queries — "lightbulbs" must find the claimed kid-lightbulbs profile, not
-    // lose to a generic scraped card).
+    // Known artists are looked up two ways, both concurrent with the platform
+    // fan-out: claimed profiles by exact slug of the query (covers queries that
+    // ARE the artist's name), and any known artist by name-contains — a partial
+    // query like "patrick" must surface Patrick Hardy when a past search already
+    // resolved and persisted him, and "lightbulbs" must surface the claimed
+    // kid-lightbulbs profile instead of a generic scraped card.
     const slug = artistSlug(normalizedQuery);
     const claimedExactPromise: Promise<AggregatedResult | null> = getArtistBySlug(slug)
-      .then(dbArtist => toClaimedResult(dbArtist, slug))
+      .then(dbArtist => dbArtist?.matchConfidence === 'claimed' ? toStoredResult(dbArtist, slug) : null)
       .catch(err => {
         console.error('[DB] Claimed artist lookup failed:', err);
         return null;
       });
-    const claimedByNamePromise: Promise<AggregatedResult[]> = findClaimedArtistSlugsByName(normalizedQuery)
+    const knownByNamePromise: Promise<AggregatedResult[]> = findKnownArtistSlugsByName(normalizedQuery)
       .then(slugs => Promise.all(
         slugs.map(s =>
-          getArtistBySlug(s)
-            .then(dbArtist => toClaimedResult(dbArtist, s))
+          getArtistBySlug(s, { allowStale: true })
+            .then(dbArtist => toStoredResult(dbArtist, s))
             .catch(() => null)
         )
       ))
       .then(list => list.filter((r): r is AggregatedResult => r !== null))
       .catch(err => {
-        console.error('[DB] Claimed artist name search failed:', err);
+        console.error('[DB] Known artist name search failed:', err);
         return [];
       });
 
     const searchResult = await searchAllPlatforms(normalizedQuery);
     const claimedExact = await claimedExactPromise;
-    const claimedByName = await claimedByNamePromise;
-    const claimedArtists = claimedExact ? [claimedExact, ...claimedByName] : claimedByName;
+    const knownByName = await knownByNamePromise;
+    const storedArtists = claimedExact ? [claimedExact, ...knownByName] : knownByName;
     const results = searchResult.results;
 
     // UC5: Capture zero-result searches for monitoring (volume signal for coverage gaps)
@@ -1943,13 +1951,17 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       }
     }
 
-    // Fold claimed profiles in: replace generic same-name results in place,
-    // lead with an exact query match, append the rest.
-    const finalResults = mergeClaimedIntoResults(results, claimedArtists, normalizedQuery);
+    // Fold stored artists in: claimed cards replace generic same-name results
+    // in place, known artists fill holes the platforms missed.
+    const finalResults = mergeStoredArtistsIntoResults(results, storedArtists, normalizedQuery);
 
-    // Persist artist results to the database (skip claimed results, they're already in DB)
+    // Persist artist results to the database. Skip claimed results (already in
+    // DB) and known- cards (served FROM the DB — persisting them back would
+    // refresh updated_at without re-verifying anything).
     try {
-      await persistSearchResults(finalResults.filter(r => r.matchConfidence !== 'claimed'));
+      await persistSearchResults(finalResults.filter(r =>
+        r.matchConfidence !== 'claimed' && !r.id.startsWith('known-')
+      ));
     } catch (err) {
       console.error('[DB] Background persist failed:', err);
     }

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -90,6 +90,15 @@ export interface SearchResponse {
   hasPendingEnrichment?: boolean;
 }
 
+// A name-only platform hit: a URL plus the display name the platform showed for it.
+// Keyed by normalized name in the maps the fetchers return; the display name is kept
+// so results created from these hits carry the artist's real name instead of a
+// reconstruction from the URL slug (which for Bandwagon can be an opaque account id).
+export interface NameOnlyEntry {
+  url: string;
+  displayName?: string;
+}
+
 export interface MergeOverride {
   id: string;
   group_name: string;
@@ -300,6 +309,32 @@ export function namesMatch(name1: string, name2: string): boolean {
   return false;
 }
 
+/**
+ * Whether two names are the same modulo a leading article ("Argent Grub" vs
+ * "The Argent Grub").
+ *
+ * Deliberately much stricter than `namesMatch`: substring matching would also
+ * equate "Argent" with "Rod Argent" and attach one artist's links to another.
+ * Article variance is the only cross-platform naming drift safe to bridge
+ * without release data to corroborate.
+ */
+export function namesEqualIgnoringArticles(name1: string, name2: string): boolean {
+  const strip = (s: string) => normalizeForComparison(s.replace(/^\s*(the|a|an)\s+/i, ''));
+  const n1 = strip(name1);
+  const n2 = strip(name2);
+  return n1.length > 0 && n1 === n2;
+}
+
+/**
+ * Whether a URL slug is an opaque account id rather than a human-readable name
+ * (e.g. Bandwagon's fallback handles like "695d15c12f0f56fdced0a5e6").
+ * Such slugs must never be reconstructed into a display name.
+ */
+export function looksLikeOpaqueId(slug: string): boolean {
+  const bare = slug.replace(/^@/, '');
+  return /^[0-9a-f]{16,}$/i.test(bare) || /^\d{6,}$/.test(bare);
+}
+
 export function textMatchScore(name: string, query: string): number {
   const normName = normalizeForComparison(name);
   const normQuery = normalizeForComparison(query);
@@ -307,6 +342,44 @@ export function textMatchScore(name: string, query: string): number {
   if (normName.startsWith(normQuery)) return 2;
   if (normName.includes(normQuery)) return 1;
   return 0;
+}
+
+/**
+ * Pick partial-match artist names out of a MusicBrainz search result list.
+ *
+ * MB is a real search engine (Lucene), but the pipeline historically read only
+ * its top hit — so an artist whose name merely *contains* the query ("argent"
+ * -> "Goodnight Argent") was invisible. These names are discovery candidates:
+ * they get verified against Bandcamp before they can become results, so the
+ * bar here is deliberately looser than the enrichment gate.
+ *
+ * `excludeName` is the artist already chosen for enrichment; suggesting them
+ * again would duplicate a result.
+ */
+export function collectMbSuggestions(
+  artists: { name: string; score: number }[],
+  query: string,
+  excludeName?: string | null,
+): string[] {
+  const queryNorm = normalizeForComparison(query);
+  const excludeNorm = excludeName ? normalizeForComparison(excludeName) : null;
+  if (!queryNorm) return [];
+
+  const suggestions: string[] = [];
+  const seen = new Set<string>();
+  for (const artist of artists) {
+    // Below 70, MB's matches stop containing the query as a name fragment and
+    // start being token-soup — not worth a probe.
+    if (artist.score < 70) continue;
+    const norm = normalizeForComparison(artist.name);
+    if (!norm || norm === queryNorm || norm === excludeNorm || seen.has(norm)) continue;
+    // Only names the user could plausibly have been typing toward.
+    if (textMatchScore(artist.name, query) === 0) continue;
+    seen.add(norm);
+    suggestions.push(artist.name);
+    if (suggestions.length >= 4) break;
+  }
+  return suggestions;
 }
 
 // ---------------------------------------------------------------------------

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -808,47 +808,55 @@ export function mergeByReleaseOverlap(disambiguated: AggregatedResult[]): Aggreg
 }
 
 // ---------------------------------------------------------------------------
-// Claimed-profile merge
+// Stored-artist merge (claimed profiles + previously-resolved artists)
 // ---------------------------------------------------------------------------
 
 /**
- * Fold claimed artist profiles into the final search results.
+ * Fold artists from the database into the final search results.
  *
- * A claimed profile is the artist's own curated page — when the platforms also
+ * Claimed profiles are the artist's own curated page: when the platforms also
  * produced a generic result under the same name (or the same name modulo a
  * leading article), the claimed card replaces it in place, keeping its
- * relevance position. A claimed artist the platforms missed entirely is
- * appended. An exact match on the query leads the list, preserving the
- * longstanding "your own name finds your page first" behavior.
+ * relevance position; an exact match on the query leads the list. Non-claimed
+ * stored artists (previously resolved and persisted searches) are gap-fillers
+ * only — they're appended when the name is missing entirely, and never
+ * displace a result the live pipeline just verified, which is fresher.
  */
-export function mergeClaimedIntoResults(
+export function mergeStoredArtistsIntoResults(
   results: AggregatedResult[],
-  claimed: AggregatedResult[],
+  stored: AggregatedResult[],
   query: string,
 ): AggregatedResult[] {
   const queryNorm = normalizeForComparison(query);
   const merged = [...results];
-  const seenSlugs = new Set<string>();
+  const seenIds = new Set<string>();
 
-  for (const artist of claimed) {
-    if (artist.claimedSlug) {
-      // The exact-slug and name-contains lookups can both find the same artist.
-      if (seenSlugs.has(artist.claimedSlug)) continue;
-      seenSlugs.add(artist.claimedSlug);
-    }
+  for (const artist of stored) {
+    // The exact-slug and name-contains lookups can both find the same artist.
+    if (seenIds.has(artist.id)) continue;
+    seenIds.add(artist.id);
 
-    const replaceIdx = merged.findIndex(r =>
+    const sameNameIdx = merged.findIndex(r =>
       r.type === 'artist' &&
       r.matchConfidence !== 'claimed' &&
       (normalizeForComparison(r.name) === normalizeForComparison(artist.name) ||
         namesEqualIgnoringArticles(r.name, artist.name))
     );
-    if (replaceIdx !== -1) merged.splice(replaceIdx, 1);
+
+    if (artist.matchConfidence !== 'claimed') {
+      // A stored non-claimed artist only fills a hole.
+      if (sameNameIdx === -1 && !merged.some(r => normalizeForComparison(r.name) === normalizeForComparison(artist.name))) {
+        merged.push(artist);
+      }
+      continue;
+    }
+
+    if (sameNameIdx !== -1) merged.splice(sameNameIdx, 1);
 
     if (normalizeForComparison(artist.name) === queryNorm) {
       merged.unshift(artist);
-    } else if (replaceIdx !== -1) {
-      merged.splice(replaceIdx, 0, artist);
+    } else if (sameNameIdx !== -1) {
+      merged.splice(sameNameIdx, 0, artist);
     } else {
       merged.push(artist);
     }

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -808,6 +808,56 @@ export function mergeByReleaseOverlap(disambiguated: AggregatedResult[]): Aggreg
 }
 
 // ---------------------------------------------------------------------------
+// Claimed-profile merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Fold claimed artist profiles into the final search results.
+ *
+ * A claimed profile is the artist's own curated page — when the platforms also
+ * produced a generic result under the same name (or the same name modulo a
+ * leading article), the claimed card replaces it in place, keeping its
+ * relevance position. A claimed artist the platforms missed entirely is
+ * appended. An exact match on the query leads the list, preserving the
+ * longstanding "your own name finds your page first" behavior.
+ */
+export function mergeClaimedIntoResults(
+  results: AggregatedResult[],
+  claimed: AggregatedResult[],
+  query: string,
+): AggregatedResult[] {
+  const queryNorm = normalizeForComparison(query);
+  const merged = [...results];
+  const seenSlugs = new Set<string>();
+
+  for (const artist of claimed) {
+    if (artist.claimedSlug) {
+      // The exact-slug and name-contains lookups can both find the same artist.
+      if (seenSlugs.has(artist.claimedSlug)) continue;
+      seenSlugs.add(artist.claimedSlug);
+    }
+
+    const replaceIdx = merged.findIndex(r =>
+      r.type === 'artist' &&
+      r.matchConfidence !== 'claimed' &&
+      (normalizeForComparison(r.name) === normalizeForComparison(artist.name) ||
+        namesEqualIgnoringArticles(r.name, artist.name))
+    );
+    if (replaceIdx !== -1) merged.splice(replaceIdx, 1);
+
+    if (normalizeForComparison(artist.name) === queryNorm) {
+      merged.unshift(artist);
+    } else if (replaceIdx !== -1) {
+      merged.splice(replaceIdx, 0, artist);
+    } else {
+      merged.push(artist);
+    }
+  }
+
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
 // Phase 4: filterAndSort
 // ---------------------------------------------------------------------------
 

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -39,9 +39,29 @@ const KNOWN_MASTODON_INSTANCES = [
   'sfba.social', 'universeodon.com', 'c.im', 'toot.cafe',
 ];
 
+// The hostname of a URL, or null when it isn't parseable as one.
+function hostnameOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+// True when the URL's host IS the instance (or a subdomain of it). Must compare
+// hostnames, not substrings of the whole URL: the instance list contains short
+// domains like "c.im", and a substring check matched it inside the URL-encoded
+// query string of a Wix asset URL ("...%2C.imageEncoding..."), shipping that
+// asset URL as an artist's "Mastodon profile".
+function hostMatchesInstance(url: string, instances: string[]): boolean {
+  const host = hostnameOf(url);
+  if (!host) return false;
+  return instances.some(instance => host === instance || host.endsWith(`.${instance}`));
+}
+
 // Check if a URL belongs to a known Mastodon instance
-export function isMastodonInstance(urlLower: string): boolean {
-  return KNOWN_MASTODON_INSTANCES.some(instance => urlLower.includes(instance));
+export function isMastodonInstance(url: string): boolean {
+  return hostMatchesInstance(url, KNOWN_MASTODON_INSTANCES);
 }
 
 // Known PeerTube instances (non-exhaustive, covers popular + music-focused ones)
@@ -57,8 +77,8 @@ const KNOWN_PEERTUBE_INSTANCES = [
 ];
 
 // Check if a URL belongs to a known PeerTube instance
-export function isPeerTubeInstance(urlLower: string): boolean {
-  return KNOWN_PEERTUBE_INSTANCES.some(instance => urlLower.includes(instance));
+export function isPeerTubeInstance(url: string): boolean {
+  return hostMatchesInstance(url, KNOWN_PEERTUBE_INSTANCES);
 }
 
 // Convert a Mastodon handle (@user@server) to a URL

--- a/apps/web/tests/unit/aggregation.test.ts
+++ b/apps/web/tests/unit/aggregation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   aggregateResults,
-  mergeClaimedIntoResults,
+  mergeStoredArtistsIntoResults,
   type PlatformResult,
   type AggregatedResult,
 } from '../../../../api/functions/search-utils';
@@ -89,10 +89,10 @@ describe('aggregateResults', () => {
 });
 
 // ---------------------------------------------------------------------------
-// mergeClaimedIntoResults
+// mergeStoredArtistsIntoResults
 // ---------------------------------------------------------------------------
 
-describe('mergeClaimedIntoResults', () => {
+describe('mergeStoredArtistsIntoResults', () => {
   const generic = (name: string): AggregatedResult => ({
     id: name.toLowerCase().replace(/\s/g, ''),
     name,
@@ -114,7 +114,7 @@ describe('mergeClaimedIntoResults', () => {
     // The "lightbulbs" bug: the platforms built a generic Kid Lightbulbs card
     // that ignored the artist's own claimed profile.
     const results = [generic('Lightbulb Factory'), generic('Kid Lightbulbs')];
-    const merged = mergeClaimedIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'lightbulbs');
+    const merged = mergeStoredArtistsIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'lightbulbs');
     expect(merged).toHaveLength(2);
     expect(merged[1].matchConfidence).toBe('claimed');
     expect(merged[1].claimedSlug).toBe('kid-lightbulbs');
@@ -123,34 +123,58 @@ describe('mergeClaimedIntoResults', () => {
   it('appends a claimed artist the platforms missed entirely', () => {
     // The "blood" bug: Cloud Blood has a claimed page but no platform hit.
     const results = [generic('Blood')];
-    const merged = mergeClaimedIntoResults(results, [claimed('Cloud Blood', 'cloud-blood')], 'blood');
+    const merged = mergeStoredArtistsIntoResults(results, [claimed('Cloud Blood', 'cloud-blood')], 'blood');
     expect(merged.map(r => r.name)).toEqual(['Blood', 'Cloud Blood']);
     expect(merged[1].matchConfidence).toBe('claimed');
   });
 
   it('puts an exact query match first', () => {
     const results = [generic('Kid Lightbulbs Tribute'), generic('Kid Lightbulbs')];
-    const merged = mergeClaimedIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'kid lightbulbs');
+    const merged = mergeStoredArtistsIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'kid lightbulbs');
     expect(merged[0].claimedSlug).toBe('kid-lightbulbs');
     expect(merged).toHaveLength(2);
   });
 
   it('replaces article-variant names too', () => {
     const results = [generic('Argent Grub')];
-    const merged = mergeClaimedIntoResults(results, [claimed('The Argent Grub', 'the-argent-grub')], 'argent');
+    const merged = mergeStoredArtistsIntoResults(results, [claimed('The Argent Grub', 'the-argent-grub')], 'argent');
     expect(merged).toHaveLength(1);
     expect(merged[0].matchConfidence).toBe('claimed');
   });
 
   it('dedupes when the exact and name-contains lookups find the same artist', () => {
     const kid = claimed('Kid Lightbulbs', 'kid-lightbulbs');
-    const merged = mergeClaimedIntoResults([], [kid, { ...kid }], 'kid lightbulbs');
+    const merged = mergeStoredArtistsIntoResults([], [kid, { ...kid }], 'kid lightbulbs');
     expect(merged).toHaveLength(1);
   });
 
   it('leaves unrelated results untouched', () => {
     const results = [generic('Radiohead')];
-    const merged = mergeClaimedIntoResults(results, [], 'radiohead');
+    const merged = mergeStoredArtistsIntoResults(results, [], 'radiohead');
     expect(merged).toEqual(results);
+  });
+
+  const known = (name: string, slug: string): AggregatedResult => ({
+    id: `known-${slug}`,
+    name,
+    type: 'artist',
+    platforms: [{ sourceId: 'bandcamp', url: `https://${slug.replace(/-/g, '')}.bandcamp.com` }],
+    matchConfidence: 'verified',
+  });
+
+  it('appends a known (previously-resolved) artist the platforms missed', () => {
+    // The "patrick" bug: Patrick Hardy was persisted by past exact searches
+    // but partial queries never consulted the artists table.
+    const results = [generic('Patrick')];
+    const merged = mergeStoredArtistsIntoResults(results, [known('Patrick Hardy', 'patrick-hardy')], 'patrick');
+    expect(merged.map(r => r.name)).toEqual(['Patrick', 'Patrick Hardy']);
+  });
+
+  it('never lets a stored non-claimed artist displace a live result', () => {
+    // The live pipeline just verified this result; the stored copy may be stale.
+    const live = generic('Patrick Hardy');
+    const merged = mergeStoredArtistsIntoResults([live], [known('Patrick Hardy', 'patrick-hardy')], 'patrick');
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe(live.id);
   });
 });

--- a/apps/web/tests/unit/aggregation.test.ts
+++ b/apps/web/tests/unit/aggregation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   aggregateResults,
+  mergeClaimedIntoResults,
   type PlatformResult,
   type AggregatedResult,
 } from '../../../../api/functions/search-utils';
@@ -84,5 +85,72 @@ describe('aggregateResults', () => {
 
     const aggregated = aggregateResults(results, 'artist');
     expect(aggregated[0].imageUrl).toBe('https://img.com/photo.jpg');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeClaimedIntoResults
+// ---------------------------------------------------------------------------
+
+describe('mergeClaimedIntoResults', () => {
+  const generic = (name: string): AggregatedResult => ({
+    id: name.toLowerCase().replace(/\s/g, ''),
+    name,
+    type: 'artist',
+    platforms: [{ sourceId: 'bandcamp', url: `https://${name.toLowerCase().replace(/\s/g, '')}.bandcamp.com` }],
+    matchConfidence: 'verified',
+  });
+
+  const claimed = (name: string, slug: string): AggregatedResult => ({
+    id: `claimed-${slug}`,
+    name,
+    type: 'artist',
+    platforms: [{ sourceId: 'officialsite', url: `https://${slug}.example.com` }],
+    matchConfidence: 'claimed',
+    claimedSlug: slug,
+  });
+
+  it('replaces a generic same-name result in place, keeping its position', () => {
+    // The "lightbulbs" bug: the platforms built a generic Kid Lightbulbs card
+    // that ignored the artist's own claimed profile.
+    const results = [generic('Lightbulb Factory'), generic('Kid Lightbulbs')];
+    const merged = mergeClaimedIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'lightbulbs');
+    expect(merged).toHaveLength(2);
+    expect(merged[1].matchConfidence).toBe('claimed');
+    expect(merged[1].claimedSlug).toBe('kid-lightbulbs');
+  });
+
+  it('appends a claimed artist the platforms missed entirely', () => {
+    // The "blood" bug: Cloud Blood has a claimed page but no platform hit.
+    const results = [generic('Blood')];
+    const merged = mergeClaimedIntoResults(results, [claimed('Cloud Blood', 'cloud-blood')], 'blood');
+    expect(merged.map(r => r.name)).toEqual(['Blood', 'Cloud Blood']);
+    expect(merged[1].matchConfidence).toBe('claimed');
+  });
+
+  it('puts an exact query match first', () => {
+    const results = [generic('Kid Lightbulbs Tribute'), generic('Kid Lightbulbs')];
+    const merged = mergeClaimedIntoResults(results, [claimed('Kid Lightbulbs', 'kid-lightbulbs')], 'kid lightbulbs');
+    expect(merged[0].claimedSlug).toBe('kid-lightbulbs');
+    expect(merged).toHaveLength(2);
+  });
+
+  it('replaces article-variant names too', () => {
+    const results = [generic('Argent Grub')];
+    const merged = mergeClaimedIntoResults(results, [claimed('The Argent Grub', 'the-argent-grub')], 'argent');
+    expect(merged).toHaveLength(1);
+    expect(merged[0].matchConfidence).toBe('claimed');
+  });
+
+  it('dedupes when the exact and name-contains lookups find the same artist', () => {
+    const kid = claimed('Kid Lightbulbs', 'kid-lightbulbs');
+    const merged = mergeClaimedIntoResults([], [kid, { ...kid }], 'kid lightbulbs');
+    expect(merged).toHaveLength(1);
+  });
+
+  it('leaves unrelated results untouched', () => {
+    const results = [generic('Radiohead')];
+    const merged = mergeClaimedIntoResults(results, [], 'radiohead');
+    expect(merged).toEqual(results);
   });
 });

--- a/apps/web/tests/unit/enrichment-social.test.ts
+++ b/apps/web/tests/unit/enrichment-social.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isMastodonInstance,
+  isPeerTubeInstance,
+  parseSocialUrl,
+} from '../../../../api/search/enrichment';
+
+// The bug these guard: instance matching used substring-of-the-whole-URL, and the
+// instance list contains short domains like "c.im". A Wix asset URL whose
+// URL-encoded query string contained "...%2C.imageEncoding..." matched "c.im" and
+// shipped as an artist's "Mastodon profile". Matching must be by hostname.
+
+describe('isMastodonInstance', () => {
+  it('matches a profile on a known instance', () => {
+    expect(isMastodonInstance('https://mastodon.social/@artist')).toBe(true);
+    expect(isMastodonInstance('https://c.im/@someone')).toBe(true);
+  });
+
+  it('matches subdomains of a known instance', () => {
+    expect(isMastodonInstance('https://media.mastodon.social/whatever')).toBe(true);
+  });
+
+  it('rejects URLs that merely contain an instance name as a substring', () => {
+    // The actual Wix asset URL bug: "%2C.imageEncodingAVIF" contains "c.im".
+    expect(isMastodonInstance(
+      'https://siteassets.parastorage.com/pages/thunderbolt?experiments=.dynamicslots%2c.imageencodingavif'
+    )).toBe(false);
+    // A domain that ends with the instance string without being a subdomain.
+    expect(isMastodonInstance('https://public.im/@x')).toBe(false);
+    expect(isMastodonInstance('https://notmastodon.social.example.com/@x')).toBe(false);
+  });
+
+  it('rejects unparseable URLs', () => {
+    expect(isMastodonInstance('not a url')).toBe(false);
+  });
+});
+
+describe('isPeerTubeInstance', () => {
+  it('matches a known instance by hostname', () => {
+    expect(isPeerTubeInstance('https://tilvids.com/c/channel')).toBe(true);
+  });
+
+  it('rejects substring-only matches', () => {
+    expect(isPeerTubeInstance('https://example.com/?ref=tilvids.com')).toBe(false);
+  });
+});
+
+describe('parseSocialUrl', () => {
+  it('still classifies mainstream platforms', () => {
+    expect(parseSocialUrl('https://www.instagram.com/artist')?.platform).toBe('instagram');
+    expect(parseSocialUrl('https://bsky.app/profile/artist')?.platform).toBe('bluesky');
+  });
+
+  it('classifies known Mastodon instances by hostname only', () => {
+    expect(parseSocialUrl('https://mastodon.art/@artist')?.platform).toBe('mastodon');
+    expect(parseSocialUrl(
+      'https://siteassets.parastorage.com/x?y=%2c.imageencodingavif'
+    )).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/normalize.test.ts
+++ b/apps/web/tests/unit/normalize.test.ts
@@ -4,7 +4,10 @@ import {
   normalizeSearchQuery,
   normalizeForComparison,
   namesMatch,
+  namesEqualIgnoringArticles,
+  looksLikeOpaqueId,
   textMatchScore,
+  collectMbSuggestions,
   bandcampSlugCandidates,
 } from '../../../../api/functions/search-utils';
 
@@ -141,5 +144,93 @@ describe('textMatchScore', () => {
 
   it('returns 0 for no match', () => {
     expect(textMatchScore('Radiohead', 'kid lightbulbs')).toBe(0);
+  });
+});
+
+describe('namesEqualIgnoringArticles', () => {
+  it('matches names differing only by a leading article', () => {
+    expect(namesEqualIgnoringArticles('Argent Grub', 'The Argent Grub')).toBe(true);
+    expect(namesEqualIgnoringArticles('The Beths', 'Beths')).toBe(true);
+    expect(namesEqualIgnoringArticles('A Perfect Circle', 'Perfect Circle')).toBe(true);
+  });
+
+  it('matches identical names', () => {
+    expect(namesEqualIgnoringArticles('Kid Lightbulbs', 'kid lightbulbs')).toBe(true);
+  });
+
+  it('rejects substring relationships that are different artists', () => {
+    // This is why namesMatch is NOT used for name-only attachment.
+    expect(namesEqualIgnoringArticles('Argent', 'Rod Argent')).toBe(false);
+    expect(namesEqualIgnoringArticles('Argent', 'The Argent Grub')).toBe(false);
+  });
+
+  it('does not treat "The..." as part of a longer word', () => {
+    // "Theresa" must not become "resa".
+    expect(namesEqualIgnoringArticles('Theresa', 'resa')).toBe(false);
+  });
+
+  it('rejects empty names', () => {
+    expect(namesEqualIgnoringArticles('The', 'A')).toBe(false);
+  });
+});
+
+describe('looksLikeOpaqueId', () => {
+  it('flags hex account ids like Bandwagon fallback handles', () => {
+    expect(looksLikeOpaqueId('695d15c12f0f56fdced0a5e6')).toBe(true);
+    expect(looksLikeOpaqueId('@695d15c12f0f56fdced0a5e6')).toBe(true);
+  });
+
+  it('flags long numeric ids', () => {
+    expect(looksLikeOpaqueId('123456789')).toBe(true);
+  });
+
+  it('does not flag real artist slugs', () => {
+    expect(looksLikeOpaqueId('the-argent-grub')).toBe(false);
+    expect(looksLikeOpaqueId('kidlightbulbs')).toBe(false);
+    expect(looksLikeOpaqueId('ben-g')).toBe(false);
+    // Short hex-looking words are usually words.
+    expect(looksLikeOpaqueId('decade')).toBe(false);
+  });
+});
+
+describe('collectMbSuggestions', () => {
+  // Real MB response shape for the query "argent" (2026-07).
+  const argentArtists = [
+    { name: 'Argent', score: 100 },
+    { name: 'Rod Argent', score: 88 },
+    { name: 'Argent', score: 78 },
+    { name: 'Argent', score: 78 },
+    { name: 'Goodnight Argent', score: 72 },
+  ];
+
+  it('suggests partial-name matches beyond the top hit', () => {
+    expect(collectMbSuggestions(argentArtists, 'argent', 'Argent'))
+      .toEqual(['Rod Argent', 'Goodnight Argent']);
+  });
+
+  it('excludes the query itself and the enriched artist', () => {
+    const suggestions = collectMbSuggestions(argentArtists, 'argent', 'Argent');
+    expect(suggestions).not.toContain('Argent');
+  });
+
+  it('drops low-scored hits', () => {
+    expect(collectMbSuggestions([{ name: 'Argent Something', score: 50 }], 'argent')).toEqual([]);
+  });
+
+  it('drops hits whose name does not contain the query', () => {
+    expect(collectMbSuggestions([{ name: 'The Zombies', score: 90 }], 'argent')).toEqual([]);
+  });
+
+  it('dedupes by normalized name and caps at 4', () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ name: `Argent ${i}`, score: 90 }));
+    expect(collectMbSuggestions(many, 'argent')).toHaveLength(4);
+    expect(collectMbSuggestions([
+      { name: 'Rod Argent', score: 90 },
+      { name: 'ROD ARGENT', score: 85 },
+    ], 'argent')).toEqual(['Rod Argent']);
+  });
+
+  it('returns nothing for an empty query', () => {
+    expect(collectMbSuggestions(argentArtists, '!!!')).toEqual([]);
   });
 });

--- a/apps/web/tests/unit/search-parsers.test.ts
+++ b/apps/web/tests/unit/search-parsers.test.ts
@@ -7,6 +7,7 @@ import {
   parseBandcampReleaseCounts,
   parseBandcampSearchResults,
   parseMirloArtistPage,
+  parseMirloArtistSearch,
   parseBandcampReleaseTitles,
   parseBandwagonSearchResults,
   parseJamcoopDirectory,
@@ -749,5 +750,76 @@ describe('parsePatreonSearchResults', () => {
     }
     const results = parsePatreonSearchResults({ data: campaigns });
     expect(results.length).toBeLessThanOrEqual(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMirloArtistSearch
+// ---------------------------------------------------------------------------
+
+describe('parseMirloArtistSearch', () => {
+  const artist = (name: string, urlSlug: string, extra: Record<string, unknown> = {}) =>
+    ({ name, urlSlug, ...extra });
+
+  it('keeps an artist whose name contains the query (the "argent" case)', () => {
+    const data = { results: [artist('The Argent Grub', 'the-argent-grub')] };
+    const results = parseMirloArtistSearch(data, 'argent');
+    expect(results).toEqual([{
+      sourceId: 'mirlo',
+      name: 'The Argent Grub',
+      type: 'artist',
+      url: 'https://mirlo.space/the-argent-grub',
+    }]);
+  });
+
+  it('keeps an exact match and an artist name contained in the query', () => {
+    const data = { results: [artist('Kid Lightbulbs', 'kidlightbulbs')] };
+    expect(parseMirloArtistSearch(data, 'Kid Lightbulbs')).toHaveLength(1);
+    expect(parseMirloArtistSearch(data, 'Kid Lightbulbs Band')).toHaveLength(1);
+  });
+
+  it("drops Mirlo's loose substring fuzz that doesn't relate to the query", () => {
+    // Mirlo's ?name= filter returns "Other Nothing" for the query "the".
+    const data = { results: [artist('Botfly Mother', 'botfly-mother')] };
+    expect(parseMirloArtistSearch(data, 'argent')).toEqual([]);
+  });
+
+  it('drops disabled and deleted artists', () => {
+    const data = {
+      results: [
+        artist('Argent One', 'argent-one', { enabled: false }),
+        artist('Argent Two', 'argent-two', { deletedAt: '2026-01-01T00:00:00Z' }),
+        artist('Argent Three', 'argent-three'),
+      ],
+    };
+    const results = parseMirloArtistSearch(data, 'argent');
+    expect(results.map(r => r.name)).toEqual(['Argent Three']);
+  });
+
+  it('drops entries with malformed slugs or missing fields', () => {
+    const data = {
+      results: [
+        artist('Argent Bad', 'weird/slug?x=1'),
+        { name: 'Argent NoSlug' },
+        { urlSlug: 'no-name' },
+        artist('Argent Good', 'argent-good'),
+      ],
+    };
+    const results = parseMirloArtistSearch(data, 'argent');
+    expect(results.map(r => r.name)).toEqual(['Argent Good']);
+  });
+
+  it('caps results at 5', () => {
+    const data = {
+      results: Array.from({ length: 8 }, (_, i) => artist(`Argent ${i}`, `argent-${i}`)),
+    };
+    expect(parseMirloArtistSearch(data, 'argent')).toHaveLength(5);
+  });
+
+  it('handles junk input without throwing', () => {
+    expect(parseMirloArtistSearch(null, 'argent')).toEqual([]);
+    expect(parseMirloArtistSearch({}, 'argent')).toEqual([]);
+    expect(parseMirloArtistSearch({ results: 'nope' }, 'argent')).toEqual([]);
+    expect(parseMirloArtistSearch({ results: [artist('A', 'a')] }, '!!!')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

Searching **"argent"** returned only the 1970s band Argent and missed **The Argent Grub** entirely — even though Bandwagon's search returns them for that query and Mirlo's API returns them as its *first* result. The pipeline was doing name *lookups* derived from the query spelling, not searches. This PR is Tier 1 of the search-improvement plan: recover the recall that upstream platforms already offer.

## What changed

**Mirlo: slug guess → real search API.** Production fetched `mirlo.space/<query-with-spaces-removed>` and could only ever find an artist whose slug equals the query. It now calls `api.mirlo.space/v1/artists?name=` (host already covered by the `*.mirlo.space` allowlist), re-filters Mirlo's loose substring matching (`parseMirloArtistSearch`, tested), and caches with the standard never-cache-failures predicate.

**MusicBrainz: limit 1 → 5, partial matches become discovery candidates.** The top hit still owns enrichment behind the existing strict gates. Lower-ranked hits whose name contains the query (score ≥ 70) are returned as `suggestedNames` — e.g. "Goodnight Argent" for "argent".

**New Phase 1.5 — discover a name, verify the presence.** Artist names surfaced by Mirlo, Bandwagon, or MB suggestions are fed through the existing Bandcamp probe. "argent" → Mirlo says "The Argent Grub" → probe verifies `theargentgrub.bandcamp.com` (a subdomain the query spelling could never derive) with the same identity + release checks as always. Capped at 3 candidate probes per search, all cached in Supabase.

**Name-only hits keep their real display names.** Bandwagon/Faircamp/Jam.coop/Patreon/Beatport/EVEN matches now carry the name the platform displayed (`NameOnlyEntry`), and attachment tolerates leading-article variance ("Argent Grub" ↔ "The Argent Grub") but nothing looser — substring matching would cross-attach homonyms ("Argent" vs "Rod Argent").

## Bug fixes in the same paths

- Result names can no longer be opaque account ids: searching "argent" surfaced a result literally named `@695d15c12f0f56fdced0a5e6` (a Bandwagon account id reconstructed from the URL).
- Mastodon/PeerTube instance detection now matches hostnames, not URL substrings. The instance `c.im` matched inside `...%2C.imageEncoding...` in a Wix asset URL, which shipped as the band Argent's "Mastodon profile".

## Compatibility & risk

- Old name-only cache entries (bare URL strings) are coerced on read; they age out with the 30-min TTL.
- Worst-case added latency: one parallel round of ≤3 Bandcamp probes (≤2.5s) on cold searches that discover new names; zero once cached. The latency-focused PR comes next.
- Ampwall remains a stub (their site rejects non-browser clients; needs a product decision or partner ask).

## Verification

- `parseMirloArtistSearch` validated against the live Mirlo API: "argent" → The Argent Grub at `mirlo.space/the-argent-grub`.
- New unit tests for the parser, `collectMbSuggestions`, `namesEqualIgnoringArticles`, `looksLikeOpaqueId`, and the mastodon hostname fix. Full unit (419) + api (110) suites and `npm run build` green.
- `tsc` over the changed api files shows only the three pre-existing errors (api/ isn't build-typechecked; baseline compared via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)