### PR TITLE
Artist pages: let claimed artists add dividers between their links

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -2,6 +2,7 @@ import { Context } from "https://edge.netlify.com";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
 import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
+import { mainLinkDividerIndexes } from "../shared/link-dividers.ts";
 
 // Allowed embed domains for featured releases (must match api/functions/artist-profile.ts)
 const ALLOWED_EMBED_DOMAINS = [
@@ -184,19 +185,28 @@ export default async function handler(request: Request, context: Context) {
     const pageUrl = `https://unstream.stream/a/${slug}`;
 
     // Separate main platforms from social
-    const mainPlatforms = platforms.filter((p: { platform: string }) => {
+    const isMainPlatform = (p: { platform: string }) => {
       const info = PLATFORM_INFO[p.platform];
       return !info || info.category !== 'social';
-    });
+    };
+    const mainPlatforms = platforms.filter(isMainPlatform);
     const socialPlatforms = platforms.filter((p: { platform: string }) => {
       const info = PLATFORM_INFO[p.platform];
       return info?.category === 'social';
     });
 
+    // Artist-placed dividers, translated into indexes in mainPlatforms
+    const dividerIndexes = new Set(
+      isClaimed ? mainLinkDividerIndexes(platforms, isMainPlatform, profile?.link_dividers) : []
+    );
+
     const bcFriday = isBandcampFriday();
 
     // Build platform links HTML (shared by both claimed and unclaimed)
-    const platformLinksHtml = mainPlatforms.map((p: { platform: string; url: string; display_name?: string }) => {
+    const platformLinksHtml = mainPlatforms.map((p: { platform: string; url: string; display_name?: string }, index: number) => {
+      const divider = dividerIndexes.has(index)
+        ? '<hr style="border:0;border-top:1px solid var(--border);margin:4px 0">'
+        : '';
       const info = PLATFORM_INFO[p.platform];
       const isOther = p.platform === 'other' || p.platform.startsWith('other_');
       const linkName = isOther ? escapeHtml(p.display_name || 'Link') : (info?.name || escapeHtml(p.display_name || p.platform));
@@ -206,7 +216,7 @@ export default async function handler(request: Request, context: Context) {
       const payout = isBCFriday ? '~97%' : info?.payoutPercent;
       const payoutLabel = payout ? `<span style="font-size:12px;color:var(--muted)">${payout} to artist</span>` : '';
       const bcFridayLabel = isBCFriday ? '<span style="font-size:11px;font-weight:700;color:#1da0c3;animation:bc-pulse 2s ease-in-out infinite">Bandcamp Friday!</span>' : '';
-      return `<a href="${escapeHtml(p.url)}" target="_blank" rel="noopener noreferrer" style="display:flex;align-items:center;gap:12px;padding:12px 16px;border-radius:12px;border:1px solid ${isBCFriday ? '#1da0c340' : 'var(--border)'};background:${isBCFriday ? '#1da0c310' : linkColor + '08'};text-decoration:none;color:var(--text);transition:background 0.15s">
+      return `${divider}<a href="${escapeHtml(p.url)}" target="_blank" rel="noopener noreferrer" style="display:flex;align-items:center;gap:12px;padding:12px 16px;border-radius:12px;border:1px solid ${isBCFriday ? '#1da0c340' : 'var(--border)'};background:${isBCFriday ? '#1da0c310' : linkColor + '08'};text-decoration:none;color:var(--text);transition:background 0.15s">
         <span style="font-size:20px;display:inline-flex;align-items:center;justify-content:center">${linkIcon}</span>
         <span style="flex:1;font-weight:500">${linkName}</span>
         ${payoutLabel}${bcFridayLabel}

--- a/api/functions/__tests__/link-dividers.test.ts
+++ b/api/functions/__tests__/link-dividers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { mainLinkDividerIndexes } from '../../shared/link-dividers';
+
+// The artist page splits links into "Support directly" (main) and "Follow"
+// (social), but divider positions are stored against the full link order — so
+// the translation is what these tests care about.
+const link = (platform: string) => ({ platform });
+const isMain = (l: { platform: string }) => l.platform !== 'instagram';
+
+describe('mainLinkDividerIndexes', () => {
+  it('returns nothing when the artist placed no dividers', () => {
+    const links = [link('bandcamp'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, null)).toEqual([]);
+    expect(mainLinkDividerIndexes(links, isMain, [])).toEqual([]);
+  });
+
+  it('maps a position to the main link it sits above', () => {
+    const links = [link('bandcamp'), link('mirlo'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, [2])).toEqual([2]);
+  });
+
+  it('shifts past social links, which render in their own section', () => {
+    // instagram is stored second, so the divider at position 2 sits above the
+    // third stored link — the second *main* link.
+    const links = [link('bandcamp'), link('instagram'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, [2])).toEqual([1]);
+  });
+
+  it('drops a leading divider', () => {
+    const links = [link('bandcamp'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, [0])).toEqual([]);
+  });
+
+  it('drops a trailing divider', () => {
+    const links = [link('bandcamp'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, [2])).toEqual([]);
+  });
+
+  it('collapses repeated dividers in the same gap', () => {
+    const links = [link('bandcamp'), link('instagram'), link('patreon')];
+    expect(mainLinkDividerIndexes(links, isMain, [1, 2])).toEqual([1]);
+  });
+
+  it('handles several dividers in order', () => {
+    const links = [link('bandcamp'), link('mirlo'), link('patreon'), link('ko-fi')];
+    expect(mainLinkDividerIndexes(links, isMain, [1, 3])).toEqual([1, 3]);
+  });
+});

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -6,6 +6,7 @@ import { getArtistProfileBySlug } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { PLATFORMS } from '../shared/platform-registry';
 import { isBandcampFriday } from '../shared/bandcamp-friday';
+import { mainLinkDividerIndexes } from '../shared/link-dividers';
 import { sanitizeEmbed } from './artist-profile';
 
 const CORS_HEADERS: Record<string, string> = {
@@ -59,10 +60,11 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     const bcFriday = isBandcampFriday();
 
     // Split links into main (non-social) and social
-    const mainLinks = allLinks.filter(l => {
+    const isMainLink = (l: { platform: string }) => {
       const info = PLATFORMS[l.platform];
       return !info || info.category !== 'social';
-    });
+    };
+    const mainLinks = allLinks.filter(isMainLink);
     const socialLinks = allLinks.filter(l => {
       const info = PLATFORMS[l.platform];
       return info?.category === 'social';
@@ -120,6 +122,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
         verifiedAt: profile.verified_at,
       } : null,
       links,
+      // Indexes into `links` above which a horizontal divider is drawn.
+      linkDividers: mainLinkDividerIndexes(allLinks, isMainLink, profile?.link_dividers),
       socialLinks: social,
       bandcampFriday: bcFriday,
     };

--- a/api/functions/artist-profile.ts
+++ b/api/functions/artist-profile.ts
@@ -32,11 +32,20 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Methods': 'PUT, OPTIONS',
 };
 
+// A `platform: 'divider'` entry is a position marker in the artist's link
+// order, not a link — it carries no URL and is stored on the profile
+// (artist_profiles.link_dividers) rather than as an artist_links row.
 interface LinkUpdate {
   platform: string;
-  url: string;
+  url?: string;
   displayName?: string;
 }
+
+export const DIVIDER_PLATFORM = 'divider';
+
+// Cap dividers per profile. Every gap in a link list is a legitimate divider
+// position, so this only rules out a payload that isn't a real link list.
+const MAX_DIVIDERS = 20;
 
 // Allowed embed domains for featured releases
 export const ALLOWED_EMBED_DOMAINS = [
@@ -329,8 +338,11 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update links' }) };
     }
 
-    // Insert new links
-    const validLinks = (body.links || []).filter(l => {
+    // Split the submitted order into links and divider positions. The editor
+    // sends one ordered list containing both, so the artist's arrangement of
+    // links and dividers stays a single source of truth.
+    const entries = (body.links || []).filter(l => {
+      if (l.platform === DIVIDER_PLATFORM) return true;
       if (!l.platform || !l.url) return false;
       try {
         const parsed = new URL(l.url);
@@ -339,6 +351,35 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
         return false;
       }
     });
+
+    const validLinks = entries.filter(l => l.platform !== DIVIDER_PLATFORM) as (LinkUpdate & { url: string })[];
+
+    // Positions count preceding links. Leading (0), trailing (=== link count),
+    // and repeated positions are dropped — a rule with nothing on one side
+    // reads as a bug rather than as grouping.
+    const dividerPositions: number[] = [];
+    let linksSoFar = 0;
+    for (const entry of entries) {
+      if (entry.platform !== DIVIDER_PLATFORM) {
+        linksSoFar++;
+      } else if (linksSoFar > 0 && !dividerPositions.includes(linksSoFar)) {
+        dividerPositions.push(linksSoFar);
+      }
+    }
+    const finalDividers = dividerPositions
+      .filter(p => p < validLinks.length)
+      .slice(0, MAX_DIVIDERS);
+
+    const { error: dividerError } = await client
+      .from('artist_profiles')
+      .update({ link_dividers: finalDividers.length > 0 ? finalDividers : null, updated_at: new Date().toISOString() })
+      .eq('id', profile.id);
+
+    if (dividerError) {
+      console.error('[Profile] Divider update failed:', dividerError);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update links' }) };
+    }
+
     if (validLinks.length > 0) {
       // Assign unique platform IDs for "other" links to satisfy unique(artist_id, platform)
       let otherCount = 0;
@@ -366,7 +407,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
       }
     }
 
-    console.log(`[Profile] Updated ${validLinks.length} links for artist "${artist.name}"`);
+    console.log(`[Profile] Updated ${validLinks.length} links and ${finalDividers.length} dividers for artist "${artist.name}"`);
   }
 
   // --- Bust caches ---

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -63,6 +63,9 @@ interface ArtistProfile {
   websiteUrl?: string;
   featuredEmbed?: string;
   verified: boolean;
+  // Divider positions in the artist's link order — see api/shared/link-dividers.ts.
+  // Carried here so the artist edit page can rebuild the arrangement it saved.
+  linkDividers?: number[];
 }
 
 interface ArtistResult {
@@ -112,6 +115,7 @@ export interface ArtistProfileRow {
   custom_image_url: string | null;
   featured_embed: string | null;
   verified_at: string | null;
+  link_dividers: number[] | null;
 }
 
 export interface ArtistProfileBundle {
@@ -146,7 +150,7 @@ export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfil
     const [profileResult, linksResult] = await Promise.all([
       client
         .from('artist_profiles')
-        .select('bio, custom_image_url, featured_embed, verified_at')
+        .select('bio, custom_image_url, featured_embed, verified_at, link_dividers')
         .eq('artist_id', artistId)
         .single(),
       client
@@ -508,7 +512,7 @@ export async function getArtistBySlug(
       row.match_confidence === 'claimed'
         ? client
             .from('artist_profiles')
-            .select('bio, custom_image_url, website_url, featured_embed, verified_at')
+            .select('bio, custom_image_url, website_url, featured_embed, verified_at, link_dividers')
             .eq('artist_id', row.id)
             .single()
         : Promise.resolve({ data: null }),
@@ -532,6 +536,7 @@ export async function getArtistBySlug(
           websiteUrl: profileData.website_url || undefined,
           featuredEmbed: profileData.featured_embed || undefined,
           verified: !!profileData.verified_at,
+          ...(profileData.link_dividers?.length ? { linkDividers: profileData.link_dividers } : {}),
         };
       }
     }

--- a/api/shared/link-dividers.ts
+++ b/api/shared/link-dividers.ts
@@ -1,0 +1,42 @@
+// Link dividers for claimed artist pages — shared between the edge function and
+// API endpoints, because both render the artist page.
+//
+// A divider is a position in the artist's full ordered link list, stored on
+// artist_profiles.link_dividers as "the number of links before it". The artist
+// page renders non-social links ("Support directly") and social links ("Follow")
+// in separate sections, so a stored position has to be translated into the main
+// list before it can be drawn.
+
+/**
+ * Translate stored divider positions into indexes in the main (non-social) link
+ * list: a returned index N means "draw a divider above main link N".
+ *
+ * `orderedLinks` must be the artist's full link list in display order, socials
+ * included — that's the ordering the stored positions count against.
+ *
+ * A divider next to a social link falls into the nearest main-list gap rather
+ * than disappearing. Leading, trailing, and repeated dividers are dropped: a
+ * rule with nothing on one side reads as a rendering bug, not as grouping.
+ */
+export function mainLinkDividerIndexes<T>(
+  orderedLinks: T[],
+  isMainLink: (link: T) => boolean,
+  positions: number[] | null | undefined
+): number[] {
+  if (!positions || positions.length === 0) return [];
+
+  const slots = new Set(positions);
+  const indexes: number[] = [];
+  let mainCount = 0;
+  let pending = false;
+
+  for (let i = 0; i < orderedLinks.length; i++) {
+    if (slots.has(i)) pending = true;
+    if (!isMainLink(orderedLinks[i])) continue;
+    if (pending && mainCount > 0) indexes.push(mainCount);
+    pending = false;
+    mainCount++;
+  }
+
+  return indexes;
+}

--- a/apps/web/src/components/RichArtistProfile.tsx
+++ b/apps/web/src/components/RichArtistProfile.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { Fragment, useState, useCallback } from 'react';
 import type { ArtistPagePayload } from '../types/artist-page';
 import { sources } from '../services/sources';
 import { analytics } from '../services/analytics';
@@ -26,6 +26,7 @@ function getLocationText(artist: ArtistPagePayload['artist']): string {
 
 export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave, isSaved = false, disabledSave = false }: RichArtistProfileProps) {
   const { artist, profile, links, socialLinks } = payload;
+  const dividerIndexes = new Set(payload.linkDividers ?? []);
   const imageUrl = profile?.customImageUrl || artist.imageUrl;
   const locationText = getLocationText(artist);
 
@@ -154,7 +155,7 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
               Support directly
             </h2>
             <div className="grid gap-2">
-              {links.map((link) => {
+              {links.map((link, index) => {
                 const source = sources[link.platform as SourceId];
                 const isOther = link.platform === 'other' || link.platform.startsWith('other_');
                 const linkName = link.displayName || (isOther ? 'Link' : (source?.name || link.platform));
@@ -162,37 +163,42 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
                 const isBCFriday = link.bandcampFriday;
 
                 return (
-                  <a
-                    key={link.platform + link.url}
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-track-platform={link.platform}
-                    className={`flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors ${
-                      isBCFriday
-                        ? 'border-[#1da0c3]/25 bg-[#1da0c3]/[0.06] hover:bg-[#1da0c3]/10'
-                        : 'border-border hover:bg-bg-hover'
-                    }`}
-                    style={!isBCFriday ? { backgroundColor: `${linkColor}08` } : undefined}
-                    onClick={() => handleLinkClick(link.platform)}
-                  >
-                    <span className="text-xl inline-flex items-center justify-center w-5">
-                      {source && !isOther && source.icon !== '🔗' && typeof source.icon === 'string' && source.icon.length <= 2 ? (
-                        <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source.icon} className="w-5 h-5" />
-                      ) : (
-                        <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source?.icon || '🔗'} className="w-5 h-5" />
-                      )}
-                    </span>
-                    <span className="flex-1 font-medium text-text-primary">{linkName}</span>
-                    {link.payoutPercent && (
-                      <span className="text-xs text-text-muted">{link.payoutPercent} to artist</span>
+                  <Fragment key={link.platform + link.url}>
+                    {/* Group divider placed by the artist */}
+                    {dividerIndexes.has(index) && (
+                      <hr className="border-0 border-t border-border my-1" />
                     )}
-                    {isBCFriday && (
-                      <span className="text-[11px] font-bold text-[#1da0c3] animate-pulse">
-                        Bandcamp Friday!
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-track-platform={link.platform}
+                      className={`flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors ${
+                        isBCFriday
+                          ? 'border-[#1da0c3]/25 bg-[#1da0c3]/[0.06] hover:bg-[#1da0c3]/10'
+                          : 'border-border hover:bg-bg-hover'
+                      }`}
+                      style={!isBCFriday ? { backgroundColor: `${linkColor}08` } : undefined}
+                      onClick={() => handleLinkClick(link.platform)}
+                    >
+                      <span className="text-xl inline-flex items-center justify-center w-5">
+                        {source && !isOther && source.icon !== '🔗' && typeof source.icon === 'string' && source.icon.length <= 2 ? (
+                          <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source.icon} className="w-5 h-5" />
+                        ) : (
+                          <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source?.icon || '🔗'} className="w-5 h-5" />
+                        )}
                       </span>
-                    )}
-                  </a>
+                      <span className="flex-1 font-medium text-text-primary">{linkName}</span>
+                      {link.payoutPercent && (
+                        <span className="text-xs text-text-muted">{link.payoutPercent} to artist</span>
+                      )}
+                      {isBCFriday && (
+                        <span className="text-[11px] font-bold text-[#1da0c3] animate-pulse">
+                          Bandcamp Friday!
+                        </span>
+                      )}
+                    </a>
+                  </Fragment>
                 );
               })}
             </div>

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -10,6 +10,11 @@ import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 import type { SourceId } from '../types';
 
+// A divider entry is a horizontal rule on the public artist page, not a link.
+// It lives in this list so it can be reordered alongside the links; the API
+// stores it as a position in the link order (see api/shared/link-dividers.ts).
+const DIVIDER_PLATFORM = 'divider';
+
 interface LinkEntry {
   platform: string;
   url: string;
@@ -159,13 +164,24 @@ export function ArtistEditPage() {
         }
 
         const data = await response.json();
-        const existingLinks: LinkEntry[] = (data.platforms || []).map(
+        const storedLinks: LinkEntry[] = (data.platforms || []).map(
           (p: { sourceId: string; url: string; displayName?: string }) => ({
             platform: p.sourceId.startsWith('other') ? 'other' : p.sourceId,
             url: p.url,
             displayName: p.displayName || '',
           })
         );
+
+        // Dividers are stored as positions in the link order ("2" means after
+        // the second link), so put them back into the editable list.
+        const dividerPositions: number[] = data.profile?.linkDividers || [];
+        const existingLinks: LinkEntry[] = [];
+        storedLinks.forEach((link, index) => {
+          if (dividerPositions.includes(index)) {
+            existingLinks.push({ platform: DIVIDER_PLATFORM, url: '' });
+          }
+          existingLinks.push(link);
+        });
 
         dispatch({
           type: 'LOAD_DATA',
@@ -200,6 +216,10 @@ export function ArtistEditPage() {
 
   function addOtherLink() {
     set('links', [...form.links, { platform: 'other', url: '', displayName: '' }]);
+  }
+
+  function addDivider() {
+    set('links', [...form.links, { platform: DIVIDER_PLATFORM, url: '' }]);
   }
 
   function updateLink(index: number, field: 'platform' | 'url' | 'displayName', value: string) {
@@ -284,8 +304,10 @@ export function ArtistEditPage() {
       }
     }
 
-    const validLinks = form.links.filter(l => l.url.trim());
+    // Dividers ride along in the same ordered list — they have no URL to check.
+    const validLinks = form.links.filter(l => l.platform === DIVIDER_PLATFORM || l.url.trim());
     for (const link of validLinks) {
+      if (link.platform === DIVIDER_PLATFORM) continue;
       try {
         new URL(link.url);
       } catch {
@@ -318,11 +340,13 @@ export function ArtistEditPage() {
           featuredEmbed: form.featuredEmbed || null,
           customImageUrl: form.customImageUrl,
           location: { city: form.city, country: form.country },
-          links: validLinks.map(l => ({
-            platform: l.platform,
-            url: l.url,
-            displayName: l.displayName || undefined,
-          })),
+          links: validLinks.map(l => l.platform === DIVIDER_PLATFORM
+            ? { platform: DIVIDER_PLATFORM }
+            : {
+                platform: l.platform,
+                url: l.url,
+                displayName: l.displayName || undefined,
+              }),
         }),
       });
 
@@ -599,11 +623,22 @@ export function ArtistEditPage() {
                 >
                   + Add other link
                 </button>
+                <button
+                  onClick={addDivider}
+                  className="text-sm text-text-muted hover:text-text-primary transition-colors"
+                  title="Add a horizontal divider to group your links"
+                >
+                  + Add divider
+                </button>
               </div>
             </div>
 
             <p className="text-xs text-text-muted">
               Unstream highlights platforms where artists earn a larger share. We recommend prioritizing direct-support platforms like Bandcamp, Mirlo, and Faircamp over major streaming services.
+            </p>
+
+            <p className="text-xs text-text-muted">
+              Dividers draw a horizontal line between links on your artist page, so you can group them. Move them with the arrows like any other row — social links always appear in their own "Follow" section, so a divider next to one moves to the nearest gap.
             </p>
 
             {form.links.length === 0 && (
@@ -616,6 +651,7 @@ export function ArtistEditPage() {
               {form.links.map((link, index) => {
                 const streamingWarning = getStreamingWarning(link.url);
                 const isOther = link.platform === 'other';
+                const isDivider = link.platform === DIVIDER_PLATFORM;
 
                 return (
                   <div key={index} className="space-y-1">
@@ -642,7 +678,13 @@ export function ArtistEditPage() {
                         </button>
                       </div>
 
-                      {isOther ? (
+                      {isDivider ? (
+                        /* Divider: renders as a horizontal rule on the public page */
+                        <div className="flex-1 flex items-center gap-3 min-w-0">
+                          <span className="text-xs uppercase tracking-wider text-text-muted">Divider</span>
+                          <span className="flex-1 border-t border-border" />
+                        </div>
+                      ) : isOther ? (
                         /* Custom link: name input + URL */
                         <div className="flex-1 flex items-center gap-2 min-w-0">
                           <input
@@ -693,7 +735,7 @@ export function ArtistEditPage() {
                       <button
                         onClick={() => removeLink(index)}
                         className="text-text-muted hover:text-red-400 transition-colors p-1"
-                        title="Remove link"
+                        title={isDivider ? 'Remove divider' : 'Remove link'}
                       >
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/apps/web/src/types/artist-page.ts
+++ b/apps/web/src/types/artist-page.ts
@@ -22,6 +22,9 @@ export interface ArtistPagePayload {
     payoutPercent: string | null;
     bandcampFriday: boolean;
   }>;
+  // Indexes into `links` above which the artist placed a horizontal divider.
+  // Older cached responses may omit it — treat a missing value as no dividers.
+  linkDividers?: number[];
   socialLinks: Array<{
     platform: string;
     url: string;

--- a/apps/web/tests/unit/RichArtistProfile.test.tsx
+++ b/apps/web/tests/unit/RichArtistProfile.test.tsx
@@ -144,6 +144,18 @@ describe('RichArtistProfile', () => {
     expect(screen.getByText('Bandcamp Friday!')).toBeTruthy();
   });
 
+  it('renders no dividers when linkDividers is absent', () => {
+    render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
+    expect(document.querySelectorAll('hr').length).toBe(0);
+  });
+
+  it('renders a divider above the link index it points at', () => {
+    render(<RichArtistProfile payload={{ ...basePayload, linkDividers: [1] }} slug="kid-lightbulbs" />);
+    const divider = document.querySelector('hr');
+    expect(divider).toBeTruthy();
+    expect(divider!.nextElementSibling?.getAttribute('data-track-platform')).toBe('patreon');
+  });
+
   it('renders the social links section only when socialLinks.length > 0', () => {
     render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
     expect(screen.getByText('Follow')).toBeTruthy();

--- a/supabase/migrations/20260729160000_artist-link-dividers.sql
+++ b/supabase/migrations/20260729160000_artist-link-dividers.sql
@@ -1,0 +1,17 @@
+-- Migration: link dividers on claimed artist profiles
+--
+-- Claimed artists can group the links on their artist page by dropping
+-- horizontal dividers between them. A divider is a position in the artist's
+-- link order, not a link: storing it as a row in artist_links would mean every
+-- reader of that table (search results, the public API, the Apple app) had to
+-- know to filter it out, and a divider row would need a fake URL to satisfy
+-- `url text not null`.
+--
+-- Each element is "the number of links before this divider" in the artist's
+-- full ordered link list — the same ordering artist_links.display_order
+-- expresses. 0 (leading) and >= link count (trailing) are dropped on write and
+-- ignored on read; see api/shared/link-dividers.ts.
+ALTER TABLE artist_profiles ADD COLUMN IF NOT EXISTS link_dividers integer[];
+
+COMMENT ON COLUMN artist_profiles.link_dividers IS
+  'Positions of horizontal dividers in the artist''s link list, counted as the number of preceding links.';


### PR DESCRIPTION
An artist with a verified profile asked for dividers in the list of their platform links, so they can group them on their artist page.

## What changed

**Editor** (`/artist-edit/:slug`) — a third button, **+ Add divider**, next to "Add platform" and "Add other link". A divider appears as a row labelled "Divider" with a rule through it, reorders with the same ▲▼ arrows, and removes with the same ✕.

**Public page** (`/a/:slug`) — renders as a horizontal line between links in the "Support directly" list.

## Why a position, not a row

A divider is stored as a position in the artist's link order — a new `artist_profiles.link_dividers integer[]`, where each element is "the number of links before this divider".

The obvious alternative, a row in `artist_links`, was rejected: it would need a fake URL to satisfy `url text not null`, and every reader of that table would have to learn to filter it out — search results (`db.ts` maps all rows into `platforms`), the public v1 API, the Apple app, the embed widget. Positions keep the change contained to the artist page.

This is safe because the two non-artist writers to `artist_links` both bail on claimed artists (`persistSearchResults`, `persistEnrichment` check `match_confidence === 'claimed'`), and `PUT /api/artist-profile` deletes all rows and re-inserts with `display_order = index` — so the order the positions count against is exactly the artist's own list.

## Reviewer notes

- **Two renderers.** `/a/:slug` is server-rendered by `api/edge/artist-page-static.ts`, but a client-side navigation into it never hits the edge — React `ArtistPage` fetches `/api/artist-page` and renders `RichArtistProfile.tsx`. Both are updated, and both call the same shared helper.
- `api/shared/link-dividers.ts` is the one module both Deno (edge) and Node (functions) can import. It translates stored positions into indexes in the *main* (non-social) list, and drops leading, trailing, and repeated dividers — a rule with nothing on one side reads as a rendering bug, not as grouping.
- **Socials are a separate section.** A divider placed next to a social link falls into the nearest gap in the main list rather than vanishing. The editor says so rather than hiding it.
- **Migration** `20260729160000_artist-link-dividers.sql` adds one nullable column; it auto-applies on merge. No RLS change — `artist_profiles` policies already cover it.
- **Not verified end-to-end locally.** `npm run dev` implements no artist endpoints (`apps/web/server/` is search only), so the editor's load/save round-trip only exists in production. Rendering is covered by tests; the save path was reviewed by reading, not by running. Worth a click-through on the deploy preview.

## Tests

`npm run build` green. New: 7 cases for the position→index translation (`api/functions/__tests__/link-dividers.test.ts`) and 2 for divider rendering in `RichArtistProfile.test.tsx`. Full suites: 468 web unit, 157 API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)