### PR TITLE
Releases: schema and pure utils

### DIFF
--- a/api/functions/__tests__/release-utils.test.ts
+++ b/api/functions/__tests__/release-utils.test.ts
@@ -1,0 +1,255 @@
+// Tests for release-utils.
+//
+// Several of these are regressions for specific bugs in the abandoned first attempt at this
+// feature (PR #336), which shipped zero tests. Each is labelled, because they look like
+// trivia until you know they were real: a "hash" that was actually the first three bytes of
+// the input, a normalizer that deleted every non-Latin title, and a slug map that clobbered
+// within a single run.
+
+import { describe, it, expect } from 'vitest';
+import {
+  releaseMatchKey,
+  releaseSlug,
+  shortHash,
+  uniqueReleaseSlug,
+  mapReleaseType,
+  parseReleaseDate,
+  deriveStatus,
+} from '../release-utils';
+
+describe('releaseMatchKey', () => {
+  it('folds accents so spellings agree', () => {
+    expect(releaseMatchKey('Björk')).toBe(releaseMatchKey('Bjork'));
+    expect(releaseMatchKey('Tanerélle')).toBe(releaseMatchKey('Tanerelle'));
+    expect(releaseMatchKey('Sigur Rós')).toBe(releaseMatchKey('Sigur Ros'));
+  });
+
+  it('ignores case, spacing and punctuation', () => {
+    expect(releaseMatchKey('Carrie & Lowell')).toBe(releaseMatchKey('carrie & lowell'));
+    expect(releaseMatchKey('Album Name.')).toBe(releaseMatchKey('Album  Name'));
+    expect(releaseMatchKey('Carrie & Lowell')).toBe('carrielowell');
+  });
+
+  // PR #336 regression: a bare [^a-z0-9] strip turned these into "" and the ingest then
+  // did `if (!norm) continue`, so every CJK/Cyrillic/Greek title was silently dropped from
+  // the catalog with no log line.
+  it('does NOT collapse non-Latin titles to an empty string', () => {
+    for (const title of ['東京', 'Привет', 'Ⅱ', 'こんにちは', '서울']) {
+      expect(releaseMatchKey(title), `${title} should produce a key`).not.toBe('');
+    }
+  });
+
+  it('keeps distinct non-Latin titles distinct', () => {
+    expect(releaseMatchKey('東京')).not.toBe(releaseMatchKey('大阪'));
+    expect(releaseMatchKey('Привет')).not.toBe(releaseMatchKey('Пока'));
+  });
+
+  // The over-merge trap: stripping to ASCII would reduce both of these to "tokyo" and
+  // merge two different records. Under-merging is recoverable; a wrong merge is not.
+  it('does not merge titles that differ only outside ASCII', () => {
+    expect(releaseMatchKey('Tokyo 東京')).not.toBe(releaseMatchKey('Tokyo 大阪'));
+  });
+
+  it('returns empty only when there are genuinely no letters or numbers', () => {
+    expect(releaseMatchKey('!!!???')).toBe('');
+    expect(releaseMatchKey('')).toBe('');
+  });
+});
+
+describe('shortHash', () => {
+  // PR #336 regression. It used Buffer.from(title).toString('hex').slice(0, 6), which is
+  // the first three bytes of the *input*, so all three of these collided — exactly the case
+  // the comment said it existed to handle.
+  it('distinguishes strings that share a long prefix', () => {
+    const a = shortHash('Album Name.');
+    const b = shortHash('Album Name!');
+    const c = shortHash('Album Name?');
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it('is deterministic and fixed-width', () => {
+    expect(shortHash('x')).toBe(shortHash('x'));
+    expect(shortHash('a very much longer input string')).toHaveLength(8);
+  });
+});
+
+describe('releaseSlug', () => {
+  it('produces readable slugs', () => {
+    expect(releaseSlug('Carrie & Lowell')).toBe('carrie-lowell');
+    expect(releaseSlug('Hail To The Thief')).toBe('hail-to-the-thief');
+    expect(releaseSlug('  Leading and trailing  ')).toBe('leading-and-trailing');
+  });
+
+  it('transliterates accents rather than dropping them', () => {
+    expect(releaseSlug('Björk')).toBe('bjork');
+    expect(releaseSlug('Sigur Rós - Takk...')).toBe('sigur-ros-takk');
+  });
+
+  // PR #336 regression: these produced "" and the release was then skipped entirely.
+  it('never returns an empty slug for a titled release', () => {
+    for (const title of ['東京', 'Привет', 'Ⅱ', '!!!']) {
+      const slug = releaseSlug(title);
+      expect(slug, `${title} produced an empty slug`).not.toBe('');
+      expect(slug).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it('gives different non-Latin titles different slugs', () => {
+    expect(releaseSlug('東京')).not.toBe(releaseSlug('大阪'));
+  });
+
+  it('caps length and leaves no trailing hyphen', () => {
+    const slug = releaseSlug('A'.repeat(50) + ' ' + 'B'.repeat(60));
+    expect(slug.length).toBeLessThanOrEqual(80);
+    expect(slug.endsWith('-')).toBe(false);
+  });
+});
+
+describe('uniqueReleaseSlug', () => {
+  it('uses the plain slug when free', () => {
+    expect(uniqueReleaseSlug('Carrie & Lowell', new Set())).toBe('carrie-lowell');
+  });
+
+  it('disambiguates on collision', () => {
+    const taken = new Set(['album-name']);
+    const slug = uniqueReleaseSlug('Album Name', taken);
+    expect(slug).not.toBe('album-name');
+    expect(slug.startsWith('album-name-')).toBe(true);
+  });
+
+  // PR #336 regression: the "already taken" set was read once per artist before the insert
+  // loop and never updated, so two titles that slugified the same in one run both got the
+  // bare slug and the second overwrote the first.
+  it('keeps giving fresh slugs as the caller accumulates them', () => {
+    const taken = new Set<string>();
+    const slugs = ['Album Name.', 'Album Name!', 'Album Name?', 'Album Name'].map(t => {
+      const s = uniqueReleaseSlug(t, taken);
+      taken.add(s);
+      return s;
+    });
+    expect(new Set(slugs).size).toBe(4);
+  });
+
+  it('resolves the identical-title case rather than returning a duplicate', () => {
+    const taken = new Set<string>();
+    const a = uniqueReleaseSlug('Same Title', taken); taken.add(a);
+    const b = uniqueReleaseSlug('Same Title', taken); taken.add(b);
+    const c = uniqueReleaseSlug('Same Title', taken);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
+describe('mapReleaseType', () => {
+  it('passes through our own vocabulary', () => {
+    for (const t of ['album', 'ep', 'single', 'compilation', 'live', 'remix', 'other'] as const) {
+      expect(mapReleaseType(t)).toBe(t);
+    }
+  });
+
+  it('is case and whitespace insensitive', () => {
+    expect(mapReleaseType('  Album ')).toBe('album');
+    expect(mapReleaseType('EP')).toBe('ep');
+  });
+
+  it('reads Bandcamp item-id prefixes', () => {
+    expect(mapReleaseType('album-1891263657')).toBe('album');
+    expect(mapReleaseType('track-456')).toBe('single');
+    expect(mapReleaseType('track')).toBe('single');
+  });
+
+  // PR #336 regression: its mapper collapsed everything to album-or-single and could never
+  // emit 'ep' or 'compilation'. Type is the strongest dedup signal we have for artists with
+  // no shared identifier, so losing it is expensive.
+  it('can actually emit every granular type', () => {
+    expect(mapReleaseType('mini-album')).toBe('ep');
+    expect(mapReleaseType('Compilation Album')).toBe('compilation');
+    expect(mapReleaseType('Live Album')).toBe('live');
+    expect(mapReleaseType('Remixes')).toBe('remix');
+  });
+
+  it('falls back to other rather than guessing album', () => {
+    expect(mapReleaseType('mixtape')).toBe('other');
+    expect(mapReleaseType('')).toBe('other');
+    expect(mapReleaseType(null)).toBe('other');
+    expect(mapReleaseType(undefined)).toBe('other');
+  });
+});
+
+describe('parseReleaseDate', () => {
+  const now = new Date('2026-07-31T00:00:00Z');
+
+  it('accepts ISO dates', () => {
+    expect(parseReleaseDate('2025-05-30', now)).toEqual({ date: '2025-05-30', precision: 'day' });
+  });
+
+  it('accepts the textual formats Bandcamp uses', () => {
+    expect(parseReleaseDate('December 6, 2024', now)).toEqual({ date: '2024-12-06', precision: 'day' });
+    expect(parseReleaseDate('Dec 6, 2024', now)).toEqual({ date: '2024-12-06', precision: 'day' });
+    expect(parseReleaseDate('30 May 2025 00:00:00 GMT', now)).toEqual({ date: '2025-05-30', precision: 'day' });
+  });
+
+  // A date-only string through `new Date(s)` parses as local midnight and can format back
+  // as the previous day. Netlify runs UTC so functions were safe, but a migration or script
+  // run from a laptop was not.
+  it('does not shift the day by timezone', () => {
+    expect(parseReleaseDate('December 6, 2024', now).date).toBe('2024-12-06');
+    expect(parseReleaseDate('2024-12-06', now).date).toBe('2024-12-06');
+  });
+
+  it('records partial precision instead of inventing a day', () => {
+    expect(parseReleaseDate('2024-12', now)).toEqual({ date: '2024-12-01', precision: 'month' });
+    expect(parseReleaseDate('2024', now)).toEqual({ date: '2024-01-01', precision: 'year' });
+  });
+
+  // This is live data, not a hypothetical: Mirlo carries a release dated 2925-11-02.
+  // Unbounded it sorts to the top of every chronology and lands in every ICS subscriber's
+  // calendar permanently.
+  it('rejects the typo years that are actually in upstream data', () => {
+    expect(parseReleaseDate('2925-11-02', now)).toEqual({ date: null, precision: 'unknown' });
+    expect(parseReleaseDate('0202-01-01', now)).toEqual({ date: null, precision: 'unknown' });
+    expect(parseReleaseDate('1899-12-31', now)).toEqual({ date: null, precision: 'unknown' });
+  });
+
+  it('keeps genuine future announcements', () => {
+    // Mirlo really does schedule this far out — verified live.
+    expect(parseReleaseDate('2027-09-07', now).date).toBe('2027-09-07');
+    expect(parseReleaseDate('2026-10-10', now).date).toBe('2026-10-10');
+  });
+
+  it('rejects impossible calendar dates instead of rolling them over', () => {
+    expect(parseReleaseDate('2024-02-31', now).date).toBeNull();
+    expect(parseReleaseDate('2024-13-01', now).date).toBeNull();
+  });
+
+  it('treats missing and unparseable input as unknown, not as a date', () => {
+    for (const input of [null, undefined, '', '   ', 'sometime last year', 'TBA']) {
+      expect(parseReleaseDate(input, now)).toEqual({ date: null, precision: 'unknown' });
+    }
+  });
+});
+
+describe('deriveStatus', () => {
+  const now = new Date('2026-07-31T12:00:00Z');
+
+  it('marks future dates as announced', () => {
+    expect(deriveStatus('2027-09-07', false, now)).toBe('announced');
+    expect(deriveStatus('2026-08-01', false, now)).toBe('announced');
+  });
+
+  it('marks past and same-day dates as released', () => {
+    expect(deriveStatus('2025-01-01', false, now)).toBe('released');
+    expect(deriveStatus('2026-07-31', false, now)).toBe('released');
+  });
+
+  it('trusts an upstream pre-order flag over the date', () => {
+    // Bandcamp and Mirlo both expose this, and it's more reliable than a possibly
+    // imprecise date.
+    expect(deriveStatus('2020-01-01', true, now)).toBe('announced');
+  });
+
+  it('treats an undated release as released rather than coming soon', () => {
+    // Undated releases are overwhelmingly back-catalog; telling a fan something is coming
+    // when we don't know is the worse error.
+    expect(deriveStatus(null, false, now)).toBe('released');
+  });
+});

--- a/api/functions/release-utils.ts
+++ b/api/functions/release-utils.ts
@@ -1,0 +1,289 @@
+// Pure helpers for release entities: match keys, slugs, type mapping, date hygiene.
+//
+// No network, no database, no cache — everything here is a function of its arguments, so
+// it's all unit-testable. Keep it that way: this module is the one every later phase of
+// the Releases work depends on, and the three worst bugs in the abandoned first attempt
+// (PR #336) were all in about fifteen lines of untested normalization.
+
+import { createHash } from 'crypto';
+import { normalizeAccents } from './search-utils';
+
+// ---------------------------------------------------------------------------
+// Match keys
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalized title used to decide whether two releases are the same one. Never displayed.
+ *
+ * Built on `normalizeAccents` (NFD-fold, drop combining marks) so "Björk" and "Bjork"
+ * agree, but the character-class step keeps **any** Unicode letter or number rather than
+ * only `[a-z0-9]`.
+ *
+ * That difference is the whole point. `normalizeForComparison` in search-utils strips to
+ * ASCII, which turns "東京", "Привет", and "Ⅱ" into the empty string — and an empty key
+ * either drops the release from the catalog or, worse, matches every other non-Latin
+ * title. Stripping to ASCII would also make "Tokyo 東京" and "Tokyo 大阪" both normalize to
+ * "tokyo" and merge two different records, which violates the rule this whole feature is
+ * built on: under-merge, never over-merge.
+ */
+export function releaseMatchKey(title: string): string {
+  return normalizeAccents(title)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+// ---------------------------------------------------------------------------
+// Slugs
+// ---------------------------------------------------------------------------
+
+/** Longest slug we'll emit, before any collision suffix. Keeps URLs and indexes sane. */
+const MAX_SLUG_LENGTH = 80;
+
+/**
+ * URL segment for /a/{artist}/{slug}, derived from the title.
+ *
+ * Accents fold to ASCII so the slug stays typable. A title with no ASCII-safe characters
+ * at all (CJK, Cyrillic, Greek) has no reasonable transliteration available here, so it
+ * falls back to a content hash rather than the empty string — PR #336 emitted "" for these
+ * and then skipped the release entirely, silently excluding every non-Latin title from the
+ * catalog.
+ */
+export function releaseSlug(title: string): string {
+  const base = normalizeAccents(title)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, ''); // trailing hyphen from the truncation above
+
+  if (base) return base;
+
+  const key = releaseMatchKey(title);
+  // `release-` prefix keeps these recognizable as generated rather than titled.
+  return key ? `release-${shortHash(key)}` : `release-${shortHash(title)}`;
+}
+
+/**
+ * Deterministic short digest for disambiguating slugs.
+ *
+ * A real hash, not a prefix of the input: PR #336 used
+ * `Buffer.from(title).toString('hex').slice(0, 6)`, which is just the first three bytes of
+ * the title — so "Album Name.", "Album Name!", and "Album Name?" all produced the same
+ * suffix, which is precisely the case it existed to separate.
+ *
+ * `createHash` from node:crypto, not `crypto.subtle`, which isn't available in Netlify
+ * Functions.
+ */
+export function shortHash(input: string): string {
+  return createHash('sha1').update(input).digest('hex').slice(0, 8);
+}
+
+/**
+ * Pick a slug that doesn't collide with `taken`.
+ *
+ * Callers must add each returned slug to `taken` before the next call — the abandoned
+ * first attempt fetched existing slugs once per artist and never updated the set as it
+ * inserted, so two new titles that slugified identically in the same run both got the bare
+ * slug and the second silently overwrote the first.
+ */
+export function uniqueReleaseSlug(title: string, taken: ReadonlySet<string>): string {
+  const base = releaseSlug(title);
+  if (!taken.has(base)) return base;
+
+  const withHash = `${base}-${shortHash(title)}`;
+  if (!taken.has(withHash)) return withHash;
+
+  // Same title twice under one artist (a reissue, or two sources disagreeing). Walk a
+  // counter rather than returning something already in use.
+  for (let n = 2; n < 100; n++) {
+    const candidate = `${withHash}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  // Effectively unreachable; better than looping forever or returning a dup.
+  return `${base}-${shortHash(`${title}:${taken.size}`)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Release types
+// ---------------------------------------------------------------------------
+
+export type ReleaseType = 'album' | 'ep' | 'single' | 'compilation' | 'live' | 'remix' | 'other';
+
+const RELEASE_TYPES: ReadonlySet<string> = new Set<ReleaseType>([
+  'album', 'ep', 'single', 'compilation', 'live', 'remix', 'other',
+]);
+
+/**
+ * Map a source's own type string onto ours, preserving granularity.
+ *
+ * Matching *within* a type is the strongest dedup signal available for artists with no
+ * shared identifier, so collapsing everything to album-or-single throws away the thing we
+ * most need. PR #336's mapper could only ever emit 'album' or 'single' — 'ep' and
+ * 'compilation' were unreachable in every code path.
+ *
+ * Unrecognized values become 'other' rather than being guessed into 'album': a wrong type
+ * blocks a legitimate match, and 'other' at least fails honestly.
+ */
+export function mapReleaseType(raw: string | null | undefined): ReleaseType {
+  if (!raw) return 'other';
+  const s = raw.toLowerCase().trim();
+
+  if (RELEASE_TYPES.has(s)) return s as ReleaseType;
+
+  // Bandcamp encodes type in its item ids ("album-123", "track-456") and URL paths.
+  if (s === 'track' || s.startsWith('track-')) return 'single';
+  if (s.startsWith('album-')) return 'album';
+
+  if (s === 'lp' || s === 'full-length' || s === 'fulllength') return 'album';
+  if (s === 'e.p.' || s === 'e.p' || s === 'mini-album') return 'ep';
+  if (s === 'compilation album' || s === 'comp' || s === 'anthology') return 'compilation';
+  if (s === 'live album' || s === 'live recording') return 'live';
+  if (s === 'remix album' || s === 'remixes') return 'remix';
+  if (s === 'digital single' || s === '7"' || s === 'maxi-single') return 'single';
+
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Dates
+// ---------------------------------------------------------------------------
+
+export type DatePrecision = 'day' | 'month' | 'year' | 'unknown';
+
+export interface ParsedReleaseDate {
+  /** ISO yyyy-mm-dd, or null when there's no usable date. */
+  date: string | null;
+  precision: DatePrecision;
+}
+
+/** Earliest plausible release date. Matches the CHECK constraint on releases.release_date. */
+const MIN_YEAR = 1900;
+
+/**
+ * How far ahead a release date may sit. Genuine announcements run well over a year out
+ * (Mirlo had one dated 2027-09-07 against a 2026 today), so the bound has to be generous
+ * enough not to reject real pre-orders while still catching typos.
+ */
+const MAX_YEARS_AHEAD = 3;
+
+/**
+ * Parse and sanity-bound a source's release date.
+ *
+ * The bound is not defensive programming, it's a live data problem: Mirlo currently
+ * carries a release dated **2925-11-02**. Unbounded, one typo sorts to the top of every
+ * chronology and lands in every calendar subscriber's feed forever.
+ *
+ * Partial dates are kept at the precision they arrived with rather than being padded
+ * silently — MusicBrainz returns year-only and month-only dates, and rendering "1 January"
+ * for a year-only date states a fact the source never gave us. The padding still happens
+ * (a date column needs a full date) but `precision` records that it was our doing.
+ *
+ * `now` is injectable so tests don't depend on the wall clock.
+ */
+export function parseReleaseDate(
+  raw: string | null | undefined,
+  now: Date = new Date()
+): ParsedReleaseDate {
+  if (!raw) return { date: null, precision: 'unknown' };
+
+  const s = String(raw).trim();
+  if (!s) return { date: null, precision: 'unknown' };
+
+  let year: number;
+  let month = 1;
+  let day = 1;
+  let precision: DatePrecision;
+
+  const ymd = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  const ym = s.match(/^(\d{4})-(\d{2})$/);
+  const y = s.match(/^(\d{4})$/);
+
+  if (ymd) {
+    [year, month, day] = [Number(ymd[1]), Number(ymd[2]), Number(ymd[3])];
+    precision = 'day';
+  } else if (ym) {
+    [year, month] = [Number(ym[1]), Number(ym[2])];
+    precision = 'month';
+  } else if (y) {
+    year = Number(y[1]);
+    precision = 'year';
+  } else {
+    // Formats like "December 6, 2024" and Bandcamp's "06 Dec 2024 00:00:00 GMT".
+    // Parsed as UTC noon rather than via bare `new Date(s)`, which interprets a
+    // date-only string as local midnight and can format back as the previous day.
+    const parsed = parseTextualDate(s);
+    if (!parsed) return { date: null, precision: 'unknown' };
+    [year, month, day] = parsed;
+    precision = 'day';
+  }
+
+  if (!isCalendarDate(year, month, day)) return { date: null, precision: 'unknown' };
+
+  const maxYear = now.getUTCFullYear() + MAX_YEARS_AHEAD;
+  if (year < MIN_YEAR || year > maxYear) return { date: null, precision: 'unknown' };
+
+  const iso = `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  return { date: iso, precision };
+}
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+/** "December 6, 2024" / "6 Dec 2024 ..." -> [y, m, d]. Null when neither shape matches. */
+function parseTextualDate(s: string): [number, number, number] | null {
+  const monthFirst = s.match(/^([A-Za-z]{3,})\.?\s+(\d{1,2}),?\s+(\d{4})/);
+  if (monthFirst) {
+    const m = MONTHS[monthFirst[1].slice(0, 3).toLowerCase()];
+    if (m) return [Number(monthFirst[3]), m, Number(monthFirst[2])];
+  }
+
+  const dayFirst = s.match(/^(\d{1,2})\s+([A-Za-z]{3,})\.?\s+(\d{4})/);
+  if (dayFirst) {
+    const m = MONTHS[dayFirst[2].slice(0, 3).toLowerCase()];
+    if (m) return [Number(dayFirst[3]), m, Number(dayFirst[1])];
+  }
+
+  return null;
+}
+
+/** Reject 2024-02-31 and friends — Date would roll them over into March. */
+function isCalendarDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const d = new Date(Date.UTC(year, month - 1, day, 12));
+  return (
+    d.getUTCFullYear() === year &&
+    d.getUTCMonth() === month - 1 &&
+    d.getUTCDate() === day
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+export type ReleaseStatus = 'announced' | 'released';
+
+/**
+ * Is this release out yet?
+ *
+ * Stored rather than computed per request so feeds and chronologies can filter cheaply,
+ * and because a list that silently mixes future and past releases under "newest first"
+ * reads as broken. An upstream pre-order flag wins over the date — Bandcamp and Mirlo both
+ * expose one, and it's more reliable than comparing a possibly-imprecise date.
+ *
+ * Undated releases count as released: they're overwhelmingly back-catalog, and promising a
+ * fan something is "coming" when we simply don't know is the worse error.
+ */
+export function deriveStatus(
+  date: string | null,
+  isPreorder: boolean = false,
+  now: Date = new Date()
+): ReleaseStatus {
+  if (isPreorder) return 'announced';
+  if (!date) return 'released';
+
+  const today = now.toISOString().slice(0, 10);
+  return date > today ? 'announced' : 'released';
+}

--- a/supabase/migrations/20260731120000_releases.sql
+++ b/supabase/migrations/20260731120000_releases.sql
@@ -1,0 +1,239 @@
+-- Migration: releases, release_sources, release_offers
+--
+-- First-class release entities under an artist, for Unstream Releases. Three tables,
+-- because a release is one thing that exists in several places, each of which may sell it
+-- in several formats at different prices:
+--
+--   releases         one row per actual release (album, EP, single…)
+--   release_sources  where that release can be found — one row per platform
+--   release_offers   what you can buy there — one row per format, with price
+--
+-- Schema only. No application code reads or writes these yet.
+--
+-- Deliberately NOT here: the `artist_links.latest_release` jsonb lift proposed in the
+-- original spec. That column holds one release per platform per artist, so lifting it
+-- would produce a "discography" of length 1. Catalog ingest supersedes it. The jsonb
+-- column stays as-is — it remains load-bearing for search disambiguation
+-- (allReleaseTitles, release-overlap merging), which is a separate consumer with a
+-- separate shape.
+
+-- ---------------------------------------------------------------------------
+-- releases
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS releases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  artist_id uuid NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+
+  -- Display-quality title, as the source presents it (accents and punctuation intact).
+  title text NOT NULL,
+
+  -- URL segment for /a/{artist}/{slug}. Unique per artist.
+  slug text NOT NULL,
+
+  -- Normalized title used for dedup only — never displayed. Built with
+  -- normalizeForComparison() from search-utils.ts, which NFD-folds accents rather than
+  -- deleting them, so non-Latin titles survive instead of collapsing to an empty string.
+  match_key text NOT NULL,
+
+  -- Source-native type. Kept granular on purpose: matching *within* a type is the single
+  -- most useful dedup signal we have, and collapsing everything to album-or-single throws
+  -- it away. 'other' is the escape hatch for source values we don't recognize.
+  release_type text NOT NULL DEFAULT 'other'
+    CHECK (release_type IN ('album', 'ep', 'single', 'compilation', 'live', 'remix', 'other')),
+
+  -- Sanity-bounded on the way in. The lower bound is a CHECK; the upper bound
+  -- (roughly today + 3 years) can't be, because now() isn't immutable and CHECK
+  -- constraints must be. Enforced in release-utils instead. This matters: Mirlo has a
+  -- live release dated 2925-11-02, which unbounded would sort to the top of every
+  -- chronology and land in every subscriber's calendar.
+  release_date date CHECK (release_date IS NULL OR release_date >= DATE '1900-01-01'),
+
+  -- How much of release_date is real. MusicBrainz returns year-only and month-only dates,
+  -- and rendering "January 1" for a year-only date invents a fact — it also poisons any
+  -- date-proximity dedup that assumes day precision.
+  date_precision text NOT NULL DEFAULT 'day'
+    CHECK (date_precision IN ('day', 'month', 'year', 'unknown')),
+
+  -- 'announced' = dated in the future or flagged as a pre-order upstream. Derived on
+  -- ingest, stored so feeds and chronologies can filter without recomputing per request.
+  -- A list that silently mixes future and past releases under "newest first" reads as broken.
+  status text NOT NULL DEFAULT 'released'
+    CHECK (status IN ('announced', 'released')),
+
+  artwork_url text,
+
+  -- Cross-source identity anchors. Both are pre-existing groupings we get for free:
+  -- MusicBrainz release groups, and Discogs masters (which already collapse every
+  -- pressing of a record into one entity). Where either is present, dedup is exact
+  -- rather than a title guess.
+  musicbrainz_release_group_id text,
+  discogs_master_id text,
+
+  -- Suppression and review, shipped with the schema rather than added later. Auto-created
+  -- releases inherit the Bandcamp probe's residual wrong-artist rate, and a wrong release
+  -- here becomes a durable URL asserting that an artist made a record they didn't.
+  -- Ingest must never write is_hidden.
+  is_hidden boolean NOT NULL DEFAULT false,
+  needs_review boolean NOT NULL DEFAULT false,
+
+  -- Provenance. 'claimed' means a verified artist authored or corrected this row.
+  -- Mirrors artist_links.source so there's one convention in the codebase.
+  source text NOT NULL DEFAULT 'auto'
+    CHECK (source IN ('auto', 'claimed')),
+
+  -- Field-level provenance: names of columns a verified artist has edited, which a
+  -- re-crawl must leave alone. Scheduled ingest re-runs forever, so without this every
+  -- crawl quietly reverts an artist's corrections — data loss that is slow, repeated, and
+  -- by design, which makes it far harder to notice than a one-off bad write.
+  -- e.g. '{title,release_date}'
+  curated_fields text[] NOT NULL DEFAULT '{}',
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (artist_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_releases_artist_id ON releases (artist_id);
+
+-- The primary read for both the artist-page section and the feeds: one artist's releases,
+-- newest first. release_date is nullable and V1 data often lacks it, so created_at is a
+-- stable tiebreaker — otherwise "newest first" is nondeterministic between requests.
+CREATE INDEX IF NOT EXISTS idx_releases_artist_chrono
+  ON releases (artist_id, release_date DESC NULLS LAST, created_at DESC);
+
+-- Dedup lookups happen within (artist, type) — see the release_type comment.
+CREATE INDEX IF NOT EXISTS idx_releases_match
+  ON releases (artist_id, release_type, match_key);
+
+-- Identity anchors are unique per artist where present. Partial indexes because Postgres
+-- treats NULLs as distinct, so a plain unique index would allow unlimited NULL rows but
+-- also wouldn't express "at most one row per MBID per artist" the way this does.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_releases_mbid
+  ON releases (artist_id, musicbrainz_release_group_id)
+  WHERE musicbrainz_release_group_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_releases_discogs_master
+  ON releases (artist_id, discogs_master_id)
+  WHERE discogs_master_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- release_sources
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS release_sources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_id uuid NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+
+  -- Platform id from api/shared/platform-registry.ts. No is_streaming boolean: the
+  -- registry already carries category (marketplace / patronage / decentralized / library
+  -- / official / social) plus payout, which is strictly more information and one place to
+  -- maintain.
+  platform text NOT NULL,
+
+  url text NOT NULL,
+
+  -- The platform's own stable id for this release — Bandcamp's data-item-id
+  -- ("album-1891263657", which also encodes album-vs-track), Mirlo's trackGroup id,
+  -- a Discogs release id. This is what makes re-ingest idempotent: a title can change
+  -- upstream, an id doesn't, so we update in place instead of minting a duplicate.
+  external_id text,
+
+  source text NOT NULL DEFAULT 'auto'
+    CHECK (source IN ('auto', 'claimed')),
+
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (release_id, platform)
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_sources_release_id ON release_sources (release_id);
+
+-- Global, not per-release: the same (platform, external_id) must never appear under two
+-- releases, or one upstream record has been split in two. This is the constraint that
+-- makes re-crawls safe.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_release_sources_external
+  ON release_sources (platform, external_id)
+  WHERE external_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- release_offers
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS release_offers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_source_id uuid NOT NULL REFERENCES release_sources(id) ON DELETE CASCADE,
+
+  format text NOT NULL DEFAULT 'other'
+    CHECK (format IN ('digital', 'vinyl', 'cassette', 'cd', 'book', 'merch', 'other')),
+
+  -- Nullable: plenty of releases are name-your-price, free, or listed without a figure.
+  price numeric(10, 2) CHECK (price IS NULL OR price >= 0),
+  currency text CHECK (currency IS NULL OR currency ~ '^[A-Z]{3}$'),
+
+  availability text NOT NULL DEFAULT 'unknown'
+    CHECK (availability IN ('available', 'preorder', 'sold_out', 'unknown')),
+
+  -- Prices change and vinyl sells out. Offers are a claim with an age, not a fact —
+  -- surface this so a page can say how fresh it is instead of promising stale stock.
+  captured_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (release_source_id, format)
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_offers_source_id ON release_offers (release_source_id);
+
+-- ---------------------------------------------------------------------------
+-- updated_at trigger (releases only — the others carry last_seen_at / captured_at)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION set_releases_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_releases_updated_at ON releases;
+CREATE TRIGGER trg_releases_updated_at
+  BEFORE UPDATE ON releases
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- RLS — public read, service write (same shape as artists / artist_links)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE releases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE release_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE release_offers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public read access" ON releases;
+DROP POLICY IF EXISTS "Public read access" ON release_sources;
+DROP POLICY IF EXISTS "Public read access" ON release_offers;
+
+CREATE POLICY "Public read access" ON releases FOR SELECT USING (true);
+CREATE POLICY "Public read access" ON release_sources FOR SELECT USING (true);
+CREATE POLICY "Public read access" ON release_offers FOR SELECT USING (true);
+
+-- Writes are service-role only. The service key bypasses RLS, so the absence of
+-- insert/update/delete policies is what keeps anon and authenticated clients read-only —
+-- deliberate, not an oversight. Artist curation will go through an authenticated function
+-- that checks profile ownership server-side, not through a client-side RLS policy.
+
+COMMENT ON TABLE releases IS
+  'One row per release under an artist. Display entity for Unstream Releases; artist_links.latest_release remains the separate search-disambiguation shape.';
+COMMENT ON TABLE release_sources IS
+  'Where a release can be found — one row per platform. external_id is the platform''s stable id, which makes re-ingest idempotent.';
+COMMENT ON TABLE release_offers IS
+  'What you can buy at a source: format, price, availability. captured_at because prices and stock go stale.';
+COMMENT ON COLUMN releases.curated_fields IS
+  'Column names a verified artist has edited. Scheduled ingest must not overwrite these.';
+COMMENT ON COLUMN releases.match_key IS
+  'Normalized title for dedup only, via normalizeForComparison(). Never displayed.';


### PR DESCRIPTION
Step 1 of Unstream Releases. **Schema plus the pure helper module** every later phase depends on. No application code reads or writes these tables yet — deployable and reversible on its own.

Scope per the agreed plan: three sources (Bandcamp → Discogs → MusicBrainz, no iTunes), demand-driven cataloging, three fan-facing pillars.

## Three tables

A release is one thing that exists in several places, each of which may sell it in several formats at different prices:

| Table | Holds |
|---|---|
| `releases` | one row per actual release |
| `release_sources` | where it can be found — one row per platform |
| `release_offers` | what you can buy there — format, price, availability |

`release_offers` exists in V1 even though the UI comes later, because it's the differentiator — *"vinyl $30 · Bandcamp · ≈$25 to the artist"* is a page nobody else has — and retrofitting it after pages ship costs more than including it now.

## Design decisions that are load-bearing

**`external_id`, globally unique per platform.** The platform's own stable id — Bandcamp's `data-item-id="album-1891263657"`, Mirlo's trackGroup id, a Discogs release id. This is what makes re-ingest idempotent: a title can change upstream, an id can't, so we update in place instead of minting a duplicate. The original spec had no external-id concept at all.

**`curated_fields` + `source`, shipped now for a UI that comes later.** Cataloging re-runs on a schedule. Without field-level provenance, every crawl silently reverts an artist's corrections — data loss that is slow, repeated, and *by design*, which makes it much harder to notice than a one-off bad write. Adding these columns later needs a migration **plus a backfill plus determining which values a human authored**, which is unknowable after the fact. They're nearly free today. Mirrors the existing `artist_links.source` convention.

**`date_precision`.** MusicBrainz returns year-only and month-only dates. Rendering "1 January" for a year-only date invents a fact, and it poisons any date-proximity dedup that assumes day precision.

**`status` (announced/released).** Stored, not computed per request, so feeds filter cheaply — and because a list that silently mixes future and past releases under "newest first" reads as broken.

**No `is_streaming` boolean.** The platform registry already carries `category` and payout, which is strictly more information in one place. (The spec's version also listed four platform ids Unstream doesn't index, and defaulted `true` for a catalog that's overwhelmingly not streaming.)

**Granular `release_type`.** Matching *within* a type is the strongest dedup signal available for artists with no shared identifier.

## release-utils.ts

Pure — no network, DB, or cache. Carries regressions for the three bugs that sank the first attempt ([#336](https://github.com/brandonlucasgreen/unstream/pull/336), which shipped zero tests):

1. **The "hash" wasn't one.** `Buffer.from(title).toString('hex').slice(0, 6)` is the first three bytes of the *input*, so `Album Name.`, `Album Name!` and `Album Name?` all produced the same suffix — precisely the case it existed to separate. Now `createHash('sha1')` (node:crypto, not `crypto.subtle`, which Netlify Functions lack).
2. **Non-Latin titles were deleted.** A bare `[^a-z0-9]` strip reduced `東京`, `Привет`, and `Ⅱ` to `""`, and the ingest then did `if (!norm) continue` — silently excluding every CJK/Cyrillic/Greek title from the catalog with no log line. The match key now keeps any Unicode letter or number while still folding accents via the existing `normalizeAccents`.
3. **Same-run slug collisions clobbered.** The taken-slug set was read once per artist and never updated as rows were inserted.

Worth noting on (2): the obvious fix — reuse `normalizeForComparison` from search-utils — is *also* wrong here. It strips to ASCII, so `Tokyo 東京` and `Tokyo 大阪` would both normalize to `tokyo` and **merge two different records.** Under-merging is recoverable; a wrong merge asserts two albums are one and nobody notices. So this builds on `normalizeAccents` and changes only the character-class step.

**Date bounds are about live data, not hypotheticals.** Mirlo currently carries a release dated **2925-11-02**. Unbounded, one typo sorts to the top of every chronology and lands in every calendar subscriber's feed permanently. Genuine future dates are preserved — Mirlo really does schedule to 2027-09-07.

## Testing

`npm run migrate:dry-run` is broken (passes `--project-ref`, rejected by the current CLI), so the migration was validated by **applying it twice to a throwaway `postgres:15-alpine` container** and asserting each constraint rejects what it should:

- date lower bound; per-artist slug uniqueness; same slug allowed under a *different* artist
- partial unique indexes on MBID and Discogs master (multiple NULLs allowed, duplicates rejected)
- **global `(platform, external_id)` uniqueness across different releases** — the constraint that makes re-crawls safe
- `(release_id, platform)` uniqueness; enum CHECKs; uppercase-only currency; negative prices; name-your-price nulls accepted
- cascade deletes; the `updated_at` trigger; `curated_fields` array round-trip
- second application is a clean no-op (idempotent)

Plus: **34 unit tests**, `npm run test:api` 198 passing, `npm run build` clean, explicit `tsc --strict` over `release-utils.ts` clean.

## Two choices worth a second opinion

- **`schema.sql` deliberately untouched.** It only covers `artists`, `artist_links`, `artist_profiles`; every table added since (suppressions, probes, usernames, saved_artists, merge overrides) lives in migrations only. Editing it would recreate the schema.sql/migration disagreement that #336 shipped. Happy to add it if you'd rather keep that file current.
- **Table named `releases`, not `artist_releases`.** It reads as a first-class entity (which is the point of the feature) and keeps the child tables coherent as `release_sources`/`release_offers`. The counter-argument is consistency with `artist_links`/`artist_profiles`. Cheap to rename now, expensive later — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)