### PR TITLE
Bandcamp grid parser: keep the release id, URL and artwork it already reads

### DIFF
--- a/api/functions/__tests__/bandcamp-grid-releases.test.ts
+++ b/api/functions/__tests__/bandcamp-grid-releases.test.ts
@@ -1,0 +1,221 @@
+// parseBandcampGridReleases — the catalog-building read of a Bandcamp /music page.
+//
+// The grid markup below is copied from a live page (sufjanstevens.bandcamp.com/music,
+// fetched 2026-07-31) rather than invented, including its real whitespace and attribute
+// order, so a Bandcamp markup change shows up here as a failure instead of as silently
+// empty catalogs in production.
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseBandcampGridReleases,
+  parseBandcampReleaseCounts,
+  parseBandcampReleaseTitles,
+} from '../search-parsers';
+
+/** Real grid-item markup, verbatim in shape. */
+function gridItem(opts: {
+  itemId?: string;
+  href: string;
+  title: string;
+  img?: string;
+  lazyImg?: string;
+}): string {
+  const img = opts.lazyImg
+    ? `<img data-original="${opts.lazyImg}" src="data:image/gif;base64,R0lGOD" alt="" />`
+    : opts.img === undefined
+      ? '<img src="https://f4.bcbits.com/img/a1059506682_2.jpg" alt="" />'
+      : opts.img === ''
+        ? ''
+        : `<img src="${opts.img}" alt="" />`;
+
+  return `
+<li ${opts.itemId ? `data-item-id="${opts.itemId}"` : ''}
+    data-band-id="203035041"
+    class="music-grid-item square first-four
+
+    "
+    data-bind="css: {'featured': featured()}"
+>
+    <a href="${opts.href}">
+        <div class="art">
+            ${img}
+        </div>
+        <p class="title">
+            ${opts.title}
+        </p>
+    </a>
+</li>`;
+}
+
+function page(items: string[]): string {
+  return `<html><body><ol class="editable-grid music-grid">${items.join('\n')}</ol></body></html>`;
+}
+
+const REAL_PAGE = page([
+  gridItem({
+    itemId: 'album-1891263657',
+    href: '/album/carrie-lowell-10th-anniversary-edition',
+    title: 'Carrie &amp; Lowell (10th Anniversary Edition)',
+  }),
+  gridItem({ itemId: 'album-2222222222', href: '/album/javelin', title: 'Javelin' }),
+  gridItem({ itemId: 'track-3333333333', href: '/track/goodbye-evergreen', title: 'Goodbye Evergreen' }),
+]);
+
+describe('parseBandcampGridReleases', () => {
+  it('reads id, type, href, title and artwork from a real grid', () => {
+    const releases = parseBandcampGridReleases(REAL_PAGE);
+
+    expect(releases).toHaveLength(3);
+    expect(releases[0]).toEqual({
+      externalId: 'album-1891263657',
+      type: 'album',
+      href: '/album/carrie-lowell-10th-anniversary-edition',
+      title: 'Carrie & Lowell (10th Anniversary Edition)',
+      artworkUrl: 'https://f4.bcbits.com/img/a1059506682_2.jpg',
+    });
+  });
+
+  // The id is worth more than the title for identity: an artist can rename a release and
+  // the id doesn't move, so re-reading a page updates a row rather than creating a second.
+  it('captures the stable per-release id that the titles parser throws away', () => {
+    const ids = parseBandcampGridReleases(REAL_PAGE).map(r => r.externalId);
+    expect(ids).toEqual(['album-1891263657', 'album-2222222222', 'track-3333333333']);
+  });
+
+  it('distinguishes albums from tracks by the id prefix', () => {
+    const byType = parseBandcampGridReleases(REAL_PAGE).map(r => r.type);
+    expect(byType).toEqual(['album', 'album', 'track']);
+  });
+
+  it('keeps display-quality titles, unlike the match-key parser', () => {
+    const titles = parseBandcampGridReleases(REAL_PAGE).map(r => r.title);
+    // Entity-decoded, original case and punctuation intact.
+    expect(titles[0]).toBe('Carrie & Lowell (10th Anniversary Edition)');
+
+    // Contrast: the existing parser folds and strips for matching purposes.
+    const matchTitles = parseBandcampReleaseTitles(REAL_PAGE);
+    expect(matchTitles[0]).not.toBe(titles[0]);
+  });
+
+  it('preserves accents and non-Latin characters in titles', () => {
+    const releases = parseBandcampGridReleases(
+      page([
+        gridItem({ itemId: 'album-1', href: '/album/takk', title: 'Takk... — Sigur Rós' }),
+        gridItem({ itemId: 'album-2', href: '/album/tokyo', title: '東京' }),
+      ])
+    );
+    expect(releases[0].title).toBe('Takk... — Sigur Rós');
+    expect(releases[1].title).toBe('東京');
+  });
+
+  it('reads lazy-loaded artwork from data-original, not the placeholder', () => {
+    const releases = parseBandcampGridReleases(
+      page([
+        gridItem({
+          itemId: 'album-1',
+          href: '/album/x',
+          title: 'X',
+          lazyImg: 'https://f4.bcbits.com/img/a9999999999_16.jpg',
+        }),
+      ])
+    );
+    expect(releases[0].artworkUrl).toBe('https://f4.bcbits.com/img/a9999999999_16.jpg');
+  });
+
+  it('returns null artwork rather than a data: placeholder or a fake URL', () => {
+    const noImg = parseBandcampGridReleases(
+      page([gridItem({ itemId: 'album-1', href: '/album/x', title: 'X', img: '' })])
+    );
+    expect(noImg[0].artworkUrl).toBeNull();
+  });
+
+  it('falls back to the URL path when data-item-id is absent', () => {
+    const releases = parseBandcampGridReleases(
+      page([
+        gridItem({ href: '/album/no-id', title: 'No Id' }),
+        gridItem({ href: '/track/no-id-track', title: 'No Id Track' }),
+      ])
+    );
+    expect(releases.map(r => [r.externalId, r.type])).toEqual([
+      [null, 'album'],
+      [null, 'track'],
+    ]);
+  });
+
+  it('skips items with no usable href or title', () => {
+    const releases = parseBandcampGridReleases(
+      page([
+        `<li data-item-id="album-1" class="music-grid-item"><a href="/album/ok"><p class="title">Ok</p></a></li>`,
+        `<li data-item-id="album-2" class="music-grid-item"><p class="title">No link</p></li>`,
+        `<li data-item-id="album-3" class="music-grid-item"><a href="/album/untitled"></a></li>`,
+      ])
+    );
+    expect(releases.map(r => r.title)).toEqual(['Ok']);
+  });
+
+  it('ignores grid entries that are neither album nor track', () => {
+    const releases = parseBandcampGridReleases(
+      page([
+        gridItem({ itemId: 'album-1', href: '/album/real', title: 'Real' }),
+        gridItem({ itemId: 'package-9', href: '/merch/t-shirt', title: 'T-Shirt' }),
+      ])
+    );
+    expect(releases.map(r => r.title)).toEqual(['Real']);
+  });
+
+  it('deduplicates repeated items', () => {
+    const dup = gridItem({ itemId: 'album-1', href: '/album/x', title: 'X' });
+    expect(parseBandcampGridReleases(page([dup, dup]))).toHaveLength(1);
+  });
+
+  // A one-release artist gets a 303 to the release page, which has no grid — only a
+  // #discography sidebar. Reading it is what stops such an artist being mistaken for a
+  // parked squatter, so the catalog parser has to handle it too.
+  it('falls back to the sidebar discography layout', () => {
+    const sidebar = `<html><body>
+      <div id="discography" class="sidebar">
+        <ul>
+          <li><div class="trackTitle"><a href="/album/subtitles-for-blushing">Subtitles For Blushing</a></div></li>
+          <li><div class="trackTitle"><a href="/track/a-single">A Single</a></div></li>
+        </ul>
+      </div>
+    </body></html>`;
+
+    const releases = parseBandcampGridReleases(sidebar);
+    expect(releases).toEqual([
+      { externalId: null, type: 'album', href: '/album/subtitles-for-blushing', title: 'Subtitles For Blushing', artworkUrl: null },
+      { externalId: null, type: 'track', href: '/track/a-single', title: 'A Single', artworkUrl: null },
+    ]);
+  });
+
+  it('prefers the grid and does not also read the sidebar when both are present', () => {
+    const both = `<html><body>
+      <ol class="music-grid">${gridItem({ itemId: 'album-1', href: '/album/from-grid', title: 'From Grid' })}</ol>
+      <div id="discography"><li><div class="trackTitle"><a href="/album/from-sidebar">From Sidebar</a></div></li></div>
+    </body></html>`;
+    expect(parseBandcampGridReleases(both).map(r => r.title)).toEqual(['From Grid']);
+  });
+
+  it('returns an empty array for a parked account with no releases', () => {
+    expect(parseBandcampGridReleases('<html><body><p>nothing here</p></body></html>')).toEqual([]);
+  });
+
+  it('does not throw on malformed HTML', () => {
+    expect(() => parseBandcampGridReleases('<html><ol class="music-grid"><li class="music-grid-item"')).not.toThrow();
+    expect(() => parseBandcampGridReleases('')).not.toThrow();
+  });
+});
+
+describe('existing Bandcamp parsers are unaffected', () => {
+  // The new parser reads the same DOM; these guard against having changed shared behaviour.
+  it('release counts still split album vs track', () => {
+    expect(parseBandcampReleaseCounts(REAL_PAGE)).toEqual({ albums: 2, tracks: 1 });
+  });
+
+  it('release titles still return normalized match keys', () => {
+    const titles = parseBandcampReleaseTitles(REAL_PAGE);
+    expect(titles).toHaveLength(3);
+    // Normalized for comparison: lowercase, punctuation and spacing stripped.
+    expect(titles[1]).toBe('javelin');
+  });
+});

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -318,6 +318,125 @@ export function parseBandcampReleaseTitles(html: string): string[] {
   return titles;
 }
 
+export interface BandcampGridRelease {
+  /**
+   * Bandcamp's own id for the release, e.g. "album-1891263657". Null in the
+   * single-release sidebar layout, which doesn't carry one — callers that need a stable
+   * key there should fall back to the resolved URL.
+   */
+  externalId: string | null;
+  type: 'album' | 'track';
+  /** As written in the page: usually root-relative ("/album/…"). Callers resolve it. */
+  href: string;
+  /** Display-quality title — original case, accents and punctuation intact. */
+  title: string;
+  artworkUrl: string | null;
+}
+
+/**
+ * Every release on a Bandcamp `/music` page, with the identity and artwork the page
+ * already carries.
+ *
+ * `parseBandcampReleaseTitles` reads the same grid but keeps only accent-folded titles,
+ * because it exists to answer "is this the right artist?". This one exists to build a
+ * catalog, so it keeps what that discards:
+ *
+ * - **`data-item-id`** — a stable per-release id, *and* an album-vs-track type prefix.
+ *   Worth more than the title for identity: an artist can rename a release, but the id
+ *   doesn't move, so re-reading a page updates a row instead of creating a second one.
+ * - **`href`** — the release URL.
+ * - **artwork** — `src`, or `data-original` when Bandcamp lazy-loads it.
+ *
+ * What is *not* here, deliberately: release dates. They are not in the grid at all — only
+ * on individual release pages — so a catalog with dates costs one extra request per
+ * release rather than coming free with this parse. Anything relying on dates has to opt
+ * into that cost knowingly.
+ *
+ * Falls back to the `#discography` sidebar for the single-release layout, for the same
+ * reason `parseBandcampReleaseCounts` does: a one-release artist is otherwise
+ * indistinguishable from a parked account.
+ */
+export function parseBandcampGridReleases(html: string): BandcampGridRelease[] {
+  const root = parse(html);
+  const releases: BandcampGridRelease[] = [];
+  const seen = new Set<string>();
+
+  for (const item of root.querySelectorAll('.music-grid-item')) {
+    if (releases.length >= MAX_GRID_RELEASES) break;
+
+    const externalId = item.getAttribute('data-item-id') ?? null;
+    const link = item.querySelector('a');
+    const href = link?.getAttribute('href');
+    const title = item.querySelector('.title')?.textContent?.trim();
+    if (!href || !title) continue;
+
+    // Prefer the id's prefix; fall back to the URL path when the attribute is missing.
+    const type = releaseTypeFromIdOrHref(externalId, href);
+    if (!type) continue;
+
+    const dedupeKey = externalId ?? href;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    releases.push({
+      externalId,
+      type,
+      href,
+      // The grid renders a release's title and its artist on separate lines inside
+      // .title for label pages; keep only the first line as the title.
+      title: title.split('\n')[0].trim(),
+      artworkUrl: artworkFrom(item),
+    });
+  }
+
+  if (releases.length > 0) return releases;
+
+  for (const entry of parseBandcampSidebarDiscography(root)) {
+    if (releases.length >= MAX_GRID_RELEASES) break;
+    const type = releaseTypeFromIdOrHref(null, entry.href);
+    if (!type || !entry.title) continue;
+    if (seen.has(entry.href)) continue;
+    seen.add(entry.href);
+
+    releases.push({
+      externalId: null,
+      type,
+      href: entry.href,
+      title: entry.title,
+      artworkUrl: null,
+    });
+  }
+
+  return releases;
+}
+
+/**
+ * Upper bound on releases read from one page. Not a real Bandcamp limit — grids are
+ * typically well under this — just a guard against a pathological page consuming the
+ * whole function budget.
+ */
+const MAX_GRID_RELEASES = 500;
+
+function releaseTypeFromIdOrHref(
+  externalId: string | null,
+  href: string
+): 'album' | 'track' | null {
+  if (externalId?.startsWith('album-')) return 'album';
+  if (externalId?.startsWith('track-')) return 'track';
+  if (href.includes('/album/')) return 'album';
+  if (href.includes('/track/')) return 'track';
+  return null;
+}
+
+function artworkFrom(item: HTMLElement): string | null {
+  const img = item.querySelector('img');
+  if (!img) return null;
+  // data-original holds the real URL when the grid lazy-loads and src is a placeholder.
+  const src = img.getAttribute('data-original') || img.getAttribute('src') || '';
+  if (!src || src.startsWith('data:')) return null;
+  return src;
+}
+
 // ---------------------------------------------------------------------------
 // Bandwagon
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Prerequisite for Bandcamp catalog ingest. Pure parser change — **no existing behaviour changes**, and it's independent of the schema in #356, so the two can land in either order.

## What and why

`parseBandcampReleaseTitles` already walks the `.music-grid-item` DOM on a `/music` page, but keeps only accent-folded titles, because it exists to answer *"is this the right artist?"*. Building a release catalog needs what that discards — and it's all in the node the parser is already standing in:

| Kept now | Why it matters |
|---|---|
| **`data-item-id`** (`"album-1891263657"`) | A stable per-release id **and** an album-vs-track type prefix |
| **`href`** | The release URL |
| **artwork** | `src`, or `data-original` when the grid lazy-loads |

The id is the valuable part. It's worth more than the title for identity: **an artist can rename a release, but the id doesn't move**, so re-reading a page updates a row instead of minting a duplicate. `parseBandcampReleaseCounts` already reads this same attribute for its album/track split, so this follows an established pattern rather than introducing one.

## What is deliberately not here: dates

Release dates are **not in the grid at all** — only on individual release pages. So a catalog *with* dates costs one extra request per release rather than coming free with this parse.

This is documented on the function itself, because an earlier review of this feature got it wrong and concluded full-catalog capture was free. Anything that needs dates has to opt into that cost knowingly.

## Verified against the real page

Not just the fixture. Run against the live 168KB `sufjanstevens.bandcamp.com/music` (fetched 2026-07-31):

```
grid releases parsed: 16
with externalId:      16
with artwork:         16
types:                { album: 15, track: 1 }
duplicate ids?        false
any empty titles?     false
```

`{ album: 15, track: 1 }` matches `parseBandcampReleaseCounts` on the same HTML exactly, and titles come through entity-decoded and display-quality (`Carrie & Lowell (10th Anniversary Edition)`).

The fixture markup in the tests is **copied from that page**, including its real whitespace and attribute ordering, so a Bandcamp markup change fails a test rather than silently emptying catalogs in production.

## Edge cases covered

- Single-release **`#discography` sidebar** layout — handled for the same reason `parseBandcampReleaseCounts` handles it: otherwise a one-release artist is indistinguishable from a parked squatter. Grid wins when both are present.
- Missing `data-item-id` → falls back to the URL path for type
- Lazy-loaded artwork → reads `data-original`, not the `data:` placeholder
- Non-release grid entries (merch/packages) skipped
- Accents and non-Latin titles preserved (`Takk... — Sigur Rós`, `東京`)
- Malformed/empty HTML doesn't throw; parked account returns `[]`
- Duplicates deduped; items with no href or title skipped

Two extra tests assert the **existing** parsers still behave identically, since the new one reads the same DOM.

## Testing

- 17 tests added
- `npm run test:api` — 181 passing (16 files)
- `npm run build` — clean
- explicit `tsc --strict` over `search-parsers.ts` — clean (`api/` isn't in the build's typecheck, so verified by hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)