### PR TITLE
Fix mobile Safari zoom-on-focus on header search bar

### DIFF
--- a/apps/web/src/components/HeaderSearch.tsx
+++ b/apps/web/src/components/HeaderSearch.tsx
@@ -84,7 +84,14 @@ export function HeaderSearch({
         aria-label="Search artists"
         enterKeyHint="search"
         autoFocus={autoFocus}
-        className="w-full bg-bg-secondary border border-border rounded-lg pl-9 pr-3 py-2 text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary transition-colors"
+        // text-base (16px) below lg: iOS Safari zooms in on focus for any input
+        // under 16px, which also breaks the page's responsive width until the
+        // user manually zooms back out. Desktop keeps text-sm to match the nav.
+        className={
+          'w-full bg-bg-secondary border border-border rounded-lg pl-9 pr-3 py-2 ' +
+          'text-base lg:text-sm text-text-primary placeholder-text-muted ' +
+          'focus:outline-none focus:border-accent-primary transition-colors'
+        }
         role="combobox"
         aria-expanded={suggest.isOpen}
         aria-controls="header-search-suggestions"


### PR DESCRIPTION
## Summary
- The persistent header search input (`HeaderSearch.tsx`) used `text-sm` (14px), and iOS Safari auto-zooms in on focus for any input under 16px font-size, breaking the page's responsive width until the user manually zoomed back out.
- Bumped the input to `text-base` (16px) below the `lg` breakpoint (mobile/tablet), keeping `text-sm` on desktop to match the surrounding nav text where zoom isn't a concern.

## Test plan
- [x] Verified in the dev server at a 375x812 mobile viewport that the input's computed `font-size` is now `16px`
- [x] Confirmed the mobile search row layout/visual size is unchanged (screenshot before/after)
- [x] `npm run lint` — no new errors introduced (file is clean; pre-existing unrelated test errors elsewhere)