### PR TITLE
Search: instant typeahead from the local artist index (/api/suggest + pg_trgm)

### DIFF
--- a/api/functions/__tests__/search-suggest.test.ts
+++ b/api/functions/__tests__/search-suggest.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockSuggestArtists: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  // Pass-through cache: always calls the fetcher, records the shouldCache verdict.
+  mockCacheGetOrFetch: vi.fn(),
+  lastShouldCache: { value: null as boolean | null },
+}));
+
+vi.mock('../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    suggestArtists: mocks.mockSuggestArtists,
+  };
+});
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+vi.mock('../cache', () => ({
+  cacheGetOrFetch: mocks.mockCacheGetOrFetch,
+}));
+
+import { handler } from '../search-suggest';
+import { rankArtistSuggestions } from '../db';
+
+beforeEach(() => {
+  mocks.mockSuggestArtists.mockReset();
+  mocks.lastShouldCache.value = null;
+  mocks.mockCacheGetOrFetch.mockImplementation(
+    async (_key: string, fetchFn: () => Promise<unknown>, _ttl: number, shouldCache?: (d: unknown) => boolean) => {
+      const data = await fetchFn();
+      mocks.lastShouldCache.value = shouldCache ? shouldCache(data) : true;
+      return { data, cached: false };
+    },
+  );
+});
+
+describe('search-suggest handler', () => {
+  it('returns suggestions for a valid query', async () => {
+    mocks.mockSuggestArtists.mockResolvedValue([
+      { slug: 'the-argent-grub', name: 'The Argent Grub', imageUrl: null },
+    ]);
+    const res = await handler({ queryStringParameters: { query: 'argent' } });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].name).toBe('The Argent Grub');
+  });
+
+  it('returns an empty 200 for sub-2-character queries without hitting the DB', async () => {
+    const res = await handler({ queryStringParameters: { query: 'a' } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).suggestions).toEqual([]);
+    expect(mocks.mockSuggestArtists).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing query', async () => {
+    const res = await handler({ queryStringParameters: {} });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('does not cache a DB failure as "no suggestions"', async () => {
+    mocks.mockSuggestArtists.mockResolvedValue(null);
+    const res = await handler({ queryStringParameters: { query: 'argent' } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).suggestions).toEqual([]);
+    expect(mocks.lastShouldCache.value).toBe(false);
+  });
+
+  it('does cache a genuine empty answer', async () => {
+    mocks.mockSuggestArtists.mockResolvedValue([]);
+    await handler({ queryStringParameters: { query: 'zzzznobody' } });
+    expect(mocks.lastShouldCache.value).toBe(true);
+  });
+});
+
+describe('rankArtistSuggestions', () => {
+  const rows = [
+    { slug: 'goodnight-argent', name: 'Goodnight Argent', image_url: null },
+    { slug: 'argent', name: 'Argent', image_url: 'https://img/argent.jpg' },
+    { slug: 'the-argent-grub', name: 'The Argent Grub', image_url: null },
+    { slug: 'argentheart', name: 'ArgentHeart', image_url: null },
+  ];
+
+  it('puts prefix matches first, shorter names before longer', () => {
+    const ranked = rankArtistSuggestions(rows, 'argent', 8);
+    expect(ranked.map(r => r.name)).toEqual([
+      'Argent', 'ArgentHeart', 'The Argent Grub', 'Goodnight Argent',
+    ]);
+  });
+
+  it('respects the limit and dedupes by slug', () => {
+    const dupes = [...rows, { slug: 'argent', name: 'Argent', image_url: null }];
+    const ranked = rankArtistSuggestions(dupes, 'argent', 2);
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0]).toEqual({ slug: 'argent', name: 'Argent', imageUrl: 'https://img/argent.jpg' });
+  });
+
+  it('drops rows with missing fields', () => {
+    const ranked = rankArtistSuggestions(
+      [{ slug: '', name: 'X', image_url: null }, { slug: 'ok', name: 'Argent', image_url: null }],
+      'argent',
+      8,
+    );
+    expect(ranked.map(r => r.slug)).toEqual(['ok']);
+  });
+});

--- a/api/functions/__tests__/search-suggest.test.ts
+++ b/api/functions/__tests__/search-suggest.test.ts
@@ -4,9 +4,10 @@ const mocks = vi.hoisted(() => ({
   mockSuggestArtists: vi.fn(),
   mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
   mockGetClientIp: vi.fn(() => '127.0.0.1'),
-  // Pass-through cache: always calls the fetcher, records the shouldCache verdict.
+  // Pass-through cache: always calls the fetcher, records key + shouldCache verdict.
   mockCacheGetOrFetch: vi.fn(),
   lastShouldCache: { value: null as boolean | null },
+  lastCacheKey: { value: null as string | null },
 }));
 
 vi.mock('../db', async (importOriginal) => {
@@ -20,19 +21,26 @@ vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));
-vi.mock('../cache', () => ({
-  cacheGetOrFetch: mocks.mockCacheGetOrFetch,
-}));
+vi.mock('../cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cache')>();
+  return {
+    ...actual, // keep the real artistCacheKey — the collision tests exercise it
+    cacheGetOrFetch: mocks.mockCacheGetOrFetch,
+  };
+});
 
 import { handler } from '../search-suggest';
 import { rankArtistSuggestions } from '../db';
 
 beforeEach(() => {
   mocks.mockSuggestArtists.mockReset();
+  mocks.mockCheckRateLimit.mockClear();
   mocks.lastShouldCache.value = null;
+  mocks.lastCacheKey.value = null;
   mocks.mockCacheGetOrFetch.mockImplementation(
-    async (_key: string, fetchFn: () => Promise<unknown>, _ttl: number, shouldCache?: (d: unknown) => boolean) => {
+    async (key: string, fetchFn: () => Promise<unknown>, _ttl: number, shouldCache?: (d: unknown) => boolean) => {
       const data = await fetchFn();
+      mocks.lastCacheKey.value = key;
       mocks.lastShouldCache.value = shouldCache ? shouldCache(data) : true;
       return { data, cached: false };
     },
@@ -75,6 +83,34 @@ describe('search-suggest handler', () => {
     mocks.mockSuggestArtists.mockResolvedValue([]);
     await handler({ queryStringParameters: { query: 'zzzznobody' } });
     expect(mocks.lastShouldCache.value).toBe(true);
+  });
+
+  it('keys the cache on the same term the DB queries with', async () => {
+    // Regression: the key used normalizeForComparison (strips ALL punctuation)
+    // while the DB matched with hyphens preserved — "sufjan-stevens" and
+    // "sufjan stevens" shared a key but produced different ILIKE patterns, so
+    // whichever ran first answered for both.
+    mocks.mockSuggestArtists.mockResolvedValue([]);
+    await handler({ queryStringParameters: { query: 'sufjan-stevens' } });
+    const hyphenKey = mocks.lastCacheKey.value;
+    expect(mocks.mockSuggestArtists).toHaveBeenLastCalledWith('sufjan-stevens');
+
+    await handler({ queryStringParameters: { query: 'sufjan stevens' } });
+    expect(mocks.lastCacheKey.value).not.toBe(hyphenKey);
+    expect(mocks.mockSuggestArtists).toHaveBeenLastCalledWith('sufjan stevens');
+  });
+
+  it('uses the lenient rate-limit tier, not the shared standard bucket', async () => {
+    mocks.mockSuggestArtists.mockResolvedValue([]);
+    await handler({ queryStringParameters: { query: 'argent' } });
+    expect(mocks.mockCheckRateLimit).toHaveBeenCalledWith('127.0.0.1', 'lenient', expect.anything());
+  });
+
+  it('sends the shared public CORS headers', async () => {
+    mocks.mockSuggestArtists.mockResolvedValue([]);
+    const res = await handler({ queryStringParameters: { query: 'argent' } });
+    expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*');
   });
 });
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -453,6 +453,78 @@ export async function getArtistBySlug(slug: string): Promise<ArtistResult | null
  * Persist artist search results to the database.
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */
+// --- Typeahead suggestions ---
+
+export interface ArtistSuggestion {
+  slug: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+/**
+ * Rank raw suggestion rows for a typeahead term: prefix matches first, then
+ * shorter names, then alphabetical. Pure and exported for tests.
+ */
+export function rankArtistSuggestions(
+  rows: { slug: string; name: string; image_url: string | null }[],
+  term: string,
+  limit: number,
+): ArtistSuggestion[] {
+  const termLower = term.toLowerCase();
+  const seen = new Set<string>();
+  return rows
+    .filter(r => {
+      if (!r.slug || !r.name || seen.has(r.slug)) return false;
+      seen.add(r.slug);
+      return true;
+    })
+    .sort((a, b) => {
+      const aPrefix = a.name.toLowerCase().startsWith(termLower) ? 0 : 1;
+      const bPrefix = b.name.toLowerCase().startsWith(termLower) ? 0 : 1;
+      if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+      if (a.name.length !== b.name.length) return a.name.length - b.name.length;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, limit)
+    .map(r => ({ slug: r.slug, name: r.name, imageUrl: r.image_url }));
+}
+
+/**
+ * Name-substring lookup over artists Unstream has already resolved, for
+ * search-as-you-type. Only verified/claimed rows are suggested — the artists
+ * table accumulates whatever people search, and 'unverified' is where the
+ * junk lives.
+ *
+ * Backed by the pg_trgm GIN index on artists.name (migration
+ * 20260729071000_artist-name-trgm.sql); without it this ILIKE is a seq scan.
+ *
+ * Returns null when the DB could not be asked (no client, query error) —
+ * callers must not cache that as "no suggestions".
+ */
+export async function suggestArtists(term: string, limit = 8): Promise<ArtistSuggestion[] | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  // Strip ILIKE wildcards so user input can't change the match shape
+  // (same reasoning as the slug guard in getArtistBySlug).
+  const cleaned = term.replace(/[%_,()]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (cleaned.length < 2) return [];
+
+  const { data, error } = await client
+    .from('artists')
+    .select('slug, name, image_url')
+    .ilike('name', `%${cleaned}%`)
+    .or('match_confidence.eq.verified,match_confidence.eq.claimed,source.eq.claimed')
+    .limit(40);
+
+  if (error) {
+    console.error('[DB] suggestArtists error:', error);
+    return null;
+  }
+
+  return rankArtistSuggestions(data ?? [], cleaned, limit);
+}
+
 export async function persistSearchResults(results: ArtistResult[]): Promise<void> {
   const client = getClient();
   if (!client) return;

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -492,6 +492,18 @@ export function rankArtistSuggestions(
 }
 
 /**
+ * The exact term suggestArtists matches with: ILIKE wildcards stripped so user
+ * input can't change the match shape (same reasoning as the slug guard in
+ * getArtistBySlug). Exported so callers key caches on THIS string — a cache
+ * key normalized any other way collides across inputs that query differently
+ * ("sufjan-stevens" vs "sufjan stevens"), serving one spelling's results to
+ * the other.
+ */
+export function cleanSuggestTerm(term: string): string {
+  return term.replace(/[%_,()]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Name-substring lookup over artists Unstream has already resolved, for
  * search-as-you-type. Only verified/claimed rows are suggested — the artists
  * table accumulates whatever people search, and 'unverified' is where the
@@ -507,9 +519,7 @@ export async function suggestArtists(term: string, limit = 8): Promise<ArtistSug
   const client = getClient();
   if (!client) return null;
 
-  // Strip ILIKE wildcards so user input can't change the match shape
-  // (same reasoning as the slug guard in getArtistBySlug).
-  const cleaned = term.replace(/[%_,()]/g, ' ').replace(/\s+/g, ' ').trim();
+  const cleaned = cleanSuggestTerm(term);
   if (cleaned.length < 2) return [];
 
   const { data, error } = await client

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -30,10 +30,12 @@ function getRedis(): Redis | null {
 // Anonymous / web app tiers
 let standardLimiter: Ratelimit | null = null;   // 30 req/min for general endpoints
 let strictLimiter: Ratelimit | null = null;      // 10 req/min for expensive endpoints
+let lenientLimiter: Ratelimit | null = null;     // 120 req/min for cheap high-frequency endpoints (typeahead)
 
 // Per-day quota limiters (new)
 let standardDailyLimiter: Ratelimit | null = null;  // 1000 req/day for general
 let strictDailyLimiter: Ratelimit | null = null;    // 500 req/day for expensive
+let lenientDailyLimiter: Ratelimit | null = null;   // 5000 req/day for cheap high-frequency
 
 // API key tiers
 let freeLimiter: Ratelimit | null = null;        // 30 req/min
@@ -66,6 +68,33 @@ function getStrictLimiter(): Ratelimit | null {
     prefix: 'rl:strict',
   });
   return strictLimiter;
+}
+
+// High-frequency, low-cost endpoints (typeahead suggestions): fires on every
+// debounced typing pause, so it needs its own bucket — sharing 'standard'
+// would let an actively-searching user 429 themselves out of account actions.
+function getLenientLimiter(): Ratelimit | null {
+  if (lenientLimiter) return lenientLimiter;
+  const r = getRedis();
+  if (!r) return null;
+  lenientLimiter = new Ratelimit({
+    redis: r,
+    limiter: Ratelimit.slidingWindow(120, '1 m'),
+    prefix: 'rl:lenient',
+  });
+  return lenientLimiter;
+}
+
+function getLenientDailyLimiter(): Ratelimit | null {
+  if (lenientDailyLimiter) return lenientDailyLimiter;
+  const r = getRedis();
+  if (!r) return null;
+  lenientDailyLimiter = new Ratelimit({
+    redis: r,
+    limiter: Ratelimit.slidingWindow(5000, '24 h'),
+    prefix: 'rl:daily:lenient',
+  });
+  return lenientDailyLimiter;
 }
 
 function getStandardDailyLimiter(): Ratelimit | null {
@@ -156,7 +185,7 @@ function getProDailyLimiter(): Ratelimit | null {
 // Original rate limit check (for web app / anonymous requests)
 // ---------------------------------------------------------------------------
 
-export type RateLimitTier = 'standard' | 'strict';
+export type RateLimitTier = 'standard' | 'strict' | 'lenient';
 
 interface RateLimitResult {
   limited: boolean;
@@ -179,8 +208,12 @@ export async function checkRateLimit(
   tier: RateLimitTier,
   corsHeaders: Record<string, string>
 ): Promise<RateLimitResult> {
-  const limiter = tier === 'strict' ? getStrictLimiter() : getStandardLimiter();
-  const dailyLimiter = tier === 'strict' ? getStrictDailyLimiter() : getStandardDailyLimiter();
+  const limiter = tier === 'strict' ? getStrictLimiter()
+    : tier === 'lenient' ? getLenientLimiter()
+    : getStandardLimiter();
+  const dailyLimiter = tier === 'strict' ? getStrictDailyLimiter()
+    : tier === 'lenient' ? getLenientDailyLimiter()
+    : getStandardDailyLimiter();
 
   // If Redis isn't configured, allow the request (fail open)
   if (!limiter) return { limited: false };

--- a/api/functions/search-suggest.ts
+++ b/api/functions/search-suggest.ts
@@ -1,0 +1,56 @@
+// GET /api/suggest?query=<partial name>
+//
+// Typeahead suggestions for the search bar. Reads only the local artists table
+// (every artist Unstream has ever resolved), so it answers in one DB read —
+// no platform fan-out, no external requests. The full search still happens on
+// submit; this only helps people find the right name faster.
+
+import { cacheGetOrFetch } from './cache';
+import { suggestArtists, type ArtistSuggestion } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { validateQuery } from './middleware';
+import { normalizeForComparison } from './search-utils';
+
+const SUGGEST_CACHE_TTL = 5 * 60; // seconds; the artists table changes slowly
+
+export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string> }) {
+  const corsHeaders = { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' };
+
+  const ip = getClientIp(event.headers || {});
+  const rl = await checkRateLimit(ip, 'standard', corsHeaders);
+  if (rl.limited) return rl.response;
+
+  const queryResult = validateQuery(event.queryStringParameters?.query);
+  if ('error' in queryResult) {
+    return {
+      statusCode: 400,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: queryResult.error }),
+    };
+  }
+  const query = queryResult.query;
+
+  // Below two characters a suggestion list is noise; an empty 200 (not a 400)
+  // keeps the client logic trivial while someone is mid-keystroke.
+  let suggestions: ArtistSuggestion[] = [];
+  if (query.trim().length >= 2) {
+    const cacheKey = `suggest:${normalizeForComparison(query)}`;
+    const { data } = await cacheGetOrFetch<ArtistSuggestion[] | null>(
+      cacheKey,
+      () => suggestArtists(query),
+      SUGGEST_CACHE_TTL,
+      // null means the DB couldn't be asked — a failure, not "no suggestions".
+      (data) => data !== null,
+    );
+    suggestions = data ?? [];
+  }
+
+  return {
+    statusCode: 200,
+    headers: {
+      ...corsHeaders,
+      'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate',
+    },
+    body: JSON.stringify({ query, suggestions }),
+  };
+}

--- a/api/functions/search-suggest.ts
+++ b/api/functions/search-suggest.ts
@@ -5,19 +5,21 @@
 // no platform fan-out, no external requests. The full search still happens on
 // submit; this only helps people find the right name faster.
 
-import { cacheGetOrFetch } from './cache';
-import { suggestArtists, type ArtistSuggestion } from './db';
+import { cacheGetOrFetch, artistCacheKey } from './cache';
+import { suggestArtists, cleanSuggestTerm, type ArtistSuggestion } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
-import { validateQuery } from './middleware';
-import { normalizeForComparison } from './search-utils';
+import { validateQuery, buildPublicCorsHeaders } from './middleware';
 
 const SUGGEST_CACHE_TTL = 5 * 60; // seconds; the artists table changes slowly
 
 export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string> }) {
-  const corsHeaders = { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' };
+  const corsHeaders = buildPublicCorsHeaders();
 
+  // 'lenient' tier: the debounced typeahead fires on every typing pause, so it
+  // must not share the 30/min 'standard' bucket with account/settings actions —
+  // an actively-searching user would 429 themselves out of unrelated endpoints.
   const ip = getClientIp(event.headers || {});
-  const rl = await checkRateLimit(ip, 'standard', corsHeaders);
+  const rl = await checkRateLimit(ip, 'lenient', corsHeaders);
   if (rl.limited) return rl.response;
 
   const queryResult = validateQuery(event.queryStringParameters?.query);
@@ -30,14 +32,20 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   }
   const query = queryResult.query;
 
+  // The cache key and the DB query must be derived from the SAME string:
+  // keying on a more aggressively normalized form collides inputs that produce
+  // different ILIKE patterns ("sufjan-stevens" vs "sufjan stevens"), serving
+  // whichever variant was queried first to all the others for the TTL.
+  const cleaned = cleanSuggestTerm(query);
+
   // Below two characters a suggestion list is noise; an empty 200 (not a 400)
   // keeps the client logic trivial while someone is mid-keystroke.
   let suggestions: ArtistSuggestion[] = [];
-  if (query.trim().length >= 2) {
-    const cacheKey = `suggest:${normalizeForComparison(query)}`;
+  if (cleaned.length >= 2) {
+    const cacheKey = artistCacheKey('suggest', cleaned);
     const { data } = await cacheGetOrFetch<ArtistSuggestion[] | null>(
       cacheKey,
-      () => suggestArtists(query),
+      () => suggestArtists(cleaned),
       SUGGEST_CACHE_TTL,
       // null means the DB couldn't be asked — a failure, not "no suggestions".
       (data) => data !== null,

--- a/apps/web/server/api.ts
+++ b/apps/web/server/api.ts
@@ -39,6 +39,15 @@ export async function handleApiRequest(req: IncomingMessage, res: ServerResponse
     return true;
   }
 
+  if (url.pathname === '/api/suggest') {
+    // Dev-only stub. Production suggestions come from the Supabase artists
+    // table (api/functions/search-suggest.ts), which the dev server doesn't
+    // talk to — an empty list keeps the typeahead silently inert in dev.
+    const query = url.searchParams.get('query') || '';
+    sendJson(res, 200, { query, suggestions: [] });
+    return true;
+  }
+
   if (url.pathname === '/api/search/musicbrainz') {
     if (req.method !== 'GET') {
       sendJson(res, 405, { error: 'Method not allowed' });

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -105,6 +105,10 @@ export function SearchBar({ onSearch, isLoading, initialQuery, onReset }: Search
   }, [showSuggestions, suggestions, highlightIndex, pickSuggestion, closeSuggestions]);
 
   const handleReset = useCallback(() => {
+    // Cancel any pending debounce/fetch — a stale response landing after the
+    // reset would reopen the dropdown against an empty input.
+    clearTimeout(debounceRef.current);
+    abortRef.current?.abort();
     setQuery('');
     setSuggestions([]);
     closeSuggestions();

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -7,27 +7,116 @@ interface SearchBarProps {
   onReset?: () => void;
 }
 
+interface Suggestion {
+  slug: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+const SUGGEST_DEBOUNCE_MS = 250;
+const SUGGEST_MIN_CHARS = 2;
+
 export function SearchBar({ onSearch, isLoading, initialQuery, onReset }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery || '');
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const abortRef = useRef<AbortController | undefined>(undefined);
 
   // Update query when initialQuery changes (for URL resolution or reset)
   useEffect(() => {
     setQuery(initialQuery || '');
   }, [initialQuery]);
 
+  const closeSuggestions = useCallback(() => {
+    setShowSuggestions(false);
+    setHighlightIndex(-1);
+  }, []);
+
+  const submitSearch = useCallback((term: string) => {
+    closeSuggestions();
+    clearTimeout(debounceRef.current);
+    abortRef.current?.abort();
+    if (term.trim()) {
+      onSearch(term.trim());
+    }
+  }, [onSearch, closeSuggestions]);
+
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
-    if (query.trim()) {
-      onSearch(query.trim());
+    submitSearch(query);
+  }, [query, submitSearch]);
+
+  const handleChange = useCallback((value: string) => {
+    setQuery(value);
+    setHighlightIndex(-1);
+    clearTimeout(debounceRef.current);
+
+    const term = value.trim();
+    if (term.length < SUGGEST_MIN_CHARS) {
+      abortRef.current?.abort();
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
     }
-  }, [query, onSearch]);
+
+    debounceRef.current = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      try {
+        const response = await fetch(`/api/suggest?query=${encodeURIComponent(term)}`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) return;
+        const data = await response.json() as { suggestions?: Suggestion[] };
+        const next = data.suggestions || [];
+        setSuggestions(next);
+        setShowSuggestions(next.length > 0);
+      } catch {
+        // Aborted or network hiccup — typeahead is best-effort, the real
+        // search happens on submit.
+      }
+    }, SUGGEST_DEBOUNCE_MS);
+  }, []);
+
+  const pickSuggestion = useCallback((suggestion: Suggestion) => {
+    setQuery(suggestion.name);
+    submitSearch(suggestion.name);
+  }, [submitSearch]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!showSuggestions || suggestions.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightIndex(i => (i + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightIndex(i => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (e.key === 'Enter' && highlightIndex >= 0) {
+      e.preventDefault();
+      pickSuggestion(suggestions[highlightIndex]);
+    } else if (e.key === 'Escape') {
+      closeSuggestions();
+    }
+  }, [showSuggestions, suggestions, highlightIndex, pickSuggestion, closeSuggestions]);
 
   const handleReset = useCallback(() => {
     setQuery('');
+    setSuggestions([]);
+    closeSuggestions();
     inputRef.current?.focus();
     onReset?.();
-  }, [onReset]);
+  }, [onReset, closeSuggestions]);
+
+  // Cancel any in-flight suggestion work on unmount
+  useEffect(() => () => {
+    clearTimeout(debounceRef.current);
+    abortRef.current?.abort();
+  }, []);
 
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-2xl mx-auto">
@@ -37,10 +126,18 @@ export function SearchBar({ onSearch, isLoading, initialQuery, onReset }: Search
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => handleChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onFocus={() => { if (suggestions.length > 0 && query.trim().length >= SUGGEST_MIN_CHARS) setShowSuggestions(true); }}
+            onBlur={closeSuggestions}
             placeholder="Search for artists..."
             className="search-input w-full pr-16"
             disabled={isLoading}
+            role="combobox"
+            aria-expanded={showSuggestions}
+            aria-controls="search-suggestions"
+            aria-activedescendant={highlightIndex >= 0 ? `search-suggestion-${highlightIndex}` : undefined}
+            aria-autocomplete="list"
           />
           {onReset && (
             <button
@@ -50,6 +147,28 @@ export function SearchBar({ onSearch, isLoading, initialQuery, onReset }: Search
             >
               Reset
             </button>
+          )}
+          {showSuggestions && (
+            <ul
+              id="search-suggestions"
+              role="listbox"
+              className="absolute z-20 mt-1 w-full rounded border border-border bg-bg-primary shadow-lg overflow-hidden"
+            >
+              {suggestions.map((suggestion, index) => (
+                <li
+                  key={suggestion.slug}
+                  id={`search-suggestion-${index}`}
+                  role="option"
+                  aria-selected={index === highlightIndex}
+                  // onMouseDown so the pick lands before the input's onBlur closes the list
+                  onMouseDown={(e) => { e.preventDefault(); pickSuggestion(suggestion); }}
+                  onMouseEnter={() => setHighlightIndex(index)}
+                  className={`px-4 py-2 cursor-pointer text-left ${index === highlightIndex ? 'bg-bg-secondary' : ''}`}
+                >
+                  {suggestion.name}
+                </li>
+              ))}
+            </ul>
           )}
         </div>
         <button

--- a/apps/web/tests/unit/SearchBar.test.tsx
+++ b/apps/web/tests/unit/SearchBar.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { SearchBar } from '../../src/components/SearchBar';
+
+const SUGGESTIONS = {
+  query: 'argent',
+  suggestions: [
+    { slug: 'argent', name: 'Argent', imageUrl: null },
+    { slug: 'the-argent-grub', name: 'The Argent Grub', imageUrl: null },
+  ],
+};
+
+describe('SearchBar typeahead', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => SUGGESTIONS,
+    })));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  async function typeAndSettle(value: string) {
+    fireEvent.change(screen.getByRole('combobox'), { target: { value } });
+    // Run the debounce timer and let the fetch promise resolve, inside act()
+    // so the resulting state updates are flushed.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+  }
+
+  it('shows suggestions after the debounce', async () => {
+    render(<SearchBar onSearch={vi.fn()} isLoading={false} />);
+    await typeAndSettle('argent');
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+    expect(fetch).toHaveBeenCalledWith('/api/suggest?query=argent', expect.anything());
+  });
+
+  it('does not fetch for queries under two characters', async () => {
+    render(<SearchBar onSearch={vi.fn()} isLoading={false} />);
+    await typeAndSettle('a');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('picks a suggestion with arrow keys + Enter and searches it', async () => {
+    const onSearch = vi.fn();
+    render(<SearchBar onSearch={onSearch} isLoading={false} />);
+    await typeAndSettle('argent');
+
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSearch).toHaveBeenCalledWith('The Argent Grub');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('picks a suggestion on mouse down', async () => {
+    const onSearch = vi.fn();
+    render(<SearchBar onSearch={onSearch} isLoading={false} />);
+    await typeAndSettle('argent');
+
+    fireEvent.mouseDown(screen.getByText('Argent'));
+    expect(onSearch).toHaveBeenCalledWith('Argent');
+  });
+
+  it('closes the list on Escape and submits the raw query on Enter', async () => {
+    const onSearch = vi.fn();
+    render(<SearchBar onSearch={onSearch} isLoading={false} />);
+    await typeAndSettle('argent');
+
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+
+    fireEvent.submit(input.closest('form')!);
+    expect(onSearch).toHaveBeenCalledWith('argent');
+  });
+});

--- a/apps/web/tests/unit/SearchBar.test.tsx
+++ b/apps/web/tests/unit/SearchBar.test.tsx
@@ -73,6 +73,21 @@ describe('SearchBar typeahead', () => {
     expect(onSearch).toHaveBeenCalledWith('Argent');
   });
 
+  it('reset cancels a pending debounce so a stale fetch cannot reopen the dropdown', async () => {
+    // Regression: handleReset cleared the input but left the debounce timer and
+    // in-flight fetch alive — the response landed ~250ms later and reopened the
+    // suggestion dropdown against an empty input box.
+    render(<SearchBar onSearch={vi.fn()} isLoading={false} onReset={vi.fn()} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'argent' } });
+    // Reset before the debounce fires.
+    fireEvent.click(screen.getByText('Reset'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
   it('closes the list on Escape and submits the raw query on Enter', async () => {
     const onSearch = vi.fn();
     render(<SearchBar onSearch={onSearch} isLoading={false} />);

--- a/netlify.toml
+++ b/netlify.toml
@@ -44,6 +44,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/suggest"
+  to = "/.netlify/functions/search-suggest"
+  status = 200
+
+[[redirects]]
   from = "/api/search/musicbrainz"
   to = "/.netlify/functions/search-musicbrainz"
   status = 200

--- a/supabase/migrations/20260729071000_artist-name-trgm.sql
+++ b/supabase/migrations/20260729071000_artist-name-trgm.sql
@@ -1,0 +1,15 @@
+-- Migration: trigram index on artists.name for the /api/suggest typeahead endpoint.
+--
+-- Before this, the only name access paths were slug equality lookups
+-- (idx_artists_slug); a substring search like ILIKE '%argen%' would be a
+-- sequential scan over the whole table. pg_trgm + a GIN index turns that into
+-- an index scan, which is what makes search-as-you-type viable.
+--
+-- No RLS change: the suggest endpoint reads through the service-role client
+-- like all other search-path DB access, and this migration adds no tables or
+-- columns.
+
+create extension if not exists pg_trgm;
+
+create index if not exists idx_artists_name_trgm
+  on artists using gin (name gin_trgm_ops);


### PR DESCRIPTION
## Why

Every search today is submit-only and pays for the full 10-platform fan-out (10–20s cold). But Unstream already has a local index it never uses for search: the Supabase `artists` table accumulates every artist ever resolved. This PR makes known artists findable in milliseconds while typing — the incremental first step toward search backed by our own index.

## What changed

- **Migration** `20260729071000_artist-name-trgm.sql`: `pg_trgm` + GIN trigram index on `artists.name`. Applied automatically by the supabase-migrate workflow on merge. (Heads-up: `npm run migrate:dry-run` is broken independently of this PR — the script passes a `--project-ref` flag the current Supabase CLI doesn't accept.)
- **`/api/suggest`** (new `search-suggest.ts`): one indexed DB read, rate-limited, Upstash-cached 5 min. Only verified/claimed artists are suggested — `unverified` rows are where junk from arbitrary searches lives. A DB failure returns empty but is *not* cached ("never cache uncertainty").
- **SearchBar typeahead**: 250 ms debounce, accessible combobox pattern (arrow keys / Enter / Escape / mouse), aborts stale requests, degrades to nothing when the endpoint has no answers. Selecting a suggestion runs the normal search for that exact name.
- Dev server gets an inert stub (dev doesn't talk to Supabase).

## Verification

- Live in the running app: typing "argent" produced exactly one debounced request; the dropdown rendered; picking **The Argent Grub** navigated to `?q=The+Argent+Grub` and ran the search.
- jsdom tests for keyboard + mouse selection and the min-length gate; endpoint tests for validation, ranking, and the failure-vs-empty caching distinction. Full build green.
- The suggest quality improves as PR #338 lands and verified artists accumulate — the index is populated by real searches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)