### PR TITLE
Scroll to the top of the page on navigation

### DIFF
--- a/apps/web/src/components/ScrollToTop.tsx
+++ b/apps/web/src/components/ScrollToTop.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+import { useLocation, useNavigationType } from 'react-router-dom'
+
+/**
+ * Scrolls to the top of the page when the user navigates to a new page.
+ *
+ * Browsers keep the current scroll position across SPA (pushState) navigations,
+ * so clicking a link halfway down a page used to drop you halfway down the next
+ * page. React Router has no built-in scroll reset when using <BrowserRouter>.
+ *
+ * Three cases are deliberately left alone:
+ * - POP (back/forward): the browser restores the previous scroll position itself.
+ * - Same pathname: the search page rewrites `?q=` as you search, and yanking the
+ *   page to the top mid-search would be worse than the bug this fixes.
+ * - URLs with a hash: the target anchor decides where the page lands.
+ */
+export function ScrollToTop() {
+  const { pathname, hash } = useLocation()
+  const navigationType = useNavigationType()
+  const previousPathname = useRef(pathname)
+
+  useEffect(() => {
+    const pathnameChanged = previousPathname.current !== pathname
+    previousPathname.current = pathname
+
+    if (!pathnameChanged) return
+    if (navigationType === 'POP') return
+    if (hash) return
+
+    window.scrollTo(0, 0)
+  }, [pathname, hash, navigationType])
+
+  return null
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,6 +8,7 @@ import './index.css'
 import App from './App.tsx'
 import { ArtistPage } from './pages/ArtistPage.tsx'
 import { AppLoadingFallback, AppErrorFallback } from './components/AppFallback'
+import { ScrollToTop } from './components/ScrollToTop'
 
 initSentry()
 
@@ -49,6 +50,7 @@ createRoot(document.getElementById('root')!).render(
     <Sentry.ErrorBoundary fallback={<AppErrorFallback />}>
       <AuthProvider>
         <BrowserRouter>
+          <ScrollToTop />
           <Suspense fallback={<AppLoadingFallback />}>
             <Routes>
               <Route path="/" element={<App />} />

--- a/apps/web/tests/unit/ScrollToTop.test.tsx
+++ b/apps/web/tests/unit/ScrollToTop.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Link, useNavigate } from 'react-router-dom';
+import { ScrollToTop } from 'src/components/ScrollToTop';
+
+function GuidesPage() {
+  return (
+    <>
+      <Link to="/artist/beyonce">To artist</Link>
+      <Link to="/guides?page=2">Same page, new query</Link>
+      <Link to="/artist/beyonce#releases">To artist anchor</Link>
+    </>
+  );
+}
+
+function ArtistPage() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Go back</button>;
+}
+
+function renderApp() {
+  return render(
+    <MemoryRouter initialEntries={['/guides']}>
+      <ScrollToTop />
+      <Routes>
+        <Route path="/guides" element={<GuidesPage />} />
+        <Route path="/artist/:slug" element={<ArtistPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ScrollToTop', () => {
+  let scrollTo: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollTo = vi.fn();
+    window.scrollTo = scrollTo as unknown as typeof window.scrollTo;
+  });
+
+  afterEach(cleanup);
+
+  it('does not scroll on the initial render', () => {
+    renderApp();
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to the top when the pathname changes', () => {
+    renderApp();
+    fireEvent.click(screen.getByText('To artist'));
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('leaves the scroll position alone when only the query string changes', () => {
+    renderApp();
+    fireEvent.click(screen.getByText('Same page, new query'));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('leaves the scroll position alone when the URL has a hash', () => {
+    renderApp();
+    fireEvent.click(screen.getByText('To artist anchor'));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('leaves back navigation to the browser', () => {
+    renderApp();
+    fireEvent.click(screen.getByText('To artist'));
+    scrollTo.mockClear();
+    fireEvent.click(screen.getByText('Go back'));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Browsers keep the current scroll position across SPA pushState navigations
and React Router's <BrowserRouter> has no built-in scroll reset, so clicking
a link halfway down a page landed you halfway down the next page.

A small ScrollToTop component mounted inside the router resets scroll when
the pathname changes. It deliberately stays out of the way for back/forward
(the browser restores position itself), same-pathname navigations (the search
page rewrites ?q= as you type), and URLs with a hash anchor.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DXZi629BJrChcBr9o53ukb