### PR TITLE
Release: Mac app 3.3.0

### DIFF
--- a/api/functions/desktop-version.ts
+++ b/api/functions/desktop-version.ts
@@ -1,10 +1,15 @@
 import type { Handler } from '@netlify/functions';
 
-// Desktop app version info - update this when releasing new versions
+// Desktop app version info — update this on every Mac release.
+//
+// This is what the Mac app's automatic update check reads. It sat at 2.1.0 while the
+// app shipped 3.2.0, which went unnoticed because nothing called the checker; as of
+// v3.3.0 it runs at launch, so a stale value here means users are told they're up to
+// date when they aren't. Keep it in step with Info-macOS.plist.
 const VERSION_INFO = {
-  latestVersion: '2.1.0',
+  latestVersion: '3.3.0',
   downloadUrl: 'https://github.com/brandonlucasgreen/unstream/releases/latest',
-  releaseNotes: 'Artist analytics - verified artists can now see search appearances, page views, and link clicks on their dashboard',
+  releaseNotes: 'Keyboard shortcuts, right-click menus, drag-and-drop links, a real Settings window, and "Find on Unstream" in the system Services menu',
 };
 
 export const handler: Handler = async (event) => {

--- a/apps/mac/Unstream/Info-iOS.plist
+++ b/apps/mac/Unstream/Info-iOS.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>lol.bgreen.Unstream.releaseCheck</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -17,9 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
-	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>3.3.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -31,8 +33,16 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>12</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright 2025-2026 brandon lucas green</string>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>
@@ -51,15 +61,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>BGTaskSchedulerPermittedIdentifiers</key>
-	<array>
-		<string>lol.bgreen.Unstream.releaseCheck</string>
-	</array>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2025-2026 brandon lucas green</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<key>SUPABASE_ANON_KEY</key>
-	<string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM</string>
 </dict>
 </plist>

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -17,9 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
-	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>3.3.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -31,10 +29,20 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>12</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
 	<key>LSUIElement</key>
 	<true/>
-	<!-- Services menu entry. NSMessage must match the selector prefix on
-	     ServicesProvider (findOnUnstream:userData:error:). -->
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Unstream needs to check what music is playing so it can find the artist on ethical platforms.</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright 2025-2026 brandon lucas green</string>
 	<key>NSServices</key>
 	<array>
 		<dict>
@@ -54,16 +62,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.music</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
-	<key>NSAppleEventsUsageDescription</key>
-	<string>Unstream needs to check what music is playing so it can find the artist on ethical platforms.</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2025-2026 brandon lucas green</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>SUPABASE_ANON_KEY</key>
 	<string>eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ3b2djbHF6cHNidnFieWhocWJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMzMTMyODcsImV4cCI6MjA4ODg4OTI4N30.AUcgWjqcsIbcTm-RkjaY2jtVMYmAHaPVE52oGeOsblM</string>
 </dict>

--- a/apps/mac/UnstreamShareExtension/Info.plist
+++ b/apps/mac/UnstreamShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
+	<string>3.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/mac/project.yml
+++ b/apps/mac/project.yml
@@ -85,8 +85,8 @@ targets:
         CFBundleName: UnstreamShare
         CFBundleDisplayName: Share to Unstream
         CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
-        CFBundleVersion: "11"
-        CFBundleShortVersionString: "3.2.0"
+        CFBundleVersion: "12"
+        CFBundleShortVersionString: "3.3.0"
         CFBundlePackageType: XPC!
         NSExtension:
           NSExtensionAttributes:


### PR DESCRIPTION
Version bump for the Mac 3.3.0 release, plus a stale endpoint that this release makes load-bearing.

## Version bump

3.2.0 → **3.3.0**, build 11 → **12**, across `Info-macOS.plist`, `Info-iOS.plist`, and the share extension in `project.yml`.

## The desktop version endpoint had drifted

`api/functions/desktop-version.ts` still advertised **2.1.0** while the app shipped 3.2.0. That went unnoticed because nothing ever called the update checker — `checkForUpdatesIfNeeded()` was defined and never invoked.

#349 wired it to run at launch, so a stale value here now actively tells users they're up to date when they aren't. Updated to 3.3.0 with real release notes and a comment tying it to `Info-macOS.plist` so the two stay in step on future releases.

## Build status

The DMG is already built and notarized from this commit:

- Developer ID Application: Brandon Green (CV926C8KS8)
- Hardened runtime enabled (`flags=0x10000(runtime)`)
- Notarization submission `cc9921cd-f89b-4c80-b6e7-b87b59a9e43a` — **Accepted**
- Stapled, and verified from inside the mounted image: `spctl` reports `accepted / source=Notarized Developer ID`

Verified in the signed bundle rather than assumed: version 3.3.0 (12), the `com.radiccio.mac` Apple Events entitlement present with `com.parachord.desktop` removed, `NSServices` carrying "Find on Unstream", and `Metadata.appintents` present.

That last one closes a caveat from #349 — the Radiccio entitlement fix could not be verified in an ad-hoc build, because unsigned builds apply no entitlements and run unsandboxed.

## Tests

`test:api` 157 passed, `test:unit` 468 passed. `npm run lint` reports 69 errors, all pre-existing in `apps/web/server/*` and `App.tsx` — none in touched files, and lint is not part of `npm run build`.

A GitHub release is staged as a **draft** with the DMG attached; it needs merging here first so the tag lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)