### PR TITLE
Fix nested <a> hydration warning in SourceBadge AI-policy badge

### DIFF
--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -82,33 +82,32 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
           </svg>
         )}
-        {/* Show AI policy indicators on marketplace and decentralized badges */}
+        {/* Show AI policy indicators on marketplace and decentralized badges.
+            Rendered as a span (not <a>) because an <a> can't be nested inside
+            the platform link — clicking opens the policy page via window.open. */}
         {hasAiPolicy && (
-          source.aiPolicy === 'formal' ? (
-            <a
-              href={source.aiPolicyUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ai-policy-badge text-[10px] font-medium px-1 py-0.5 rounded inline-flex items-center gap-0.5 no-underline"
-              style={{ backgroundColor: '#22c55e30' }}
-              onClick={(e) => { e.stopPropagation(); analytics.trackPlatformClick(`${label} AI policy`); }}
-            >
-              <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
-              AI policy
-            </a>
-          ) : (
-            <a
-              href={source.aiPolicyUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ai-policy-badge text-[10px] font-medium px-1 py-0.5 rounded inline-flex items-center gap-0.5 no-underline"
-              style={{ backgroundColor: '#f59e0b30' }}
-              onClick={(e) => { e.stopPropagation(); analytics.trackPlatformClick(`${label} AI policy`); }}
-            >
-              <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
-              AI discouraged
-            </a>
-          )
+          <span
+            role="link"
+            tabIndex={0}
+            className="ai-policy-badge text-[10px] font-medium px-1 py-0.5 rounded inline-flex items-center gap-0.5 cursor-pointer"
+            style={{ backgroundColor: source.aiPolicy === 'formal' ? '#22c55e30' : '#f59e0b30' }}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              analytics.trackPlatformClick(`${label} AI policy`);
+              if (source.aiPolicyUrl) window.open(source.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                if (source.aiPolicyUrl) window.open(source.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+              }
+            }}
+          >
+            <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5z"/></svg>
+            {source.aiPolicy === 'formal' ? 'AI policy' : 'AI discouraged'}
+          </span>
         )}
       </span>
     </a>

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -45,6 +45,11 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
   // Only show AI policy badges on marketplaces and decentralized platforms
   const hasAiPolicy = (source.category === 'marketplace' || source.category === 'decentralized') && (source.aiPolicy === 'formal' || source.aiPolicy === 'discouraged');
 
+  const openAiPolicy = () => {
+    analytics.trackPlatformClick(`${label} AI policy`);
+    if (source.aiPolicyUrl) window.open(source.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+  };
+
   // Theme-aware colors: dark/light/medium brand colors all get readable text + bg
   const { textColor, bgColor } = badgeColors(source.color);
 
@@ -84,7 +89,9 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
         )}
         {/* Show AI policy indicators on marketplace and decentralized badges.
             Rendered as a span (not <a>) because an <a> can't be nested inside
-            the platform link — clicking opens the policy page via window.open. */}
+            the platform link — activating it opens the policy page via window.open.
+            Click and keyboard (Enter/Space) both funnel through openAiPolicy so
+            analytics tracking stays consistent across input methods. */}
         {hasAiPolicy && (
           <span
             role="link"
@@ -94,14 +101,13 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              analytics.trackPlatformClick(`${label} AI policy`);
-              if (source.aiPolicyUrl) window.open(source.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+              openAiPolicy();
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
-                if (source.aiPolicyUrl) window.open(source.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+                openAiPolicy();
               }
             }}
           >

--- a/apps/web/tests/unit/SourceBadge.test.tsx
+++ b/apps/web/tests/unit/SourceBadge.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SourceBadge } from 'src/components/SourceBadge';
+import type { Source } from 'src/types';
+
+vi.mock('src/services/analytics', () => ({
+  analytics: { trackPlatformClick: vi.fn() },
+}));
+
+vi.mock('src/components/PlatformIcon', () => ({
+  PlatformIcon: () => <span data-testid="platform-icon" />,
+}));
+
+import { analytics } from 'src/services/analytics';
+
+const bandcampSource: Source = {
+  id: 'bandcamp',
+  name: 'Bandcamp',
+  color: '#1da0c3',
+  icon: '🎵',
+  category: 'marketplace',
+  artistPayoutPercent: '80-85%',
+  aiPolicy: 'formal',
+  aiPolicyUrl: 'https://blog.bandcamp.com/2026/01/13/keeping-bandcamp-human/',
+} as Source;
+
+describe('SourceBadge AI policy badge', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('does not nest an <a> inside the platform link', () => {
+    render(<SourceBadge source={bandcampSource} url="https://bandcamp.com/some-artist" />);
+    const outerLink = screen.getByText('Bandcamp').closest('a');
+    expect(outerLink?.querySelector('a')).toBeNull();
+  });
+
+  it('tracks analytics and opens the policy URL on click, without triggering the outer link', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<SourceBadge source={bandcampSource} url="https://bandcamp.com/some-artist" />);
+
+    const badge = screen.getByText('AI policy');
+    fireEvent.click(badge);
+
+    expect(analytics.trackPlatformClick).toHaveBeenCalledWith('Bandcamp AI policy');
+    expect(openSpy).toHaveBeenCalledWith(bandcampSource.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+
+    openSpy.mockRestore();
+  });
+
+  it('tracks analytics and opens the policy URL on keyboard activation (Enter)', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<SourceBadge source={bandcampSource} url="https://bandcamp.com/some-artist" />);
+
+    const badge = screen.getByText('AI policy');
+    fireEvent.keyDown(badge, { key: 'Enter' });
+
+    expect(analytics.trackPlatformClick).toHaveBeenCalledWith('Bandcamp AI policy');
+    expect(openSpy).toHaveBeenCalledWith(bandcampSource.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+
+    openSpy.mockRestore();
+  });
+
+  it('tracks analytics and opens the policy URL on keyboard activation (Space)', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<SourceBadge source={bandcampSource} url="https://bandcamp.com/some-artist" />);
+
+    const badge = screen.getByText('AI policy');
+    fireEvent.keyDown(badge, { key: ' ' });
+
+    expect(analytics.trackPlatformClick).toHaveBeenCalledWith('Bandcamp AI policy');
+    expect(openSpy).toHaveBeenCalledWith(bandcampSource.aiPolicyUrl, '_blank', 'noopener,noreferrer');
+
+    openSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What changed

The AI-policy badge ("AI policy" / "AI discouraged") in `SourceBadge` was an `<a>` rendered inside the platform link's outer `<a>`. Nested anchors are invalid HTML, and React 19 logged **"In HTML, `<a>` cannot be a descendant of `<a>`. This will cause a hydration error."** on every search results render.

The badge is now a `<span role="link" tabIndex={0}>` in the exact same position, so the visual layout is unchanged:

- Clicking it calls `preventDefault()`/`stopPropagation()` so the outer platform link doesn't fire, tracks the same analytics event, and opens the policy page via `window.open(..., '_blank', 'noopener,noreferrer')`.
- Enter/Space keyboard handling added, since a span isn't natively activatable like an anchor.
- The two near-identical formal/discouraged branches were collapsed into one element.

## Why

Invalid nesting means the browser can reparent the DOM unpredictably, and React 19 flags it as a future hydration hazard. It also spammed the console on every search.

## Verification (dev server, searched "Big Thief" — renders both badge variants)

- Console shows zero errors after results render; the nesting warning is gone.
- `document.querySelectorAll('a a')` returns 0.
- Click test with a stubbed `window.open`: badge opened the Bandcamp AI-policy blog post; the outer `bigthief.bandcamp.com` link did not fire.
- Computed styles confirm the layout held (same 10px font, green/amber tinted backgrounds, no underline, pointer cursor).
- 390/390 unit tests pass; lint matches the pre-existing baseline (no new issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)