### PR TITLE
Fix privacy policy dark-mode links and missing top padding

### DIFF
--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -9,9 +9,9 @@ export function PrivacyPolicyPage() {
       <Header />
 
       {/* Content */}
-      <main className="px-4 pb-16">
+      <main className="pt-8 px-4 pb-16">
         <div className="max-w-3xl mx-auto">
-          <article className="prose prose-lg max-w-none text-text-primary">
+          <article className="prose prose-lg dark:prose-invert max-w-none prose-a:text-accent-primary text-text-primary">
             <h2 className="font-display text-3xl font-semibold text-text-primary mb-6">Privacy Policy</h2>
             <p className="text-text-muted text-sm mb-8">Last updated: March 13, 2026</p>
 


### PR DESCRIPTION
Add dark:prose-invert so Tailwind Typography's own light-mode text/link
colors don't override the dark theme (mailto links were illegible),
matching the pattern already used on GuidePage/DevelopersPage. Add pt-8
to main so the heading isn't flush against the header.