### PR TITLE
Admin: remove individual platform links from search results

### DIFF
--- a/api/functions/__tests__/link-suppressions.test.ts
+++ b/api/functions/__tests__/link-suppressions.test.ts
@@ -6,6 +6,7 @@ import {
   applyLinkSuppressions,
   isUrlSuppressed,
   normalizeUrlForMatch,
+  urlMatchPrefilter,
   filterAndSort,
   type LinkSuppression,
 } from '../search-utils';
@@ -29,9 +30,43 @@ describe('normalizeUrlForMatch', () => {
       .toBe(normalizeUrlForMatch('https://taylorswift.bandcamp.com'));
   });
 
+  // The same page arrives as http from older stored rows and some MusicBrainz
+  // relations, and www-prefixed from official-site scrapes. A suppression saved
+  // from one spelling has to match the others.
+  it('ignores the scheme', () => {
+    expect(normalizeUrlForMatch('http://taylorswift.bandcamp.com'))
+      .toBe(normalizeUrlForMatch('https://taylorswift.bandcamp.com'));
+  });
+
+  it('ignores a leading www.', () => {
+    expect(normalizeUrlForMatch('https://www.discogs.com/artist/1024240'))
+      .toBe(normalizeUrlForMatch('https://discogs.com/artist/1024240'));
+  });
+
   it('does not conflate different paths', () => {
     expect(normalizeUrlForMatch('https://x.bandcamp.com/music'))
       .not.toBe(normalizeUrlForMatch('https://x.bandcamp.com'));
+  });
+
+  it('keeps the query string, which is what distinguishes search links', () => {
+    expect(normalizeUrlForMatch('https://duckduckgo.com/?q=site:ko-fi.com+a'))
+      .not.toBe(normalizeUrlForMatch('https://duckduckgo.com/?q=site:ko-fi.com+b'));
+  });
+
+  it('does not treat a lookalike host as the same page', () => {
+    expect(normalizeUrlForMatch('https://bandcamp.com.evil.test/x'))
+      .not.toBe(normalizeUrlForMatch('https://bandcamp.com/x'));
+  });
+
+  it('falls back to a plain key for an unparseable URL', () => {
+    expect(normalizeUrlForMatch('  Not A Url/ ')).toBe('not a url');
+  });
+});
+
+describe('urlMatchPrefilter', () => {
+  it('drops the query so one SQL pattern covers every spelling', () => {
+    expect(urlMatchPrefilter('http://WWW.Discogs.com/artist/1024240/?foo=1'))
+      .toBe('discogs.com/artist/1024240');
   });
 });
 
@@ -42,6 +77,10 @@ describe('isUrlSuppressed', () => {
 
   it('matches the scoped artist regardless of URL casing or trailing slash', () => {
     expect(isUrlSuppressed('https://taylorswift.bandcamp.com/', 'Taylor Swift', perArtist)).toBe(true);
+  });
+
+  it('matches when a later source hands back the same page over http', () => {
+    expect(isUrlSuppressed('http://taylorswift.bandcamp.com', 'Taylor Swift', perArtist)).toBe(true);
   });
 
   it('leaves the same URL alone for a different artist', () => {

--- a/api/functions/__tests__/link-suppressions.test.ts
+++ b/api/functions/__tests__/link-suppressions.test.ts
@@ -1,0 +1,146 @@
+// Admin link suppressions: removing one wrong platform link from a result
+// without removing the artist.
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyLinkSuppressions,
+  isUrlSuppressed,
+  normalizeUrlForMatch,
+  filterAndSort,
+  type LinkSuppression,
+} from '../search-utils';
+
+type Result = Parameters<typeof applyLinkSuppressions>[0][number];
+
+function artist(name: string, platforms: { sourceId: string; url: string }[], imageUrl?: string): Result {
+  return {
+    id: `test-${name}`,
+    name,
+    type: 'artist',
+    imageUrl,
+    platforms: platforms as Result['platforms'],
+    matchConfidence: 'verified',
+  } as Result;
+}
+
+describe('normalizeUrlForMatch', () => {
+  it('ignores case and trailing slashes', () => {
+    expect(normalizeUrlForMatch('https://TaylorSwift.Bandcamp.com/'))
+      .toBe(normalizeUrlForMatch('https://taylorswift.bandcamp.com'));
+  });
+
+  it('does not conflate different paths', () => {
+    expect(normalizeUrlForMatch('https://x.bandcamp.com/music'))
+      .not.toBe(normalizeUrlForMatch('https://x.bandcamp.com'));
+  });
+});
+
+describe('isUrlSuppressed', () => {
+  const perArtist: LinkSuppression[] = [
+    { url: 'https://taylorswift.bandcamp.com', artist_name_norm: 'taylorswift' },
+  ];
+
+  it('matches the scoped artist regardless of URL casing or trailing slash', () => {
+    expect(isUrlSuppressed('https://taylorswift.bandcamp.com/', 'Taylor Swift', perArtist)).toBe(true);
+  });
+
+  it('leaves the same URL alone for a different artist', () => {
+    expect(isUrlSuppressed('https://taylorswift.bandcamp.com', 'Taylor Swift Tribute', perArtist)).toBe(false);
+  });
+
+  it('matches every artist when the scope is global', () => {
+    const global: LinkSuppression[] = [
+      { url: 'https://buymeacoffee.com/impostor', artist_name_norm: null },
+    ];
+    expect(isUrlSuppressed('https://buymeacoffee.com/impostor', 'Anyone At All', global)).toBe(true);
+  });
+
+  it('returns false with no suppressions', () => {
+    expect(isUrlSuppressed('https://x.bandcamp.com', 'X', [])).toBe(false);
+  });
+});
+
+describe('applyLinkSuppressions', () => {
+  it('removes only the suppressed link and keeps the artist', () => {
+    const results = [
+      artist('Taylor Swift', [
+        { sourceId: 'bandcamp', url: 'https://taylorswift.bandcamp.com' },
+        { sourceId: 'discogs', url: 'https://www.discogs.com/artist/1024240' },
+      ]),
+    ];
+
+    applyLinkSuppressions(results, [
+      { url: 'https://taylorswift.bandcamp.com', artist_name_norm: 'taylorswift' },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].platforms.map(p => p.sourceId)).toEqual(['discogs']);
+  });
+
+  it('does not touch a homonym artist who owns the same URL', () => {
+    const results = [
+      artist('Abhorrence', [{ sourceId: 'bandcamp', url: 'https://abhorrence.bandcamp.com' }]),
+      artist('Abhorrence FIN', [{ sourceId: 'bandcamp', url: 'https://abhorrence.bandcamp.com' }]),
+    ];
+
+    applyLinkSuppressions(results, [
+      { url: 'https://abhorrence.bandcamp.com', artist_name_norm: 'abhorrencefin' },
+    ]);
+
+    expect(results[0].platforms).toHaveLength(1);
+    expect(results[1].platforms).toHaveLength(0);
+  });
+
+  it('clears a Bandcamp-sourced photo when the Bandcamp link goes', () => {
+    const results = [
+      artist(
+        'Taylor Swift',
+        [{ sourceId: 'bandcamp', url: 'https://taylorswift.bandcamp.com' }],
+        'https://f4.bcbits.com/img/0012345678_10.jpg',
+      ),
+    ];
+
+    applyLinkSuppressions(results, [
+      { url: 'https://taylorswift.bandcamp.com', artist_name_norm: 'taylorswift' },
+    ]);
+
+    expect(results[0].imageUrl).toBeUndefined();
+  });
+
+  it('leaves a photo from another source in place', () => {
+    const results = [
+      artist(
+        'Taylor Swift',
+        [{ sourceId: 'bandcamp', url: 'https://taylorswift.bandcamp.com' }],
+        'https://mirlo.space/img/artist.jpg',
+      ),
+    ];
+
+    applyLinkSuppressions(results, [
+      { url: 'https://taylorswift.bandcamp.com', artist_name_norm: 'taylorswift' },
+    ]);
+
+    expect(results[0].imageUrl).toBe('https://mirlo.space/img/artist.jpg');
+  });
+
+  it('is a no-op with an empty suppression list', () => {
+    const results = [artist('X', [{ sourceId: 'bandcamp', url: 'https://x.bandcamp.com' }])];
+    applyLinkSuppressions(results, []);
+    expect(results[0].platforms).toHaveLength(1);
+  });
+
+  it('leaves a result with nothing but search links to be dropped by filterAndSort', () => {
+    const results = [
+      artist('Taylor Swift', [
+        { sourceId: 'bandcamp', url: 'https://taylorswift.bandcamp.com' },
+        { sourceId: 'buymeacoffee', url: 'https://buymeacoffee.com/explore-creators' },
+      ]),
+    ];
+
+    applyLinkSuppressions(results, [
+      { url: 'https://taylorswift.bandcamp.com', artist_name_norm: 'taylorswift' },
+    ]);
+
+    expect(filterAndSort(results, 'taylor swift')).toHaveLength(0);
+  });
+});

--- a/api/functions/admin-link-suppression.ts
+++ b/api/functions/admin-link-suppression.ts
@@ -1,0 +1,228 @@
+// API endpoint: GET/POST/DELETE /api/admin/link-suppression
+//
+// Admin-only. Removes a single wrong platform link from search results without
+// removing the artist — the case merge overrides can't express, e.g. a
+// plausible-looking *.bandcamp.com page attached to a major artist who has no
+// Bandcamp presence at all.
+
+import { getClient, deleteStoredLinksForUrl } from './db';
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { normalizeForComparison, normalizeUrlForMatch } from './search-utils';
+import { Sentry } from '../lib/sentry';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * A URL shaped like something the search pipeline could have produced.
+ *
+ * Deliberately not the SSRF allowlist (isUrlHostnameAllowed): that list covers
+ * hosts we *fetch*, and the whole point here is to remove links we never fetch —
+ * social profiles, official sites, Qobuz, MusicBrainz-supplied URLs. Nothing
+ * requests this URL; it is only compared against search results and displayed in
+ * the admin list, so the check just rejects non-web schemes and nonsense.
+ */
+function isStorableLinkUrl(url: string): boolean {
+  if (url.length > 2048) return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+    return parsed.hostname.includes('.');
+  } catch {
+    return false;
+  }
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string> | null;
+  body?: string;
+}) {
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const admin = await authenticateAdmin(
+    event.headers['authorization'] || event.headers['Authorization'] || undefined
+  );
+  if (!admin) {
+    return {
+      statusCode: 401,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return {
+      statusCode: 500,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Database not configured' }),
+    };
+  }
+
+  // GET: list suppressions, newest first, for review and undo
+  if (event.httpMethod === 'GET') {
+    const { data, error } = await client
+      .from('platform_link_suppressions')
+      .select('id, url, source_id, artist_name, artist_name_norm, reason, created_by, created_at')
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    if (error) {
+      console.error('[Admin] Failed to list link suppressions:', error);
+      Sentry.captureMessage('Admin link suppression list failed', {
+        level: 'error',
+        extra: { detail: error.message },
+      });
+      return {
+        statusCode: 500,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Failed to load suppressions' }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ suppressions: data || [] }),
+    };
+  }
+
+  // DELETE: undo a suppression. The link comes back on the next uncached search.
+  if (event.httpMethod === 'DELETE') {
+    const id = event.queryStringParameters?.id;
+    if (!id || !UUID_REGEX.test(id)) {
+      return {
+        statusCode: 400,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'A valid suppression id is required' }),
+      };
+    }
+
+    const { error } = await client.from('platform_link_suppressions').delete().eq('id', id);
+    if (error) {
+      console.error('[Admin] Failed to delete link suppression:', error);
+      return {
+        statusCode: 500,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Failed to remove suppression' }),
+      };
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ success: true }) };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  let body: {
+    url?: string;
+    source_id?: string | null;
+    artist_name?: string | null;
+    scope?: 'artist' | 'global';
+    reason?: string | null;
+  };
+
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Invalid JSON' }),
+    };
+  }
+
+  const url = (body.url || '').trim();
+  if (!url) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'url is required' }),
+    };
+  }
+
+  if (!isStorableLinkUrl(url)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'url must be an http(s) link' }),
+    };
+  }
+
+  const scope = body.scope === 'global' ? 'global' : 'artist';
+  const artistName = (body.artist_name || '').trim();
+  if (scope === 'artist' && !artistName) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'artist_name is required unless scope is "global"' }),
+    };
+  }
+
+  const normalizedUrl = normalizeUrlForMatch(url);
+  const row = {
+    url: normalizedUrl,
+    source_id: body.source_id || null,
+    artist_name: artistName || null,
+    // Null scope = suppress everywhere; partial unique indexes keep one row per
+    // (url, artist) and one global row per url.
+    artist_name_norm: scope === 'global' ? null : normalizeForComparison(artistName),
+    reason: (body.reason || '').trim() || null,
+    created_by: admin.email,
+  };
+
+  const { data, error } = await client
+    .from('platform_link_suppressions')
+    .insert(row)
+    .select()
+    .single();
+
+  // Already suppressed at this scope — the admin clicked twice, or two tabs are
+  // open. Treat as success rather than surfacing a database error.
+  const alreadySuppressed = error?.code === '23505';
+
+  if (error && !alreadySuppressed) {
+    console.error('[Admin] Failed to save link suppression:', error);
+    Sentry.captureMessage('Admin link suppression save failed', {
+      level: 'error',
+      extra: { detail: error.message, url: normalizedUrl, scope },
+    });
+    return {
+      statusCode: 500,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        error: 'Failed to save suppression',
+        detail: error.message || error.code || String(error),
+      }),
+    };
+  }
+
+  // Also clear stored copies, so the link disappears from the artist page and
+  // from DB-backed search cards rather than only from freshly fetched results.
+  const storedRemoved = await deleteStoredLinksForUrl(
+    normalizedUrl,
+    scope === 'global' ? null : artistName
+  );
+
+  return {
+    statusCode: 201,
+    headers: CORS_HEADERS,
+    body: JSON.stringify({
+      success: true,
+      suppression: data ?? null,
+      alreadySuppressed,
+      storedLinksRemoved: storedRemoved,
+    }),
+  };
+}

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2,6 +2,7 @@
 // All operations are optional — if Supabase is not configured, they no-op gracefully.
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
 
 let supabase: SupabaseClient | null = null;
 
@@ -255,9 +256,11 @@ export async function deleteStoredLinksForUrl(url: string, artistName: string | 
   const client = getClient();
   if (!client) return 0;
 
-  const target = url.trim().replace(/\/+$/, '').toLowerCase();
-  // ilike treats % and _ as wildcards; a URL may legitimately contain either.
-  const pattern = `${target.replace(/[%_\\]/g, m => `\\${m}`)}%`;
+  const target = normalizeUrlForMatch(url);
+  // Coarse prefilter on host+path so rows stored as http://, https:// or with a
+  // www. prefix are all candidates; ilike treats % and _ as wildcards, and a URL
+  // may legitimately contain either.
+  const pattern = `%${urlMatchPrefilter(url).replace(/[%_\\]/g, m => `\\${m}`)}%`;
 
   try {
     let artistId: string | null = null;
@@ -281,10 +284,10 @@ export async function deleteStoredLinksForUrl(url: string, artistName: string | 
       return 0;
     }
 
-    // The prefix match above is a filter, not the decision — compare normalized
-    // URLs so `.../music` isn't deleted along with `...`.
+    // The ilike above is a filter, not the decision — compare match keys so
+    // `.../music` isn't deleted along with `...`.
     const ids = ((data as { id: string; url: string }[]) || [])
-      .filter(row => row.url.trim().replace(/\/+$/, '').toLowerCase() === target)
+      .filter(row => normalizeUrlForMatch(row.url) === target)
       .map(row => row.id);
     if (ids.length === 0) return 0;
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -197,6 +197,110 @@ export async function getMergeOverrides(): Promise<MergeOverrideRow[]> {
   }
 }
 
+// --- Platform link suppressions ---
+
+export interface LinkSuppressionRow {
+  id: string;
+  url: string;
+  source_id: string | null;
+  artist_name: string | null;
+  artist_name_norm: string | null;
+  reason: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+/**
+ * Admin decisions of the form "this URL does not belong on this artist".
+ *
+ * Returns [] on any failure, like getMergeOverrides — a suppression list that
+ * can't be read must not take the search response down with it. The cost of
+ * failing open is that a known-bad link reappears until the next request.
+ */
+export async function getLinkSuppressions(): Promise<
+  Pick<LinkSuppressionRow, 'url' | 'artist_name_norm'>[]
+> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const { data, error } = await client
+      .from('platform_link_suppressions')
+      .select('url, artist_name_norm');
+
+    if (error) {
+      console.error('[DB] Failed to fetch link suppressions:', error);
+      return [];
+    }
+
+    return (data as Pick<LinkSuppressionRow, 'url' | 'artist_name_norm'>[]) || [];
+  } catch (error) {
+    console.error('[DB] getLinkSuppressions error:', error);
+    return [];
+  }
+}
+
+/**
+ * Delete stored copies of a link from artist_links.
+ *
+ * Suppressing a link filters it out of search responses, but past searches may
+ * already have persisted it (persistSearchResults / persistEnrichment), and the
+ * artist page reads artist_links directly — so without this the bad link stays
+ * visible at /a/:slug. Scoped to one artist when artistName is given.
+ *
+ * Best-effort: returns the number of rows deleted, 0 on any failure. The
+ * suppression itself is what guarantees the link stays out of search results.
+ */
+export async function deleteStoredLinksForUrl(url: string, artistName: string | null): Promise<number> {
+  const client = getClient();
+  if (!client) return 0;
+
+  const target = url.trim().replace(/\/+$/, '').toLowerCase();
+  // ilike treats % and _ as wildcards; a URL may legitimately contain either.
+  const pattern = `${target.replace(/[%_\\]/g, m => `\\${m}`)}%`;
+
+  try {
+    let artistId: string | null = null;
+    if (artistName) {
+      const { data: artist } = await client
+        .from('artists')
+        .select('id')
+        .eq('slug', artistSlug(artistName))
+        .single();
+      // No stored artist row means nothing to clean up for this scope.
+      if (!artist) return 0;
+      artistId = (artist as { id: string }).id;
+    }
+
+    let query = client.from('artist_links').select('id, url').ilike('url', pattern);
+    if (artistId) query = query.eq('artist_id', artistId);
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('[DB] Failed to look up stored links for suppression:', error);
+      return 0;
+    }
+
+    // The prefix match above is a filter, not the decision — compare normalized
+    // URLs so `.../music` isn't deleted along with `...`.
+    const ids = ((data as { id: string; url: string }[]) || [])
+      .filter(row => row.url.trim().replace(/\/+$/, '').toLowerCase() === target)
+      .map(row => row.id);
+    if (ids.length === 0) return 0;
+
+    const { error: deleteError } = await client.from('artist_links').delete().in('id', ids);
+    if (deleteError) {
+      console.error('[DB] Failed to delete stored links for suppression:', deleteError);
+      return 0;
+    }
+
+    return ids.length;
+  } catch (error) {
+    console.error('[DB] deleteStoredLinksForUrl error:', error);
+    return 0;
+  }
+}
+
 // --- Bandcamp slug-probe cache (UNS-152) ---
 
 export interface BandcampProbeRow {

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -3,10 +3,10 @@
 
 import { Sentry } from '../lib/sentry';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
-import { persistEnrichment } from './db';
+import { persistEnrichment, getLinkSuppressions } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';
-import { normalizeAccents, normalizeForComparison, normalizeSearchQuery } from './search-utils';
+import { normalizeAccents, normalizeForComparison, normalizeSearchQuery, isUrlSuppressed, type LinkSuppression } from './search-utils';
 
 // Import all shared enrichment functions and types
 import {
@@ -380,6 +380,35 @@ function unavailableResult(query: string): MusicBrainzSearchResponse {
   };
 }
 
+/**
+ * Drop links an admin has suppressed for this artist.
+ *
+ * Applied to the response *after* the cache read, never inside the cached
+ * function: a suppression added today must take effect on the next request
+ * rather than waiting out a 30-minute cache entry. Phase 1 does the same at the
+ * end of its own pipeline (applyLinkSuppressions), but this endpoint's links are
+ * merged into the results client-side, so they need their own pass — otherwise a
+ * removed link reappears the moment enrichment lands.
+ */
+function stripSuppressedLinks(
+  result: MusicBrainzSearchResponse,
+  suppressions: LinkSuppression[],
+): MusicBrainzSearchResponse {
+  if (suppressions.length === 0 || !result.artistName) return result;
+
+  const artistName = result.artistName;
+  const suppressed = (url: string) => isUrlSuppressed(url, artistName, suppressions);
+
+  return {
+    ...result,
+    officialUrl: result.officialUrl && suppressed(result.officialUrl) ? null : result.officialUrl,
+    discogsUrl: result.discogsUrl && suppressed(result.discogsUrl) ? null : result.discogsUrl,
+    socialLinks: result.socialLinks.filter(s => !suppressed(s.url)),
+    discoveredPlatforms: result.discoveredPlatforms.filter(p => !suppressed(p.url)),
+    platformUrls: result.platformUrls.filter(u => !suppressed(u)),
+  };
+}
+
 // Netlify function handler
 export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string> }) {
   const corsHeaders = { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' };
@@ -400,6 +429,10 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   try {
     // Normalize the query to handle accented characters (e.g., "Tanerélle" -> "Tanerelle")
     const normalizedQuery = normalizeSearchQuery(query);
+
+    // Rides along with the MusicBrainz round-trips below instead of adding a
+    // serial hop. getLinkSuppressions catches its own errors ([] on failure).
+    const suppressionsPromise = getLinkSuppressions();
 
     // Use Redis cache to avoid hitting MusicBrainz rate limits
     const cacheKey = artistCacheKey('musicbrainz', normalizedQuery);
@@ -436,13 +469,17 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       };
     }
 
+    // Suppressed links are stripped before anything else sees them, so they are
+    // neither returned to the client nor persisted into the artist database.
+    const filtered = stripSuppressedLinks(result, await suppressionsPromise);
+
     // Persist enrichment to the artist database.
     // Also persist on MB-miss if we at least captured location (from the
     // Bandcamp/Mirlo fallback), keyed on the normalized query's slug.
-    const persistName = result.artistName || (result.location ? normalizedQuery : null);
+    const persistName = filtered.artistName || (filtered.location ? normalizedQuery : null);
     if (persistName) {
       try {
-        await persistEnrichment(persistName, result);
+        await persistEnrichment(persistName, filtered);
       } catch (err) {
         console.error('[DB] Background enrichment persist failed:', err);
       }
@@ -455,7 +492,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
         'Access-Control-Allow-Origin': '*',
         'Cache-Control': 's-maxage=300, stale-while-revalidate',
       },
-      body: JSON.stringify(result),
+      body: JSON.stringify(filtered),
     };
   } catch (error) {
     console.error('MusicBrainz endpoint error:', error);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { findBandcampArtist } from '../search/bandcamp-probe';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
-import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, findKnownArtistSlugsByName } from './db';
+import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, getLinkSuppressions, findKnownArtistSlugsByName } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
 import { parseMirloArtistSearch } from './search-parsers';
@@ -31,6 +31,7 @@ import {
   mergeByReleaseOverlap,
   filterAndSort,
   applyMergeOverrides,
+  applyLinkSuppressions,
   mergeStoredArtistsIntoResults,
   displayNameFromSlug,
   isBandcampSearchLink,
@@ -1653,6 +1654,8 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
   // fetch now so it rides along with the platform fan-out instead of adding a
   // round-trip afterwards. getMergeOverrides catches its own errors ([] on failure).
   const overridesPromise = getMergeOverrides();
+  // Same for admin link suppressions, applied last (Phase 5).
+  const suppressionsPromise = getLinkSuppressions();
 
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
   const [bandcampResults, bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
@@ -1843,6 +1846,13 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
   await attachNameOnlyPlatforms(merged, nameOnlyMaps);
   // Re-merge: new results from Phase 4 may overlap with existing ones
   const finalMerged = mergeByReleaseOverlap(merged);
+
+  // Phase 5: Drop admin-suppressed links. Deliberately the last step before
+  // filtering — every earlier phase can add links (probe, enrichment, overrides,
+  // name-only platforms), and a suppression applied mid-pipeline would be undone
+  // by whichever phase ran after it.
+  applyLinkSuppressions(finalMerged, await suppressionsPromise);
+
   const finalResults = filterAndSort(finalMerged, query);
   // Enrichment counts as applied only when the identity matched AND the
   // url-rels data actually arrived. Claiming completion on a partial fetch is

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -264,9 +264,43 @@ export interface LinkSuppression {
   artist_name_norm: string | null;
 }
 
-/** Compare two platform URLs ignoring case and trailing slashes. */
+/**
+ * A key identifying the *page* a platform URL points at, for suppression matching.
+ *
+ * Scheme and a leading `www.` are dropped, and the trailing slash and case are
+ * normalized, because the same page reaches us in several spellings: probe results
+ * are https, some MusicBrainz relations and older stored `artist_links` rows are
+ * http, and official-site scrapes carry whatever the page linked. A suppression
+ * saved from one spelling has to match all of them, or the removed link quietly
+ * comes back through a different source.
+ *
+ * The query string is kept — it is what distinguishes one search-only link from
+ * another (`?q=artist-a` vs `?q=artist-b`).
+ */
 export function normalizeUrlForMatch(url: string): string {
-  return url.trim().replace(/\/+$/, '').toLowerCase();
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.hostname.replace(/^www\./, '');
+    const path = parsed.pathname.replace(/\/+$/, '');
+    return `${host}${path}${parsed.search}${parsed.hash}`.toLowerCase();
+  } catch {
+    // Not a parseable URL (shouldn't happen — the admin endpoint validates, and
+    // platform URLs come from parsed pages). Fall back to a plain string key so
+    // the comparison stays total rather than throwing mid-pipeline.
+    return trimmed.replace(/\/+$/, '').toLowerCase();
+  }
+}
+
+/**
+ * The host-and-path part of a match key, for coarse SQL prefiltering.
+ *
+ * Deliberately drops the query string so a single `ILIKE %…%` can find rows in
+ * any scheme or `www.` spelling; the exact decision is still
+ * `normalizeUrlForMatch` equality in JS.
+ */
+export function urlMatchPrefilter(url: string): string {
+  return normalizeUrlForMatch(url).split(/[?#]/)[0];
 }
 
 export function isUrlSuppressed(

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -249,6 +249,71 @@ export function applyMergeOverrides(
 }
 
 // ---------------------------------------------------------------------------
+// Admin link suppressions (remove one wrong platform link from a result)
+// ---------------------------------------------------------------------------
+
+/**
+ * One admin decision: "this URL does not belong on this artist."
+ *
+ * `artist_name_norm` scopes the removal to a single normalized artist name, so a
+ * homonym who genuinely owns the page keeps it — the same reason
+ * `splitSuspiciousPlatforms` exists. A null scope removes the URL everywhere.
+ */
+export interface LinkSuppression {
+  url: string;
+  artist_name_norm: string | null;
+}
+
+/** Compare two platform URLs ignoring case and trailing slashes. */
+export function normalizeUrlForMatch(url: string): string {
+  return url.trim().replace(/\/+$/, '').toLowerCase();
+}
+
+export function isUrlSuppressed(
+  url: string,
+  artistName: string,
+  suppressions: LinkSuppression[],
+): boolean {
+  if (suppressions.length === 0) return false;
+  const urlKey = normalizeUrlForMatch(url);
+  const nameNorm = normalizeForComparison(artistName);
+  return suppressions.some(s =>
+    normalizeUrlForMatch(s.url) === urlKey &&
+    (s.artist_name_norm === null || s.artist_name_norm === nameNorm)
+  );
+}
+
+/**
+ * Strip admin-suppressed links from every result, in place.
+ *
+ * Runs at the very end of the pipeline, after disambiguation and after the
+ * deferred name-only platforms are attached, so a link can't be re-added behind
+ * the suppression. Results left with nothing but search-only links are dropped
+ * by `filterAndSort`, which runs next.
+ */
+export function applyLinkSuppressions(
+  aggregated: AggregatedResult[],
+  suppressions: LinkSuppression[],
+): void {
+  if (suppressions.length === 0) return;
+
+  for (const result of aggregated) {
+    const removed = result.platforms.filter(p => isUrlSuppressed(p.url, result.name, suppressions));
+    if (removed.length === 0) continue;
+
+    result.platforms = result.platforms.filter(p => !removed.includes(p));
+    console.log(`[Suppression] Removed ${removed.length} link(s) from "${result.name}": ${removed.map(p => p.url).join(', ')}`);
+
+    // The result photo has no provenance field, so a suppressed Bandcamp page
+    // would keep supplying the artist image after its link is gone. Bandcamp
+    // images are the only ones served from bcbits.com, so this is safe to key on.
+    if (removed.some(p => p.sourceId === 'bandcamp') && result.imageUrl?.includes('bcbits.com')) {
+      result.imageUrl = undefined;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // String normalization
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -212,6 +212,17 @@ function App() {
     });
   }, []);
 
+  // Admin removed a link: drop it locally so the card reflects the change now.
+  // The suppression itself is server-side, but the CDN may serve this query's
+  // cached response for a few minutes yet.
+  const handleLinkRemoved = useCallback((resultId: string, url: string) => {
+    setResults(prev => prev.map(r =>
+      r.id === resultId
+        ? { ...r, platforms: r.platforms.filter(p => p.url !== url) }
+        : r
+    ));
+  }, []);
+
   const handleMergeSelected = useCallback(() => {
     const selectedResults = results.filter(r => selectedForMerge.has(r.id));
     navigate('/admin/merge', { state: { results: selectedResults } });
@@ -292,6 +303,7 @@ function App() {
                       isAdmin={isAdmin}
                       isSelected={selectedForMerge.has(result.id)}
                       onToggleSelect={handleToggleSelect}
+                      onLinkRemoved={handleLinkRemoved}
                     />
                   ))}
                 </div>

--- a/apps/web/src/components/AdminRemoveLinkDialog.tsx
+++ b/apps/web/src/components/AdminRemoveLinkDialog.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+import type { PlatformLink } from '../types';
+import { getSource } from './ResultCardUtils';
+
+interface AdminRemoveLinkDialogProps {
+  artistName: string;
+  platform: PlatformLink;
+  onClose: () => void;
+  /** Called after the suppression is saved, so the card can drop the link. */
+  onRemoved: (url: string) => void;
+}
+
+/**
+ * Admin-only: remove one wrong platform link from a search result.
+ *
+ * Scope matters. "This artist only" is the default because two real artists can
+ * share a name and one of them may genuinely own the page — the same problem the
+ * search pipeline's disambiguation exists to solve. "Everywhere" is for links
+ * that are wrong under any name.
+ */
+export function AdminRemoveLinkDialog({ artistName, platform, onClose, onRemoved }: AdminRemoveLinkDialogProps) {
+  const { session } = useAuth();
+  const [scope, setScope] = useState<'artist' | 'global'>('artist');
+  const [reason, setReason] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const source = getSource(platform.sourceId);
+
+  const handleRemove = async () => {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/link-suppression', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify({
+          url: platform.url,
+          source_id: platform.sourceId,
+          artist_name: artistName,
+          scope,
+          reason: reason.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to remove link (${response.status})`);
+      }
+
+      onRemoved(platform.url);
+      onClose();
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.removeLink' } });
+      setError(err instanceof Error ? err.message : 'Failed to remove link.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
+      <div className="w-full max-w-md rounded-2xl bg-bg-primary border border-border p-5 space-y-4">
+        <h2 className="font-display text-lg font-bold text-text-primary">Remove this link</h2>
+
+        <div className="space-y-1 text-sm">
+          <p className="text-text-secondary">
+            <span className="font-medium text-text-primary">{source.name}</span> on{' '}
+            <span className="font-medium text-text-primary">{artistName}</span>
+          </p>
+          <p className="text-text-muted break-all text-xs">{platform.url}</p>
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium text-text-primary mb-1">Apply to</legend>
+          <label className="flex items-start gap-2 text-sm text-text-secondary cursor-pointer">
+            <input
+              type="radio"
+              name="suppression-scope"
+              checked={scope === 'artist'}
+              onChange={() => setScope('artist')}
+              className="mt-1"
+            />
+            <span>
+              <span className="text-text-primary">{artistName} only</span>
+              <span className="block text-xs text-text-muted">
+                Another artist with the same name keeps this link.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm text-text-secondary cursor-pointer">
+            <input
+              type="radio"
+              name="suppression-scope"
+              checked={scope === 'global'}
+              onChange={() => setScope('global')}
+              className="mt-1"
+            />
+            <span>
+              <span className="text-text-primary">Every artist</span>
+              <span className="block text-xs text-text-muted">
+                This URL never appears in any search result.
+              </span>
+            </span>
+          </label>
+        </fieldset>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-text-primary" htmlFor="suppression-reason">
+            Reason (optional)
+          </label>
+          <input
+            id="suppression-reason"
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Not the real artist"
+            className="w-full px-3 py-2 rounded-lg bg-surface border border-border text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+          />
+        </div>
+
+        {error && (
+          <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-1">
+          <button
+            onClick={handleRemove}
+            disabled={saving}
+            className="px-4 py-2 rounded-xl bg-accent-primary text-white font-medium hover:bg-accent-primary/90 transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Removing...' : 'Remove link'}
+          </button>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl bg-surface border border-border text-text-primary hover:bg-surface-secondary transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -72,6 +72,7 @@ export function Header() {
         ...(isAdmin && pendingVerifyCount > 0
           ? [{ to: '/admin/verify', label: `Verify (${pendingVerifyCount})`, emphasis: true }]
           : []),
+        ...(isAdmin ? [{ to: '/admin/links', label: 'Links' }] : []),
         { to: '/dashboard', label: 'Dashboard', emphasis: true },
         { to: '/settings', label: 'Settings' },
       ]

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { MobileNav, type NavItem } from './MobileNav';
+import { MobileNav, isNavGroup, type NavEntry, type NavGroup } from './MobileNav';
+import { NavDropdown } from './NavDropdown';
 import { useAuth } from '../contexts/AuthContext';
 
 function UnstreamLogo() {
@@ -65,14 +66,31 @@ export function Header() {
     navigate('/login');
   }
 
+  // Every admin destination in one group rather than a growing row of top-level
+  // items. /admin/merge is deliberately absent: it acts on results selected on a
+  // search page and has nothing to show when opened directly.
+  //
+  // The group carries the pending-verification emphasis so a queue waiting for
+  // review is still visible without opening the menu.
+  const adminGroup: NavGroup = {
+    label: 'Admin',
+    emphasis: pendingVerifyCount > 0,
+    items: [
+      {
+        to: '/admin/verify',
+        label: pendingVerifyCount > 0 ? `Verify (${pendingVerifyCount})` : 'Verify',
+        emphasis: pendingVerifyCount > 0,
+      },
+      { to: '/admin/links', label: 'Removed links' },
+      { to: '/admin/analytics', label: 'Analytics' },
+    ],
+  };
+
   // Shared by the inline desktop nav and the mobile hamburger menu, so new
   // items only need adding in one place.
-  const navItems: NavItem[] = session
+  const navItems: NavEntry[] = session
     ? [
-        ...(isAdmin && pendingVerifyCount > 0
-          ? [{ to: '/admin/verify', label: `Verify (${pendingVerifyCount})`, emphasis: true }]
-          : []),
-        ...(isAdmin ? [{ to: '/admin/links', label: 'Links' }] : []),
+        ...(isAdmin ? [adminGroup] : []),
         { to: '/dashboard', label: 'Dashboard', emphasis: true },
         { to: '/settings', label: 'Settings' },
       ]
@@ -94,15 +112,17 @@ export function Header() {
             {user?.email}
           </span>
         )}
-        {navItems.map(item => (
+        {navItems.map(entry => isNavGroup(entry) ? (
+          <NavDropdown key={entry.label} group={entry} />
+        ) : (
           <Link
-            key={item.to}
-            to={item.to}
-            className={item.emphasis
+            key={entry.to}
+            to={entry.to}
+            className={entry.emphasis
               ? 'text-accent-primary hover:underline font-medium'
               : 'text-text-muted hover:text-text-primary transition-colors'}
           >
-            {item.label}
+            {entry.label}
           </Link>
         ))}
         {session && (

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -8,6 +8,20 @@ export type NavItem = {
   emphasis?: boolean;
 };
 
+/** A labelled set of links — a dropdown on desktop, an indented block here. */
+export type NavGroup = {
+  label: string;
+  items: NavItem[];
+  /** Accent-coloured when something inside needs attention. */
+  emphasis?: boolean;
+};
+
+export type NavEntry = NavItem | NavGroup;
+
+export function isNavGroup(entry: NavEntry): entry is NavGroup {
+  return 'items' in entry;
+}
+
 /**
  * Full-height drawer that houses the header nav on small screens: a hamburger
  * in the header slides a panel in from the right over the page content. The
@@ -23,7 +37,7 @@ export function MobileNav({
   email,
   onSignOut,
 }: {
-  items: NavItem[];
+  items: NavEntry[];
   email?: string;
   onSignOut?: () => void;
 }) {
@@ -115,17 +129,40 @@ export function MobileNav({
             <p className="truncate px-6 pb-4 text-xs text-text-muted">{email}</p>
           )}
 
+          {/* Groups render as a heading plus indented links rather than a
+              collapsible section: the drawer is full-height, so hiding a handful
+              of admin links behind another tap would only add a step. */}
           <div className="flex flex-col border-t border-border">
-            {items.map(item => (
+            {items.map(entry => isNavGroup(entry) ? (
+              <div key={entry.label} className="border-b border-border">
+                <p className={`px-6 pt-4 pb-1 text-xs font-medium uppercase tracking-wider ${
+                  entry.emphasis ? 'text-accent-primary' : 'text-text-muted'
+                }`}>
+                  {entry.label}
+                </p>
+                {entry.items.map(item => (
+                  <Link
+                    key={item.to}
+                    to={item.to}
+                    onClick={close}
+                    className={`block px-6 py-3 text-base hover:bg-bg-hover transition-colors ${
+                      item.emphasis ? 'text-accent-primary font-medium' : 'text-text-primary'
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            ) : (
               <Link
-                key={item.to}
-                to={item.to}
+                key={entry.to}
+                to={entry.to}
                 onClick={close}
                 className={`border-b border-border px-6 py-4 text-base hover:bg-bg-hover transition-colors ${
-                  item.emphasis ? 'text-accent-primary font-medium' : 'text-text-primary'
+                  entry.emphasis ? 'text-accent-primary font-medium' : 'text-text-primary'
                 }`}
               >
-                {item.label}
+                {entry.label}
               </Link>
             ))}
           </div>

--- a/apps/web/src/components/NavDropdown.tsx
+++ b/apps/web/src/components/NavDropdown.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { NavGroup } from './MobileNav';
+
+/**
+ * Desktop-only nav dropdown for a group of links (currently the admin pages).
+ *
+ * Closes on outside click, Escape, and navigation. The mobile drawer renders the
+ * same group inline instead — see MobileNav.
+ */
+export function NavDropdown({ group }: { group: NavGroup }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false);
+    }
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        className={`flex items-center gap-1 transition-colors ${
+          group.emphasis
+            ? 'text-accent-primary font-medium hover:underline'
+            : 'text-text-muted hover:text-text-primary'
+        }`}
+      >
+        {group.label}
+        <svg
+          className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-2 min-w-44 rounded-xl border border-border bg-bg-primary py-1 shadow-lg">
+          {group.items.map(item => (
+            <Link
+              key={item.to}
+              to={item.to}
+              onClick={() => setOpen(false)}
+              className={`block px-4 py-2 text-sm hover:bg-bg-hover transition-colors ${
+                item.emphasis ? 'text-accent-primary font-medium' : 'text-text-primary'
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import type { SearchResult } from '../types';
+import type { PlatformLink, SearchResult } from '../types';
 import { analytics } from '../services/analytics';
 import { ResultCardHeader } from './ResultCardHeader';
 import { ResultCardRelease } from './ResultCardRelease';
@@ -7,6 +7,7 @@ import { ResultCardPlatforms } from './ResultCardPlatforms';
 import { LoginInterstitial } from './LoginInterstitial';
 import { ResultCardSocial } from './ResultCardSocial';
 import { ResultCardActions } from './ResultCardActions';
+import { AdminRemoveLinkDialog } from './AdminRemoveLinkDialog';
 
 import {
   categorizePlatforms,
@@ -20,9 +21,11 @@ interface ResultCardProps {
   isAdmin?: boolean;
   isSelected?: boolean;
   onToggleSelect?: (id: string) => void;
+  /** Admin-only: called after a link is suppressed so the list drops it. */
+  onLinkRemoved?: (resultId: string, url: string) => void;
 }
 
-export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: ResultCardProps) {
+export function ResultCard({ result, isAdmin, isSelected, onToggleSelect, onLinkRemoved }: ResultCardProps) {
   const searchTracked = useRef(false);
   const { session, isArtistSaved, saveArtist, removeSavedArtist } = useAuth();
 
@@ -36,6 +39,11 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
   const [shareCopied, setShareCopied] = useState(false);
   const [saved, setSaved] = useState(false);
   const [showLoginInterstitial, setShowLoginInterstitial] = useState(false);
+  const [linkToRemove, setLinkToRemove] = useState<PlatformLink | null>(null);
+
+  // Only admins get the per-link remove control, and only when the page can
+  // actually drop the link from its list afterwards.
+  const handleRemoveLink = isAdmin && onLinkRemoved ? setLinkToRemove : undefined;
 
   useEffect(() => {
     if (result.type === 'artist' && result.id) {
@@ -139,47 +147,63 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect }: Resu
             <ResultCardPlatforms
               platforms={categorized.marketplace}
               category="marketplace"
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.patronage.length > 0 && (
             <ResultCardPlatforms
               platforms={categorized.patronage}
               category="patronage"
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.decentralized.length > 0 && (
             <ResultCardPlatforms
               platforms={categorized.decentralized}
               category="decentralized"
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.library.length > 0 && (
             <ResultCardPlatforms
               platforms={categorized.library}
               category="library"
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.official.length > 0 && (
             <ResultCardPlatforms
               platforms={categorized.official}
               category="official"
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.social.length > 0 && (
             <ResultCardSocial
               platforms={categorized.social}
               claimedSlug={result.claimedSlug}
+              onRemoveLink={handleRemoveLink}
             />
           )}
           {categorized.curated.length > 0 && (
             <ResultCardPlatforms
               platforms={categorized.curated}
               category="curated"
+              onRemoveLink={handleRemoveLink}
             />
           )}
 
           <ResultCardActions result={result} />
         </div>
+
+      {linkToRemove && (
+        <AdminRemoveLinkDialog
+          artistName={result.name}
+          platform={linkToRemove}
+          onClose={() => setLinkToRemove(null)}
+          onRemoved={(url) => onLinkRemoved?.(result.id, url)}
+        />
+      )}
 
       {showLoginInterstitial && (
         <LoginInterstitial

--- a/apps/web/src/components/ResultCardPlatforms.tsx
+++ b/apps/web/src/components/ResultCardPlatforms.tsx
@@ -7,14 +7,45 @@ interface ResultCardPlatformsProps {
   platforms: PlatformLink[];
   category: string;
   compact?: boolean;
+  /** Admin-only: when set, each badge gets a remove control. */
+  onRemoveLink?: (platform: PlatformLink) => void;
 }
 
-export function ResultCardPlatforms({ platforms, category, compact = false }: ResultCardPlatformsProps) {
+function PlatformBadge({ platform, onRemoveLink }: { platform: PlatformLink; onRemoveLink?: (platform: PlatformLink) => void }) {
+  const badge = (
+    <SourceBadge
+      source={getSource(platform.sourceId)}
+      url={platform.url}
+      isDirectLink={isDirectLink(platform.url, platform.sourceId)}
+      displayName={platform.displayName}
+    />
+  );
+
+  if (!onRemoveLink) return badge;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      {badge}
+      <button
+        onClick={() => onRemoveLink(platform)}
+        className="text-text-muted hover:text-red-400 transition-colors"
+        title="Remove this link (admin)"
+        aria-label={`Remove the ${getSource(platform.sourceId).name} link`}
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </span>
+  );
+}
+
+export function ResultCardPlatforms({ platforms, category, compact = false, onRemoveLink }: ResultCardPlatformsProps) {
   const [showAll, setShowAll] = useState(false);
-  
+
   // If compact mode, limit to 4 platforms, otherwise show all
-  const visiblePlatforms = compact && platforms.length > 4 
-    ? platforms.slice(0, 4) 
+  const visiblePlatforms = compact && platforms.length > 4
+    ? platforms.slice(0, 4)
     : platforms;
   const hasMore = compact && platforms.length > 4;
 
@@ -29,13 +60,7 @@ export function ResultCardPlatforms({ platforms, category, compact = false }: Re
       )}
       <div className="flex flex-wrap gap-2">
         {visiblePlatforms.map(platform => (
-          <SourceBadge
-            key={platform.sourceId}
-            source={getSource(platform.sourceId)}
-            url={platform.url}
-            isDirectLink={isDirectLink(platform.url, platform.sourceId)}
-            displayName={platform.displayName}
-          />
+          <PlatformBadge key={platform.sourceId} platform={platform} onRemoveLink={onRemoveLink} />
         ))}
       </div>
       {hasMore && (
@@ -49,13 +74,7 @@ export function ResultCardPlatforms({ platforms, category, compact = false }: Re
       {showAll && hasMore && (
         <div className="flex flex-wrap gap-2">
           {platforms.slice(4).map(platform => (
-            <SourceBadge
-              key={platform.sourceId}
-              source={getSource(platform.sourceId)}
-              url={platform.url}
-              isDirectLink={isDirectLink(platform.url, platform.sourceId)}
-              displayName={platform.displayName}
-            />
+            <PlatformBadge key={platform.sourceId} platform={platform} onRemoveLink={onRemoveLink} />
           ))}
         </div>
       )}

--- a/apps/web/src/components/ResultCardSocial.tsx
+++ b/apps/web/src/components/ResultCardSocial.tsx
@@ -6,9 +6,11 @@ import { analytics } from '../services/analytics';
 interface ResultCardSocialProps {
   platforms: PlatformLink[];
   claimedSlug: string | undefined;
+  /** Admin-only: when set, each icon gets a remove control. */
+  onRemoveLink?: (platform: PlatformLink) => void;
 }
 
-export function ResultCardSocial({ platforms, claimedSlug }: ResultCardSocialProps) {
+export function ResultCardSocial({ platforms, claimedSlug, onRemoveLink }: ResultCardSocialProps) {
   if (platforms.length === 0) return null;
 
   return (
@@ -18,8 +20,8 @@ export function ResultCardSocial({ platforms, claimedSlug }: ResultCardSocialPro
       </h4>
       <div className="flex flex-wrap gap-3">
         {platforms.map(platform => (
+          <span key={platform.sourceId} className="inline-flex items-center gap-1">
           <a
-            key={platform.sourceId}
             href={platform.url}
             target="_blank"
             rel="noopener noreferrer"
@@ -33,6 +35,19 @@ export function ResultCardSocial({ platforms, claimedSlug }: ResultCardSocialPro
           >
             <SocialIcon platform={platform.sourceId} />
           </a>
+          {onRemoveLink && (
+            <button
+              onClick={() => onRemoveLink(platform)}
+              className="text-text-muted hover:text-red-400 transition-colors"
+              title="Remove this link (admin)"
+              aria-label={`Remove the ${getSource(platform.sourceId).name} link`}
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+          </span>
         ))}
       </div>
     </div>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -22,6 +22,7 @@ const SupportPage = lazy(() => import('./pages/SupportPage.tsx').then(m => ({ de
 const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage.tsx').then(m => ({ default: m.PrivacyPolicyPage })))
 const AdminMergePage = lazy(() => import('./pages/AdminMergePage.tsx').then(m => ({ default: m.AdminMergePage })))
 const AdminVerifyPage = lazy(() => import('./pages/AdminVerifyPage.tsx').then(m => ({ default: m.AdminVerifyPage })))
+const AdminLinksPage = lazy(() => import('./pages/AdminLinksPage.tsx').then(m => ({ default: m.AdminLinksPage })))
 const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage.tsx').then(m => ({ default: m.ResetPasswordPage })))
 const GuidesIndexPage = lazy(() => import('./pages/GuidesIndexPage.tsx').then(m => ({ default: m.GuidesIndexPage })))
 const GuidePage = lazy(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
@@ -68,6 +69,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="/guides/:slug" element={<GuidePage />} />
               <Route path="/admin/merge" element={<AdminMergePage />} />
               <Route path="/admin/verify" element={<AdminVerifyPage />} />
+              <Route path="/admin/links" element={<AdminLinksPage />} />
               <Route path="/admin/analytics" element={<AdminAnalyticsPage />} />
               <Route path="/developers" element={<DevelopersPage />} />
               <Route path="/extension" element={<ExtensionPage />} />

--- a/apps/web/src/pages/AdminLinksPage.tsx
+++ b/apps/web/src/pages/AdminLinksPage.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+import { Header } from '../components/Header';
+
+interface LinkSuppression {
+  id: string;
+  url: string;
+  source_id: string | null;
+  artist_name: string | null;
+  artist_name_norm: string | null;
+  reason: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+/**
+ * Admin review of removed platform links, with undo.
+ *
+ * Removals happen inline on search results (the ✕ next to each platform badge);
+ * this page exists so they can be audited and reversed.
+ */
+export function AdminLinksPage() {
+  const { isAdmin, session } = useAuth();
+  const navigate = useNavigate();
+  const [suppressions, setSuppressions] = useState<LinkSuppression[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  const fetchSuppressions = useCallback(async () => {
+    if (!session?.access_token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/admin/link-suppression', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` },
+      });
+      if (!response.ok) throw new Error(`Failed to load (${response.status})`);
+      const data = await response.json();
+      setSuppressions(data.suppressions || []);
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.linkSuppressions.list' } });
+      setError(err instanceof Error ? err.message : 'Failed to load removed links.');
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.access_token]);
+
+  useEffect(() => {
+    if (isAdmin) fetchSuppressions();
+  }, [isAdmin, fetchSuppressions]);
+
+  const handleRestore = async (id: string) => {
+    setRestoringId(id);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/link-suppression?id=${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${session?.access_token}` },
+      });
+      if (!response.ok) throw new Error(`Failed to restore (${response.status})`);
+      setSuppressions(prev => prev.filter(s => s.id !== id));
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.linkSuppressions.restore' } });
+      setError(err instanceof Error ? err.message : 'Failed to restore link.');
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+        <p className="text-text-muted">Not authorized.</p>
+        <button onClick={() => navigate('/')} className="text-accent-primary hover:underline">
+          Back to search
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-text-primary">Removed Links</h1>
+          <p className="text-text-secondary text-sm mt-1">
+            Platform links hidden from search results. Restore one and it comes back on the next
+            uncached search.
+          </p>
+        </div>
+
+        {error && (
+          <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-text-muted text-sm">Loading...</p>
+        ) : suppressions.length === 0 ? (
+          <p className="text-text-muted text-sm">
+            No links have been removed yet. Use the ✕ next to a platform badge on a search result.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {suppressions.map(s => (
+              <div
+                key={s.id}
+                className="p-4 rounded-lg bg-surface border border-border space-y-2"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1 min-w-0">
+                    <p className="text-sm text-text-primary">
+                      {s.source_id ? `${s.source_id} — ` : ''}
+                      {s.artist_name_norm === null ? 'all artists' : s.artist_name}
+                    </p>
+                    <p className="text-xs text-text-muted break-all">{s.url}</p>
+                    {s.reason && <p className="text-xs text-text-secondary">{s.reason}</p>}
+                    <p className="text-xs text-text-muted">
+                      {new Date(s.created_at).toLocaleString()}
+                      {s.created_by ? ` · ${s.created_by}` : ''}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => handleRestore(s.id)}
+                    disabled={restoringId === s.id}
+                    className="px-3 py-1.5 rounded-lg bg-surface-secondary border border-border text-sm text-text-primary hover:bg-bg-tertiary transition-colors disabled:opacity-50 flex-shrink-0"
+                  >
+                    {restoringId === s.id ? 'Restoring...' : 'Restore'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/tests/unit/AdminRemoveLink.test.tsx
+++ b/apps/web/tests/unit/AdminRemoveLink.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+// Admin per-link removal on a search result: the control is admin-only, and the
+// dialog sends the scope the admin chose.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render as renderComponent, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ResultCard } from 'src/components/ResultCard';
+import type { SearchResult } from 'src/types';
+
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    session: { access_token: 'admin-token' },
+    isArtistSaved: () => false,
+    saveArtist: vi.fn(),
+    removeSavedArtist: vi.fn(),
+  }),
+}));
+
+vi.mock('src/services/analytics', () => ({
+  analytics: {
+    trackPlatformClick: vi.fn(),
+    trackArtistSearchAppearance: vi.fn(),
+    trackArtistLinkClick: vi.fn(),
+    trackSearch: vi.fn(),
+  },
+}));
+
+vi.mock('@sentry/react', () => ({ captureException: vi.fn() }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const RESULT: SearchResult = {
+  id: 'test-taylor',
+  name: 'Taylor Swift',
+  type: 'artist',
+  matchConfidence: 'verified',
+  platforms: [
+    { sourceId: 'bandcamp', url: 'https://taylorswift.bandcamp.com' },
+    { sourceId: 'discogs', url: 'https://www.discogs.com/artist/1024240' },
+  ],
+};
+
+// ResultCard's subtree renders react-router <Link>s, so it needs a router context.
+const render = (ui: React.ReactElement) => renderComponent(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('ResultCard admin link removal', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  });
+
+  afterEach(cleanup);
+
+  it('shows no remove control for non-admins', () => {
+    render(<ResultCard result={RESULT} />);
+    expect(screen.queryByLabelText(/Remove the .* link/)).toBeNull();
+  });
+
+  it('shows a remove control per platform for admins', () => {
+    render(<ResultCard result={RESULT} isAdmin onLinkRemoved={vi.fn()} />);
+    expect(screen.getAllByLabelText(/Remove the .* link/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('suppresses the link for this artist only by default', async () => {
+    const onLinkRemoved = vi.fn();
+    render(<ResultCard result={RESULT} isAdmin onLinkRemoved={onLinkRemoved} />);
+
+    fireEvent.click(screen.getByLabelText('Remove the Bandcamp link'));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove link' }));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/admin/link-suppression');
+    expect(JSON.parse(options.body)).toMatchObject({
+      url: 'https://taylorswift.bandcamp.com',
+      source_id: 'bandcamp',
+      artist_name: 'Taylor Swift',
+      scope: 'artist',
+    });
+    expect(onLinkRemoved).toHaveBeenCalledWith('test-taylor', 'https://taylorswift.bandcamp.com');
+  });
+
+  it('sends a global scope when the admin picks every artist', async () => {
+    render(<ResultCard result={RESULT} isAdmin onLinkRemoved={vi.fn()} />);
+
+    fireEvent.click(screen.getByLabelText('Remove the Bandcamp link'));
+    fireEvent.click(screen.getByRole('radio', { name: /Every artist/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove link' }));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).scope).toBe('global');
+  });
+
+  it('keeps the dialog open and reports the error when the save fails', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({ error: 'Database not configured' }) });
+    const onLinkRemoved = vi.fn();
+    render(<ResultCard result={RESULT} isAdmin onLinkRemoved={onLinkRemoved} />);
+
+    fireEvent.click(screen.getByLabelText('Remove the Bandcamp link'));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove link' }));
+
+    await waitFor(() => expect(screen.getByText('Database not configured')).toBeTruthy());
+    expect(onLinkRemoved).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/MobileNav.test.tsx
+++ b/apps/web/tests/unit/MobileNav.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { MobileNav, type NavItem } from 'src/components/MobileNav';
+import { MobileNav, type NavEntry, type NavItem } from 'src/components/MobileNav';
 
 vi.mock('react-router-dom', () => ({
   Link: ({ children, to, onClick, className }: {
@@ -141,5 +141,31 @@ describe('MobileNav', () => {
     expect(focus).toHaveBeenLastCalledWith({ preventScroll: true });
 
     focus.mockRestore();
+  });
+
+  // Admin pages arrive as a group. The drawer shows them as a labelled block of
+  // links rather than another tap-to-expand level.
+  it('renders a nav group as a heading plus its links', () => {
+    const items: NavEntry[] = [
+      {
+        label: 'Admin',
+        emphasis: true,
+        items: [
+          { to: '/admin/verify', label: 'Verify (2)', emphasis: true },
+          { to: '/admin/links', label: 'Removed links' },
+          { to: '/admin/analytics', label: 'Analytics' },
+        ],
+      },
+      ...loggedInItems,
+    ];
+
+    render(<MobileNav items={items} />);
+    fireEvent.click(trigger());
+
+    expect(screen.getByText('Admin')).toBeTruthy();
+    for (const label of ['Verify (2)', 'Removed links', 'Analytics', 'Dashboard', 'Settings']) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+    expect(screen.getByText('Removed links').getAttribute('href')).toBe('/admin/links');
   });
 });

--- a/apps/web/tests/unit/NavDropdown.test.tsx
+++ b/apps/web/tests/unit/NavDropdown.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { NavDropdown } from 'src/components/NavDropdown';
+import type { NavGroup } from 'src/components/MobileNav';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, onClick }: { children: ReactNode; to: string; onClick?: () => void }) =>
+    <a href={to} onClick={onClick}>{children}</a>,
+}));
+
+const ADMIN: NavGroup = {
+  label: 'Admin',
+  items: [
+    { to: '/admin/verify', label: 'Verify' },
+    { to: '/admin/links', label: 'Removed links' },
+    { to: '/admin/analytics', label: 'Analytics' },
+  ],
+};
+
+function toggle() {
+  return screen.getByRole('button', { name: /Admin/ });
+}
+
+describe('NavDropdown', () => {
+  afterEach(cleanup);
+
+  it('hides its links until opened', () => {
+    render(<NavDropdown group={ADMIN} />);
+    expect(screen.queryByText('Analytics')).toBeNull();
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(toggle());
+
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Removed links').getAttribute('href')).toBe('/admin/links');
+    expect(screen.getByText('Analytics')).toBeTruthy();
+  });
+
+  it('closes on Escape', () => {
+    render(<NavDropdown group={ADMIN} />);
+    fireEvent.click(toggle());
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Analytics')).toBeNull();
+  });
+
+  it('closes on a click outside', () => {
+    render(<NavDropdown group={ADMIN} />);
+    fireEvent.click(toggle());
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText('Analytics')).toBeNull();
+  });
+
+  it('closes after following one of its links', () => {
+    render(<NavDropdown group={ADMIN} />);
+    fireEvent.click(toggle());
+    fireEvent.click(screen.getByText('Analytics'));
+    expect(screen.queryByText('Analytics')).toBeNull();
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -164,6 +164,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/admin/link-suppression"
+  to = "/.netlify/functions/admin-link-suppression"
+  status = 200
+
+[[redirects]]
   from = "/api/discord/interaction"
   to = "/.netlify/functions/discord-interaction"
   status = 200

--- a/supabase/migrations/20260729130000_platform-link-suppressions.sql
+++ b/supabase/migrations/20260729130000_platform-link-suppressions.sql
@@ -13,7 +13,9 @@
 
 CREATE TABLE IF NOT EXISTS platform_link_suppressions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  -- Normalized by the API: lowercased, trailing slashes stripped.
+  -- Match key, not a display URL: normalizeUrlForMatch() in search-utils.ts
+  -- lowercases, strips the scheme, a leading www., and trailing slashes, so the
+  -- same page suppresses whichever spelling a source hands back.
   url text NOT NULL,
   -- Platform the link belonged to, for display in the admin list only.
   source_id text,

--- a/supabase/migrations/20260729130000_platform-link-suppressions.sql
+++ b/supabase/migrations/20260729130000_platform-link-suppressions.sql
@@ -1,0 +1,44 @@
+-- Migration: platform link suppressions
+--
+-- Lets an admin remove a single wrong platform link from a search result without
+-- removing the artist. The motivating case: a *.bandcamp.com page that looks
+-- legitimate but isn't the major artist it appears under. Merge overrides can't
+-- express this — they merge and re-create whole results — and the link may be
+-- auto-generated (probe, MusicBrainz relation) rather than stored anywhere
+-- editable.
+--
+-- Scope: artist_name_norm holds the normalized artist name the link was removed
+-- from, so a homonym who genuinely owns that page keeps it. NULL means "remove
+-- this URL everywhere", for links that are wrong under any name.
+
+CREATE TABLE IF NOT EXISTS platform_link_suppressions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Normalized by the API: lowercased, trailing slashes stripped.
+  url text NOT NULL,
+  -- Platform the link belonged to, for display in the admin list only.
+  source_id text,
+  -- Display name as shown in the result, kept so the admin list is readable.
+  artist_name text,
+  -- Normalized artist name this suppression is scoped to; NULL = all artists.
+  artist_name_norm text,
+  reason text,
+  created_by text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- One row per (URL, artist), plus at most one global row per URL. Two partial
+-- indexes rather than one COALESCE expression index, because Postgres treats
+-- NULLs as distinct in a plain unique index — a single index on
+-- (url, artist_name_norm) would happily accept duplicate global rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_link_suppressions_url_artist
+  ON platform_link_suppressions (url, artist_name_norm)
+  WHERE artist_name_norm IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_link_suppressions_url_global
+  ON platform_link_suppressions (url)
+  WHERE artist_name_norm IS NULL;
+
+-- Server-only table. Reads and writes go through the service-role client in
+-- api/functions/db.ts, which bypasses RLS. Having no policies is deliberate:
+-- the anon key must not be able to read or change moderation state.
+ALTER TABLE platform_link_suppressions ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Why

Taylor Swift's search results include a `*.bandcamp.com` page that looks legitimate but isn't her. Removing the artist is the wrong fix; there was no way to remove just the one link. Merge overrides can't express this — they merge and re-create whole results — and the offending links are often auto-generated (slug probe, MusicBrainz relations) rather than stored anywhere editable.

## What changed

**Admin UI**
- A ✕ next to each platform badge and social icon on a search result (admins only). It opens a dialog showing artist / platform / URL with a scope choice:
  - **This artist only** (default) — the URL is hidden under that name; a homonym who genuinely owns the page keeps it.
  - **Every artist** — the URL never appears in any result.
- Optional reason field. The card drops the link immediately.
- New `/admin/links` page listing every removal (platform, artist, URL, reason, who, when) with a **Restore** button. Linked from the admin header nav.

**Backend**
- New `platform_link_suppressions` table — server-only, RLS enabled with no policies (service-role only), two partial unique indexes so one global row and per-artist rows coexist.
- `applyLinkSuppressions` (`search-utils.ts`) runs as the **last** step of the Phase 1 pipeline, after the probe, enrichment, merge overrides, and deferred name-only platforms. A suppression applied mid-pipeline would be undone by whichever phase ran next. Results left with only search links are dropped by the existing `filterAndSort`.
- `search-musicbrainz.ts` strips suppressed links from its own response, applied *after* the cache read so a new suppression takes effect on the next request. Phase 2 links are merged in client-side, so without this pass a removed link reappears the moment enrichment lands.
- `deleteStoredLinksForUrl` clears matching `artist_links` rows on save, so the link also disappears from `/a/:slug` and DB-backed result cards instead of only from freshly fetched results.
- `GET/POST/DELETE /api/admin/link-suppression`, admin-authenticated, CORS via `buildCorsHeaders`.

## Reviewer notes

- **Not** gated on `isUrlHostnameAllowed`: that allowlist covers hosts we *fetch*, and the links most in need of removal (socials, official sites, Qobuz, MB-supplied URLs) aren't on it and are never fetched. Validation is scheme + hostname shape + length.
- Insert rather than upsert: Postgres can't infer `ON CONFLICT` against a partial index, so a duplicate (`23505`) is reported as success — "already suppressed".
- Suppressing a Bandcamp link also clears a `bcbits.com` result photo. Results carry no image provenance, and the fake page would otherwise keep supplying the picture after its link is gone.
- Suppression reads fail open (`[]` on error), matching `getMergeOverrides` — a suppression list that can't be read must not take the search response down with it.
- The migration deploys automatically on merge. Search responses carry `s-maxage=300`, so a removal can take a few minutes to reach cached queries. The dev server implements no admin endpoints (same as `/admin/merge` today), so removals only work against a deploy.

## Testing

`npm run build` green: 143 API tests, 453 web unit tests. New coverage:
- `api/functions/__tests__/link-suppressions.test.ts` — URL normalization, per-artist vs global scope, homonym isolation, photo clearing, interaction with `filterAndSort`.
- `apps/web/tests/unit/AdminRemoveLink.test.tsx` — control is admin-only, default vs global scope reaches the server, failure keeps the dialog open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)