### PR TITLE
Release: Mac app 3.3.1 — fix saved artists not loading

### DIFF
--- a/api/functions/desktop-version.ts
+++ b/api/functions/desktop-version.ts
@@ -7,9 +7,9 @@ import type { Handler } from '@netlify/functions';
 // v3.3.0 it runs at launch, so a stale value here means users are told they're up to
 // date when they aren't. Keep it in step with Info-macOS.plist.
 const VERSION_INFO = {
-  latestVersion: '3.3.0',
+  latestVersion: '3.3.1',
   downloadUrl: 'https://github.com/brandonlucasgreen/unstream/releases/latest',
-  releaseNotes: 'Keyboard shortcuts, right-click menus, drag-and-drop links, a real Settings window, and "Find on Unstream" in the system Services menu',
+  releaseNotes: 'Fixes saved artists not loading after signing in',
 };
 
 export const handler: Handler = async (event) => {

--- a/apps/mac/Unstream/Info-iOS.plist
+++ b/apps/mac/Unstream/Info-iOS.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/mac/Unstream/Services/SavedArtistsSync.swift
+++ b/apps/mac/Unstream/Services/SavedArtistsSync.swift
@@ -40,8 +40,18 @@ class SavedArtistsSync: ObservableObject {
         isSyncing = true
         syncError = nil
 
+        // A delta pull is only meaningful when there is something to merge into.
+        // `lastSyncTime` lives in UserDefaults and so outlives quit/relaunch,
+        // sign-out and sign-in, while `syncedArtists` is in-memory and starts empty
+        // every launch. Sending the cursor with an empty list asked the server "what
+        // changed since yesterday", got "nothing", merged nothing into nothing, and
+        // showed an empty Saved Artists tab with no error — the list only appeared
+        // after the poll loop's five-minute forced pull. Treat an empty list as
+        // needing a full pull regardless of the cursor.
+        let needsFullPull = force || syncedArtists.isEmpty
+
         var urlString = "\(baseURL)/saved-artists/sync"
-        if !force, let since = lastSyncTime {
+        if !needsFullPull, let since = lastSyncTime {
             let encoded = since.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
             urlString += "?since=\(encoded)"
         }
@@ -74,7 +84,7 @@ class SavedArtistsSync: ObservableObject {
 
             let decoded = try JSONDecoder().decode(SyncResponse.self, from: data)
 
-            if force {
+            if needsFullPull {
                 syncedArtists = decoded.artists.filter { $0.deleted != true }.sorted { $0.name < $1.name }
             } else {
                 // Merge: replace existing entries by slug, append new ones.

--- a/apps/mac/UnstreamShareExtension/Info.plist
+++ b/apps/mac/UnstreamShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/mac/project.yml
+++ b/apps/mac/project.yml
@@ -85,8 +85,8 @@ targets:
         CFBundleName: UnstreamShare
         CFBundleDisplayName: Share to Unstream
         CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
-        CFBundleVersion: "12"
-        CFBundleShortVersionString: "3.3.0"
+        CFBundleVersion: "13"
+        CFBundleShortVersionString: "3.3.1"
         CFBundlePackageType: XPC!
         NSExtension:
           NSExtensionAttributes:


### PR DESCRIPTION
Hotfix for a bug reported immediately after 3.3.0 shipped: **Saved Artists rendered empty after signing in, with no error shown.**

The artists were present on the web app, which ruled out the data and the server straight away.

## Root cause

In `apps/mac/Unstream/Services/SavedArtistsSync.swift`:

- `lastSyncTime` is persisted in **UserDefaults**, so it survives quit, relaunch, sign-out and sign-in.
- `syncedArtists` is **in-memory** and starts empty every launch.
- Every caller passes `force: false` except the poll loop's every-fifth iteration (~5 min).

So each launch asked the server *"what changed since `<cursor>`"*, correctly got nothing, merged nothing into an empty list, and showed an empty tab. `pull()` only sets `syncError` on an HTTP failure, so there was nothing for the user to see.

The cursor is then advanced **even on an empty response**, which made the state self-perpetuating: once empty, always empty, until the poll loop's five-minute forced pull.

Confirmed rather than inferred — `defaults read lol.bgreen.Unstream sync.lastSyncTime` returned a live cursor on the affected machine.

**This is pre-existing, not a 3.3.0 regression.** `SavedArtistsSync.swift` is untouched by #349; 3.2.0 had the identical bug. Upgrading and signing in fresh is simply the shape that exposes it, because you arrive holding a cursor and your first pull is a delta.

## Fix

```swift
let needsFullPull = force || syncedArtists.isEmpty
```

A delta pull is only meaningful when there is something to merge into, so an empty list forces a full pull regardless of the cursor — covering launch, sign-in and sign-out uniformly. The response handler uses the same decision, so a full pull gets full-pull semantics (tombstones filtered, list replaced wholesale) rather than falling through to the merge path.

**The general rule:** a durable cursor must never outlive the ephemeral data it indexes. Persist both or neither, and don't advance a cursor on an empty response when the local set is empty — that turns a transient miss into a permanent one.

## Workaround for anyone who reports it before updating

```bash
defaults delete lol.bgreen.Unstream sync.lastSyncTime
```

## Release

3.3.0 → **3.3.1**, build 12 → **13**, across both plists and `project.yml`. `desktop-version.ts` updated so the automatic update check offers it.

DMG built from this commit and ready to upload:

- Developer ID Application: Brandon Green (CV926C8KS8), hardened runtime (`flags=0x10000(runtime)`)
- Notarization `36eb6296-951b-494c-b289-a74236653f14` — **Accepted**, stapled
- Verified from inside the mounted image: `accepted / source=Notarized Developer ID`, version 3.3.1 (13)

`test:api` 164 passed.

### Note on the v3.3.0 tag

The `v3.3.0` tag points at `5321950` (#350), which predates the version bump in #351 — so the tag's tree still says 3.2.0. The DMG that was uploaded is genuinely 3.3.0, so only the tag is misplaced. The 3.3.1 release should be tagged after this merges so its tag contains the matching version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)