### PR TITLE
Extract the hardened fetch path into a shared module

### DIFF
--- a/api/functions/__tests__/safe-fetch.test.ts
+++ b/api/functions/__tests__/safe-fetch.test.ts
@@ -1,0 +1,146 @@
+// Direct tests for the shared safe-fetch module.
+//
+// check-releases-ssrf.test.ts already exercises this heavily *through* the handler; these
+// pin the exported surface itself, because it is now shared and the next caller (release
+// catalog ingest) won't go through that handler. The properties worth locking are the two
+// that are easy to reimplement wrongly: every hop gets re-validated, and refusal is the
+// default whenever a check can't be completed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ lookup: vi.fn(), fetch: vi.fn() }));
+vi.mock('dns/promises', () => ({ lookup: mocks.lookup }));
+
+import { safeFetch, safeHostname, resolvesToPublicAddress, MAX_REDIRECTS, FETCH_USER_AGENT } from '../safe-fetch';
+
+function res(status: number, opts: { location?: string; url?: string } = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url: opts.url ?? '',
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? opts.location ?? null : null) },
+    text: async () => '',
+  } as unknown as Response;
+}
+
+const PUBLIC = [{ address: '93.184.216.34', family: 4 }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.lookup.mockResolvedValue(PUBLIC);
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+describe('safeHostname', () => {
+  it('extracts the hostname', () => {
+    expect(safeHostname('https://example.com/a/b?c=d')).toBe('example.com');
+  });
+
+  it('returns a sentinel rather than throwing on junk', () => {
+    expect(safeHostname('not a url')).toBe('<unparseable>');
+    expect(safeHostname('')).toBe('<unparseable>');
+  });
+});
+
+describe('resolvesToPublicAddress', () => {
+  it('accepts a host whose every answer is public', async () => {
+    mocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:4700::1111', family: 6 },
+    ]);
+    expect(await resolvesToPublicAddress('example.com')).toBe(true);
+  });
+
+  it('rejects a host resolving into private space', async () => {
+    mocks.lookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    expect(await resolvesToPublicAddress('169-254-169-254.nip.io')).toBe(false);
+  });
+
+  it('rejects when any single answer is private', async () => {
+    mocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: 'fd00::1', family: 6 },
+    ]);
+    expect(await resolvesToPublicAddress('dual-stack.example.com')).toBe(false);
+  });
+
+  it('refuses on resolver failure, empty answers, or a junk hostname', async () => {
+    mocks.lookup.mockRejectedValue(new Error('ENOTFOUND'));
+    expect(await resolvesToPublicAddress('nope.example.com')).toBe(false);
+
+    mocks.lookup.mockResolvedValue([]);
+    expect(await resolvesToPublicAddress('empty.example.com')).toBe(false);
+
+    expect(await resolvesToPublicAddress('<unparseable>')).toBe(false);
+    expect(await resolvesToPublicAddress('')).toBe(false);
+  });
+});
+
+describe('safeFetch', () => {
+  it('fetches a public host with manual redirects and a UA', async () => {
+    mocks.fetch.mockResolvedValue(res(200));
+
+    const r = await safeFetch('https://example.com/x');
+
+    expect(r?.status).toBe(200);
+    expect(mocks.fetch.mock.calls[0][1]).toMatchObject({
+      redirect: 'manual',
+      headers: { 'User-Agent': FETCH_USER_AGENT },
+    });
+  });
+
+  it('follows a redirect and re-resolves the new host', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://elsewhere.example.com/y' }))
+      .mockResolvedValue(res(200));
+
+    await safeFetch('https://example.com/x');
+
+    expect(mocks.lookup.mock.calls.map(c => c[0])).toEqual(['example.com', 'elsewhere.example.com']);
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://elsewhere.example.com/y');
+  });
+
+  it('refuses a redirect into private space without fetching it', async () => {
+    mocks.lookup.mockImplementation(async (h: string) =>
+      h === 'example.com' ? PUBLIC : [{ address: '169.254.169.254', family: 4 }]
+    );
+    mocks.fetch.mockResolvedValueOnce(res(302, { location: 'https://evil.example.com/' }));
+
+    expect(await safeFetch('https://example.com/x')).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an unsafe target outright, before any DNS or fetch', async () => {
+    expect(await safeFetch('http://169.254.169.254/latest/meta-data/')).toBeNull();
+    expect(await safeFetch('file:///etc/passwd')).toBeNull();
+    expect(mocks.lookup).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('bounds a redirect loop at MAX_REDIRECTS + 1 attempts', async () => {
+    mocks.fetch.mockResolvedValue(res(302, { location: 'https://example.com/loop' }));
+
+    expect(await safeFetch('https://example.com/loop')).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(MAX_REDIRECTS + 1);
+  });
+
+  it('returns a 3xx with no Location as-is, so callers fail closed on .ok', async () => {
+    mocks.fetch.mockResolvedValue(res(302));
+
+    const r = await safeFetch('https://example.com/x');
+
+    expect(r?.status).toBe(302);
+    expect(r?.ok).toBe(false);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a relative Location against the current URL', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: '/moved' }))
+      .mockResolvedValue(res(200));
+
+    await safeFetch('https://example.com/deep/path');
+
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://example.com/moved');
+  });
+});

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,14 +1,8 @@
 import { parse } from 'node-html-parser';
-import { lookup } from 'dns/promises';
-import { isPrivateIpAddress, isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
+import { isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { isStoredArtistLink } from './db';
-
-const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
-
-// Bandcamp Pro artists point custom domains at their store, so a single request can
-// legitimately redirect off *.bandcamp.com. Follow a few hops, validating each one.
-const MAX_REDIRECTS = 5;
+import { safeFetch, safeHostname } from './safe-fetch';
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -32,103 +26,6 @@ interface CheckReleasesResponse {
   artistName: string;
   release: ReleaseResult | null;
   error?: string;
-}
-
-/**
- * Fetch with a timeout, validating **every** hop against `isSafePublicHostname`.
- *
- * Node's fetch follows redirects transparently, which means a check on the URL we were
- * given says nothing about the URL we actually retrieve. That matters here for two
- * reasons: this endpoint fetches caller-supplied URLs, and it then follows a link found
- * *inside* the page it fetched. Redirects are resolved manually so each destination is
- * re-validated before another request goes out.
- *
- * Returns null when a target is refused or the redirect chain is too long — callers treat
- * that the same as an unreachable platform.
- */
-async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Response | null> {
-  let current = url;
-
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    if (!isSafePublicHostname(current)) {
-      // Hostname only — the full URL is caller-supplied and shouldn't land in logs.
-      console.warn(`[check-releases] refused unsafe fetch target: ${safeHostname(current)}`);
-      return null;
-    }
-
-    if (!(await resolvesToPublicAddress(safeHostname(current)))) {
-      console.warn(`[check-releases] refused target resolving to private space: ${safeHostname(current)}`);
-      return null;
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    let response: Response;
-    try {
-      response = await fetch(current, {
-        headers: { 'User-Agent': USER_AGENT },
-        redirect: 'manual',
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    if (response.status < 300 || response.status >= 400) return response;
-
-    // A 3xx with no Location has nowhere to go. Returning it as-is is deliberate rather
-    // than unhandled: callers check `.ok`, which is false for a 3xx, so it fails closed.
-    const location = response.headers.get('location');
-    if (!location) return response;
-    current = new URL(location, current).toString();
-  }
-
-  console.warn(`[check-releases] too many redirects from ${safeHostname(url)}`);
-  return null;
-}
-
-function safeHostname(urlString: string): string {
-  try {
-    return new URL(urlString).hostname;
-  } catch {
-    return '<unparseable>';
-  }
-}
-
-/**
- * Does every DNS answer for this hostname point at a public address?
- *
- * String checks on a hostname are not enough, and this is the gap that made them
- * insufficient: `169-254-169-254.nip.io` is a perfectly ordinary public name that resolves
- * to 169.254.169.254 — the cloud metadata endpoint. Wildcard-DNS services hand those out
- * for free, and a Bandcamp Pro artist can point a custom domain anywhere, so an
- * allowlisted `*.bandcamp.com` input can redirect to a name that resolves into private
- * space. Nothing textual catches that; only resolution does.
- *
- * **All** answers must be public, so a dual-stack host can't smuggle a private AAAA past a
- * public A record. Any resolver failure or NXDOMAIN returns false — for a security
- * predicate, "couldn't check" has to mean "refuse".
- *
- * Residual risk, stated precisely rather than hand-waved: Node's `fetch` performs its own
- * resolution when it connects, so a hostname whose DNS answers *change* between this check
- * and that connect — rotating records or a very low TTL — can still slip through. Closing
- * that needs the connection pinned to the address we validated, which means a custom
- * undici dispatcher; `undici` isn't a declared dependency here (only transitively
- * available), so pinning is deliberately left as a follow-up rather than built on a package
- * that could vanish on any install. What this does close is the one-shot case, which is
- * what was actually reachable. Note also that exfiltration is separately limited: the
- * parsers only extract an RSS `<item><title>` or a Bandcamp `.music-grid-item`, so a
- * typical internal endpoint yields nothing even when reached.
- */
-async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
-  if (!hostname || hostname === '<unparseable>') return false;
-  try {
-    const answers = await lookup(hostname, { all: true, verbatim: true });
-    if (answers.length === 0) return false;
-    return answers.every(a => !isPrivateIpAddress(a.address));
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/api/functions/safe-fetch.ts
+++ b/api/functions/safe-fetch.ts
@@ -1,0 +1,121 @@
+// One outbound-fetch path for anything that retrieves a URL we didn't hardcode.
+//
+// Extracted from check-releases.ts so it can be shared. The reason it must be shared rather
+// than reimplemented: the checks here are not obvious, and each one exists because the
+// obvious version was wrong.
+//
+//   1. Validating the URL you were *given* says nothing about the URL you *retrieve*.
+//      Node's fetch follows redirects transparently, so redirects are resolved manually
+//      here and every hop is re-validated.
+//   2. A hostname string check is not an SSRF boundary. `169-254-169-254.nip.io` is an
+//      ordinary public name that resolves to the cloud metadata address, and wildcard-DNS
+//      services hand those out for free. Every hop is also resolved and every answer has to
+//      be public.
+//
+// Any code fetching a URL that came from a request body, a database row, or scraped markup
+// should use this. `isUrlHostnameAllowed` alone is not sufficient.
+
+import { lookup } from 'dns/promises';
+import { isPrivateIpAddress, isSafePublicHostname } from './middleware';
+
+export const FETCH_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+// Bandcamp Pro artists point custom domains at their store, so a single request can
+// legitimately redirect off *.bandcamp.com. Follow a few hops, validating each one.
+export const MAX_REDIRECTS = 5;
+
+/** Hostname for logging. The full URL may be caller-supplied, so it doesn't go in logs. */
+export function safeHostname(urlString: string): string {
+  try {
+    return new URL(urlString).hostname;
+  } catch {
+    return '<unparseable>';
+  }
+}
+
+/**
+ * Does every DNS answer for this hostname point at a public address?
+ *
+ * String checks on a hostname are not enough, and this is the gap that made them
+ * insufficient: `169-254-169-254.nip.io` is a perfectly ordinary public name that resolves
+ * to 169.254.169.254 — the cloud metadata endpoint. Wildcard-DNS services hand those out
+ * for free, and a Bandcamp Pro artist can point a custom domain anywhere, so an
+ * allowlisted `*.bandcamp.com` input can redirect to a name that resolves into private
+ * space. Nothing textual catches that; only resolution does.
+ *
+ * **All** answers must be public, so a dual-stack host can't smuggle a private AAAA past a
+ * public A record. Any resolver failure or NXDOMAIN returns false — for a security
+ * predicate, "couldn't check" has to mean "refuse".
+ *
+ * Residual risk, stated precisely rather than hand-waved: Node's `fetch` performs its own
+ * resolution when it connects, so a hostname whose DNS answers *change* between this check
+ * and that connect — rotating records or a very low TTL — can still slip through. Closing
+ * that needs the connection pinned to the address we validated, which means a custom
+ * undici dispatcher; `undici` isn't a declared dependency here (only transitively
+ * available), so pinning is deliberately left as a follow-up rather than built on a package
+ * that could vanish on any install. What this does close is the one-shot case, which is
+ * what was actually reachable.
+ */
+export async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
+  if (!hostname || hostname === '<unparseable>') return false;
+  try {
+    const answers = await lookup(hostname, { all: true, verbatim: true });
+    if (answers.length === 0) return false;
+    return answers.every(a => !isPrivateIpAddress(a.address));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch with a timeout, validating **every** hop — both as a string and by resolution.
+ *
+ * Returns null when a target is refused or the redirect chain is too long. Callers treat
+ * that the same as an unreachable host.
+ *
+ * Note this answers "is this target safe to fetch", **not** "are we allowed to fetch this
+ * at all". Those are different questions and conflating them has already caused one bug:
+ * an allowlist check belongs at the point where the URL enters the system, and when you
+ * follow a link found inside fetched content you must additionally confine it (e.g. to the
+ * host you landed on). See `checkBandcamp` in check-releases.ts for that pattern.
+ */
+export async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Response | null> {
+  let current = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (!isSafePublicHostname(current)) {
+      console.warn(`[safe-fetch] refused unsafe fetch target: ${safeHostname(current)}`);
+      return null;
+    }
+
+    if (!(await resolvesToPublicAddress(safeHostname(current)))) {
+      console.warn(`[safe-fetch] refused target resolving to private space: ${safeHostname(current)}`);
+      return null;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(current, {
+        headers: { 'User-Agent': FETCH_USER_AGENT },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    // A 3xx with no Location has nowhere to go. Returning it as-is is deliberate rather
+    // than unhandled: callers check `.ok`, which is false for a 3xx, so it fails closed.
+    const location = response.headers.get('location');
+    if (!location) return response;
+    current = new URL(location, current).toString();
+  }
+
+  console.warn(`[safe-fetch] too many redirects from ${safeHostname(url)}`);
+  return null;
+}


### PR DESCRIPTION
**Pure relocation, no behaviour change.** Prerequisite for release catalog ingest, kept as its own PR so the diff is easy to read and the revert-check flag is easy to dismiss.

## Why share it rather than let ingest do its own fetching

Ingest has to fetch Bandcamp URLs **read out of `artist_links`** — and those aren't trustworthy (a claimed artist can store any URL there; that's the separate task already spun out). So ingest needs the same protections `check-releases` just got.

Reimplementing them is the failure mode worth designing against, because neither check is obvious and each exists because the obvious version was wrong:

1. **Validating the URL you were *given* says nothing about the URL you *retrieve*.** Node's `fetch` follows redirects transparently, so redirects are resolved manually and every hop re-validated.
2. **A hostname string check is not an SSRF boundary.** `169-254-169-254.nip.io` is an ordinary public name that resolves to `169.254.169.254`. Every hop is also resolved, and every answer must be public.

Both lessons now sit at the top of the shared module rather than buried inside one endpoint.

## What moved, and what didn't

**Moved** to `api/functions/safe-fetch.ts`: `safeFetch`, `safeHostname`, `resolvesToPublicAddress`, plus the `FETCH_USER_AGENT` / `MAX_REDIRECTS` constants.

**Deliberately stayed** in `check-releases.ts`: `mayFetch`. It answers *"may we fetch this on an **anonymous caller's** behalf"* — allowlisted, or already stored for this artist — which is specific to that endpoint. Ingest has no anonymous caller, and its URLs come *from* `artist_links`, so the stored-link half would be trivially true and tell it nothing. Ingest will use `isUrlHostnameAllowed` directly to reject a stored URL that isn't actually a Bandcamp link.

Signature is unchanged to keep this a pure move; the only functional difference is the log prefix (`[check-releases]` → `[safe-fetch]`).

One docstring addition worth noting: `safeFetch` now says plainly that it answers **"safe to fetch", not "allowed to fetch"**. Conflating those two questions is exactly what produced the second-hop finding in #355, so it's recorded where the next caller will read it.

## Regression proof

- **All 292 pre-existing API tests pass untouched** — including the 77 that exercise this code through the `check-releases` handler. For a pure move, that's the evidence that matters.
- **13 new tests** pin the now-public exported surface directly, since ingest won't go through that handler: every-hop re-resolution, refusal-by-default on resolver failure / empty answers / junk hostnames, the private-AAAA-behind-public-A case, the redirect bound, relative `Location` resolution, and the deliberate 3xx-without-`Location` fall-through.
- `npm run test:api` — 305 passing (19 files)
- `npm run build` — clean
- Explicit `tsc --strict` over both files — only the pre-existing `mirloRssCache is possibly null`, which reproduces on `main`

## For the semantic-revert check

This is a **relocation, not a revert.** The moved code is byte-identical apart from the log prefix, and the DNS validation added in #355 (825df10) is preserved in full — see the `resolvesToPublicAddress` docstring, which still carries the `nip.io` rationale and the undici-pinning follow-up note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)