### PR TITLE
Harden check-releases: validate every fetch hop, meter the endpoint

### DIFF
--- a/api/functions/__tests__/check-releases-ssrf.test.ts
+++ b/api/functions/__tests__/check-releases-ssrf.test.ts
@@ -15,7 +15,12 @@ const mocks = vi.hoisted(() => ({
   getClientIp: vi.fn(() => '1.2.3.4'),
   isStoredArtistLink: vi.fn(),
   fetch: vi.fn(),
+  lookup: vi.fn(),
 }));
+
+// DNS is mocked so the suite is hermetic and so we can express the case that motivated
+// resolution-time checks at all: a hostname that looks public and resolves private.
+vi.mock('dns/promises', () => ({ lookup: mocks.lookup }));
 
 // Rate limiting and the DB are the two side-effecting dependencies. Redis is never touched
 // because checkRateLimit itself is mocked — CI has real Upstash credentials, so a test that
@@ -30,7 +35,7 @@ vi.mock('../db', () => ({
 }));
 
 import { handler } from '../check-releases';
-import { isSafePublicHostname, isUrlHostnameAllowed } from '../middleware';
+import { isPrivateIpAddress, isSafePublicHostname, isUrlHostnameAllowed } from '../middleware';
 
 function post(body: unknown) {
   return handler({
@@ -58,6 +63,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.checkRateLimit.mockResolvedValue({ limited: false });
   mocks.isStoredArtistLink.mockResolvedValue(false);
+  // Default: everything resolves to an ordinary public address.
+  mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
   vi.stubGlobal('fetch', mocks.fetch);
 });
 
@@ -232,6 +239,140 @@ describe('redirect handling', () => {
     await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
 
     expect(mocks.fetch.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+});
+
+describe('isPrivateIpAddress', () => {
+  it.each([
+    ['169.254.169.254', 'AWS/Azure/GCP metadata'],
+    ['127.0.0.1', 'loopback'],
+    ['127.99.99.99', 'loopback range'],
+    ['10.1.2.3', 'private class A'],
+    ['172.16.0.1', 'private class B'],
+    ['172.31.255.255', 'private class B upper bound'],
+    ['192.168.1.1', 'private class C'],
+    ['192.0.0.1', 'IETF protocol assignments'],
+    ['100.64.0.1', 'CGNAT'],
+    ['0.0.0.0', 'this network'],
+    ['224.0.0.1', 'multicast'],
+    ['255.255.255.255', 'broadcast'],
+    ['::1', 'IPv6 loopback'],
+    ['::', 'IPv6 unspecified'],
+    ['fd00::1', 'IPv6 unique-local'],
+    ['fc00::1', 'IPv6 unique-local'],
+    ['fe80::1', 'IPv6 link-local'],
+    ['::ffff:127.0.0.1', 'IPv4-mapped loopback, dotted'],
+    ['::ffff:7f00:1', 'IPv4-mapped loopback, hex groups (how Node normalizes it)'],
+    ['::ffff:a9fe:a9fe', 'IPv4-mapped metadata address'],
+    ['not-an-address', 'unparseable'],
+    ['', 'empty'],
+  ])('treats %s as private (%s)', addr => {
+    expect(isPrivateIpAddress(addr)).toBe(true);
+  });
+
+  it.each([
+    ['93.184.216.34'],
+    ['1.1.1.1'],
+    ['172.15.0.1'],   // just below the private class B range
+    ['172.32.0.1'],   // just above it
+    ['100.63.0.1'],   // just below CGNAT
+    ['100.128.0.1'],  // just above CGNAT
+    ['2606:4700::1111'],
+    ['::ffff:93.184.216.34'],
+  ])('treats %s as public', addr => {
+    expect(isPrivateIpAddress(addr)).toBe(false);
+  });
+});
+
+describe('resolution-time checks', () => {
+  // The gap that string checks could never close, and the reason the docstring on
+  // isSafePublicHostname now says so explicitly: a name that is textually ordinary and
+  // resolves to the metadata address. Wildcard DNS services hand these out for free.
+  it('refuses a public hostname that resolves to the metadata address', async () => {
+    mocks.isStoredArtistLink.mockResolvedValue(true);
+    mocks.lookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { faircamp: 'https://169-254-169-254.nip.io/feed.rss' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).release).toBeNull();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  // The exact path the review flagged: input is allowlisted, so no stored link is needed —
+  // a Bandcamp Pro custom domain the attacker controls DNS for does the rest.
+  it('refuses a redirect to a host that resolves into private space', async () => {
+    mocks.lookup.mockImplementation(async (host: string) =>
+      host === 'someone.bandcamp.com'
+        ? [{ address: '93.184.216.34', family: 4 }]
+        : [{ address: '169.254.169.254', family: 4 }]
+    );
+    mocks.fetch.mockResolvedValueOnce(res(301, { location: 'https://evil.example.com/music' }));
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).release).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(1); // the redirect was never followed
+  });
+
+  it('refuses a dual-stack host smuggling a private AAAA behind a public A', async () => {
+    mocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: 'fd00::1', family: 6 },
+    ]);
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(JSON.parse(r.body).release).toBeNull();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses when resolution fails rather than assuming the target is fine', async () => {
+    mocks.lookup.mockRejectedValue(Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses when resolution returns nothing', async () => {
+    mocks.lookup.mockResolvedValue([]);
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows an ordinary public host', async () => {
+    mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch).toHaveBeenCalled();
+  });
+
+  it('checks each hop, not just the first', async () => {
+    mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://music.sufjan.com/music' }))
+      .mockResolvedValue(res(200, { body: '<html></html>', url: 'https://music.sufjan.com/music' }));
+
+    await post({ artistName: 'Sufjan Stevens', platforms: { bandcamp: 'https://sufjanstevens.bandcamp.com' } });
+
+    const resolved = mocks.lookup.mock.calls.map(c => c[0]);
+    expect(resolved).toContain('sufjanstevens.bandcamp.com');
+    expect(resolved).toContain('music.sufjan.com');
   });
 });
 

--- a/api/functions/__tests__/check-releases-ssrf.test.ts
+++ b/api/functions/__tests__/check-releases-ssrf.test.ts
@@ -376,6 +376,88 @@ describe('resolution-time checks', () => {
   });
 });
 
+describe('second-hop album link is confined to the host we landed on', () => {
+  // safeFetch asks "is this target safe to fetch", not "is it allowlisted or stored for this
+  // artist" the way mayFetch does for the entry URL. So without a host check, any absolute
+  // href appearing in fetched markup becomes a URL this endpoint will request — a narrower
+  // trust boundary than the entry point's, and a residual "fetch an arbitrary third-party
+  // URL on our behalf" primitive even though internal targets stay blocked.
+  const gridWith = (href: string) =>
+    `<html><body><li class="music-grid-item"><a href="${href}"><p class="title">A Release</p></a></li></body></html>`;
+
+  it('follows a root-relative album link, which is what Bandcamp actually emits', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(
+        res(200, { body: gridWith('/album/real-release'), url: 'https://someone.bandcamp.com/music' })
+      )
+      .mockResolvedValue(res(200, { body: '"datePublished": "30 May 2025 00:00:00 GMT"' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://someone.bandcamp.com/album/real-release');
+  });
+
+  it('refuses an absolute cross-host album link embedded in the fetched page', async () => {
+    mocks.fetch.mockResolvedValueOnce(
+      res(200, {
+        body: gridWith('https://attacker.example.com/expensive-endpoint'),
+        url: 'https://someone.bandcamp.com/music',
+      })
+    );
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).release).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(1); // second hop never issued
+  });
+
+  it('refuses a protocol-relative cross-host link', async () => {
+    mocks.fetch.mockResolvedValueOnce(
+      res(200, { body: gridWith('//attacker.example.com/x'), url: 'https://someone.bandcamp.com/music' })
+    );
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // The case the host check has to keep working: after a Bandcamp Pro custom-domain
+  // redirect, same-origin means the custom domain, not *.bandcamp.com.
+  it('allows a same-host link on a custom domain reached via redirect', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://music.sufjan.com/music' }))
+      .mockResolvedValueOnce(
+        res(200, { body: gridWith('/album/javelin'), url: 'https://music.sufjan.com/music' })
+      )
+      .mockResolvedValue(res(200, { body: '"datePublished": "30 May 2025 00:00:00 GMT"' }));
+
+    await post({ artistName: 'Sufjan Stevens', platforms: { bandcamp: 'https://sufjanstevens.bandcamp.com' } });
+
+    expect(String(mocks.fetch.mock.calls[2][0])).toBe('https://music.sufjan.com/album/javelin');
+  });
+
+  it('refuses a link back to bandcamp.com once we have landed on a custom domain', async () => {
+    // Same-host, not same-platform: after the redirect the trusted origin is the custom
+    // domain, so a link elsewhere is out of scope even if it looks like Bandcamp.
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://music.sufjan.com/music' }))
+      .mockResolvedValueOnce(
+        res(200, {
+          body: gridWith('https://someoneelse.bandcamp.com/album/x'),
+          url: 'https://music.sufjan.com/music',
+        })
+      );
+
+    await post({ artistName: 'Sufjan Stevens', platforms: { bandcamp: 'https://sufjanstevens.bandcamp.com' } });
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('rate limiting', () => {
   it('uses the lenient tier, because clients loop once per saved artist', async () => {
     // A strict (10/min) tier would silently break release alerts for every artist past the

--- a/api/functions/__tests__/check-releases-ssrf.test.ts
+++ b/api/functions/__tests__/check-releases-ssrf.test.ts
@@ -1,0 +1,293 @@
+// check-releases was an unauthenticated, unvalidated, unmetered outbound fetcher: it took
+// URLs from the request body, fetched them, then followed a link found *inside* the fetched
+// page, and reflected parsed fields back to the caller.
+//
+// The non-obvious half of the fix is that validating the URL we were *given* says nothing
+// about the URL we actually *retrieve* — Node's fetch follows redirects transparently, and
+// Bandcamp Pro artists really do redirect off *.bandcamp.com onto custom domains
+// (sufjanstevens.bandcamp.com -> music.sufjan.com). So every hop has to be re-validated.
+// These tests pin that down, plus the rate-limit tier that keeps shipped clients working.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => '1.2.3.4'),
+  isStoredArtistLink: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+// Rate limiting and the DB are the two side-effecting dependencies. Redis is never touched
+// because checkRateLimit itself is mocked — CI has real Upstash credentials, so a test that
+// reached the real limiter would talk to production.
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getClientIp: mocks.getClientIp,
+}));
+
+vi.mock('../db', () => ({
+  isStoredArtistLink: mocks.isStoredArtistLink,
+}));
+
+import { handler } from '../check-releases';
+import { isSafePublicHostname, isUrlHostnameAllowed } from '../middleware';
+
+function post(body: unknown) {
+  return handler({
+    httpMethod: 'POST',
+    headers: { 'x-nf-client-connection-ip': '1.2.3.4' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A minimal Response stand-in; only what safeFetch and the parsers read. */
+function res(
+  status: number,
+  opts: { body?: string; location?: string; url?: string } = {}
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url: opts.url ?? '',
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? opts.location ?? null : null) },
+    text: async () => opts.body ?? '',
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.checkRateLimit.mockResolvedValue({ limited: false });
+  mocks.isStoredArtistLink.mockResolvedValue(false);
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+describe('isSafePublicHostname', () => {
+  // These are the targets that make an SSRF bug serious rather than merely rude.
+  it.each([
+    ['http://169.254.169.254/latest/meta-data/', 'AWS metadata'],
+    ['http://metadata.google.internal/', 'GCP metadata'],
+    ['http://100.100.100.200/', 'Alibaba metadata'],
+    ['http://127.0.0.1:8080/', 'loopback'],
+    ['http://127.1.2.3/', 'loopback range beyond 127.0.0.1'],
+    ['http://10.0.0.5/', 'private class A'],
+    ['http://172.16.0.1/', 'private class B'],
+    ['http://192.168.1.1/', 'private class C'],
+    ['http://[::1]/', 'IPv6 loopback'],
+    ['http://[::ffff:127.0.0.1]/', 'IPv4-mapped IPv6 loopback'],
+    ['http://2130706433/', 'decimal-encoded loopback'],
+    ['http://0177.0.0.1/', 'octal-encoded loopback'],
+    ['http://buildserver.local/', 'mDNS .local'],
+    ['http://vault.internal/', '.internal namespace'],
+    ['file:///etc/passwd', 'non-HTTP scheme'],
+    ['gopher://example.com/', 'non-HTTP scheme'],
+  ])('rejects %s (%s)', url => {
+    expect(isSafePublicHostname(url)).toBe(false);
+  });
+
+  it('accepts ordinary public hosts, including ones off the allowlist', () => {
+    expect(isSafePublicHostname('https://sufjanstevens.bandcamp.com/music')).toBe(true);
+    // The whole point of splitting this out: a Bandcamp custom domain is a legitimate
+    // redirect target even though no allowlist entry covers it.
+    expect(isSafePublicHostname('https://music.sufjan.com/music')).toBe(true);
+    expect(isSafePublicHostname('https://music.someartist.com/feed.rss')).toBe(true);
+  });
+});
+
+describe('isUrlHostnameAllowed still gates on the allowlist', () => {
+  it('admits allowlisted hosts and rejects arbitrary public ones', () => {
+    expect(isUrlHostnameAllowed('https://artist.bandcamp.com/music')).toBe(true);
+    expect(isUrlHostnameAllowed('https://mirlo.space/foo')).toBe(true);
+    expect(isUrlHostnameAllowed('https://artist.faircamp.net/')).toBe(true);
+    expect(isUrlHostnameAllowed('https://music.sufjan.com/music')).toBe(false);
+    expect(isUrlHostnameAllowed('https://evil.example.com/')).toBe(false);
+  });
+
+  it('cannot be talked into an unsafe target by an allowlisted-looking name', () => {
+    // "faircamp" as a non-leftmost label normally passes; a private address must not.
+    expect(isUrlHostnameAllowed('http://10.0.0.1/')).toBe(false);
+    expect(isUrlHostnameAllowed('file://bandcamp.com/etc/passwd')).toBe(false);
+  });
+});
+
+describe('handler input validation', () => {
+  it('refuses a metadata address supplied as a platform URL', async () => {
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'http://169.254.169.254/latest/meta-data/' },
+    });
+
+    expect(r.statusCode).toBe(400);
+    expect(JSON.parse(r.body).error).toMatch(/no platform url could be verified/i);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses an arbitrary public URL that we have never stored', async () => {
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { faircamp: 'https://victim.example.com/expensive-endpoint' },
+    });
+
+    expect(r.statusCode).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows a self-hosted Faircamp domain that is already stored for the artist', async () => {
+    // The reason a bare allowlist is the wrong tool here: real Faircamp lives on arbitrary
+    // domains, so "have we already discovered this link for this artist?" is the check.
+    mocks.isStoredArtistLink.mockResolvedValue(true);
+    mocks.fetch.mockResolvedValue(res(200, { body: '<rss></rss>' }));
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { faircamp: 'https://music.someartist.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(mocks.isStoredArtistLink).toHaveBeenCalledWith('https://music.someartist.com', 'Someone');
+    expect(mocks.fetch).toHaveBeenCalled();
+  });
+
+  it('does not consult the database for an allowlisted host', async () => {
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.isStoredArtistLink).not.toHaveBeenCalled();
+  });
+
+  it('still checks the platforms it can verify when another is refused', async () => {
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: {
+        bandcamp: 'https://someone.bandcamp.com',
+        faircamp: 'http://192.168.0.10/',
+      },
+    });
+
+    expect(r.statusCode).toBe(200);
+    const fetched = mocks.fetch.mock.calls.map(c => String(c[0]));
+    expect(fetched.some(u => u.includes('someone.bandcamp.com'))).toBe(true);
+    expect(fetched.some(u => u.includes('192.168.0.10'))).toBe(false);
+  });
+});
+
+describe('redirect handling', () => {
+  it('follows a Bandcamp custom-domain redirect', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://music.sufjan.com/music' }))
+      .mockResolvedValue(res(200, { body: '<html></html>', url: 'https://music.sufjan.com/music' }));
+
+    const r = await post({
+      artistName: 'Sufjan Stevens',
+      platforms: { bandcamp: 'https://sufjanstevens.bandcamp.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://music.sufjan.com/music');
+  });
+
+  it('does NOT follow a redirect to an internal address', async () => {
+    // The bypass this whole change exists to close: input passes the allowlist, then the
+    // server hands us a Location pointing at cloud metadata.
+    mocks.fetch.mockResolvedValueOnce(
+      res(302, { location: 'http://169.254.169.254/latest/meta-data/' })
+    );
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).release).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(1); // never followed
+  });
+
+  it('refuses a relative redirect that resolves onto an internal host', async () => {
+    mocks.fetch.mockResolvedValueOnce(res(302, { location: '//169.254.169.254/meta' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up on a redirect loop instead of following it forever', async () => {
+    mocks.fetch.mockResolvedValue(res(302, { location: 'https://someone.bandcamp.com/music' }));
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(r.statusCode).toBe(200);
+    // MAX_REDIRECTS is 5, so 6 attempts at most — bounded, not unbounded.
+    expect(mocks.fetch.mock.calls.length).toBeLessThanOrEqual(6);
+  });
+
+  it('passes redirect: manual so hops cannot be followed behind our back', async () => {
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.fetch.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+});
+
+describe('rate limiting', () => {
+  it('uses the lenient tier, because clients loop once per saved artist', async () => {
+    // A strict (10/min) tier would silently break release alerts for every artist past the
+    // tenth in both the Mac app and the extension, which swallow the error and move on.
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    await post({ artistName: 'Someone', platforms: { bandcamp: 'https://someone.bandcamp.com' } });
+
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith('1.2.3.4', 'lenient', expect.anything());
+  });
+
+  it('returns the limiter response and fetches nothing when limited', async () => {
+    const limited = { statusCode: 429, headers: {}, body: '{"error":"rate limited"}' };
+    mocks.checkRateLimit.mockResolvedValue({ limited: true, response: limited });
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    expect(r).toBe(limited);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('backward compatibility with shipped clients', () => {
+  // The Mac app (3.3.x) and extension (2.5.x) are already released against this contract.
+  it('keeps the response shape', async () => {
+    mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
+
+    const r = await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    });
+
+    const parsed = JSON.parse(r.body);
+    expect(Object.keys(parsed).sort()).toEqual(['artistName', 'release']);
+    expect(parsed.artistName).toBe('Someone');
+  });
+
+  it('still rejects a request with no platform URLs', async () => {
+    const r = await post({ artistName: 'Someone', platforms: {} });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('still rejects a non-POST method', async () => {
+    const r = await handler({ httpMethod: 'GET', headers: {} });
+    expect(r.statusCode).toBe(405);
+  });
+
+  it('answers the CORS preflight with a wildcard origin for native clients', async () => {
+    const r = await handler({ httpMethod: 'OPTIONS', headers: {} });
+    expect(r.statusCode).toBe(204);
+    expect(r.headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+});

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -76,8 +76,10 @@ async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Respons
 
     if (response.status < 300 || response.status >= 400) return response;
 
+    // A 3xx with no Location has nowhere to go. Returning it as-is is deliberate rather
+    // than unhandled: callers check `.ok`, which is false for a 3xx, so it fails closed.
     const location = response.headers.get('location');
-    if (!location) return response; // 3xx without a target — nothing to follow
+    if (!location) return response;
     current = new URL(location, current).toString();
   }
 
@@ -209,10 +211,31 @@ async function checkBandcamp(artistUrl: string): Promise<ReleaseResult | null> {
 
     if (!href || !title) return null;
 
-    // Build full URL. `href` comes out of fetched HTML, so it is untrusted input — it is
-    // resolved against the page we actually landed on (which may be a custom domain after
-    // a redirect) and then re-validated by safeFetch before the second request.
-    const fullUrl = href.startsWith('http') ? href : new URL(href, response.url || baseUrl).toString();
+    // `href` comes out of fetched HTML, so it is untrusted input. Resolve it against the
+    // page we actually landed on — which may be a custom domain after a redirect — and then
+    // confine it to that same host.
+    //
+    // The host check matters because safeFetch only asks "is this target safe to fetch",
+    // not "is this target allowlisted or stored for this artist" the way mayFetch does for
+    // the entry URL. Without it, any absolute href appearing in fetched markup becomes a
+    // URL this endpoint will request, which is a narrower trust boundary than the one
+    // established at the entry point and leaves a "fetch an arbitrary third-party URL on
+    // our behalf" primitive. Bandcamp's own templates always link same-origin (verified
+    // against a live /music page: every grid href is root-relative), so this costs nothing
+    // real and still supports the custom-domain redirect this function is built around.
+    const landedUrl = response.url || musicUrl;
+    let fullUrl: string;
+    try {
+      fullUrl = new URL(href, landedUrl).toString();
+      if (new URL(fullUrl).host !== new URL(landedUrl).host) {
+        console.warn(
+          `[check-releases] refused cross-host album link: ${safeHostname(fullUrl)} from ${safeHostname(landedUrl)}`
+        );
+        return null;
+      }
+    } catch {
+      return null;
+    }
 
     // Fetch the album page to get release date
     const albumResponse = await safeFetch(fullUrl);

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,4 +1,13 @@
 import { parse } from 'node-html-parser';
+import { isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { isStoredArtistLink } from './db';
+
+const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+// Bandcamp Pro artists point custom domains at their store, so a single request can
+// legitimately redirect off *.bandcamp.com. Follow a few hops, validating each one.
+const MAX_REDIRECTS = 5;
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -24,20 +33,72 @@ interface CheckReleasesResponse {
   error?: string;
 }
 
-// Helper to fetch with timeout
-async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs: number = 5000): Promise<Response> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+/**
+ * Fetch with a timeout, validating **every** hop against `isSafePublicHostname`.
+ *
+ * Node's fetch follows redirects transparently, which means a check on the URL we were
+ * given says nothing about the URL we actually retrieve. That matters here for two
+ * reasons: this endpoint fetches caller-supplied URLs, and it then follows a link found
+ * *inside* the page it fetched. Redirects are resolved manually so each destination is
+ * re-validated before another request goes out.
+ *
+ * Returns null when a target is refused or the redirect chain is too long — callers treat
+ * that the same as an unreachable platform.
+ */
+async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Response | null> {
+  let current = url;
 
-  try {
-    const response = await fetch(url, {
-      ...options,
-      signal: controller.signal,
-    });
-    return response;
-  } finally {
-    clearTimeout(timeoutId);
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (!isSafePublicHostname(current)) {
+      // Hostname only — the full URL is caller-supplied and shouldn't land in logs.
+      console.warn(`[check-releases] refused unsafe fetch target: ${safeHostname(current)}`);
+      return null;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(current, {
+        headers: { 'User-Agent': USER_AGENT },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location = response.headers.get('location');
+    if (!location) return response; // 3xx without a target — nothing to follow
+    current = new URL(location, current).toString();
   }
+
+  console.warn(`[check-releases] too many redirects from ${safeHostname(url)}`);
+  return null;
+}
+
+function safeHostname(urlString: string): string {
+  try {
+    return new URL(urlString).hostname;
+  } catch {
+    return '<unparseable>';
+  }
+}
+
+/**
+ * May we fetch this URL on an anonymous caller's behalf?
+ *
+ * Allowlisted hosts pass outright. Anything else must already be stored as a link for
+ * this artist — which is how self-hosted Faircamp (arbitrary domains like
+ * music.someartist.com) and Bandcamp custom domains stay reachable without turning the
+ * endpoint into an open fetch proxy.
+ */
+async function mayFetch(url: string, artistName: string): Promise<boolean> {
+  if (!isSafePublicHostname(url)) return false;
+  if (isUrlHostnameAllowed(url)) return true;
+  return isStoredArtistLink(url, artistName);
 }
 
 // Parse various date formats into ISO string
@@ -86,13 +147,8 @@ async function checkBandcamp(artistUrl: string): Promise<ReleaseResult | null> {
       .replace(/\/$/, '');
     const musicUrl = `${baseUrl}/music`;
 
-    const response = await fetchWithTimeout(musicUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    });
-
-    if (!response.ok) return null;
+    const response = await safeFetch(musicUrl);
+    if (!response || !response.ok) return null;
 
     const html = await response.text();
     const root = parse(html);
@@ -111,17 +167,14 @@ async function checkBandcamp(artistUrl: string): Promise<ReleaseResult | null> {
 
     if (!href || !title) return null;
 
-    // Build full URL
-    const fullUrl = href.startsWith('http') ? href : new URL(href, baseUrl).toString();
+    // Build full URL. `href` comes out of fetched HTML, so it is untrusted input — it is
+    // resolved against the page we actually landed on (which may be a custom domain after
+    // a redirect) and then re-validated by safeFetch before the second request.
+    const fullUrl = href.startsWith('http') ? href : new URL(href, response.url || baseUrl).toString();
 
     // Fetch the album page to get release date
-    const albumResponse = await fetchWithTimeout(fullUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    });
-
-    if (!albumResponse.ok) return null;
+    const albumResponse = await safeFetch(fullUrl);
+    if (!albumResponse || !albumResponse.ok) return null;
 
     const albumHtml = await albumResponse.text();
 
@@ -152,13 +205,8 @@ async function checkFaircamp(faircampUrl: string): Promise<ReleaseResult | null>
     const baseUrl = faircampUrl.replace(/\/$/, '');
     const rssUrl = `${baseUrl}/feed.rss`;
 
-    const response = await fetchWithTimeout(rssUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    });
-
-    if (!response.ok) return null;
+    const response = await safeFetch(rssUrl);
+    if (!response || !response.ok) return null;
 
     const rssText = await response.text();
 
@@ -212,13 +260,10 @@ async function checkMirlo(mirloUrl: string): Promise<ReleaseResult | null> {
     // Fetch or use cached RSS feed
     const now = Date.now();
     if (!mirloRssCache || (now - mirloRssCache.fetchedAt) > MIRLO_CACHE_TTL) {
-      const response = await fetchWithTimeout('https://api.mirlo.space/v1/trackGroups?format=rss', {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-        },
-      }, 10000);
-
-      if (!response.ok) return null;
+      // Hardcoded endpoint, so there's no caller-supplied URL to validate here — it still
+      // goes through safeFetch to keep one fetch path in this file.
+      const response = await safeFetch('https://api.mirlo.space/v1/trackGroups?format=rss', 10000);
+      if (!response || !response.ok) return null;
 
       const rssText = await response.text();
 
@@ -308,110 +353,110 @@ async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult
   return results[0];
 }
 
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  // The wildcard is deliberate, not an oversight: the Mac app and the browser extension
+  // both call this endpoint, and neither sends an Origin that the shared
+  // buildCorsHeaders() allowlist (unstream.stream) would accept.
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const PLATFORM_KEYS = ['bandcamp', 'faircamp', 'mirlo'] as const;
+
+function jsonResponse(statusCode: number, body: unknown, extraHeaders: Record<string, string> = {}) {
+  return { statusCode, headers: { ...CORS_HEADERS, ...extraHeaders }, body: JSON.stringify(body) };
+}
+
 // Netlify function handler
 export async function handler(event: {
   httpMethod?: string;
+  headers?: Record<string, string | undefined>;
   body?: string;
   queryStringParameters?: Record<string, string>;
 }) {
   // Handle CORS preflight
   if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 200,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-      },
-      body: '',
-    };
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
   // Only allow POST
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({ error: 'Method not allowed. Use POST.' }),
-    };
+    return jsonResponse(405, { error: 'Method not allowed. Use POST.' });
   }
+
+  // 'lenient' (120/min, 5000/day) rather than 'strict' (10/min): the Mac app and the
+  // extension both loop once per saved artist with no delay and swallow errors, so a
+  // strict tier would silently stop release alerts for every artist past the tenth.
+  // A batch request shape is the real fix; until shipped clients support one, the limit
+  // has to fit the caller it already has.
+  const ip = getClientIp(event.headers || {});
+  const rl = await checkRateLimit(ip, 'lenient', CORS_HEADERS);
+  if (rl.limited) return rl.response;
 
   // Parse request body
   let request: CheckReleasesRequest;
   try {
     request = JSON.parse(event.body || '{}');
   } catch {
-    return {
-      statusCode: 400,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({ error: 'Invalid JSON body' }),
-    };
+    return jsonResponse(400, { error: 'Invalid JSON body' });
   }
 
   // Validate request
-  if (!request.artistName || !request.platforms) {
-    return {
-      statusCode: 400,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({ error: 'artistName and platforms are required' }),
-    };
+  if (!request.artistName || typeof request.artistName !== 'string' || !request.platforms) {
+    return jsonResponse(400, { error: 'artistName and platforms are required' });
   }
 
-  // Check if at least one platform URL is provided
-  const hasPlatform = request.platforms.bandcamp ||
-                      request.platforms.faircamp ||
-                      request.platforms.mirlo;
+  const requested = PLATFORM_KEYS.filter(
+    p => typeof request.platforms[p] === 'string' && (request.platforms[p] as string).length > 0
+  );
 
-  if (!hasPlatform) {
-    return {
-      statusCode: 400,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({ error: 'At least one platform URL is required' }),
-    };
+  if (requested.length === 0) {
+    return jsonResponse(400, { error: 'At least one platform URL is required' });
+  }
+
+  // Only fetch URLs we're willing to request on an anonymous caller's behalf.
+  const platforms: PlatformUrls = {};
+  const refused: string[] = [];
+  await Promise.all(
+    requested.map(async p => {
+      const url = request.platforms[p] as string;
+      if (await mayFetch(url, request.artistName)) platforms[p] = url;
+      else refused.push(`${p}:${safeHostname(url)}`);
+    })
+  );
+
+  if (refused.length > 0) {
+    console.warn(`[check-releases] refused unverified URL(s): ${refused.join(', ')}`);
+  }
+
+  // Refusing to look is not the same as looking and finding nothing — say so rather than
+  // returning an empty result that reads as "this artist has no new release".
+  if (Object.keys(platforms).length === 0) {
+    return jsonResponse(400, {
+      artistName: request.artistName,
+      release: null,
+      error: 'No platform URL could be verified for this artist',
+    });
   }
 
   try {
-    const release = await checkAllPlatforms(request.platforms);
+    const release = await checkAllPlatforms(platforms);
 
     const response: CheckReleasesResponse = {
       artistName: request.artistName,
       release,
     };
 
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Cache-Control': 'no-cache', // Don't cache release checks
-      },
-      body: JSON.stringify(response),
-    };
+    // Don't cache release checks
+    return jsonResponse(200, response, { 'Cache-Control': 'no-cache' });
   } catch (error) {
     console.error('Check releases error:', error);
-    return {
-      statusCode: 500,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({
-        artistName: request.artistName,
-        release: null,
-        error: 'Failed to check releases',
-      }),
-    };
+    return jsonResponse(500, {
+      artistName: request.artistName,
+      release: null,
+      error: 'Failed to check releases',
+    });
   }
 }

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,5 +1,6 @@
 import { parse } from 'node-html-parser';
-import { isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
+import { lookup } from 'dns/promises';
+import { isPrivateIpAddress, isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { isStoredArtistLink } from './db';
 
@@ -55,6 +56,11 @@ async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Respons
       return null;
     }
 
+    if (!(await resolvesToPublicAddress(safeHostname(current)))) {
+      console.warn(`[check-releases] refused target resolving to private space: ${safeHostname(current)}`);
+      return null;
+    }
+
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     let response: Response;
@@ -84,6 +90,42 @@ function safeHostname(urlString: string): string {
     return new URL(urlString).hostname;
   } catch {
     return '<unparseable>';
+  }
+}
+
+/**
+ * Does every DNS answer for this hostname point at a public address?
+ *
+ * String checks on a hostname are not enough, and this is the gap that made them
+ * insufficient: `169-254-169-254.nip.io` is a perfectly ordinary public name that resolves
+ * to 169.254.169.254 — the cloud metadata endpoint. Wildcard-DNS services hand those out
+ * for free, and a Bandcamp Pro artist can point a custom domain anywhere, so an
+ * allowlisted `*.bandcamp.com` input can redirect to a name that resolves into private
+ * space. Nothing textual catches that; only resolution does.
+ *
+ * **All** answers must be public, so a dual-stack host can't smuggle a private AAAA past a
+ * public A record. Any resolver failure or NXDOMAIN returns false — for a security
+ * predicate, "couldn't check" has to mean "refuse".
+ *
+ * Residual risk, stated precisely rather than hand-waved: Node's `fetch` performs its own
+ * resolution when it connects, so a hostname whose DNS answers *change* between this check
+ * and that connect — rotating records or a very low TTL — can still slip through. Closing
+ * that needs the connection pinned to the address we validated, which means a custom
+ * undici dispatcher; `undici` isn't a declared dependency here (only transitively
+ * available), so pinning is deliberately left as a follow-up rather than built on a package
+ * that could vanish on any install. What this does close is the one-shot case, which is
+ * what was actually reachable. Note also that exfiltration is separately limited: the
+ * parsers only extract an RSS `<item><title>` or a Bandcamp `.music-grid-item`, so a
+ * typical internal endpoint yields nothing even when reached.
+ */
+async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
+  if (!hostname || hostname === '<unparseable>') return false;
+  try {
+    const answers = await lookup(hostname, { all: true, verbatim: true });
+    if (answers.length === 0) return false;
+    return answers.every(a => !isPrivateIpAddress(a.address));
+  } catch {
+    return false;
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -308,6 +308,64 @@ export async function deleteStoredLinksForUrl(url: string, artistName: string | 
   }
 }
 
+/**
+ * Is this URL already stored as a platform link for this artist?
+ *
+ * Containment for outbound fetches that a hostname allowlist can't express. Faircamp is
+ * self-hosted on arbitrary domains (music.someartist.com), so `isUrlHostnameAllowed` —
+ * which only admits hostnames with a literal `faircamp` label — rejects most genuine
+ * Faircamp sites. Requiring the URL to be one we already discovered and persisted gives
+ * the same "you can't point us at anything you like" guarantee without breaking the
+ * platform.
+ *
+ * Fails closed: a missing client, a query error, or an unknown artist all return false,
+ * because the caller uses this to decide whether to make a request on a stranger's behalf.
+ */
+export async function isStoredArtistLink(url: string, artistName: string): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  const target = normalizeUrlForMatch(url);
+  // Coarse prefilter on host+path so rows stored as http://, https:// or with a www.
+  // prefix are all candidates; ilike treats % and _ as wildcards, and a URL may
+  // legitimately contain either.
+  const pattern = `%${urlMatchPrefilter(url).replace(/[%_\\]/g, m => `\\${m}`)}%`;
+
+  try {
+    const { data: artist, error: artistError } = await client
+      .from('artists')
+      .select('id')
+      .eq('slug', artistSlug(artistName))
+      .maybeSingle();
+
+    if (artistError) {
+      console.error('[DB] isStoredArtistLink artist lookup failed:', artistError.message);
+      return false;
+    }
+    if (!artist) return false;
+
+    const { data, error } = await client
+      .from('artist_links')
+      .select('url')
+      .eq('artist_id', (artist as { id: string }).id)
+      .ilike('url', pattern);
+
+    if (error) {
+      console.error('[DB] isStoredArtistLink link lookup failed:', error.message);
+      return false;
+    }
+
+    // The ilike is a prefilter, not the decision — compare normalized match keys so a
+    // stored `.../music` doesn't authorize fetching an unrelated deeper path.
+    return ((data as { url: string }[]) || []).some(
+      row => normalizeUrlForMatch(row.url) === target
+    );
+  } catch (error) {
+    console.error('[DB] isStoredArtistLink error:', error);
+    return false;
+  }
+}
+
 // --- Bandcamp slug-probe cache (UNS-152) ---
 
 export interface BandcampProbeRow {

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -351,9 +351,13 @@ export const ALLOWED_OUTBOUND_HOSTNAMES = new Set([
  * music.sufjan.com), so an allowlist check on the *input* URL says nothing about where
  * the request actually ends up. Validate every hop with this.
  *
- * Caveat this does NOT cover: a public hostname whose DNS resolves to a private address
- * (DNS rebinding). Defending against that needs resolution-time checks, which Node's
- * fetch doesn't expose. This closes the literal-address and known-metadata-name paths.
+ * This is a **string** check and cannot be the whole story. A textually ordinary public
+ * hostname can resolve straight into private space — `169-254-169-254.nip.io` resolves to
+ * the cloud metadata address — and no amount of inspecting the name catches that. It is not
+ * a rebinding race; there is simply no resolution here. Callers that fetch the URL must
+ * also check the resolved addresses with `isPrivateIpAddress` (see `resolvesToPublicAddress`
+ * in check-releases.ts). Use this to reject obviously-bad targets, not as an SSRF boundary
+ * on its own.
  */
 export function isSafePublicHostname(urlString: string): boolean {
   try {
@@ -382,33 +386,86 @@ export function isSafePublicHostname(urlString: string): boolean {
       return false;
     }
 
-    // Block any IPv6 address (no allowlisted hostnames are IPv6).
-    // This catches ::ffff:127.0.0.1, fe80::, fc00::, fd00::, etc.
+    // Block any IPv6 address (no allowlisted hostnames are IPv6). `new URL()` keeps the
+    // brackets, so this catches [::1], [::ffff:7f00:1], [fe80::…] and friends.
     if (hostname.includes(':')) {
       return false;
     }
 
-    // Block private IPv4 ranges
-    const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-    if (ipv4Match) {
-      const [, a, b] = ipv4Match.map(Number);
-      if (a === 10) return false;
-      if (a === 172 && b >= 16 && b <= 31) return false;
-      if (a === 192 && b === 168) return false;
-      if (a === 169 && b === 254) return false; // AWS metadata / link-local
-      if (a === 0) return false;
-      if (a === 127) return false; // full loopback range, not just 127.0.0.1
-      if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT range
+    // Literal IPv4. No encoded-notation checks are needed here: `new URL()` has already
+    // normalized decimal, octal, hex and short forms to dotted-decimal by this point
+    // (verified — 2130706433, 0177.0.0.1, 0x7f.1 and 127.1 all arrive as "127.0.0.1"),
+    // so a separate check for them would be dead code. Don't re-add one.
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+      return !isPrivateIpAddress(hostname);
     }
-
-    // Block any remaining raw IP address (not a hostname)
-    if (/^\d+$/.test(hostname)) return false; // decimal notation like 2130706433
-    if (/^0\d/.test(hostname.split('.')[0])) return false; // octal notation like 0177.0.0.1
 
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Is this IP address in a range we must never fetch from?
+ *
+ * Operates on a resolved address, not a hostname — the point is to be callable *after* DNS
+ * resolution, because a textually innocent hostname can resolve straight into private
+ * space. `169-254-169-254.nip.io` is a public name that resolves to 169.254.169.254, and no
+ * amount of string inspection catches it.
+ *
+ * Unrecognized input returns true (unsafe). This is a security predicate, so "I don't
+ * understand this address" has to mean "refuse", never "allow".
+ */
+export function isPrivateIpAddress(address: string): boolean {
+  const addr = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!addr) return true;
+
+  // IPv4-mapped IPv6. Node normalizes ::ffff:127.0.0.1 to ::ffff:7f00:1, so both the
+  // dotted and the hex-group spellings have to be understood and judged as IPv4.
+  const mapped = addr.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    const inner = mapped[1];
+    if (inner.includes('.')) return isPrivateIpv4(inner);
+    const groups = inner.split(':');
+    if (groups.length === 2) {
+      const hi = parseInt(groups[0], 16);
+      const lo = parseInt(groups[1], 16);
+      if (Number.isFinite(hi) && Number.isFinite(lo)) {
+        return isPrivateIpv4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`);
+      }
+    }
+    return true;
+  }
+
+  if (addr.includes(':')) {
+    if (addr === '::' || addr === '::1') return true;
+    const lead = parseInt(addr.split(':')[0] || '0', 16);
+    if (!Number.isFinite(lead)) return true;
+    if ((lead & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+    if ((lead & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+    return false;
+  }
+
+  return isPrivateIpv4(addr);
+}
+
+function isPrivateIpv4(address: string): boolean {
+  const m = address.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return true;
+  const parts = m.slice(1).map(Number);
+  if (parts.some(n => n > 255)) return true;
+  const [a, b] = parts;
+  if (a === 0) return true; // "this network"
+  if (a === 10) return true;
+  if (a === 127) return true; // whole loopback range, not just 127.0.0.1
+  if (a === 169 && b === 254) return true; // link-local + AWS/Azure/GCP metadata
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 192 && b === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a >= 224) return true; // multicast and reserved
+  return false;
 }
 
 /**

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -342,10 +342,20 @@ export const ALLOWED_OUTBOUND_HOSTNAMES = new Set([
 ]);
 
 /**
- * Check if a URL's hostname is in the SSRF allowlist.
- * Supports wildcard subdomains (*.domain).
+ * Reject targets that are dangerous to fetch regardless of any allowlist: non-HTTP(S)
+ * schemes, localhost, cloud metadata endpoints, and private or raw IP addresses.
+ *
+ * Split out from `isUrlHostnameAllowed` so callers that legitimately fetch hosts outside
+ * the allowlist can still refuse internal targets. The motivating case is redirects:
+ * Bandcamp Pro artists use custom domains (sufjanstevens.bandcamp.com 301s to
+ * music.sufjan.com), so an allowlist check on the *input* URL says nothing about where
+ * the request actually ends up. Validate every hop with this.
+ *
+ * Caveat this does NOT cover: a public hostname whose DNS resolves to a private address
+ * (DNS rebinding). Defending against that needs resolution-time checks, which Node's
+ * fetch doesn't expose. This closes the literal-address and known-metadata-name paths.
  */
-export function isUrlHostnameAllowed(urlString: string): boolean {
+export function isSafePublicHostname(urlString: string): boolean {
   try {
     const parsed = new URL(urlString);
     const hostname = parsed.hostname.toLowerCase();
@@ -367,6 +377,11 @@ export function isUrlHostnameAllowed(urlString: string): boolean {
       return false;
     }
 
+    // Block .local / .internal mDNS and private-namespace suffixes
+    if (hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+      return false;
+    }
+
     // Block any IPv6 address (no allowlisted hostnames are IPv6).
     // This catches ::ffff:127.0.0.1, fe80::, fc00::, fd00::, etc.
     if (hostname.includes(':')) {
@@ -382,12 +397,30 @@ export function isUrlHostnameAllowed(urlString: string): boolean {
       if (a === 192 && b === 168) return false;
       if (a === 169 && b === 254) return false; // AWS metadata / link-local
       if (a === 0) return false;
+      if (a === 127) return false; // full loopback range, not just 127.0.0.1
       if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT range
     }
 
     // Block any remaining raw IP address (not a hostname)
     if (/^\d+$/.test(hostname)) return false; // decimal notation like 2130706433
     if (/^0\d/.test(hostname.split('.')[0])) return false; // octal notation like 0177.0.0.1
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a URL's hostname is in the SSRF allowlist.
+ * Supports wildcard subdomains (*.domain).
+ */
+export function isUrlHostnameAllowed(urlString: string): boolean {
+  try {
+    // Dangerous-target checks first — an allowlisted name can never override them.
+    if (!isSafePublicHostname(urlString)) return false;
+
+    const hostname = new URL(urlString).hostname.toLowerCase();
 
     // Check exact match
     if (ALLOWED_OUTBOUND_HOSTNAMES.has(hostname)) return true;


### PR DESCRIPTION
## Why

`check-releases` on `main` is an **unauthenticated POST endpoint with no URL validation, no allowlist check, and no rate limit.** It fetches URLs from the request body, then follows a link found *inside* the fetched page, and reflects parsed fields back to the caller.

That's SSRF with partial content reflection, plus an anonymous outbound-request amplifier running from Netlify's IPs. This is independent of the Releases feature work and was flagged as "ship this anyway" during that review.

## The part that isn't obvious

**Validating the URL we are *given* says nothing about the URL we actually *retrieve*.** Node's `fetch` follows redirects transparently, and this endpoint already makes a deliberate second hop to a URL parsed out of fetched HTML.

This isn't theoretical. Bandcamp Pro artists point custom domains at their stores, so the redirect path is exercised by legitimate traffic every day:

```
sufjanstevens.bandcamp.com/music  ->  301  ->  music.sufjan.com/music
```

So an allowlist check at the boundary is redirect-bypassable, *and* a naive allowlist-only fix would break real Bandcamp and self-hosted Faircamp artists.

## What changed

**`middleware.ts`** — split the dangerous-target checks out of `isUrlHostnameAllowed` into a new exported `isSafePublicHostname`, so callers that legitimately fetch off-allowlist hosts can still refuse internal ones. `isUrlHostnameAllowed` now calls it first, so an allowlisted name can never override a private-address check. Two gaps closed while I was in there: the full `127/8` loopback range (only `127.0.0.1` was blocked) and `.local` / `.internal` suffixes.

**`check-releases.ts`**
- A single `safeFetch` path resolves redirects **manually** (`redirect: 'manual'`) and re-validates **every hop**, capped at 5.
- The second-hop album URL is resolved against the page we actually landed on (which may be a custom domain) and re-validated before use.
- Incoming URLs must be allowlisted **or** already stored as a link for that artist.
- Rate limited at the **`lenient`** tier (120/min, 5000/day).
- Refusing to look now returns an explicit error instead of an empty result.

**`db.ts`** — new `isStoredArtistLink(url, artistName)`. Faircamp is self-hosted on arbitrary domains, so `isUrlHostnameAllowed` (which needs a literal `faircamp` label) rejects most genuine Faircamp sites. "Have we already discovered this link for this artist?" gives the same containment without breaking the platform. Fails closed on any error.

## Why `lenient` and not `strict`

`strict` is 10/min. Both shipped clients loop **once per saved artist with no delay and swallow errors**:

- [`service-worker.js`](apps/extension/background/service-worker.js) — `for (const artistName of artistNames)`, weekly
- [`ReleaseAlertManager.swift:203`](apps/mac/Unstream/ReleaseAlertManager.swift:203) — `for entry in entries`

Both then commit their "last checked" state regardless. So `strict` would silently stop release alerts for every artist past the tenth, for anyone tracking more than 10 artists — trading a security hole for a broken feature. `lenient` fits the caller that actually exists.

**A batch request shape is the real fix** and is the natural follow-up once clients can ship one. I deliberately did *not* add unused batch surface here.

## Backward compatibility

Response shape, status codes, and the wildcard CORS origin are unchanged — Mac 3.3.x and extension 2.5.x are already released against this contract. The wildcard is deliberate and now carries a comment saying so: neither native client sends an `Origin` that `buildCorsHeaders()` would accept.

## Testing

**35 new tests** in `api/functions/__tests__/check-releases-ssrf.test.ts`, covering metadata endpoints (AWS/GCP/Alibaba), private ranges, loopback, IPv4-mapped IPv6, decimal/octal-encoded IPs, `.local`/`.internal`, non-HTTP schemes, **the redirect bypass**, custom-domain following, relative-redirect resolution, the redirect cap, the tier choice, and the shipped-client contract.

- `npm run test:api` — 199 passed (16 files)
- `npm run build` — passes end to end
- Explicit `tsc --strict` over the three touched files: only the pre-existing `mirloRssCache is possibly null`, confirmed identical on `origin/main` by checking out that version and re-running. `api/` isn't in the build's typecheck, so this was verified by hand.

`checkRateLimit` is mocked rather than Redis, so no test can reach the real Upstash instance CI has credentials for.

## Known limitation, stated deliberately

This does not defend against **DNS rebinding** — a public hostname whose DNS resolves to a private address. That needs resolution-time checks Node's `fetch` doesn't expose. The docstring on `isSafePublicHostname` says so rather than implying full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)