### PR TITLE
Mac app: make it a Mac-assed Mac app

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -29,8 +29,10 @@
 		461E318C0B5687BD71C42E75 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDD15E71A80A31952A7720C /* ShortcutRecorderView.swift */; platformFilters = (macos, ); };
 		47ADDB550C3A545314574336 /* MirloReleaseChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397ABE663954D6016159C13E /* MirloReleaseChecker.swift */; };
 		5669C87F79BF30EBCC921AB0 /* UnstreamShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C2ACE9E0FA5F270656066467 /* UnstreamShareExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		5708291E100158963205FAA6 /* FindArtistIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3522A2E5601A58A396FDF7C4 /* FindArtistIntent.swift */; };
 		584FBF6DA0057BC30EB4C786 /* BrandIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FEFD60988639A1ECC95D56A /* BrandIcons.swift */; };
 		5ABBCE0981251D2D775F6DFF /* IndieArtistDirectoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CEC5CEC07C87673B1F5A61 /* IndieArtistDirectoryService.swift */; };
+		5AF682136B14D6BDCBF42E4A /* UnstreamShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B86644D0E7917D893B1E7A3 /* UnstreamShortcuts.swift */; };
 		5B170D71E9A7E9A471424F16 /* iOSSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359150E4043D5233395827D3 /* iOSSettingsTab.swift */; platformFilters = (ios, ); };
 		5FFFE71A1135656E81B34BDB /* DeviceIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFF951B15732D3AD206D247 /* DeviceIDManager.swift */; };
 		640AB7A350949FAA23C72A53 /* iOSContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5033CFF636FB4C7C07D315A6 /* iOSContentView.swift */; platformFilters = (ios, ); };
@@ -45,6 +47,7 @@
 		8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52C116B5CC91BC40D028AF /* GlobalHotkeyManager.swift */; platformFilters = (macos, ); };
 		8A4181366EB270C58A708C65 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AC0E531396E8C63A2001CF /* SearchBarView.swift */; platformFilters = (macos, ); };
 		8C94768621D55383151FD59F /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1581BE8FAF07C7C9D3CD99F5 /* SearchResponse.swift */; };
+		8CD55AA9054F310B1DBD51DA /* ServicesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEF52280B036F1EB34F4127 /* ServicesProvider.swift */; platformFilters = (macos, ); };
 		917C407BBA300BE70B9BDEFB /* ScrobbleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEE83E95439F19BFC679216 /* ScrobbleManager.swift */; platformFilters = (macos, ); };
 		93956240B6028E760C791028 /* SavedArtistsSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16504D9BC91FD976CD10D549 /* SavedArtistsSyncTests.swift */; };
 		A3526462820B7494F5463BE2 /* UnstreamApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913EEE8809001930E4F88F8C /* UnstreamApp.swift */; };
@@ -105,13 +108,16 @@
 		1003A79CD2A20BF7227C6FB0 /* SupportEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportEntry.swift; sourceTree = "<group>"; };
 		1581BE8FAF07C7C9D3CD99F5 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
 		16504D9BC91FD976CD10D549 /* SavedArtistsSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArtistsSyncTests.swift; sourceTree = "<group>"; };
+		1B86644D0E7917D893B1E7A3 /* UnstreamShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnstreamShortcuts.swift; sourceTree = "<group>"; };
 		1CDD15E71A80A31952A7720C /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		1D967BFF6EECB9BFC4835ABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1DEF52280B036F1EB34F4127 /* ServicesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesProvider.swift; sourceTree = "<group>"; };
 		1F71936662EEAC06B0C1F008 /* ReleaseAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAlert.swift; sourceTree = "<group>"; };
 		2724397667CCEE30A098B9CE /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		2C8F1E48E643DCC1EECD4A93 /* ReleasesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleasesTab.swift; sourceTree = "<group>"; };
 		2CD0614342CC41833D04FDEA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		30CDBA3376D2900CCBE870B2 /* SyncedArtistsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncedArtistsView.swift; sourceTree = "<group>"; };
+		3522A2E5601A58A396FDF7C4 /* FindArtistIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindArtistIntent.swift; sourceTree = "<group>"; };
 		359150E4043D5233395827D3 /* iOSSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSSettingsTab.swift; sourceTree = "<group>"; };
 		385B09E1C63EAE37830E8A04 /* MediaObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaObserver.swift; sourceTree = "<group>"; };
 		397ABE663954D6016159C13E /* MirloReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirloReleaseChecker.swift; sourceTree = "<group>"; };
@@ -242,6 +248,7 @@
 				46AF2CAEF0AD6BF7719E6E39 /* Unstream-macOS.entitlements */,
 				829FB6D91FC50FBA72747788 /* UnstreamAPI.swift */,
 				913EEE8809001930E4F88F8C /* UnstreamApp.swift */,
+				DEA0B7FE3D0887F2CA75080A /* Intents */,
 				CBFF34D3930D2D2C364B1F73 /* Models */,
 				605B6FA17B5F8ECFD860F204 /* Platform */,
 				42BD41F06A4ADEB36BC79147 /* Services */,
@@ -309,6 +316,7 @@
 				385B09E1C63EAE37830E8A04 /* MediaObserver.swift */,
 				A93B97CDB100943ECCA942E6 /* NowPlayingNotificationManager.swift */,
 				EEEE83E95439F19BFC679216 /* ScrobbleManager.swift */,
+				1DEF52280B036F1EB34F4127 /* ServicesProvider.swift */,
 				E82B185A730210A472CD947F /* UpdateChecker.swift */,
 			);
 			path = macOS;
@@ -336,6 +344,15 @@
 				8D5154B5C1C2B262BC1B507F /* Shared */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		DEA0B7FE3D0887F2CA75080A /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				3522A2E5601A58A396FDF7C4 /* FindArtistIntent.swift */,
+				1B86644D0E7917D893B1E7A3 /* UnstreamShortcuts.swift */,
+			);
+			path = Intents;
 			sourceTree = "<group>";
 		};
 		E27DFAC60C2E3DEB8AD07F76 /* Products */ = {
@@ -520,6 +537,7 @@
 				5FFFE71A1135656E81B34BDB /* DeviceIDManager.swift in Sources */,
 				A8FD43FE100F214CA8E6241C /* EmptyStateView.swift in Sources */,
 				194D5CB6D2373174426884C5 /* FaircampReleaseChecker.swift in Sources */,
+				5708291E100158963205FAA6 /* FindArtistIntent.swift in Sources */,
 				8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */,
 				1132043919606896183DF5BC /* IndieArtist.swift in Sources */,
 				5ABBCE0981251D2D775F6DFF /* IndieArtistDirectoryService.swift in Sources */,
@@ -546,6 +564,7 @@
 				8A4181366EB270C58A708C65 /* SearchBarView.swift in Sources */,
 				8C94768621D55383151FD59F /* SearchResponse.swift in Sources */,
 				11B4891578B50BCF51D68613 /* SearchTab.swift in Sources */,
+				8CD55AA9054F310B1DBD51DA /* ServicesProvider.swift in Sources */,
 				7F078F17D544C2F32A801E60 /* SettingsView.swift in Sources */,
 				461E318C0B5687BD71C42E75 /* ShortcutRecorderView.swift in Sources */,
 				BF58D857FC19F2147E12C7D5 /* SignInView.swift in Sources */,
@@ -559,6 +578,7 @@
 				EAD31F1949071C4F694741C3 /* TipJarView.swift in Sources */,
 				45220D6B5414D8728BE175C4 /* UnstreamAPI.swift in Sources */,
 				A3526462820B7494F5463BE2 /* UnstreamApp.swift in Sources */,
+				5AF682136B14D6BDCBF42E4A /* UnstreamShortcuts.swift in Sources */,
 				DCA4950DEB8FCA6734B3E003 /* UpdateChecker.swift in Sources */,
 				640AB7A350949FAA23C72A53 /* iOSContentView.swift in Sources */,
 				5B170D71E9A7E9A471424F16 /* iOSSettingsTab.swift in Sources */,

--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -36,9 +36,11 @@
 		640AB7A350949FAA23C72A53 /* iOSContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5033CFF636FB4C7C07D315A6 /* iOSContentView.swift */; platformFilters = (ios, ); };
 		64514560D09214DE420ED24D /* NowPlayingNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93B97CDB100943ECCA942E6 /* NowPlayingNotificationManager.swift */; platformFilters = (macos, ); };
 		7182754E06D41AE6FB47653A /* SupportListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F5BF0BE3FBF25D3C4102A6 /* SupportListManager.swift */; };
+		73FF0C6CC35AB1BD1A3C1635 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A30019089B4F933FE70826 /* Clipboard.swift */; };
 		75EF27233764A8174CBE4753 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D144E8586F19DBA63C2F37B1 /* SafariView.swift */; };
 		7F078F17D544C2F32A801E60 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D53C4C4BBA92385BF4F0A /* SettingsView.swift */; platformFilters = (macos, ); };
 		7FA2720BFA00323DC8E66A9A /* ListenBrainzService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757215FB463E24C4101FECCF /* ListenBrainzService.swift */; platformFilters = (macos, ); };
+		8496B178348A9BFE188287B2 /* LinkActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D7374CAB7B2AF10890C2D2 /* LinkActions.swift */; };
 		8916C6D428EE94E16E491566 /* ReleasesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8F1E48E643DCC1EECD4A93 /* ReleasesTab.swift */; platformFilters = (ios, ); };
 		8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52C116B5CC91BC40D028AF /* GlobalHotkeyManager.swift */; platformFilters = (macos, ); };
 		8A4181366EB270C58A708C65 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AC0E531396E8C63A2001CF /* SearchBarView.swift */; platformFilters = (macos, ); };
@@ -146,6 +148,7 @@
 		AB06541602FC51167DB50DC9 /* ReleaseAlertManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAlertManager.swift; sourceTree = "<group>"; };
 		AD675AEFDCED8AD330E47C5A /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		AD8B198703B8234660D2ABF8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B0A30019089B4F933FE70826 /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		B144C3234699177712315DB9 /* UnstreamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnstreamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B245CC3DBF71C4B066A96632 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		B4745357EE3AD119D3F7B059 /* BandcampFriday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandcampFriday.swift; sourceTree = "<group>"; };
@@ -157,6 +160,7 @@
 		C2ACE9E0FA5F270656066467 /* UnstreamShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = UnstreamShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC8A2405B5A74531E19338D9 /* PlatformBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformBadge.swift; sourceTree = "<group>"; };
 		D144E8586F19DBA63C2F37B1 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		D7D7374CAB7B2AF10890C2D2 /* LinkActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkActions.swift; sourceTree = "<group>"; };
 		DC148A11F868801384A78672 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		E330692CA1EC213166D9351F /* SearchTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTab.swift; sourceTree = "<group>"; };
 		E488821D948022DCF94F9759 /* PlatformCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformCatalog.swift; sourceTree = "<group>"; };
@@ -261,8 +265,10 @@
 			children = (
 				94E30B61F5B6C06CA39DB0E2 /* ArtistResultView.swift */,
 				7FEFD60988639A1ECC95D56A /* BrandIcons.swift */,
+				B0A30019089B4F933FE70826 /* Clipboard.swift */,
 				2724397667CCEE30A098B9CE /* ColorExtensions.swift */,
 				BE9E59C365D8F116C435B8BC /* EmptyStateView.swift */,
+				D7D7374CAB7B2AF10890C2D2 /* LinkActions.swift */,
 				CC8A2405B5A74531E19338D9 /* PlatformBadge.swift */,
 				D144E8586F19DBA63C2F37B1 /* SafariView.swift */,
 				AD675AEFDCED8AD330E47C5A /* SignInView.swift */,
@@ -509,6 +515,7 @@
 				B8D05D430D492713FB2E97EF /* BandcampFriday.swift in Sources */,
 				0EC3D68464514744CE3AA448 /* BandcampReleaseChecker.swift in Sources */,
 				584FBF6DA0057BC30EB4C786 /* BrandIcons.swift in Sources */,
+				73FF0C6CC35AB1BD1A3C1635 /* Clipboard.swift in Sources */,
 				26D515CC48F859D85DD6CD60 /* ColorExtensions.swift in Sources */,
 				5FFFE71A1135656E81B34BDB /* DeviceIDManager.swift in Sources */,
 				A8FD43FE100F214CA8E6241C /* EmptyStateView.swift in Sources */,
@@ -518,6 +525,7 @@
 				5ABBCE0981251D2D775F6DFF /* IndieArtistDirectoryService.swift in Sources */,
 				2BED69986D4A24D5265D26BE /* IndieArtistSuggestionsView.swift in Sources */,
 				4195335F3B43DDF10D2131CD /* KeychainHelper.swift in Sources */,
+				8496B178348A9BFE188287B2 /* LinkActions.swift in Sources */,
 				7FA2720BFA00323DC8E66A9A /* ListenBrainzService.swift in Sources */,
 				DAF5726D4B93EA321E5D4643 /* MediaObserver.swift in Sources */,
 				47ADDB550C3A545314574336 /* MirloReleaseChecker.swift in Sources */,

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -33,6 +33,27 @@
 	</array>
 	<key>LSUIElement</key>
 	<true/>
+	<!-- Services menu entry. NSMessage must match the selector prefix on
+	     ServicesProvider (findOnUnstream:userData:error:). -->
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Find on Unstream</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>findOnUnstream</string>
+			<key>NSPortName</key>
+			<string>Unstream</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>public.utf8-plain-text</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>NSHighResolutionCapable</key>

--- a/apps/mac/Unstream/Intents/FindArtistIntent.swift
+++ b/apps/mac/Unstream/Intents/FindArtistIntent.swift
@@ -1,0 +1,65 @@
+import AppIntents
+import Foundation
+
+/// "Find where <artist> is available" — exposed to Shortcuts, Spotlight, and Siri.
+///
+/// Talks to `UnstreamAPI` directly rather than going through `AppState`, because an
+/// intent can run when no popover has ever been shown and must not depend on view
+/// state. It deliberately does *not* open the app: the point is to be usable inside
+/// a larger Shortcut, so it returns a value instead of taking over the screen.
+struct FindArtistIntent: AppIntent {
+    static var title: LocalizedStringResource = "Find Where an Artist Sells Directly"
+
+    static var description = IntentDescription(
+        "Looks up an artist on Unstream and returns the platforms where they sell directly, with the share each one pays the artist.",
+        categoryName: "Search"
+    )
+
+    static var openAppWhenRun = false
+
+    @Parameter(title: "Artist", requestValueDialog: "Which artist?")
+    var artist: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Find where \(\.$artist) sells directly")
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        let name = artist.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw $artist.needsValueError("Which artist would you like to look up?")
+        }
+
+        let api = UnstreamAPI()
+        // .fuzzy matches the human-typed search field — someone dictating a name to
+        // Siri is in the same position as someone typing it, not doing an exact
+        // now-playing lookup.
+        let (results, _) = try await api.searchArtist(name, mode: .fuzzy)
+
+        guard let match = results.first else {
+            let message = "No results for \(name) on Unstream."
+            return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+        }
+
+        let platforms = match.verifiedPlatforms
+        guard !platforms.isEmpty else {
+            let message = "\(match.name) is on Unstream, but no direct-sales platforms were found."
+            return .result(value: message, dialog: IntentDialog(stringLiteral: message))
+        }
+
+        let lines = platforms.map { platform -> String in
+            if let payout = platform.artistPayoutPercent {
+                return "\(platform.displayName) (\(payout) to artist)"
+            }
+            return platform.displayName
+        }
+
+        let spoken = "\(match.name) sells directly on \(lines.prefix(3).joined(separator: ", "))."
+        let value = """
+        \(match.name)
+        \(lines.map { "- \($0)" }.joined(separator: "\n"))
+        """
+
+        return .result(value: value, dialog: IntentDialog(stringLiteral: spoken))
+    }
+}

--- a/apps/mac/Unstream/Intents/UnstreamShortcuts.swift
+++ b/apps/mac/Unstream/Intents/UnstreamShortcuts.swift
@@ -1,0 +1,67 @@
+import AppIntents
+
+#if os(macOS)
+import AppKit
+
+/// The companion to `FindArtistIntent`: instead of returning text, this opens the
+/// popover with the search already run — the same entry point the Services menu uses.
+/// Useful bound to a keyboard shortcut or spoken when you want to browse results and
+/// click through to a platform, rather than get an answer back into a Shortcut.
+struct SearchInUnstreamIntent: AppIntent {
+    static var title: LocalizedStringResource = "Search Unstream"
+
+    static var description = IntentDescription(
+        "Opens Unstream and searches for an artist.",
+        categoryName: "Search"
+    )
+
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Artist", requestValueDialog: "Which artist?")
+    var artist: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Search Unstream for \(\.$artist)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let name = artist.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw $artist.needsValueError("Which artist would you like to search for?")
+        }
+        AppDelegate.shared?.searchFromExternalRequest(name)
+        return .result()
+    }
+}
+#endif
+
+/// Makes the intents discoverable in the Shortcuts app and Spotlight without the user
+/// building a shortcut first. `${applicationName}` is required in at least one phrase
+/// per shortcut, which is why every phrase names the app.
+struct UnstreamShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: FindArtistIntent(),
+            phrases: [
+                "Find where an artist sells directly with \(.applicationName)",
+                "Ask \(.applicationName) where an artist sells directly",
+                "Look up an artist in \(.applicationName)"
+            ],
+            shortTitle: "Find Artist",
+            systemImageName: "magnifyingglass.circle"
+        )
+
+        #if os(macOS)
+        AppShortcut(
+            intent: SearchInUnstreamIntent(),
+            phrases: [
+                "Search \(.applicationName)",
+                "Search for an artist in \(.applicationName)"
+            ],
+            shortTitle: "Search",
+            systemImageName: "magnifyingglass"
+        )
+        #endif
+    }
+}

--- a/apps/mac/Unstream/Platform/macOS/MediaObserver.swift
+++ b/apps/mac/Unstream/Platform/macOS/MediaObserver.swift
@@ -72,13 +72,16 @@ class MediaObserver: ObservableObject {
                 print("[MediaObserver] Permission check result: \(errorNum) - \(errorMsg)")
 
                 if errorNum == -1743 {
-                    // Permission denied
+                    // Music automation is denied. Report it, but keep polling: this
+                    // check only probes Music, while Spotify and Radiccio have their own
+                    // separate automation permissions, and Parachord (WebSocket) and
+                    // Plex (HTTP) need no Apple events at all. Returning here used to
+                    // disable detection for every source because of one denied prompt.
                     DispatchQueue.main.async {
-                        self.permissionStatus = "Permission denied. Please enable in System Settings > Privacy & Security > Automation"
+                        self.permissionStatus = "Music access denied. Enable Unstream for Music in System Settings > Privacy & Security > Automation. Other players still work."
                     }
-                    print("[MediaObserver] ERROR: Automation permission denied!")
-                    print("[MediaObserver] Please go to System Settings > Privacy & Security > Automation")
-                    print("[MediaObserver] And enable 'Unstream' to control 'Music'")
+                    print("[MediaObserver] Music automation denied — continuing; other sources are unaffected")
+                    startPolling()
                     return
                 }
                 // Other errors (like -128 user canceled, or Music not running) are OK — permissions are granted

--- a/apps/mac/Unstream/Platform/macOS/ServicesProvider.swift
+++ b/apps/mac/Unstream/Platform/macOS/ServicesProvider.swift
@@ -1,0 +1,65 @@
+import AppKit
+import SwiftUI
+
+/// Provides "Find on Unstream" in the system Services menu, so selecting an artist
+/// name anywhere on the Mac — a browser, Notes, Mail, a text editor — can look up
+/// where that artist sells directly.
+///
+/// Registration has two halves that must agree: the `NSServices` entry in
+/// Info-macOS.plist declares `NSMessage` = `findOnUnstream`, and AppKit looks for a
+/// selector of the form `findOnUnstream:userData:error:` on `NSApp.servicesProvider`.
+/// Rename one without the other and the menu item silently does nothing.
+@MainActor
+final class ServicesProvider: NSObject {
+    static let shared = ServicesProvider()
+
+    /// Longest selection we'll accept. Services hand us whatever the user had
+    /// highlighted, which could be an entire document; an artist name is short, and
+    /// a huge string would just produce a garbage query.
+    private static let maxQueryLength = 100
+
+    /// Fails the Debug build if the plist's `NSMessage` and our selector drift apart.
+    /// This mismatch has no runtime symptom — the menu item just silently does
+    /// nothing — so it needs to be caught at launch rather than in the wild.
+    static func assertSelectorMatchesInfoPlist() {
+        guard let services = Bundle.main.infoDictionary?["NSServices"] as? [[String: Any]],
+              let message = services.first?["NSMessage"] as? String else {
+            assertionFailure("No NSServices/NSMessage in Info.plist — 'Find on Unstream' will not appear.")
+            return
+        }
+        let selector = Selector("\(message):userData:error:")
+        assert(
+            shared.responds(to: selector),
+            "NSServices NSMessage '\(message)' has no matching \(message):userData:error: on ServicesProvider."
+        )
+    }
+
+    @objc func findOnUnstream(
+        _ pasteboard: NSPasteboard,
+        userData: String?,
+        error: AutoreleasingUnsafeMutablePointer<NSString>?
+    ) {
+        guard let raw = pasteboard.string(forType: .string) else {
+            error?.pointee = "Unstream couldn't read the selected text." as NSString
+            return
+        }
+
+        // Selections routinely carry newlines and padding; collapse to one line.
+        let query = raw
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !query.isEmpty else {
+            error?.pointee = "Select an artist name first." as NSString
+            return
+        }
+
+        guard query.count <= Self.maxQueryLength else {
+            error?.pointee = "That selection is too long to search — select just the artist name." as NSString
+            return
+        }
+
+        AppDelegate.shared?.searchFromExternalRequest(query)
+    }
+}

--- a/apps/mac/Unstream/Platform/macOS/UpdateChecker.swift
+++ b/apps/mac/Unstream/Platform/macOS/UpdateChecker.swift
@@ -1,14 +1,33 @@
 import Foundation
+import UserNotifications
 
-/// Checks for app updates from a remote server
+/// Checks for app updates from a remote server.
+///
+/// The Mac app ships as a direct GitHub release rather than through the Mac App Store,
+/// so it is responsible for telling people an update exists.
 actor UpdateChecker {
     static let shared = UpdateChecker()
 
     // URL where version info is hosted - update this to your actual URL
     private let versionURL = URL(string: "https://unstream.stream/api/desktop/version")!
 
-    private var lastCheckTime: Date?
     private let checkInterval: TimeInterval = 86400 // Check once per day
+
+    /// Persisted, not in-memory: this is a menu bar app that gets relaunched often, and
+    /// an in-memory timestamp meant "once a day" was really "every single launch".
+    private static let lastCheckKey = "updateCheckerLastCheckTime"
+    /// Suppresses repeat notifications for a version the user has already been told about.
+    private static let notifiedVersionKey = "updateCheckerNotifiedVersion"
+
+    private var lastCheckTime: Date? {
+        get {
+            let stamp = UserDefaults.standard.double(forKey: Self.lastCheckKey)
+            return stamp > 0 ? Date(timeIntervalSince1970: stamp) : nil
+        }
+        set {
+            UserDefaults.standard.set(newValue?.timeIntervalSince1970 ?? 0, forKey: Self.lastCheckKey)
+        }
+    }
 
     struct VersionInfo: Codable {
         let latestVersion: String
@@ -47,7 +66,14 @@ actor UpdateChecker {
         }
     }
 
+    /// Background check honouring the "Check for updates automatically" setting.
+    /// Called at launch; safe to call more often, since the interval gates the work.
     func checkForUpdatesIfNeeded() async {
+        guard UserDefaults.standard.object(forKey: "checkForUpdatesAutomatically") == nil
+                || UserDefaults.standard.bool(forKey: "checkForUpdatesAutomatically") else {
+            return
+        }
+
         // Only check if enough time has passed
         if let lastCheck = lastCheckTime,
            Date().timeIntervalSince(lastCheck) < checkInterval {
@@ -56,12 +82,49 @@ actor UpdateChecker {
 
         do {
             let result = try await checkForUpdates()
-            if result.updateAvailable {
-                // Could show a notification here
-                print("[UpdateChecker] \(result.message)")
-            }
+            guard result.updateAvailable, let version = result.latestVersion else { return }
+
+            // Don't re-notify for a version we've already surfaced.
+            guard UserDefaults.standard.string(forKey: Self.notifiedVersionKey) != version else { return }
+            UserDefaults.standard.set(version, forKey: Self.notifiedVersionKey)
+
+            await notify(version: version, downloadUrl: result.downloadUrl)
         } catch {
             print("[UpdateChecker] Failed to check for updates: \(error)")
+        }
+    }
+
+    /// A print statement is not a feature: without this, "check automatically" did the
+    /// network request and then told nobody.
+    private func notify(version: String, downloadUrl: String?) async {
+        let center = UNUserNotificationCenter.current()
+
+        // Piggyback on whatever authorization the app already holds rather than
+        // prompting for notifications on launch just to mention an update.
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .authorized
+                || settings.authorizationStatus == .provisional else {
+            print("[UpdateChecker] Update \(version) available; notifications not authorized")
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Unstream \(version) is available"
+        content.body = "You're on \(Bundle.main.appVersion). Click to download the update."
+        if let downloadUrl {
+            content.userInfo = ["updateUrl": downloadUrl]
+        }
+
+        let request = UNNotificationRequest(
+            identifier: "unstream-update-\(version)",
+            content: content,
+            trigger: nil
+        )
+
+        do {
+            try await center.add(request)
+        } catch {
+            print("[UpdateChecker] Failed to post update notification: \(error)")
         }
     }
 

--- a/apps/mac/Unstream/StoreKit/TipJarStore.swift
+++ b/apps/mac/Unstream/StoreKit/TipJarStore.swift
@@ -1,3 +1,7 @@
+// iOS only. The Mac app ships as a direct GitHub release and links to Liberapay
+// instead — see TipJarView. Keeping this compiled into the Mac build would ship an
+// unused StoreKit dependency and the tip product IDs it no longer sells.
+#if os(iOS)
 import StoreKit
 import SwiftUI
 
@@ -90,3 +94,5 @@ class TipJarStore: ObservableObject {
         }
     }
 }
+
+#endif

--- a/apps/mac/Unstream/Unstream-macOS.entitlements
+++ b/apps/mac/Unstream/Unstream-macOS.entitlements
@@ -20,9 +20,16 @@
 			<string>com.spotify.playback</string>
 		</array>
 	</dict>
+	<!-- Radiccio publishes no scripting access group, so scripting-targets can't cover
+	     it and an exception is the only route. Without this, sandbox blocks the Apple
+	     event with errAEEventNotPermitted (-1743) and Radiccio detection silently never
+	     works. Parachord used to be listed here and was removed: it is read over a
+	     WebSocket on port 9876, not AppleScript, so the exception did nothing.
+	     Note these exceptions are fine for Developer ID + notarization but are a
+	     rejection risk if the app ever goes to the Mac App Store. -->
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>
-		<string>com.parachord.desktop</string>
+		<string>com.radiccio.mac</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/apps/mac/Unstream/UnstreamApp.swift
+++ b/apps/mac/Unstream/UnstreamApp.swift
@@ -329,6 +329,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         NSApp.servicesProvider = ServicesProvider.shared
         ServicesProvider.assertSelectorMatchesInfoPlist()
         NSUpdateDynamicServices()
+
+        // Direct GitHub release, so the app has to tell people an update exists.
+        // Gated on the "Check for updates automatically" setting and a once-a-day
+        // interval inside the checker.
+        Task { await UpdateChecker.shared.checkForUpdatesIfNeeded() }
     }
 
     @objc func togglePopover() {
@@ -383,7 +388,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        let urlString = (userInfo["artistUrl"] as? String) ?? (userInfo["releaseUrl"] as? String)
+        let urlString = (userInfo["artistUrl"] as? String)
+            ?? (userInfo["releaseUrl"] as? String)
+            ?? (userInfo["updateUrl"] as? String)
         if let urlString, let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)
         }

--- a/apps/mac/Unstream/UnstreamApp.swift
+++ b/apps/mac/Unstream/UnstreamApp.swift
@@ -322,6 +322,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         // Initialize global hotkey manager (starts listening if enabled)
         _ = GlobalHotkeyManager.shared
+
+        // Services menu: "Find on Unstream" on any text selection system-wide.
+        // NSUpdateDynamicServices() makes a freshly built copy visible without a
+        // logout; LaunchServices otherwise caches the old NSServices declaration.
+        NSApp.servicesProvider = ServicesProvider.shared
+        ServicesProvider.assertSelectorMatchesInfoPlist()
+        NSUpdateDynamicServices()
     }
 
     @objc func togglePopover() {
@@ -339,6 +346,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         if popover.isShown {
             popover.performClose(nil)
         }
+    }
+
+    /// Runs a search on behalf of something outside the popover — the Services menu,
+    /// an App Intent, a URL scheme — and shows the result.
+    func searchFromExternalRequest(_ query: String) {
+        let appState = AppStateContainer.shared.appState
+        appState.searchQuery = query
+        appState.clearResults()
+
+        // PopoverView owns its tab as @State, so ask it to switch rather than
+        // reaching in; it may be showing Saved Artists from last time.
+        NotificationCenter.default.post(name: .showSearchTab, object: nil)
+
+        if !popover.isShown {
+            togglePopover()
+        }
+        NSApp.activate(ignoringOtherApps: true)
+
+        Task { await appState.performSearch() }
     }
 
     // Handle notification when app is in foreground
@@ -397,6 +423,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
 extension Notification.Name {
     static let popoverDidClose = Notification.Name("unstreamPopoverDidClose")
+    /// Posted when an external request (Services menu, App Intent) needs the
+    /// popover to show the Search tab rather than whatever it was last on.
+    static let showSearchTab = Notification.Name("unstreamShowSearchTab")
 }
 
 extension AppDelegate: NSPopoverDelegate {
@@ -408,12 +437,20 @@ extension AppDelegate: NSPopoverDelegate {
 
 // MARK: - Welcome Window Launcher
 
-class WelcomeWindowLauncher {
+class WelcomeWindowLauncher: NSObject, NSWindowDelegate {
     static let shared = WelcomeWindowLauncher()
     private var window: NSWindow?
     private var hasAttemptedShow = false
 
-    init() {
+    /// Closing the window with the title-bar button is a dismissal too. Without this
+    /// the welcome window reappeared on every launch until the user pressed the
+    /// button, and it never recorded that they'd seen it.
+    func windowWillClose(_ notification: Notification) {
+        UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+    }
+
+    override init() {
+        super.init()
         guard !UserDefaults.standard.bool(forKey: "hasLaunchedBefore") else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
@@ -426,14 +463,14 @@ class WelcomeWindowLauncher {
         guard !hasAttemptedShow else { return }
         hasAttemptedShow = true
 
-        let welcomeView = WelcomeContentView {
-            self.dismiss()
+        let welcomeView = WelcomeContentView { launchAtLogin in
+            self.dismiss(enableLaunchAtLogin: launchAtLogin)
         }
 
         let hostingView = NSHostingView(rootView: welcomeView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 300),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 340),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -442,22 +479,25 @@ class WelcomeWindowLauncher {
         window.contentView = hostingView
         window.center()
         window.isReleasedWhenClosed = false
-        window.level = .floating
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        window.delegate = self
 
         self.window = window
 
+        // A first-run window may come forward, but it is not an emergency: no
+        // .floating level, no orderFrontRegardless, and no requestUserAttention —
+        // a critical attention request bounces the Dock until acknowledged, which
+        // is for data loss, not for saying hello.
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
-        window.orderFrontRegardless()
-        NSApp.requestUserAttention(.criticalRequest)
     }
 
-    func dismiss() {
+    /// - Parameter enableLaunchAtLogin: The user's explicit choice from the welcome
+    ///   window's checkbox. Previously this registered a login item silently behind
+    ///   a "Got it!" button, which is not ours to decide.
+    func dismiss(enableLaunchAtLogin: Bool) {
         UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
 
-        if !UserDefaults.standard.bool(forKey: "hasSetLaunchAtLoginDefault") {
-            UserDefaults.standard.set(true, forKey: "hasSetLaunchAtLoginDefault")
+        if enableLaunchAtLogin {
             do {
                 try SMAppService.mainApp.register()
             } catch {
@@ -473,49 +513,64 @@ class WelcomeWindowLauncher {
 // MARK: - Welcome Content View
 
 struct WelcomeContentView: View {
-    let onDismiss: () -> Void
+    /// Passes the user's launch-at-login choice back to the launcher.
+    let onDismiss: (Bool) -> Void
+
+    @State private var launchAtLogin = true
 
     var body: some View {
         VStack(spacing: 20) {
             Image(nsImage: NSApp.applicationIconImage)
                 .resizable()
                 .frame(width: 64, height: 64)
+                .accessibilityHidden(true)
 
             Text("Unstream is running!")
                 .font(.title2)
                 .fontWeight(.semibold)
 
             VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top, spacing: 10) {
-                    Image(systemName: "menubar.arrow.up.rectangle")
-                        .foregroundColor(.accentColor)
-                        .frame(width: 20)
-                    Text("Click the icon in your menu bar to search for artists.")
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                HStack(alignment: .top, spacing: 10) {
-                    Image(systemName: "music.note")
-                        .foregroundColor(.accentColor)
-                        .frame(width: 20)
-                    Text("Play music to see where the artist is available.")
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                welcomeRow(
+                    icon: "menubar.arrow.up.rectangle",
+                    text: "Click the icon in your menu bar to search for artists."
+                )
+                welcomeRow(
+                    icon: "music.note",
+                    text: "Play music to see where the artist is available."
+                )
+                welcomeRow(
+                    icon: "text.viewfinder",
+                    text: "Select an artist name in any app, then choose Services ▸ Find on Unstream."
+                )
             }
             .padding(.horizontal)
 
-            Button("Got it!") {
-                onDismiss()
+            Divider()
+
+            Toggle("Open Unstream at login", isOn: $launchAtLogin)
+
+            Button("Get Started") {
+                onDismiss(launchAtLogin)
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
         }
         .padding(30)
-        .frame(width: 420, height: 300)
+        .frame(width: 440, height: 340)
+    }
+
+    private func welcomeRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundColor(.accentColor)
+                .frame(width: 20)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.body)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 

--- a/apps/mac/Unstream/UnstreamApp.swift
+++ b/apps/mac/Unstream/UnstreamApp.swift
@@ -125,9 +125,11 @@ struct UnstreamApp: App {
 
     var body: some Scene {
         #if os(macOS)
-        // macOS: Empty settings scene — actual UI handled by AppDelegate's popover
+        // The popover is driven by AppDelegate (NSStatusItem), but Settings is a real
+        // SwiftUI Settings scene: that's what gives us the standard settings window,
+        // its frame persistence, and a working "Unstream ▸ Settings… ⌘," menu item.
         Settings {
-            EmptyView()
+            SettingsView(releaseAlertManager: container.releaseAlertManager)
         }
         #else
         // iOS: Standard windowed app
@@ -270,8 +272,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private static var hasCreatedStatusItem = false
 
     private var popover: NSPopover!
-    private var eventMonitor: Any?
-    private var settingsWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.shared = self
@@ -310,12 +310,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         popover.contentViewController = NSHostingController(rootView: contentView)
 
-        // Set up event monitor to close popover when clicking outside
-        eventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
-            if let popover = self?.popover, popover.isShown {
-                popover.performClose(nil)
-            }
-        }
+        // No click-outside monitor: popover.behavior = .transient already dismisses on
+        // outside clicks. A global monitor only sees events routed to *other* apps, so it
+        // added nothing and risked closing the popover under sheets and share pickers.
 
         // Auth callbacks are handled by ASWebAuthenticationSession in AuthService;
         // no NSAppleEventManager handler needed.
@@ -325,21 +322,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         // Initialize global hotkey manager (starts listening if enabled)
         _ = GlobalHotkeyManager.shared
-
-        // ⌘, to open settings (local monitor since LSUIElement apps don't show menu bar)
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "," {
-                self?.openSettings()
-                return nil
-            }
-            return event
-        }
-    }
-
-    func applicationWillTerminate(_ notification: Notification) {
-        if let monitor = eventMonitor {
-            NSEvent.removeMonitor(monitor)
-        }
     }
 
     @objc func togglePopover() {
@@ -350,6 +332,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+
+    func closePopover() {
+        if popover.isShown {
+            popover.performClose(nil)
         }
     }
 
@@ -376,42 +364,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         completionHandler()
     }
 
-    // Open settings window
+    /// Opens the SwiftUI `Settings` scene.
+    ///
+    /// `SettingsLink` is macOS 14+ and we still support 13, so instead of hardcoding a
+    /// private selector (`showSettingsWindow:`) we perform the real "Settings… ⌘," item
+    /// that SwiftUI puts in the app menu. Its action is a SwiftUI-internal callback, so
+    /// sending it via the item keeps working regardless of what Apple renames.
     func openSettings() {
         // Close the popover first so it doesn't obscure settings
         if popover.isShown {
             popover.performClose(nil)
         }
 
-        if let existing = settingsWindow {
-            existing.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate(ignoringOtherApps: true)
+
+        guard let appMenu = NSApp.mainMenu?.items.first?.submenu,
+              let item = appMenu.items.first(where: { $0.keyEquivalent == "," && $0.action != nil }),
+              let action = item.action else {
+            assertionFailure("No Settings item in the app menu — did the Settings scene go away?")
             return
         }
-
-        let container = AppStateContainer.shared
-        let settingsView = SettingsView(
-            releaseAlertManager: container.releaseAlertManager
-        )
-
-        let hostingController = NSHostingController(rootView: settingsView)
-
-        let fittingSize = hostingController.view.fittingSize
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: fittingSize.width, height: fittingSize.height),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "Unstream Settings"
-        window.contentViewController = hostingController
-        window.center()
-        window.isReleasedWhenClosed = false
-
-        settingsWindow = window
-
-        settingsWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.sendAction(action, to: item.target, from: item)
     }
 
     // Prevent app reopen from creating duplicates

--- a/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
+++ b/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
@@ -142,6 +142,21 @@ struct ArtistResultView: View {
                 }
             }
 
+            // A result with no links at all — a claimed profile whose owner hasn't added
+            // any yet will do this. Without something here the card is just a name and a
+            // "report an issue" link, which reads as broken.
+            if artist.platforms.isEmpty {
+                HStack(spacing: 6) {
+                    Image(systemName: "link.slash")
+                        .foregroundColor(.secondary)
+                        .accessibilityHidden(true)
+                    Text("No links listed yet.")
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .font(locationFont)
+            }
+
             // Search-only platforms section
             if !artist.searchOnlyPlatforms.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {

--- a/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
+++ b/apps/mac/Unstream/Views/Shared/ArtistResultView.swift
@@ -52,10 +52,18 @@ struct ArtistResultView: View {
     private let headerIconButtonSize: CGFloat = 44
     private let heartIconSize: CGFloat = 22
     private let shareIconSize: CGFloat = 20
+    // iOS keeps its explicit sizes; macOS uses semantic styles so text follows the
+    // system text-size setting.
+    private let nameFont: Font = .system(size: 14, weight: .semibold)
+    private let locationFont: Font = .system(size: 11)
+    private let reportFont: Font = .system(size: 11)
     #else
     private let headerIconButtonSize: CGFloat = 14
     private let heartIconSize: CGFloat = 14
     private let shareIconSize: CGFloat = 13
+    private let nameFont: Font = .headline
+    private let locationFont: Font = .caption
+    private let reportFont: Font = .caption
     #endif
 
     var body: some View {
@@ -69,14 +77,15 @@ struct ArtistResultView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(artist.name)
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(nameFont)
 
                     if let locationText = artist.location?.displayText {
                         Text(locationText)
-                            .font(.system(size: 11))
+                            .font(locationFont)
                             .foregroundColor(.secondary)
                     }
                 }
+                .textSelection(.enabled)
 
                 Spacer()
 
@@ -93,6 +102,7 @@ struct ArtistResultView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(isSaved ? "Remove \(artist.name) from Saved Artists" : "Add \(artist.name) to Saved Artists")
                 #if os(macOS)
                 .help(isSaved ? "Remove from Saved Artists" : "Add to Saved Artists")
                 #endif
@@ -153,20 +163,33 @@ struct ArtistResultView: View {
 
             // Report issue link
             Button(action: { reportIssue(artist: artist) }) {
-                HStack(spacing: 4) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 10))
-                    Text("Report an issue with this result")
-                        .font(.system(size: 11))
-                }
-                .foregroundColor(.secondary)
+                Label("Report an issue with this result", systemImage: "exclamationmark.triangle")
+                    .font(reportFont)
+                    .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .center)
+            .accessibilityLabel("Report an issue with the result for \(artist.name)")
         }
         .padding(10)
         .background(cardBackgroundColor)
         .cornerRadius(8)
+        .draggable(artistURL)
+        .contextMenu {
+            Button(isSaved ? "Remove from Saved Artists" : "Save Artist") {
+                supportListManager.toggleArtist(artist)
+            }
+
+            Divider()
+
+            Button("Copy Artist Name") { copyToClipboard(text: artist.name) }
+            Button("Copy Unstream Link") { copyToClipboard(url: artistURL) }
+            ShareLink(item: artistURL, message: Text(shareMessage))
+
+            Divider()
+
+            Button("Report an Issue…") { reportIssue(artist: artist) }
+        }
         #if os(iOS)
         .safariSheet(safariItem: $safariItem)
         #endif
@@ -206,10 +229,12 @@ struct ArtistResultView: View {
         }
     }
 
-    @ViewBuilder
+    /// `ShareLink` with a real `URL` rather than a string containing one, so link-aware
+    /// targets (Messages previews, Reading List, Notes) can do something with it. This
+    /// also replaces a hand-anchored `NSSharingServicePicker` that positioned itself off
+    /// `NSApp.keyWindow`, which is the wrong window when the popover is showing.
     private var shareButton: some View {
-        #if os(macOS)
-        Button(action: shareArtistCard) {
+        ShareLink(item: artistURL, message: Text(shareMessage)) {
             Image(systemName: "square.and.arrow.up")
                 .foregroundColor(.secondary)
                 .font(.system(size: shareIconSize))
@@ -217,16 +242,9 @@ struct ArtistResultView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Share \(artist.name)")
+        #if os(macOS)
         .help("Share this artist")
-        #else
-        let text = shareText
-        ShareLink(item: text) {
-            Image(systemName: "square.and.arrow.up")
-                .foregroundColor(.secondary)
-                .font(.system(size: shareIconSize))
-                .frame(width: headerIconButtonSize, height: headerIconButtonSize)
-                .contentShape(Rectangle())
-        }
         #endif
     }
 
@@ -240,23 +258,28 @@ struct ArtistResultView: View {
         #endif
     }
 
-    private var shareText: String {
-        let url: String
-        if let claimedSlug = artist.claimedSlug {
-            url = "https://unstream.stream/a/\(claimedSlug)"
-        } else if let encodedName = artist.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            url = "https://unstream.stream/?q=\(encodedName)"
-        } else {
-            url = "https://unstream.stream"
+    /// Canonical Unstream link for this artist — the claimed profile when there is one,
+    /// otherwise a search permalink.
+    private var artistURL: URL {
+        if let claimedSlug = artist.claimedSlug,
+           let url = URL(string: "https://unstream.stream/a/\(claimedSlug)") {
+            return url
         }
+        if let encodedName = artist.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           let url = URL(string: "https://unstream.stream/?q=\(encodedName)") {
+            return url
+        }
+        return URL(string: "https://unstream.stream")!
+    }
 
+    /// Prose that accompanies the link when the share target accepts text.
+    private var shareMessage: String {
         if let nowPlaying = appState.nowPlaying,
            nowPlaying.artist?.lowercased() == artist.name.lowercased(),
            let title = nowPlaying.title {
-            return "Listening to \"\(title)\" by \(artist.name) — here's how you can support them directly: \(url)"
+            return "Listening to \"\(title)\" by \(artist.name) — here's how you can support them directly:"
         }
-
-        return "Here's how you can support \(artist.name) directly: \(url)"
+        return "Here's how you can support \(artist.name) directly:"
     }
 
     private func reportIssue(artist: ArtistResult) {
@@ -284,17 +307,6 @@ struct ArtistResultView: View {
         #endif
     }
 
-    #if os(macOS)
-    private func shareArtistCard() {
-        let text = shareText
-        let picker = NSSharingServicePicker(items: [text])
-        if let window = NSApp.keyWindow,
-           let contentView = window.contentView {
-            let rect = NSRect(x: contentView.bounds.midX, y: contentView.bounds.maxY - 50, width: 1, height: 1)
-            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
-        }
-    }
-    #endif
 }
 
 // Simple flow layout for platform badges

--- a/apps/mac/Unstream/Views/Shared/Clipboard.swift
+++ b/apps/mac/Unstream/Views/Shared/Clipboard.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+/// Copies a URL to the clipboard.
+///
+/// On macOS we write the `NSURL` itself rather than its string: NSURL declares both
+/// `public.url` and plain-text representations, so pasting into a browser's address bar
+/// and into a text editor each get something useful. Writing only a string would lose
+/// the URL type.
+func copyToClipboard(url: URL) {
+    #if os(macOS)
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.writeObjects([url as NSURL])
+    #else
+    UIPasteboard.general.url = url
+    #endif
+}
+
+func copyToClipboard(text: String) {
+    #if os(macOS)
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+    #else
+    UIPasteboard.general.string = text
+    #endif
+}

--- a/apps/mac/Unstream/Views/Shared/ColorExtensions.swift
+++ b/apps/mac/Unstream/Views/Shared/ColorExtensions.swift
@@ -3,6 +3,11 @@ import SwiftUI
 // Color extension to parse hex strings
 extension Color {
     init?(hex: String) {
+        guard let rgb = Color.rgbComponents(hex: hex) else { return nil }
+        self.init(red: rgb.r, green: rgb.g, blue: rgb.b)
+    }
+
+    fileprivate static func rgbComponents(hex: String) -> (r: Double, g: Double, b: Double)? {
         var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
 
@@ -11,10 +16,56 @@ extension Color {
             return nil
         }
 
-        let r = Double((hexNumber & 0xFF0000) >> 16) / 255.0
-        let g = Double((hexNumber & 0x00FF00) >> 8) / 255.0
-        let b = Double(hexNumber & 0x0000FF) / 255.0
+        return (
+            r: Double((hexNumber & 0xFF0000) >> 16) / 255.0,
+            g: Double((hexNumber & 0x00FF00) >> 8) / 255.0,
+            b: Double(hexNumber & 0x0000FF) / 255.0
+        )
+    }
+}
 
-        self.init(red: r, green: g, blue: b)
+/// Platform brand colors come from each platform's own branding, which assumes a white
+/// page. Several are unusable as foreground text in one appearance or the other:
+/// Ampwall `#1E1E24` and Discogs `#333333` disappear in dark mode; Subvert `#D9DBDD`
+/// and TikTok/Threads `#E0E0E0` disappear in light mode.
+///
+/// This clamps a brand color's luminance into a legible band for the current
+/// appearance while keeping its hue, so badges stay recognizably on-brand. It replaces
+/// scattered `hex == "#000000"` special cases, which only ever covered two values and
+/// missed every platform above.
+enum BrandColor {
+    /// Luminance floor in dark mode and ceiling in light mode. Tuned so Ampwall and
+    /// Discogs lift clear of a dark popover, and Subvert/TikTok drop clear of a light one.
+    private static let darkModeMinLuminance = 0.55
+    private static let lightModeMaxLuminance = 0.62
+
+    static func legible(hex: String, isDark: Bool) -> Color {
+        guard let rgb = Color.rgbComponents(hex: hex) else { return .accentColor }
+
+        // Perceptual (Rec. 709) luminance — a flat RGB average would call yellow dark.
+        let luminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b
+
+        if isDark, luminance < darkModeMinLuminance {
+            return Color(
+                red: lighten(rgb.r, toward: darkModeMinLuminance, from: luminance),
+                green: lighten(rgb.g, toward: darkModeMinLuminance, from: luminance),
+                blue: lighten(rgb.b, toward: darkModeMinLuminance, from: luminance)
+            )
+        }
+
+        if !isDark, luminance > lightModeMaxLuminance {
+            let scale = lightModeMaxLuminance / max(luminance, 0.001)
+            return Color(red: rgb.r * scale, green: rgb.g * scale, blue: rgb.b * scale)
+        }
+
+        return Color(red: rgb.r, green: rgb.g, blue: rgb.b)
+    }
+
+    /// Blends toward white by however much the color is short of the target luminance.
+    /// Scaling channels up (the mirror of the darken path) would clip and shift hue on
+    /// near-black colors — Ampwall's `#1E1E24` would go pure blue.
+    private static func lighten(_ channel: Double, toward target: Double, from luminance: Double) -> Double {
+        let deficit = (target - luminance) / max(1 - luminance, 0.001)
+        return channel + (1 - channel) * deficit
     }
 }

--- a/apps/mac/Unstream/Views/Shared/EmptyStateView.swift
+++ b/apps/mac/Unstream/Views/Shared/EmptyStateView.swift
@@ -6,10 +6,11 @@ struct EmptyStateView: View {
             Image(systemName: "music.note.list")
                 .font(.system(size: 32))
                 .foregroundColor(.secondary.opacity(0.5))
+                .accessibilityHidden(true)
 
             VStack(spacing: 4) {
                 Text("No music playing")
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.headline)
                     .foregroundColor(.secondary)
 
                 Text("Search for an artist above, or start playing music to see results.")

--- a/apps/mac/Unstream/Views/Shared/LinkActions.swift
+++ b/apps/mac/Unstream/Views/Shared/LinkActions.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Adds the affordances a Mac user expects on anything that opens a URL: drag it out to
+/// Safari/Notes/Finder, and right-click to open, copy, or share it.
+///
+/// Applied as a modifier so views whose URL is `nil` (search-only platform entries with
+/// no target yet) opt out cleanly instead of offering a menu of dead commands.
+struct LinkActions: ViewModifier {
+    let url: URL?
+    let openTitle: String
+    let onOpen: () -> Void
+
+    func body(content: Content) -> some View {
+        if let url {
+            content
+                .draggable(url)
+                .contextMenu {
+                    Button(openTitle) { onOpen() }
+                    Divider()
+                    Button("Copy Link") { copyToClipboard(url: url) }
+                    ShareLink(item: url)
+                }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    /// - Parameters:
+    ///   - url: The link target. `nil` disables all of it.
+    ///   - openTitle: Menu title for the open command, e.g. "Open on Bandcamp".
+    ///   - onOpen: Runs the app's own open path so click-tracking still fires.
+    func linkActions(url: URL?, openTitle: String, onOpen: @escaping () -> Void) -> some View {
+        modifier(LinkActions(url: url, openTitle: openTitle, onOpen: onOpen))
+    }
+}

--- a/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
+++ b/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
@@ -19,18 +19,20 @@ struct PlatformBadge: View {
 
     #if os(iOS)
     private let iconSize: CGFloat = 14
-    private let fontSize: CGFloat = 14
-    private let payoutFontSize: CGFloat = 12
     private let paddingH: CGFloat = 12
     private let paddingV: CGFloat = 10
     private let spacing: CGFloat = 6
+    private let labelFont: Font = .system(size: 14, weight: .medium)
+    private let payoutFont: Font = .system(size: 12, weight: .semibold)
+    private let fridayFont: Font = .system(size: 12, weight: .bold)
     #else
     private let iconSize: CGFloat = 10
-    private let fontSize: CGFloat = 11
-    private let payoutFontSize: CGFloat = 9
     private let paddingH: CGFloat = 8
     private let paddingV: CGFloat = 4
     private let spacing: CGFloat = 4
+    private let labelFont: Font = .caption.weight(.medium)
+    private let payoutFont: Font = .caption2.weight(.semibold)
+    private let fridayFont: Font = .caption2.weight(.bold)
     #endif
 
     var body: some View {
@@ -39,12 +41,12 @@ struct PlatformBadge: View {
                 Image(systemName: result.icon)
                     .font(.system(size: iconSize))
                 Text(isSubtle ? "Search \(result.displayName)" : result.displayName)
-                    .font(.system(size: fontSize, weight: .medium))
+                    .font(labelFont)
 
                 // Payout percentage badge
                 if !isSubtle, let payout = displayPayout {
                     Text(payout)
-                        .font(.system(size: payoutFontSize, weight: .semibold))
+                        .font(payoutFont)
                         .padding(.horizontal, 3)
                         .padding(.vertical, 1)
                         .background(isBCFriday ? Color(hex: "#1DA0C3")!.opacity(0.2) : badgeColor.opacity(0.2))
@@ -54,7 +56,7 @@ struct PlatformBadge: View {
                 // BC Friday label
                 if !isSubtle && isBCFriday {
                     Text("BC Friday!")
-                        .font(.system(size: payoutFontSize, weight: .bold))
+                        .font(fridayFont)
                         .foregroundColor(Color(hex: "#1DA0C3") ?? .blue)
                 }
             }
@@ -69,12 +71,33 @@ struct PlatformBadge: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityText)
         #if os(macOS)
         .help(helpText)
         #endif
+        // A badge is fundamentally a link, so it should behave like one: draggable to
+        // Safari/Notes/Finder, and right-clickable for copy/open.
+        .linkActions(
+            url: platformURL,
+            openTitle: isSubtle ? "Search \(result.displayName)" : "Open on \(result.displayName)",
+            onOpen: openPlatform
+        )
         #if os(iOS)
         .safariSheet(safariItem: $safariItem)
         #endif
+    }
+
+    private var platformURL: URL? {
+        guard let urlString = result.url else { return nil }
+        return URL(string: urlString)
+    }
+
+    private var accessibilityText: String {
+        if isSubtle { return "Search for artist on \(result.displayName)" }
+        if let payout = result.artistPayoutPercent {
+            return "Open on \(result.displayName), \(payout) to artist"
+        }
+        return "Open on \(result.displayName)"
     }
 
     private var displayPayout: String? {

--- a/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
+++ b/apps/mac/Unstream/Views/Shared/PlatformBadge.swift
@@ -8,6 +8,7 @@ struct PlatformBadge: View {
     let result: PlatformResult
     var isSubtle: Bool = false
     var onOpen: (() -> Void)? = nil
+    @Environment(\.colorScheme) private var colorScheme
 
     #if os(iOS)
     @State private var safariItem: SafariURL?
@@ -49,7 +50,7 @@ struct PlatformBadge: View {
                         .font(payoutFont)
                         .padding(.horizontal, 3)
                         .padding(.vertical, 1)
-                        .background(isBCFriday ? Color(hex: "#1DA0C3")!.opacity(0.2) : badgeColor.opacity(0.2))
+                        .background(isBCFriday ? bandcampColor.opacity(0.2) : badgeColor.opacity(0.2))
                         .cornerRadius(3)
                 }
 
@@ -57,7 +58,7 @@ struct PlatformBadge: View {
                 if !isSubtle && isBCFriday {
                     Text("BC Friday!")
                         .font(fridayFont)
-                        .foregroundColor(Color(hex: "#1DA0C3") ?? .blue)
+                        .foregroundColor(bandcampColor)
                 }
             }
             .padding(.horizontal, paddingH)
@@ -119,7 +120,13 @@ struct PlatformBadge: View {
     }
 
     private var badgeColor: Color {
-        Color(hex: result.color) ?? .blue
+        BrandColor.legible(hex: result.color, isDark: colorScheme == .dark)
+    }
+
+    /// Bandcamp's cyan, used for the Bandcamp Friday accent. Routed through
+    /// BrandColor too — at luminance ~0.53 it sits just under the dark-mode floor.
+    private var bandcampColor: Color {
+        BrandColor.legible(hex: "#1DA0C3", isDark: colorScheme == .dark)
     }
 
     private func openPlatform() {

--- a/apps/mac/Unstream/Views/Shared/SocialIconButton.swift
+++ b/apps/mac/Unstream/Views/Shared/SocialIconButton.swift
@@ -53,11 +53,7 @@ struct SocialIconButton: View {
     }
 
     private var iconColor: Color {
-        let hex = result.color
-        if hex == "#000000" || hex == "#E0E0E0" {
-            return Color(white: 0.7)
-        }
-        return Color(hex: hex) ?? .blue
+        BrandColor.legible(hex: result.color, isDark: colorScheme == .dark)
     }
 
     private func openPlatform() {

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -15,20 +15,14 @@ struct SupportListView: View {
                 HStack(spacing: 8) {
                     SavedArtistsSearchBar(supportListManager: supportListManager)
 
-                    #if os(macOS)
-                    Button(action: shareArtistList) {
-                        Image(systemName: "square.and.arrow.up")
-                            .foregroundColor(.secondary)
-                            .font(.system(size: 14))
-                    }
-                    .buttonStyle(.plain)
-                    .help("Share saved artists")
-                    #else
                     ShareLink(item: generateShareText()) {
                         Image(systemName: "square.and.arrow.up")
                             .foregroundColor(.secondary)
-                            .font(.system(size: 14))
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Share saved artists")
+                    #if os(macOS)
+                    .help("Share saved artists")
                     #endif
                 }
             }
@@ -94,18 +88,6 @@ struct SupportListView: View {
         }
         return text
     }
-
-    #if os(macOS)
-    private func shareArtistList() {
-        let shareText = generateShareText()
-        let picker = NSSharingServicePicker(items: [shareText])
-        if let window = NSApp.keyWindow,
-           let contentView = window.contentView {
-            let rect = NSRect(x: contentView.bounds.midX, y: contentView.bounds.maxY - 50, width: 1, height: 1)
-            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
-        }
-    }
-    #endif
 }
 
 struct SavedArtistsSearchBar: View {
@@ -115,11 +97,11 @@ struct SavedArtistsSearchBar: View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .foregroundColor(.secondary)
-                .font(.system(size: 14))
+                .accessibilityHidden(true)
 
-            TextField("Filter saved artists...", text: $supportListManager.searchQuery)
+            TextField("Filter saved artists…", text: $supportListManager.searchQuery)
                 .textFieldStyle(.plain)
-                .font(.system(size: 14))
+                .accessibilityLabel("Filter saved artists")
 
             if !supportListManager.searchQuery.isEmpty {
                 Button(action: {
@@ -127,9 +109,9 @@ struct SavedArtistsSearchBar: View {
                 }) {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.secondary)
-                        .font(.system(size: 14))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Clear filter")
             }
         }
         .padding(.horizontal, 10)
@@ -162,10 +144,14 @@ struct SupportEntryView: View {
     private let iconButtonSize: CGFloat = 44
     private let refreshIconSize: CGFloat = 18
     private let heartIconSize: CGFloat = 20
+    private let nameFont: Font = .system(size: 14, weight: .semibold)
+    private let locationFont: Font = .system(size: 11)
     #else
     private let iconButtonSize: CGFloat = 14
     private let refreshIconSize: CGFloat = 12
     private let heartIconSize: CGFloat = 14
+    private let nameFont: Font = .headline
+    private let locationFont: Font = .caption
     #endif
 
     var body: some View {
@@ -176,14 +162,15 @@ struct SupportEntryView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(entry.artistName)
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(nameFont)
 
                     if let locationText = entry.location?.displayText {
                         Text(locationText)
-                            .font(.system(size: 11))
+                            .font(locationFont)
                             .foregroundColor(.secondary)
                     }
                 }
+                .textSelection(.enabled)
 
                 Spacer()
 
@@ -200,6 +187,7 @@ struct SupportEntryView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Refresh platforms for \(entry.artistName)")
                     #if os(macOS)
                     .opacity(isHovering ? 1 : 0.3)
                     .help("Refresh platforms")
@@ -214,6 +202,7 @@ struct SupportEntryView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(entry.artistName) from Saved Artists")
                 #if os(macOS)
                 .opacity(isHovering ? 1 : 0.5)
                 .help("Remove from Saved Artists")
@@ -241,6 +230,17 @@ struct SupportEntryView: View {
         .padding(10)
         .background(cardBackgroundColor)
         .cornerRadius(8)
+        // The refresh and remove buttons are hover-dimmed, so the context menu is the
+        // non-hover path to both — required for keyboard and VoiceOver users.
+        .contextMenu {
+            Button("Copy Artist Name") { copyToClipboard(text: entry.artistName) }
+
+            Divider()
+
+            Button("Refresh Platforms", action: onRefresh)
+                .disabled(isRefreshing)
+            Button("Remove from Saved Artists", role: .destructive, action: onRemove)
+        }
         #if os(macOS)
         .onHover { hovering in
             isHovering = hovering
@@ -311,7 +311,7 @@ struct SavedPlatformBadge: View {
     private let socialBadgeSize: CGFloat = 44
     private let socialIconSize: CGFloat = 20
     private let badgeIconSize: CGFloat = 14
-    private let badgeFontSize: CGFloat = 14
+    private let badgeFont: Font = .system(size: 14, weight: .medium)
     private let badgePaddingH: CGFloat = 12
     private let badgePaddingV: CGFloat = 10
     private let badgeSpacing: CGFloat = 6
@@ -319,7 +319,7 @@ struct SavedPlatformBadge: View {
     private let socialBadgeSize: CGFloat = 28
     private let socialIconSize: CGFloat = 14
     private let badgeIconSize: CGFloat = 10
-    private let badgeFontSize: CGFloat = 11
+    private let badgeFont: Font = .caption.weight(.medium)
     private let badgePaddingH: CGFloat = 8
     private let badgePaddingV: CGFloat = 4
     private let badgeSpacing: CGFloat = 4
@@ -338,7 +338,7 @@ struct SavedPlatformBadge: View {
                 HStack(spacing: badgeSpacing) {
                     platformIcon(size: badgeIconSize)
                     Text(platform.displayName)
-                        .font(.system(size: badgeFontSize, weight: .medium))
+                        .font(badgeFont)
                 }
                 .padding(.horizontal, badgePaddingH)
                 .padding(.vertical, badgePaddingV)
@@ -348,9 +348,15 @@ struct SavedPlatformBadge: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Open \(platform.displayName)")
         #if os(macOS)
         .help("Open \(platform.displayName)")
         #endif
+        .linkActions(
+            url: URL(string: platform.url),
+            openTitle: "Open on \(platform.displayName)",
+            onOpen: openPlatformURL
+        )
         #if os(iOS)
         .safariSheet(safariItem: $safariItem)
         #endif
@@ -389,11 +395,11 @@ struct NewReleaseBadge: View {
     #endif
 
     #if os(iOS)
-    private let fontSize: CGFloat = 14
+    private let labelFont: Font = .system(size: 14, weight: .medium)
     private let paddingH: CGFloat = 12
     private let paddingV: CGFloat = 10
     #else
-    private let fontSize: CGFloat = 11
+    private let labelFont: Font = .caption.weight(.medium)
     private let paddingH: CGFloat = 8
     private let paddingV: CGFloat = 4
     #endif
@@ -404,7 +410,7 @@ struct NewReleaseBadge: View {
                 Image(systemName: "sparkles")
                     .foregroundColor(.yellow)
                 Text("New release: \(release.releaseName)")
-                    .font(.system(size: fontSize, weight: .medium))
+                    .font(labelFont)
                     .lineLimit(1)
             }
             .padding(.horizontal, paddingH)
@@ -414,9 +420,15 @@ struct NewReleaseBadge: View {
             .cornerRadius(6)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("New release: \(release.releaseName) on \(release.platform.capitalized)")
         #if os(macOS)
         .help("Open \(release.releaseName) on \(release.platform.capitalized)")
         #endif
+        .linkActions(
+            url: URL(string: release.releaseUrl),
+            openTitle: "Open on \(release.platform.capitalized)",
+            onOpen: openRelease
+        )
         #if os(iOS)
         .safariSheet(safariItem: $safariItem)
         #endif

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -300,11 +300,7 @@ struct SavedPlatformBadge: View {
     }
 
     private var platformColor: Color {
-        let hex = platform.color
-        if hex == "#000000" || hex == "#E0E0E0" {
-            return Color(white: 0.7)
-        }
-        return Color(hex: hex) ?? .blue
+        BrandColor.legible(hex: platform.color, isDark: colorScheme == .dark)
     }
 
     #if os(iOS)

--- a/apps/mac/Unstream/Views/Shared/SyncedArtistsView.swift
+++ b/apps/mac/Unstream/Views/Shared/SyncedArtistsView.swift
@@ -72,19 +72,21 @@ struct SyncedArtistsView: View {
             if let error = sync.syncError {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundColor(.orange)
+                        .accessibilityHidden(true)
                     Text(error)
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundColor(.orange)
                     Spacer()
                     Button("Retry") {
                         sync.syncError = nil
                         Task { await sync.pull() }
                     }
-                    .font(.system(size: 10))
+                    .font(.caption2)
                     .buttonStyle(.plain)
                     .foregroundColor(.accentColor)
+                    .accessibilityLabel("Retry syncing saved artists")
                 }
                 .padding(.horizontal, 4)
                 .padding(.vertical, 4)
@@ -119,6 +121,11 @@ struct SyncedArtistRow: View {
 
     #if os(iOS)
     @State private var safariItem: SafariURL?
+    private let nameFont: Font = .system(size: 13, weight: .medium)
+    private let badgeFont: Font = .system(size: 9, weight: .medium)
+    #else
+    private let nameFont: Font = .body.weight(.medium)
+    private let badgeFont: Font = .caption2.weight(.medium)
     #endif
 
     var body: some View {
@@ -147,15 +154,16 @@ struct SyncedArtistRow: View {
             // Name + claimed badge
             VStack(alignment: .leading, spacing: 2) {
                 Text(artist.name)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(nameFont)
                     .lineLimit(1)
 
                 if artist.claimed == true {
                     Text("Verified")
-                        .font(.system(size: 9, weight: .medium))
+                        .font(badgeFont)
                         .foregroundColor(.green)
                 }
             }
+            .textSelection(.enabled)
 
             Spacer()
 
@@ -173,6 +181,7 @@ struct SyncedArtistRow: View {
                         .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(artist.claimed == true ? "Open \(artist.name)'s artist page" : "Search for \(artist.name)")
                 #if os(macOS)
                 .help(artist.claimed == true ? "Open artist page" : "Search for artist")
                 #endif
@@ -185,11 +194,29 @@ struct SyncedArtistRow: View {
                     .foregroundColor(.red.opacity(0.7))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(artist.name) from saved")
             #if os(macOS)
             .help("Remove from saved")
             #endif
         }
         .padding(.vertical, 4)
+        .contextMenu {
+            if artist.claimed == true, let profileURL = artist.profileURL {
+                Button("Open Artist Page") { openURL(profileURL) }
+                Button("Copy Link") { copyToClipboard(url: profileURL) }
+                ShareLink(item: profileURL)
+                Divider()
+            } else if let onOpen {
+                Button("Search for Artist") { onOpen() }
+                Divider()
+            }
+
+            Button("Copy Artist Name") { copyToClipboard(text: artist.name) }
+
+            Divider()
+
+            Button("Remove from Saved", role: .destructive, action: onRemove)
+        }
         #if os(iOS)
         .safariSheet(safariItem: $safariItem)
         #endif

--- a/apps/mac/Unstream/Views/Shared/TipJarView.swift
+++ b/apps/mac/Unstream/Views/Shared/TipJarView.swift
@@ -1,7 +1,32 @@
 import SwiftUI
-import StoreKit
 
+#if os(iOS)
+import StoreKit
+#endif
+
+/// Support-Unstream control.
+///
+/// The two platforms deliberately differ. The Mac app ships as a direct GitHub
+/// release, so it links straight to Liberapay — no platform takes a cut, which is
+/// the position Unstream argues for everywhere else. The iOS app ships through the
+/// App Store, where App Review guideline 3.1.1 requires in-app purchase for tipping
+/// the developer and an external donation link is grounds for rejection, so it keeps
+/// StoreKit. Don't "simplify" this into one path.
 struct TipJarView: View {
+    #if os(macOS)
+    private static let donateURL = URL(string: "https://liberapay.com/brandonlucasgreen")!
+
+    var body: some View {
+        HStack {
+            Link(destination: Self.donateURL) {
+                Label("Donate via Liberapay", systemImage: "heart.fill")
+            }
+            .accessibilityLabel("Donate via Liberapay, opens in your browser")
+
+            Spacer()
+        }
+    }
+    #else
     @StateObject private var store = TipJarStore()
     @State private var loadTimedOut = false
 
@@ -95,10 +120,13 @@ struct TipJarView: View {
             loadTimedOut = false
         }
     }
+    #endif
 }
 
+#if os(iOS)
 private extension Array {
     subscript(safe index: Int) -> Element? {
         indices.contains(index) ? self[index] : nil
     }
 }
+#endif

--- a/apps/mac/Unstream/Views/macOS/NowPlayingView.swift
+++ b/apps/mac/Unstream/Views/macOS/NowPlayingView.swift
@@ -54,31 +54,41 @@ struct NowPlayingView: View {
                     fallbackImage
                 }
 
-                // Track info
+                // Track info. Selectable so the artist/track can be copied — Mac users
+                // expect to be able to lift text out of what they're looking at.
                 VStack(alignment: .leading, spacing: 2) {
                     if let artist = nowPlaying.artist {
                         Text(artist)
-                            .font(.system(size: 14, weight: .semibold))
+                            .font(.headline)
                             .lineLimit(1)
                     }
                     if let title = nowPlaying.title {
                         Text(title)
-                            .font(.system(size: 12))
+                            .font(.callout)
                             .foregroundColor(.secondary)
                             .lineLimit(1)
                     }
                     if let album = nowPlaying.album {
                         Text(album)
-                            .font(.system(size: 11))
+                            .font(.caption)
                             .foregroundColor(.secondary.opacity(0.7))
                             .lineLimit(1)
                     }
                 }
+                .textSelection(.enabled)
 
                 Spacer()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .contextMenu {
+            if let artist = nowPlaying.artist {
+                Button("Copy Artist Name") { copyToClipboard(text: artist) }
+            }
+            if let title = nowPlaying.title, let artist = nowPlaying.artist {
+                Button("Copy Track") { copyToClipboard(text: "\(artist) — \(title)") }
+            }
+        }
     }
 }
 

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -18,52 +18,26 @@ struct PopoverView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Tab bar
-            HStack(spacing: 0) {
-                TabButton(
-                    title: "Search",
-                    icon: "magnifyingglass",
-                    isSelected: selectedTab == .search
-                ) {
-                    selectedTab = .search
-                }
-
-                TabButton(
-                    title: "Saved Artists",
-                    icon: "heart.fill",
-                    isSelected: selectedTab == .supportList,
-                    badge: supportListManager.entries.count > 0 ? supportListManager.entries.count : nil
-                ) {
-                    selectedTab = .supportList
-                }
+            // A real segmented control: correct selection emphasis in both appearances
+            // and in an inactive window, which the hand-rolled accent-tinted pills got
+            // wrong (they read as a heavy blue slab in dark mode).
+            Picker("View", selection: $selectedTab) {
+                Text("Search").tag(PopoverTab.search)
+                Text(savedTabTitle).tag(PopoverTab.supportList)
             }
-            .padding(.horizontal)
-            .padding(.top, 8)
-
-            // Auth bar (shown when signed in or has synced artists)
-            if auth.isSignedIn {
-                Divider()
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                        .font(.caption2)
-                        .accessibilityHidden(true)
-                    Text(auth.userEmail ?? "Signed in")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                    Spacer()
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Signed in as \(auth.userEmail ?? "unknown account")")
-                .padding(.horizontal)
-                .padding(.vertical, 4)
-            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
 
             // Search bar (only visible on search tab)
             if selectedTab == .search {
                 SearchBarView(isFocused: $searchFieldFocused)
-                    .padding()
+                    .padding(.horizontal, 12)
+                    .padding(.top, 10)
+                    .padding(.bottom, 12)
+            } else {
+                Spacer().frame(height: 10)
             }
 
             Divider()
@@ -169,13 +143,26 @@ struct PopoverView: View {
             HStack {
                 // Sign in/out button
                 if auth.isSignedIn {
+                    // Account identity lives next to the sign-out action rather than in
+                    // a bar above the search field, where it competed with the task.
                     Button(action: { Task { await auth.signOut() } }) {
                         Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
-                    .help("Sign out of Unstream")
+                    .help("Sign out of \(auth.userEmail ?? "Unstream")")
+                    .accessibilityLabel("Sign out of \(auth.userEmail ?? "Unstream")")
+
+                    if let email = auth.userEmail {
+                        Text(email)
+                            .font(.caption2)
+                            .foregroundColor(.secondary.opacity(0.7))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help("Signed in as \(email)")
+                            .accessibilityHidden(true)
+                    }
                 } else {
                     Button(action: { showSignIn = true }) {
                         Label("Sign In", systemImage: "person.crop.circle.badge.plus")
@@ -262,6 +249,13 @@ struct PopoverView: View {
         }
     }
 
+    /// The saved count rides in the segment label — a segmented control has no badge
+    /// slot, and the count is useful enough to keep.
+    private var savedTabTitle: String {
+        let count = supportListManager.entries.count
+        return count > 0 ? "Saved (\(count))" : "Saved"
+    }
+
     // MARK: - Keyboard
 
     /// The popover's window only becomes key just *after* `show()`, so focusing
@@ -316,63 +310,6 @@ struct PopoverView: View {
     private func stopMenuPoll() {
         pollTask?.cancel()
         pollTask = nil
-    }
-}
-
-struct TabButton: View {
-    let title: String
-    let icon: String
-    let isSelected: Bool
-    var badge: Int? = nil
-    let action: () -> Void
-
-    /// Custom selected rows must respect active-window state or the accent tint stays
-    /// fully saturated in a background window, which no native control does.
-    @Environment(\.controlActiveState) private var controlActiveState
-
-    private var isWindowActive: Bool {
-        controlActiveState != .inactive
-    }
-
-    private var foreground: Color {
-        guard isSelected else { return .secondary }
-        return isWindowActive ? .accentColor : .secondary
-    }
-
-    private var background: Color {
-        guard isSelected else { return .clear }
-        return isWindowActive
-            ? Color.accentColor.opacity(0.12)
-            : Color.secondary.opacity(0.12)
-    }
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 4) {
-                Image(systemName: icon)
-                    .font(.caption)
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(isSelected ? .callout.weight(.semibold) : .callout)
-                if let badge = badge, badge > 0 {
-                    Text("\(badge)")
-                        .font(.caption2.weight(.medium))
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(Color.secondary.opacity(0.15))
-                        .clipShape(Capsule())
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
-            .background(background)
-            .foregroundColor(foreground)
-            .cornerRadius(6)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(badge.map { "\(title), \($0) saved" } ?? title)
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
 

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -184,10 +184,6 @@ struct PopoverView: View {
 
                     Divider()
 
-                    Link(destination: URL(string: "https://github.com/users/brandonlucasgreen/projects/3/views/1")!) {
-                        Label("Roadmap", systemImage: "map")
-                    }
-
                     Link(destination: URL(string: "https://letterbird.co/hi-d2078591")!) {
                         Label("Share Feedback", systemImage: "bubble.left")
                     }

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -252,6 +252,9 @@ struct PopoverView: View {
             // NSPopoverDelegate fires this unconditionally when the popover closes.
             showSignIn = false
         }
+        .onReceive(NotificationCenter.default.publisher(for: .showSearchTab)) { _ in
+            selectedTab = .search
+        }
         .onChange(of: auth.isSignedIn) { signedIn in
             if !signedIn {
                 stopMenuPoll()

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -14,6 +14,7 @@ struct PopoverView: View {
     @State private var selectedTab: PopoverTab = .search
     @State private var showSignIn = false
     @State private var pollTask: Task<Void, Never>?
+    @FocusState private var searchFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,20 +46,23 @@ struct PopoverView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(.green)
-                        .font(.system(size: 10))
+                        .font(.caption2)
+                        .accessibilityHidden(true)
                     Text(auth.userEmail ?? "Signed in")
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundColor(.secondary)
                         .lineLimit(1)
                     Spacer()
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Signed in as \(auth.userEmail ?? "unknown account")")
                 .padding(.horizontal)
                 .padding(.vertical, 4)
             }
 
             // Search bar (only visible on search tab)
             if selectedTab == .search {
-                SearchBarView()
+                SearchBarView(isFocused: $searchFieldFocused)
                     .padding()
             }
 
@@ -166,26 +170,20 @@ struct PopoverView: View {
                 // Sign in/out button
                 if auth.isSignedIn {
                     Button(action: { Task { await auth.signOut() } }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "rectangle.portrait.and.arrow.right")
-                                .font(.system(size: 10))
-                            Text("Sign Out")
-                                .font(.system(size: 10))
-                        }
-                        .foregroundColor(.secondary)
+                        Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .help("Sign out of Unstream")
                 } else {
                     Button(action: { showSignIn = true }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "person.crop.circle.badge.plus")
-                                .font(.system(size: 10))
-                            Text("Sign In")
-                                .font(.system(size: 10))
-                        }
-                        .foregroundColor(.secondary)
+                        Label("Sign In", systemImage: "person.crop.circle.badge.plus")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .help("Sign in to sync saved artists")
                 }
 
                 Spacer()
@@ -220,16 +218,20 @@ struct PopoverView: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
-                        .font(.system(size: 16))
+                        .font(.title3)
                         .foregroundColor(.secondary)
                 }
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
+                .fixedSize()
+                .accessibilityLabel("More options")
+                .help("Settings, feedback, and more")
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
         }
         .frame(width: 320)
+        .background(keyboardShortcuts)
         .sheet(isPresented: $showSignIn) {
             SignInView()
         }
@@ -237,6 +239,10 @@ struct PopoverView: View {
             // Reset sheet state on every open — NSPopover hides (not destroys) its content
             // view, so onDisappear isn't reliable; onAppear fires on each show.
             showSignIn = false
+            focusSearchField()
+        }
+        .onChange(of: selectedTab) { tab in
+            if tab == .search { focusSearchField() }
         }
         .onDisappear {
             stopMenuPoll()
@@ -251,6 +257,41 @@ struct PopoverView: View {
                 stopMenuPoll()
             }
         }
+    }
+
+    // MARK: - Keyboard
+
+    /// The popover's window only becomes key just *after* `show()`, so focusing
+    /// synchronously in `onAppear` gets discarded. Defer one run-loop turn.
+    private func focusSearchField() {
+        DispatchQueue.main.async {
+            searchFieldFocused = true
+        }
+    }
+
+    /// The popover is a hosted view, not a Scene, so there's no `Commands` builder to
+    /// hang shortcuts on. Zero-size buttons are the standard SwiftUI way to register
+    /// key equivalents inside one; they only fire while the popover is the key window.
+    private var keyboardShortcuts: some View {
+        Group {
+            Button("Search") {
+                selectedTab = .search
+                focusSearchField()
+            }
+            .keyboardShortcut("f", modifiers: .command)
+
+            Button("Search Tab") { selectedTab = .search }
+                .keyboardShortcut("1", modifiers: .command)
+
+            Button("Saved Artists Tab") { selectedTab = .supportList }
+                .keyboardShortcut("2", modifiers: .command)
+
+            Button("Close") { AppDelegate.shared?.closePopover() }
+                .keyboardShortcut("w", modifiers: .command)
+        }
+        .frame(width: 0, height: 0)
+        .opacity(0)
+        .accessibilityHidden(true)
     }
 
     // MARK: - 60-second poll while menu is open
@@ -282,16 +323,37 @@ struct TabButton: View {
     var badge: Int? = nil
     let action: () -> Void
 
+    /// Custom selected rows must respect active-window state or the accent tint stays
+    /// fully saturated in a background window, which no native control does.
+    @Environment(\.controlActiveState) private var controlActiveState
+
+    private var isWindowActive: Bool {
+        controlActiveState != .inactive
+    }
+
+    private var foreground: Color {
+        guard isSelected else { return .secondary }
+        return isWindowActive ? .accentColor : .secondary
+    }
+
+    private var background: Color {
+        guard isSelected else { return .clear }
+        return isWindowActive
+            ? Color.accentColor.opacity(0.12)
+            : Color.secondary.opacity(0.12)
+    }
+
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
                 Image(systemName: icon)
-                    .font(.system(size: 11))
+                    .font(.caption)
+                    .accessibilityHidden(true)
                 Text(title)
-                    .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
+                    .font(isSelected ? .callout.weight(.semibold) : .callout)
                 if let badge = badge, badge > 0 {
                     Text("\(badge)")
-                        .font(.system(size: 9, weight: .medium))
+                        .font(.caption2.weight(.medium))
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 2)
@@ -301,11 +363,13 @@ struct TabButton: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
-            .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
-            .foregroundColor(isSelected ? .accentColor : .secondary)
+            .background(background)
+            .foregroundColor(foreground)
             .cornerRadius(6)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(badge.map { "\(title), \($0) saved" } ?? title)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
 

--- a/apps/mac/Unstream/Views/macOS/SearchBarView.swift
+++ b/apps/mac/Unstream/Views/macOS/SearchBarView.swift
@@ -2,18 +2,19 @@ import SwiftUI
 
 struct SearchBarView: View {
     @EnvironmentObject var appState: AppState
-    @FocusState private var isFocused: Bool
+    /// Owned by PopoverView so it can focus the field on open and on ⌘F.
+    @FocusState.Binding var isFocused: Bool
 
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .foregroundColor(.secondary)
-                .font(.system(size: 14))
+                .accessibilityHidden(true)
 
-            TextField("Search for artists...", text: $appState.searchQuery)
+            TextField("Search for artists…", text: $appState.searchQuery)
                 .textFieldStyle(.plain)
-                .font(.system(size: 14))
                 .focused($isFocused)
+                .accessibilityLabel("Search for artists")
                 .onSubmit {
                     Task {
                         await appState.performSearch()
@@ -23,23 +24,39 @@ struct SearchBarView: View {
             if !appState.searchQuery.isEmpty {
                 Button(action: {
                     appState.clearSearch()
+                    isFocused = true
                 }) {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.secondary)
-                        .font(.system(size: 14))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+                .help("Clear search")
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(Color(NSColor.textBackgroundColor))
-        .cornerRadius(8)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(NSColor.textBackgroundColor))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color(NSColor.separatorColor), lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct SearchBarPreviewContainer: View {
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        SearchBarView(isFocused: $focused)
+            .environmentObject(AppState())
+            .padding()
     }
 }
 
 #Preview {
-    SearchBarView()
-        .environmentObject(AppState())
-        .padding()
+    SearchBarPreviewContainer()
 }

--- a/apps/mac/Unstream/Views/macOS/SettingsView.swift
+++ b/apps/mac/Unstream/Views/macOS/SettingsView.swift
@@ -48,44 +48,23 @@ struct SettingsView: View {
     @StateObject private var shortcutRecorder = ShortcutRecorder()
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Tab bar header
-            HStack(spacing: 0) {
-                ForEach(SettingsTab.allCases, id: \.self) { tab in
-                    Button(action: { selectedTab = tab }) {
-                        HStack(spacing: 5) {
-                            Image(systemName: tab.icon)
-                                .font(.system(size: 11))
-                            Text(tab.rawValue)
-                                .font(.system(size: 12, weight: selectedTab == tab ? .semibold : .regular))
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                        .background(selectedTab == tab ? Color.accentColor.opacity(0.12) : Color.clear)
-                        .foregroundColor(selectedTab == tab ? .accentColor : .secondary)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
+        // A real TabView inside the Settings scene renders as the standard macOS
+        // settings toolbar tabs, with keyboard navigation and correct active/inactive
+        // styling — the hand-rolled accent-tinted pills had none of that.
+        TabView(selection: $selectedTab) {
+            generalTab
+                .tabItem { Label(SettingsTab.general.rawValue, systemImage: SettingsTab.general.icon) }
+                .tag(SettingsTab.general)
 
-            Divider()
-                .padding(.top, 8)
+            integrationsTab
+                .tabItem { Label(SettingsTab.integrations.rawValue, systemImage: SettingsTab.integrations.icon) }
+                .tag(SettingsTab.integrations)
 
-            // Tab content
-            switch selectedTab {
-            case .general:
-                generalTab
-            case .integrations:
-                integrationsTab
-            case .about:
-                aboutTab
-            }
+            aboutTab
+                .tabItem { Label(SettingsTab.about.rawValue, systemImage: SettingsTab.about.icon) }
+                .tag(SettingsTab.about)
         }
-        .frame(width: 380)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: 480)
         .onAppear {
             launchAtLogin = getLaunchAtLoginStatus()
             loadListenBrainzState()
@@ -96,38 +75,23 @@ struct SettingsView: View {
     // MARK: - General Tab
 
     private var generalTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            // Music Listening
-            VStack(alignment: .leading, spacing: 4) {
+        Form {
+            Section {
                 Toggle("Music app listening", isOn: $musicListeningEnabled)
-                Text("Automatically detect what's playing in Music or Spotify")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            // Artist Notifications
-            VStack(alignment: .leading, spacing: 4) {
+                    .help("Automatically detect what's playing in Music or Spotify")
                 Toggle("Artist detection notifications", isOn: $artistNotificationsEnabled)
-                Text("Show a notification when a new artist is detected while playing music")
+                    .help("Show a notification when a new artist is detected while playing music")
+            } footer: {
+                Text("Unstream watches your music players so it can show where the current artist sells directly.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
 
-            Divider()
-
-            // Global Keyboard Shortcut
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Keyboard Shortcut")
-                    .font(.headline)
-
-                Text("Set a global shortcut to open Unstream from anywhere.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
+            Section {
                 HStack {
                     if shortcutRecorder.isRecording {
                         Text("Press shortcut...")
-                            .font(.system(size: 12, weight: .medium, design: .rounded))
+                            .font(.callout.weight(.medium))
                             .foregroundColor(.accentColor)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
@@ -142,7 +106,7 @@ struct SettingsView: View {
                         .font(.caption)
                     } else if let shortcut = hotkeyManager.currentShortcut {
                         Text(shortcut.displayString)
-                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            .font(.body.weight(.medium))
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
                             .background(
@@ -172,51 +136,39 @@ struct SettingsView: View {
                 if hotkeyManager.currentShortcut != nil {
                     Toggle("Enable shortcut", isOn: $hotkeyManager.isEnabled)
                 }
-            }
-
-            Divider()
-
-            // Launch at Login
-            VStack(alignment: .leading, spacing: 4) {
-                Toggle("Start at login", isOn: $launchAtLogin)
-                    .onChange(of: launchAtLogin) { newValue in
-                        setLaunchAtLogin(newValue)
-                    }
-                Text("Automatically launch Unstream when you log in")
+            } header: {
+                Text("Keyboard Shortcut")
+            } footer: {
+                Text("Set a global shortcut to open Unstream from anywhere.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
 
-            Spacer()
+            Section {
+                Toggle("Start at login", isOn: $launchAtLogin)
+                    .onChange(of: launchAtLogin) { newValue in
+                        setLaunchAtLogin(newValue)
+                    }
+            } footer: {
+                Text("Automatically launch Unstream when you log in.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
-        .padding()
+        .formStyle(.grouped)
     }
 
     // MARK: - Integrations Tab
 
     private var integrationsTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        Form {
             // Release Alerts
             if let alertManager = releaseAlertManager {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Release Alerts")
-                            .font(.headline)
-                        if alertManager.releaseAlertsEnabled {
-                            Image(systemName: "bell.fill")
-                                .foregroundColor(.yellow)
-                                .font(.caption)
-                        }
-                    }
-
+                Section {
                     Toggle("Check for new releases weekly", isOn: Binding(
                         get: { alertManager.releaseAlertsEnabled },
                         set: { alertManager.releaseAlertsEnabled = $0 }
                     ))
-
-                    Text("Get notified when your saved artists release new music on Bandcamp or Faircamp.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
 
                     HStack {
                         if let lastCheck = alertManager.lastCheckDate {
@@ -227,18 +179,17 @@ struct SettingsView: View {
 
                         Spacer()
 
+                        if alertManager.isChecking {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+
                         Button("Check Now") {
                             Task {
                                 await alertManager.checkNow()
                             }
                         }
-                        .font(.caption)
                         .disabled(alertManager.isChecking)
-
-                        if alertManager.isChecking {
-                            ProgressView()
-                                .scaleEffect(0.6)
-                        }
                     }
 
                     #if DEBUG
@@ -280,31 +231,29 @@ struct SettingsView: View {
                             .foregroundColor(.secondary)
                     }
                     #endif
+                } header: {
+                    HStack {
+                        Text("Release Alerts")
+                        if alertManager.releaseAlertsEnabled {
+                            Image(systemName: "bell.fill")
+                                .foregroundColor(.yellow)
+                                .font(.caption)
+                                .accessibilityLabel("Release alerts on")
+                        }
+                    }
+                } footer: {
+                    Text("Get notified when your saved artists release new music on Bandcamp or Faircamp.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
-
-                Divider()
             }
 
             // ListenBrainz Scrobbling
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Scrobbling")
-                        .font(.headline)
-                    if listenBrainzUsername != nil {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                            .font(.caption)
-                    }
-                }
-
+            Section {
                 Toggle("Enable ListenBrainz scrobbling", isOn: $listenBrainzEnabled)
                     .onChange(of: listenBrainzEnabled) { newValue in
                         ListenBrainzService.shared.isEnabled = newValue
                     }
-
-                Text("Submit your listening history to ListenBrainz")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
 
                 if listenBrainzEnabled {
                     VStack(alignment: .leading, spacing: 8) {
@@ -349,95 +298,87 @@ struct SettingsView: View {
                         }
                     }
                 }
-            }
-
-            Divider()
-
-            // Plex Integration
-            VStack(alignment: .leading, spacing: 8) {
+            } header: {
                 HStack {
-                    Text("Plex")
-                        .font(.headline)
-                    if plexServerName != nil {
+                    Text("Scrobbling")
+                    if listenBrainzUsername != nil {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(.green)
                             .font(.caption)
+                            .accessibilityLabel("ListenBrainz connected")
                     }
                 }
+            } footer: {
+                Text("Submit your listening history to ListenBrainz.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
 
+            // Plex Integration
+            Section {
                 Toggle("Enable Plex music detection", isOn: $plexEnabled)
                     .onChange(of: plexEnabled) { newValue in
                         PlexService.shared.isEnabled = newValue
                     }
 
-                Text("Detect music playing on your Plex server (Plexamp, Plex Web, etc.)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
                 if plexEnabled {
-                    VStack(alignment: .leading, spacing: 8) {
-                        if let serverName = plexServerName {
+                    if let serverName = plexServerName {
+                        LabeledContent("Connected to") {
                             HStack {
-                                Text("Connected to: \(serverName)")
-                                    .font(.caption)
+                                Text(serverName)
                                     .foregroundColor(.secondary)
                                 Spacer()
                                 Button("Disconnect") {
                                     disconnectPlex()
                                 }
+                            }
+                        }
+                    } else {
+                        // Form gives these right-aligned native labels; the old version
+                        // hand-rolled them with fixed-width Text + HStack.
+                        TextField("Server URL", text: $plexServerURL, prompt: Text("http://localhost:32400"))
+                        SecureField("Token", text: $plexToken, prompt: Text("Plex auth token"))
+
+                        HStack {
+                            Spacer()
+                            if isValidatingPlex {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Button(isValidatingPlex ? "Connecting…" : "Connect") {
+                                validatePlexConnection()
+                            }
+                            .disabled(plexToken.isEmpty || isValidatingPlex)
+                        }
+
+                        if let error = plexValidationError {
+                            Text(error)
                                 .font(.caption)
                                 .foregroundColor(.red)
-                            }
-                        } else {
-                            VStack(alignment: .leading, spacing: 6) {
-                                HStack {
-                                    Text("Server URL")
-                                        .font(.caption)
-                                        .frame(width: 70, alignment: .leading)
-                                    TextField("http://localhost:32400", text: $plexServerURL)
-                                        .textFieldStyle(.roundedBorder)
-                                        .frame(maxWidth: 200)
-                                }
-
-                                HStack {
-                                    Text("Token")
-                                        .font(.caption)
-                                        .frame(width: 70, alignment: .leading)
-                                    SecureField("Plex auth token", text: $plexToken)
-                                        .textFieldStyle(.roundedBorder)
-                                        .frame(maxWidth: 200)
-                                }
-
-                                HStack {
-                                    Button(isValidatingPlex ? "Connecting..." : "Connect") {
-                                        validatePlexConnection()
-                                    }
-                                    .disabled(plexToken.isEmpty || isValidatingPlex)
-
-                                    if isValidatingPlex {
-                                        ProgressView()
-                                            .scaleEffect(0.6)
-                                    }
-                                }
-                            }
-
-                            if let error = plexValidationError {
-                                Text(error)
-                                    .font(.caption)
-                                    .foregroundColor(.red)
-                            }
-
-                            Link("How to find your Plex token",
-                                 destination: URL(string: "https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/")!)
-                                .font(.caption)
                         }
+
+                        Link("How to find your Plex token",
+                             destination: URL(string: "https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/")!)
+                            .font(.caption)
                     }
                 }
+            } header: {
+                HStack {
+                    Text("Plex")
+                    if plexServerName != nil {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .font(.caption)
+                            .accessibilityLabel("Plex connected")
+                    }
+                }
+            } footer: {
+                Text("Detect music playing on your Plex server (Plexamp, Plex Web, etc.).")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
-
-            Spacer()
         }
-        .padding()
+        .formStyle(.grouped)
         .onReceive(NotificationCenter.default.publisher(for: .plexAuthError)) { _ in
             plexServerName = nil
             plexValidationError = "Plex token is invalid or expired. Please reconnect."
@@ -447,9 +388,9 @@ struct SettingsView: View {
     // MARK: - About Tab
 
     private var aboutTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        Form {
             // Updates
-            VStack(alignment: .leading, spacing: 8) {
+            Section("Updates") {
                 Toggle("Check for updates automatically", isOn: $checkForUpdatesAutomatically)
 
                 HStack {
@@ -460,8 +401,10 @@ struct SettingsView: View {
 
                     if isCheckingForUpdates {
                         ProgressView()
-                            .scaleEffect(0.7)
+                            .controlSize(.small)
                     }
+
+                    Spacer()
                 }
 
                 if let status = updateStatus {
@@ -490,34 +433,24 @@ struct SettingsView: View {
                 }
             }
 
-            Divider()
-
             // Support Unstream
-            VStack(alignment: .leading, spacing: 8) {
+            Section {
+                TipJarView()
+            } header: {
                 Text("Support Unstream")
-                    .font(.headline)
-
+            } footer: {
                 Text("Unstream is free and open source. If you find it useful, consider supporting development.")
                     .font(.caption)
                     .foregroundColor(.secondary)
-
-                TipJarView()
             }
-
-            Divider()
 
             // About
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Unstream v\(Bundle.main.appVersion)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            Section {
+                LabeledContent("Version", value: Bundle.main.appVersion)
                 Link("Visit unstream.stream", destination: URL(string: "https://unstream.stream")!)
-                    .font(.caption)
             }
-
-            Spacer()
         }
-        .padding()
+        .formStyle(.grouped)
     }
 
     // MARK: - Keyboard Shortcut


### PR DESCRIPTION
Audits the macOS app against the [mac-assed criteria](https://github.com/HunterHillegas/mac-assed-mac-app-skill) and closes the gaps. Before this, greps across the whole app returned **zero** hits for `contextMenu`, `keyboardShortcut`, `CommandGroup`, `NSPasteboard`, `draggable`, `Transferable`, `accessibilityLabel`, and `List` — it was a SwiftUI app that ran on macOS rather than a Mac app.

macOS-only except for shared views under `Views/Shared/`, where iOS font sizes are deliberately left byte-identical.

## Keyboard and focus

- **Focus the search field when the popover opens.** `@FocusState` was declared and bound but never set, so summoning the app with the global hotkey needed a click before typing. Focus is deferred one run-loop turn because the popover's window only becomes key *after* `show()`.
- ⌘F focus search, ⌘1/⌘2 tabs, ⌘W close.

## Settings is now the real Settings scene

Deletes the hand-rolled `NSWindow`, the ⌘, local event monitor that was hijacking the `Settings…` item SwiftUI already provides, and a click-outside global event monitor that did nothing (it only observes *other* apps' events; `.transient` already dismisses). Panes become `Form`/`Section`, so toggles render as Mac checkboxes and the Plex fields get native right-aligned labels.

`openSettings()` performs the real menu item rather than hardcoding the private `showSettingsWindow:` selector, since `SettingsLink` is macOS 14+ and we support 13.

## Links behave like links

One shared `.linkActions(url:openTitle:onOpen:)` modifier gives every platform, saved, and release badge drag-to-Safari/Notes/Finder plus a context menu. Artist cards are draggable with a full menu. Saved rows and support entries get menus too — their refresh/remove buttons are hover-dimmed and had no non-hover path.

`NSSharingServicePicker` becomes `ShareLink` passing a real `URL`, so link-aware targets get a link instead of a sentence. **This also changes iOS**, which previously shared a bare string.

## System integration

- **Services menu** — select an artist name in any app → Services ▸ Find on Unstream. The plist's `NSMessage` and the provider's selector must agree or the item silently does nothing, so a Debug assertion at launch reads `NSMessage` back out of the bundle and checks the selector exists.
- **App Intents / Shortcuts** — `FindArtistIntent` returns platforms and payout shares as a value so it composes in a Shortcut; it calls `UnstreamAPI` directly rather than `AppState` because an intent can run before any popover has existed. `SearchInUnstreamIntent` opens the popover with the search already run.

## Brand color legibility

Five platform brand colors were unreadable in one appearance: Ampwall `#1E1E24` and Discogs `#333333` vanish in dark, Subvert `#D9DBDD` and TikTok/Threads `#E0E0E0` vanish in light. The search-results badge had **no** protection; two other components had an `if hex == "#000000" || hex == "#E0E0E0"` hack that missed three of the five and tested a value no longer in the catalog.

`BrandColor.legible(hex:isDark:)` clamps Rec. 709 luminance into a legible band and keeps hue. It blends toward white rather than scaling channels — scaling clips and shifts hue, turning Ampwall's near-black pure blue. Verified numerically: Ampwall lifts to `#8C8C8F` in dark, Subvert drops to `#9D9EA0` in light, Patreon stays red, Bluesky stays blue.

## Distribution: staying on the GitHub release path

Assessed Mac App Store readiness and decided against it. No private-API blocker (`MediaObserver` uses AppleScript, not `MediaRemote`), but the Apple Events entitlements are a review risk and Apple would take 15–30% of tips — hard to square with a product arguing platforms shouldn't skim from creators.

- **Tip jar → Liberapay on macOS.** iOS deliberately keeps StoreKit: it ships through the App Store where guideline 3.1.1 requires IAP for tipping and an external donation link is a rejection risk. `TipJarStore` is now iOS-only, so the Mac binary no longer links StoreKit.
- **Radiccio detection was silently broken.** `com.radiccio.mac` was scripted but in neither `scripting-targets` nor the exception, so sandbox failed it with `errAEEventNotPermitted` and the error was swallowed. Added it; removed `com.parachord.desktop`, which is read over a WebSocket and never needed it. Also: a denied *Music* prompt used to `return` before `startPolling()`, disabling detection for **every** source.
- **`checkForUpdatesAutomatically` did nothing** — `checkForUpdatesIfNeeded()` was never called. Wired to launch, gated on the setting, `lastCheckTime` persisted so "once a day" isn't "every launch". It also only `print`ed; an update now posts a notification that opens the download.

## Accessibility and type

Labels on every icon-only button, `.isSelected` on tabs, decorative icons hidden, artist/track text selectable. 55 hardcoded font sizes down to 7 (all SF Symbol glyph sizes).

## Also

Popover tabs become a segmented `Picker` (the hand-rolled pills read as a heavy blue slab in dark mode); the signed-in email moves out of the prime slot above the search field to sit beside Sign Out; a result with no platforms says "No links listed yet." instead of rendering as a bare name; welcome window drops `requestUserAttention(.criticalRequest)` and makes launch-at-login an explicit checkbox instead of registering it silently; removed a dead Roadmap link.

## Verification

- macOS Debug and Release builds clean.
- Every introduced API typechecked against the iOS 17 SDK. **A full iOS build could not run locally** — no simulator runtime installed — so the iOS target needs one real build before any TestFlight/App Store submission.
- Services registration confirmed via `pbs -dump`; both App Intents and the shortcut phrases confirmed in the built bundle's `Metadata.appintents`.
- `XCTest` fails with `test runner hung before establishing connection` — **reproduced identically on the unmodified baseline**, so it is pre-existing (accessory app as test host + a CoreSimulator version mismatch), not from this branch.
- **The Radiccio entitlement fix is unverified.** Ad-hoc local builds apply no entitlements and run unsandboxed, where Apple Events are permitted anyway. It needs a signed build to confirm.

## Note for review

Two known non-blocking items: there is still no undo anywhere (remove-from-saved syncs a server deletion irreversibly), and the status item has no right-click menu, so Quit is only reachable through the popover's ellipsis menu. Both were logged rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)