### PR TITLE
Demand-driven release cataloging from Bandcamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ npm run generate:artists  # Fetch artist list from Wikidata
 npm run generate:data     # Generate artist page JSON + artists-manifest.json via APIs
 npm run generate:social   # Generate social media posts via Buffer
 npm run sync:bandcamp-dates  # Sync Bandcamp release dates
+npm run ingest:try -- <artist>   # Dry-run release ingest against a real Bandcamp page
 npm run sentry:sourcemaps    # Upload source maps to Sentry
 npm run migrate:dry-run   # supabase db push --dry-run against the linked project
 npm run migrate:list      # List applied vs pending migrations
@@ -159,6 +160,34 @@ This is the lesson behind a run of bug fixes (#317–#328) and it applies to eve
 - `cacheGetOrFetch` in `api/functions/cache.ts` takes a `shouldCache` predicate plus an optional short `failureTtlSeconds`. Use them for anything whose failure mode looks like an empty result.
 - Cache keys must not collide across inputs that behave differently. `query_norm` strips punctuation, but punctuation is what generates extra slug candidates — hence the `probed_slugs` column, which records which slugs were actually tried so a cached negative can't hide an artist whose name has a hyphen.
 - A silent `200` with an empty parse is a failure. Report it (Sentry) rather than letting it look like "this artist doesn't exist."
+
+### Testing release ingest locally
+
+Release cataloging only runs when `CONTEXT === 'production'`, because deploy previews and local
+runs both point at the **production** Supabase — so an ungated preview would write real
+`releases` rows and spend the real hourly crawl budget. That means ingest cannot be exercised
+on a deploy preview, and **`CONTEXT=production` is not a valid local workaround** — it would
+have your laptop writing production data.
+
+Use the dry run instead:
+
+```bash
+npm run ingest:try -- sufjanstevens          # table of what would be written
+npm run ingest:try -- sufjanstevens --json   # full row shapes
+```
+
+It runs the real path — the same SSRF-safe fetcher, the same allowlist check, the same parser
+and mapping production uses — and prints the result without touching the database. One Bandcamp
+request per run; don't loop it.
+
+There is deliberately no `--write` flag. Everything with a decision in it lives upstream of the
+database, and `persistReleases` is covered by unit tests plus a migration validated against a
+real Postgres. To test the write path, point `SUPABASE_URL` at a branch database on purpose.
+
+Once ingest is live, `release_catalog_state` is the observability surface:
+`last_attempted_at`, `releases_found`, `last_error`, `consecutive_failures`. A run that suddenly
+finds 0 releases where it previously found 20 is a parser break or a bot challenge, not an
+artist deleting their catalog.
 
 ### Platform registry
 

--- a/api/functions/__tests__/catalog-gating.test.ts
+++ b/api/functions/__tests__/catalog-gating.test.ts
@@ -1,0 +1,190 @@
+// The two gates on release cataloging: a shared secret, and production-only.
+//
+// Both matter because this is the code that writes to the production database and issues
+// outbound crawls. Deploy previews run against production Supabase, so an ungated preview
+// would write real releases and spend the real hourly crawl budget on traffic that isn't real.
+//
+// Every check here is expected to fail *closed* — the recurring mistake in this area is a
+// guard that quietly permits when its input is missing.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  claimArtistForCatalog: vi.fn(),
+  getArtistBandcampUrl: vi.fn(),
+  persistReleases: vi.fn(),
+  recordCatalogOutcome: vi.fn(),
+  safeFetch: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  claimArtistForCatalog: mocks.claimArtistForCatalog,
+  getArtistBandcampUrl: mocks.getArtistBandcampUrl,
+  persistReleases: mocks.persistReleases,
+  recordCatalogOutcome: mocks.recordCatalogOutcome,
+}));
+
+vi.mock('../safe-fetch', () => ({
+  safeFetch: mocks.safeFetch,
+  safeHostname: (u: string) => {
+    try {
+      return new URL(u).hostname;
+    } catch {
+      return '<unparseable>';
+    }
+  },
+}));
+
+import { handler } from '../catalog-artist-background';
+import { requestArtistCatalog } from '../request-catalog';
+
+const SECRET = 'test-secret-value';
+const ARTIST = '11111111-1111-1111-1111-111111111111';
+
+function post(headers: Record<string, string | undefined>, body: unknown) {
+  return handler({ httpMethod: 'POST', headers, body: JSON.stringify(body) });
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.INTERNAL_FUNCTION_SECRET = SECRET;
+  process.env.CONTEXT = 'production';
+  process.env.DEPLOY_PRIME_URL = 'https://unstream.stream';
+  mocks.claimArtistForCatalog.mockResolvedValue(false); // don't do real work by default
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('catalog-artist-background auth', () => {
+  it('rejects a request with no Authorization header', async () => {
+    const r = await post({}, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(401);
+    expect(mocks.claimArtistForCatalog).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong secret', async () => {
+    const r = await post({ authorization: 'Bearer wrong-value-x' }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(401);
+  });
+
+  // A wrong-length secret must not crash — timingSafeEqual throws on length mismatch, so the
+  // lengths are compared first.
+  it('rejects a secret of a different length without throwing', async () => {
+    const r = await post({ authorization: 'Bearer short' }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(401);
+  });
+
+  // Fail closed: an unconfigured secret closes the endpoint, it does not open it.
+  it('rejects everything when no secret is configured', async () => {
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    const r = await post({ authorization: 'Bearer anything' }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('accepts the correct secret', async () => {
+    const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(200);
+  });
+
+  it('rejects non-POST', async () => {
+    const r = await handler({ httpMethod: 'GET', headers: {} });
+    expect(r.statusCode).toBe(405);
+  });
+});
+
+describe('catalog-artist-background is production-only', () => {
+  it.each(['deploy-preview', 'branch-deploy', 'dev'])('refuses in context %s', async context => {
+    process.env.CONTEXT = context;
+
+    const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
+
+    expect(r.statusCode).toBe(403);
+    expect(mocks.claimArtistForCatalog).not.toHaveBeenCalled();
+  });
+
+  it('refuses when CONTEXT is unset', async () => {
+    delete process.env.CONTEXT;
+    const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(403);
+  });
+
+  it('proceeds in production', async () => {
+    const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.claimArtistForCatalog).toHaveBeenCalledWith(ARTIST, 'searched');
+  });
+
+  it('caps how many artists one invocation may name', async () => {
+    const many = Array.from({ length: 60 }, (_, i) => `${i}`.padStart(8, '0') + '-1111-1111-1111-111111111111');
+    await post({ authorization: `Bearer ${SECRET}` }, { artistIds: many, trigger: 'saved' });
+    expect(mocks.claimArtistForCatalog.mock.calls.length).toBeLessThanOrEqual(25);
+  });
+
+  it('rejects an empty or malformed artistIds list', async () => {
+    expect((await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [] })).statusCode).toBe(400);
+    expect((await post({ authorization: `Bearer ${SECRET}` }, { artistIds: 'nope' })).statusCode).toBe(400);
+    expect((await post({ authorization: `Bearer ${SECRET}` }, {})).statusCode).toBe(400);
+  });
+
+  it('defaults an unrecognized trigger to searched, the smaller budget', async () => {
+    await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST], trigger: 'nonsense' });
+    expect(mocks.claimArtistForCatalog).toHaveBeenCalledWith(ARTIST, 'searched');
+  });
+});
+
+describe('requestArtistCatalog is production-only', () => {
+  it.each(['deploy-preview', 'branch-deploy', 'dev'])('makes no request in context %s', async context => {
+    process.env.CONTEXT = context;
+
+    await requestArtistCatalog([ARTIST], 'saved');
+
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('makes no request when CONTEXT is unset', async () => {
+    delete process.env.CONTEXT;
+    await requestArtistCatalog([ARTIST], 'saved');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('makes no request when the secret is missing', async () => {
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    await requestArtistCatalog([ARTIST], 'saved');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('requests in production, with the secret and the trigger', async () => {
+    mocks.fetch.mockResolvedValue({ status: 202, ok: true } as Response);
+
+    await requestArtistCatalog([ARTIST], 'saved');
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mocks.fetch.mock.calls[0];
+    expect(String(url)).toContain('/.netlify/functions/catalog-artist-background');
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: `Bearer ${SECRET}` });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      artistIds: [ARTIST],
+      trigger: 'saved',
+    });
+  });
+
+  it('deduplicates ids and never throws when the handshake fails', async () => {
+    mocks.fetch.mockRejectedValue(new Error('network down'));
+
+    await expect(requestArtistCatalog([ARTIST, ARTIST, ''], 'searched')).resolves.toBeUndefined();
+
+    const body = JSON.parse(String((mocks.fetch.mock.calls[0][1] as RequestInit).body));
+    expect(body.artistIds).toEqual([ARTIST]);
+  });
+
+  it('does nothing for an empty list', async () => {
+    await requestArtistCatalog([], 'saved');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -1,0 +1,188 @@
+// Mapping a fetched Bandcamp /music page into release rows.
+//
+// The properties worth locking are the ones that would silently corrupt a catalog rather than
+// throw: telling a bot challenge apart from an empty artist, not storing a source URL that
+// points at someone else's domain, and not letting two same-slug titles in one page collide.
+
+import { describe, it, expect } from 'vitest';
+import { ingestBandcampGrid, bandcampMusicUrl } from '../release-ingest';
+
+function item(opts: { id?: string; href: string; title: string; img?: string }): string {
+  return `<li ${opts.id ? `data-item-id="${opts.id}"` : ''} class="music-grid-item">
+    <a href="${opts.href}">
+      <div class="art"><img src="${opts.img ?? 'https://f4.bcbits.com/img/a1_2.jpg'}" /></div>
+      <p class="title">${opts.title}</p>
+    </a>
+  </li>`;
+}
+
+const page = (items: string[]) => `<html><body><ol class="music-grid">${items.join('')}</ol></body></html>`;
+const PAGE_URL = 'https://someone.bandcamp.com/music';
+
+describe('ingestBandcampGrid', () => {
+  it('maps a grid into releases with resolved absolute URLs', () => {
+    const out = ingestBandcampGrid(
+      page([
+        item({ id: 'album-111', href: '/album/first-record', title: 'First Record' }),
+        item({ id: 'track-222', href: '/track/a-single', title: 'A Single' }),
+      ]),
+      PAGE_URL
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases).toHaveLength(2);
+    expect(out.releases[0]).toMatchObject({
+      title: 'First Record',
+      slug: 'first-record',
+      matchKey: 'firstrecord',
+      releaseType: 'album',
+      releaseDate: null,
+      datePrecision: 'unknown',
+      status: 'released',
+      source: { platform: 'bandcamp', url: 'https://someone.bandcamp.com/album/first-record', externalId: 'album-111' },
+    });
+    expect(out.releases[1].releaseType).toBe('single');
+  });
+
+  // Distinguishing these two is the single most repeated bug class in this codebase. A
+  // challenge means the upstream declined to answer; treating it as "no releases" records a
+  // confident wrong answer and (with a cooldown) keeps it wrong for a week.
+  it('reports a bot challenge distinctly from an empty catalog', () => {
+    const challenge = '<html><head><script src="/_fs-ch-abc/main.js"></script></head><body></body></html>';
+    expect(ingestBandcampGrid(challenge, PAGE_URL)).toEqual({ ok: false, reason: 'bot_challenge' });
+
+    expect(ingestBandcampGrid('<html><body><p>nothing</p></body></html>', PAGE_URL)).toEqual({
+      ok: false,
+      reason: 'no_releases',
+    });
+  });
+
+  // A stored source URL is shown to fans as a place to buy this artist's record, so an href
+  // out of fetched markup must not be able to point somewhere else.
+  it('drops releases whose href leaves the page host', () => {
+    const out = ingestBandcampGrid(
+      page([
+        item({ id: 'album-1', href: 'https://attacker.example.com/album/x', title: 'Offsite' }),
+        item({ id: 'album-2', href: '/album/legit', title: 'Legit' }),
+      ]),
+      PAGE_URL
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases.map(r => r.title)).toEqual(['Legit']);
+  });
+
+  it('accepts same-host links after a custom-domain redirect', () => {
+    // pageUrl is where we actually landed, which for Bandcamp Pro is the custom domain.
+    const out = ingestBandcampGrid(
+      page([item({ id: 'album-1', href: '/album/javelin', title: 'Javelin' })]),
+      'https://music.sufjan.com/music'
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases[0].source.url).toBe('https://music.sufjan.com/album/javelin');
+  });
+
+  it('deduplicates the same release listed twice on one page', () => {
+    // Bandcamp sometimes renders a release both as "featured" and in sequence.
+    const dup = item({ id: 'album-1', href: '/album/x', title: 'Repeated' });
+    const out = ingestBandcampGrid(page([dup, dup]), PAGE_URL);
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases).toHaveLength(1);
+  });
+
+  it('does not merge an album and a single that share a title', () => {
+    // Same title at different types are genuinely different releases — a lead single and the
+    // album it lands on. Under-merge, never over-merge.
+    const out = ingestBandcampGrid(
+      page([
+        item({ id: 'album-1', href: '/album/halo', title: 'Halo' }),
+        item({ id: 'track-1', href: '/track/halo', title: 'Halo' }),
+      ]),
+      PAGE_URL
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases).toHaveLength(2);
+  });
+
+  it('gives colliding slugs distinct values within one page', () => {
+    const out = ingestBandcampGrid(
+      page([
+        item({ id: 'album-1', href: '/album/a', title: 'Album Name.' }),
+        item({ id: 'album-2', href: '/album/b', title: 'Album Name!' }),
+        item({ id: 'album-3', href: '/album/c', title: 'Album Name?' }),
+      ]),
+      PAGE_URL
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    // All three normalize to the same match key, so they're one release by identity...
+    expect(out.releases).toHaveLength(1);
+  });
+
+  it('keeps non-Latin titles instead of dropping them', () => {
+    const out = ingestBandcampGrid(
+      page([
+        item({ id: 'album-1', href: '/album/tokyo', title: '東京' }),
+        item({ id: 'album-2', href: '/album/osaka', title: '大阪' }),
+      ]),
+      PAGE_URL
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases).toHaveLength(2);
+    expect(out.releases.map(r => r.title)).toEqual(['東京', '大阪']);
+    expect(new Set(out.releases.map(r => r.slug)).size).toBe(2);
+  });
+
+  it('never invents a release date from the grid', () => {
+    // Dates are not in the grid at all — they cost one request per release. Guessing one
+    // would put a fabricated date into a chronology and a subscriber's calendar.
+    const out = ingestBandcampGrid(page([item({ id: 'album-1', href: '/album/x', title: 'X' })]), PAGE_URL);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.releases[0].releaseDate).toBeNull();
+    expect(out.releases[0].datePrecision).toBe('unknown');
+  });
+
+  it('reports no_releases when every entry was unusable', () => {
+    const out = ingestBandcampGrid(
+      page([item({ id: 'album-1', href: 'https://elsewhere.example.com/x', title: 'Offsite' })]),
+      PAGE_URL
+    );
+    expect(out).toEqual({ ok: false, reason: 'no_releases' });
+  });
+});
+
+describe('bandcampMusicUrl', () => {
+  it('derives /music from any stored depth', () => {
+    for (const stored of [
+      'https://someone.bandcamp.com',
+      'https://someone.bandcamp.com/',
+      'https://someone.bandcamp.com/music',
+      'https://someone.bandcamp.com/album/a-record',
+      'https://someone.bandcamp.com/track/a-song?from=embed',
+    ]) {
+      expect(bandcampMusicUrl(stored)).toBe('https://someone.bandcamp.com/music');
+    }
+  });
+
+  it('preserves a custom domain', () => {
+    expect(bandcampMusicUrl('https://music.sufjan.com/album/javelin')).toBe('https://music.sufjan.com/music');
+  });
+
+  it('refuses junk and non-HTTP schemes', () => {
+    expect(bandcampMusicUrl('not a url')).toBeNull();
+    expect(bandcampMusicUrl('file:///etc/passwd')).toBeNull();
+    expect(bandcampMusicUrl('')).toBeNull();
+  });
+});

--- a/api/functions/__tests__/safe-fetch.test.ts
+++ b/api/functions/__tests__/safe-fetch.test.ts
@@ -1,0 +1,146 @@
+// Direct tests for the shared safe-fetch module.
+//
+// check-releases-ssrf.test.ts already exercises this heavily *through* the handler; these
+// pin the exported surface itself, because it is now shared and the next caller (release
+// catalog ingest) won't go through that handler. The properties worth locking are the two
+// that are easy to reimplement wrongly: every hop gets re-validated, and refusal is the
+// default whenever a check can't be completed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ lookup: vi.fn(), fetch: vi.fn() }));
+vi.mock('dns/promises', () => ({ lookup: mocks.lookup }));
+
+import { safeFetch, safeHostname, resolvesToPublicAddress, MAX_REDIRECTS, FETCH_USER_AGENT } from '../safe-fetch';
+
+function res(status: number, opts: { location?: string; url?: string } = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    url: opts.url ?? '',
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? opts.location ?? null : null) },
+    text: async () => '',
+  } as unknown as Response;
+}
+
+const PUBLIC = [{ address: '93.184.216.34', family: 4 }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.lookup.mockResolvedValue(PUBLIC);
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+describe('safeHostname', () => {
+  it('extracts the hostname', () => {
+    expect(safeHostname('https://example.com/a/b?c=d')).toBe('example.com');
+  });
+
+  it('returns a sentinel rather than throwing on junk', () => {
+    expect(safeHostname('not a url')).toBe('<unparseable>');
+    expect(safeHostname('')).toBe('<unparseable>');
+  });
+});
+
+describe('resolvesToPublicAddress', () => {
+  it('accepts a host whose every answer is public', async () => {
+    mocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:4700::1111', family: 6 },
+    ]);
+    expect(await resolvesToPublicAddress('example.com')).toBe(true);
+  });
+
+  it('rejects a host resolving into private space', async () => {
+    mocks.lookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    expect(await resolvesToPublicAddress('169-254-169-254.nip.io')).toBe(false);
+  });
+
+  it('rejects when any single answer is private', async () => {
+    mocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: 'fd00::1', family: 6 },
+    ]);
+    expect(await resolvesToPublicAddress('dual-stack.example.com')).toBe(false);
+  });
+
+  it('refuses on resolver failure, empty answers, or a junk hostname', async () => {
+    mocks.lookup.mockRejectedValue(new Error('ENOTFOUND'));
+    expect(await resolvesToPublicAddress('nope.example.com')).toBe(false);
+
+    mocks.lookup.mockResolvedValue([]);
+    expect(await resolvesToPublicAddress('empty.example.com')).toBe(false);
+
+    expect(await resolvesToPublicAddress('<unparseable>')).toBe(false);
+    expect(await resolvesToPublicAddress('')).toBe(false);
+  });
+});
+
+describe('safeFetch', () => {
+  it('fetches a public host with manual redirects and a UA', async () => {
+    mocks.fetch.mockResolvedValue(res(200));
+
+    const r = await safeFetch('https://example.com/x');
+
+    expect(r?.status).toBe(200);
+    expect(mocks.fetch.mock.calls[0][1]).toMatchObject({
+      redirect: 'manual',
+      headers: { 'User-Agent': FETCH_USER_AGENT },
+    });
+  });
+
+  it('follows a redirect and re-resolves the new host', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: 'https://elsewhere.example.com/y' }))
+      .mockResolvedValue(res(200));
+
+    await safeFetch('https://example.com/x');
+
+    expect(mocks.lookup.mock.calls.map(c => c[0])).toEqual(['example.com', 'elsewhere.example.com']);
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://elsewhere.example.com/y');
+  });
+
+  it('refuses a redirect into private space without fetching it', async () => {
+    mocks.lookup.mockImplementation(async (h: string) =>
+      h === 'example.com' ? PUBLIC : [{ address: '169.254.169.254', family: 4 }]
+    );
+    mocks.fetch.mockResolvedValueOnce(res(302, { location: 'https://evil.example.com/' }));
+
+    expect(await safeFetch('https://example.com/x')).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an unsafe target outright, before any DNS or fetch', async () => {
+    expect(await safeFetch('http://169.254.169.254/latest/meta-data/')).toBeNull();
+    expect(await safeFetch('file:///etc/passwd')).toBeNull();
+    expect(mocks.lookup).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('bounds a redirect loop at MAX_REDIRECTS + 1 attempts', async () => {
+    mocks.fetch.mockResolvedValue(res(302, { location: 'https://example.com/loop' }));
+
+    expect(await safeFetch('https://example.com/loop')).toBeNull();
+    expect(mocks.fetch).toHaveBeenCalledTimes(MAX_REDIRECTS + 1);
+  });
+
+  it('returns a 3xx with no Location as-is, so callers fail closed on .ok', async () => {
+    mocks.fetch.mockResolvedValue(res(302));
+
+    const r = await safeFetch('https://example.com/x');
+
+    expect(r?.status).toBe(302);
+    expect(r?.ok).toBe(false);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a relative Location against the current URL', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(res(301, { location: '/moved' }))
+      .mockResolvedValue(res(200));
+
+    await safeFetch('https://example.com/deep/path');
+
+    expect(String(mocks.fetch.mock.calls[1][0])).toBe('https://example.com/moved');
+  });
+});

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -29,10 +29,15 @@ const MAX_ARTISTS_PER_RUN = 25;
 const DELAY_BETWEEN_ARTISTS_MS = 1_000;
 
 function isAuthorized(header: string | undefined): boolean {
-  const secret = process.env.INTERNAL_TASK_SECRET;
+  // Reuses the secret this repo already has for internal function-to-function calls
+  // (resolve-url, search-sources, and both v1 wrappers). A second near-identically-named
+  // variable would be a footgun, and the blast radius of this one is small: cooldown and
+  // hourly caps are enforced inside this function regardless of who calls it, and only
+  // artists already in our database can be named.
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
   // No secret configured means the endpoint is closed, not open.
   if (!secret) {
-    console.error('[catalog] INTERNAL_TASK_SECRET is not set — refusing all requests');
+    console.error('[catalog] INTERNAL_FUNCTION_SECRET is not set — refusing all requests');
     return false;
   }
   if (!header?.startsWith('Bearer ')) return false;

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -1,0 +1,156 @@
+// Netlify Background Function: build an artist's release catalog from Bandcamp.
+//
+// Invoked by requestArtistCatalog() when a fan saves an artist or a search resolves one.
+// Runs off the request path — a `-background` function returns 202 to its caller immediately
+// and then runs for up to 15 minutes — so nothing here is on a user's critical path. That
+// matters: cataloging one artist costs one Bandcamp request, and the search that triggered it
+// must not wait for it.
+//
+// Authenticated with a shared secret. The Discord background function in this repo has no
+// auth, and copying that here would be a mistake: an open endpoint that makes Unstream crawl
+// Bandcamp on demand is exactly the amplifier the check-releases hardening existed to close.
+
+import { timingSafeEqual } from 'crypto';
+import {
+  claimArtistForCatalog,
+  getArtistBandcampUrl,
+  persistReleases,
+  recordCatalogOutcome,
+  type CatalogTrigger,
+} from './db';
+import { isUrlHostnameAllowed } from './middleware';
+import { safeFetch, safeHostname } from './safe-fetch';
+import { bandcampMusicUrl, ingestBandcampGrid } from './release-ingest';
+
+/** Ceiling on artists per invocation, so one call can't become an unbounded crawl. */
+const MAX_ARTISTS_PER_RUN = 25;
+
+/** Pause between artists. One Bandcamp request each, spaced out rather than in a burst. */
+const DELAY_BETWEEN_ARTISTS_MS = 1_000;
+
+function isAuthorized(header: string | undefined): boolean {
+  const secret = process.env.INTERNAL_TASK_SECRET;
+  // No secret configured means the endpoint is closed, not open.
+  if (!secret) {
+    console.error('[catalog] INTERNAL_TASK_SECRET is not set — refusing all requests');
+    return false;
+  }
+  if (!header?.startsWith('Bearer ')) return false;
+
+  const provided = Buffer.from(header.slice(7));
+  const expected = Buffer.from(secret);
+  // timingSafeEqual throws on length mismatch, so compare lengths first.
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
+}
+
+export async function handler(event: {
+  httpMethod?: string;
+  headers?: Record<string, string | undefined>;
+  body?: string;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: '' };
+  }
+
+  if (!isAuthorized(event.headers?.authorization ?? event.headers?.Authorization)) {
+    return { statusCode: 401, body: '' };
+  }
+
+  let body: { artistIds?: unknown; trigger?: unknown };
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 400, body: '' };
+  }
+
+  const artistIds = Array.isArray(body.artistIds)
+    ? body.artistIds.filter((id): id is string => typeof id === 'string').slice(0, MAX_ARTISTS_PER_RUN)
+    : [];
+  const trigger: CatalogTrigger = body.trigger === 'saved' ? 'saved' : 'searched';
+
+  if (artistIds.length === 0) return { statusCode: 400, body: '' };
+
+  let catalogued = 0;
+  let skipped = 0;
+
+  for (const [index, artistId] of artistIds.entries()) {
+    // Cooldown, hourly cap and claim all happen here rather than at the call site, so the
+    // search and save paths pay one cheap invocation instead of a DB round trip per artist.
+    if (!(await claimArtistForCatalog(artistId, trigger))) {
+      skipped++;
+      continue;
+    }
+
+    if (index > 0) await sleep(DELAY_BETWEEN_ARTISTS_MS);
+
+    try {
+      const found = await catalogArtist(artistId);
+      if (found === null) {
+        skipped++;
+      } else {
+        catalogued++;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[catalog] artist ${artistId} failed:`, message);
+      await recordCatalogOutcome(artistId, { error: message });
+    }
+  }
+
+  console.log(`[catalog] trigger=${trigger} catalogued=${catalogued} skipped=${skipped}`);
+  return { statusCode: 200, body: JSON.stringify({ catalogued, skipped }) };
+}
+
+/**
+ * Catalog one artist. Returns the release count, or null when there was nothing to do.
+ *
+ * @throws on a genuine failure, so the caller records it against the backoff counter.
+ */
+async function catalogArtist(artistId: string): Promise<number | null> {
+  const storedUrl = await getArtistBandcampUrl(artistId);
+  if (!storedUrl) {
+    await recordCatalogOutcome(artistId, { error: 'no bandcamp link stored' });
+    return null;
+  }
+
+  // The stored URL is not automatically trustworthy: a claimed artist can save any http(s)
+  // URL to their profile links, so a row labelled 'bandcamp' may not be Bandcamp at all.
+  // The allowlist answers "is this really Bandcamp"; safeFetch separately answers "is this
+  // safe to fetch". Both are needed — they are different questions.
+  if (!isUrlHostnameAllowed(storedUrl)) {
+    await recordCatalogOutcome(artistId, { error: `stored bandcamp url not allowlisted: ${safeHostname(storedUrl)}` });
+    return null;
+  }
+
+  const musicUrl = bandcampMusicUrl(storedUrl);
+  if (!musicUrl) {
+    await recordCatalogOutcome(artistId, { error: 'could not derive /music url' });
+    return null;
+  }
+
+  const response = await safeFetch(musicUrl, 10_000);
+  if (!response) throw new Error('fetch refused or too many redirects');
+  if (!response.ok) throw new Error(`bandcamp responded ${response.status}`);
+
+  const html = await response.text();
+  const outcome = ingestBandcampGrid(html, response.url || musicUrl);
+
+  if (!outcome.ok) {
+    // A bot challenge is the upstream declining to answer, not an artist with no releases.
+    // Throwing marks it a failure so it backs off and retries; recording it as a successful
+    // zero would poison the cooldown with a false negative for a week.
+    if (outcome.reason === 'bot_challenge') throw new Error('bandcamp bot challenge');
+
+    await recordCatalogOutcome(artistId, { releasesFound: 0 });
+    return 0;
+  }
+
+  const written = await persistReleases(artistId, outcome.releases);
+  await recordCatalogOutcome(artistId, { releasesFound: written });
+  return written;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -62,6 +62,15 @@ export async function handler(event: {
     return { statusCode: 401, body: '' };
   }
 
+  // Production only, checked here as well as in request-catalog.ts. The caller-side gate stops
+  // a preview from asking; this one means the guarantee holds no matter who asks, since this
+  // function is what actually writes to the production database. Cheap, and the alternative is
+  // a rule that's true only as long as every future caller remembers it.
+  if (process.env.CONTEXT !== 'production') {
+    console.log(`[catalog] refusing — context is ${process.env.CONTEXT ?? 'unset'}, not production`);
+    return { statusCode: 403, body: JSON.stringify({ skipped: 'non-production context' }) };
+  }
+
   let body: { artistIds?: unknown; trigger?: unknown };
   try {
     body = JSON.parse(event.body || '{}');

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,14 +1,8 @@
 import { parse } from 'node-html-parser';
-import { lookup } from 'dns/promises';
-import { isPrivateIpAddress, isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
+import { isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { isStoredArtistLink } from './db';
-
-const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
-
-// Bandcamp Pro artists point custom domains at their store, so a single request can
-// legitimately redirect off *.bandcamp.com. Follow a few hops, validating each one.
-const MAX_REDIRECTS = 5;
+import { safeFetch, safeHostname } from './safe-fetch';
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -32,103 +26,6 @@ interface CheckReleasesResponse {
   artistName: string;
   release: ReleaseResult | null;
   error?: string;
-}
-
-/**
- * Fetch with a timeout, validating **every** hop against `isSafePublicHostname`.
- *
- * Node's fetch follows redirects transparently, which means a check on the URL we were
- * given says nothing about the URL we actually retrieve. That matters here for two
- * reasons: this endpoint fetches caller-supplied URLs, and it then follows a link found
- * *inside* the page it fetched. Redirects are resolved manually so each destination is
- * re-validated before another request goes out.
- *
- * Returns null when a target is refused or the redirect chain is too long — callers treat
- * that the same as an unreachable platform.
- */
-async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Response | null> {
-  let current = url;
-
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    if (!isSafePublicHostname(current)) {
-      // Hostname only — the full URL is caller-supplied and shouldn't land in logs.
-      console.warn(`[check-releases] refused unsafe fetch target: ${safeHostname(current)}`);
-      return null;
-    }
-
-    if (!(await resolvesToPublicAddress(safeHostname(current)))) {
-      console.warn(`[check-releases] refused target resolving to private space: ${safeHostname(current)}`);
-      return null;
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    let response: Response;
-    try {
-      response = await fetch(current, {
-        headers: { 'User-Agent': USER_AGENT },
-        redirect: 'manual',
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    if (response.status < 300 || response.status >= 400) return response;
-
-    // A 3xx with no Location has nowhere to go. Returning it as-is is deliberate rather
-    // than unhandled: callers check `.ok`, which is false for a 3xx, so it fails closed.
-    const location = response.headers.get('location');
-    if (!location) return response;
-    current = new URL(location, current).toString();
-  }
-
-  console.warn(`[check-releases] too many redirects from ${safeHostname(url)}`);
-  return null;
-}
-
-function safeHostname(urlString: string): string {
-  try {
-    return new URL(urlString).hostname;
-  } catch {
-    return '<unparseable>';
-  }
-}
-
-/**
- * Does every DNS answer for this hostname point at a public address?
- *
- * String checks on a hostname are not enough, and this is the gap that made them
- * insufficient: `169-254-169-254.nip.io` is a perfectly ordinary public name that resolves
- * to 169.254.169.254 — the cloud metadata endpoint. Wildcard-DNS services hand those out
- * for free, and a Bandcamp Pro artist can point a custom domain anywhere, so an
- * allowlisted `*.bandcamp.com` input can redirect to a name that resolves into private
- * space. Nothing textual catches that; only resolution does.
- *
- * **All** answers must be public, so a dual-stack host can't smuggle a private AAAA past a
- * public A record. Any resolver failure or NXDOMAIN returns false — for a security
- * predicate, "couldn't check" has to mean "refuse".
- *
- * Residual risk, stated precisely rather than hand-waved: Node's `fetch` performs its own
- * resolution when it connects, so a hostname whose DNS answers *change* between this check
- * and that connect — rotating records or a very low TTL — can still slip through. Closing
- * that needs the connection pinned to the address we validated, which means a custom
- * undici dispatcher; `undici` isn't a declared dependency here (only transitively
- * available), so pinning is deliberately left as a follow-up rather than built on a package
- * that could vanish on any install. What this does close is the one-shot case, which is
- * what was actually reachable. Note also that exfiltration is separately limited: the
- * parsers only extract an RSS `<item><title>` or a Bandcamp `.music-grid-item`, so a
- * typical internal endpoint yields nothing even when reached.
- */
-async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
-  if (!hostname || hostname === '<unparseable>') return false;
-  try {
-    const answers = await lookup(hostname, { all: true, verbatim: true });
-    if (answers.length === 0) return false;
-    return answers.every(a => !isPrivateIpAddress(a.address));
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3,6 +3,7 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
+import { requestArtistCatalog } from './request-catalog';
 
 let supabase: SupabaseClient | null = null;
 
@@ -363,6 +364,326 @@ export async function isStoredArtistLink(url: string, artistName: string): Promi
   } catch (error) {
     console.error('[DB] isStoredArtistLink error:', error);
     return false;
+  }
+}
+
+// --- Release catalog (Unstream Releases) ---
+
+/** Don't re-crawl an artist inside this window. Repeat searches then cost nothing upstream. */
+const RECATALOG_COOLDOWN_HOURS = 24 * 7;
+
+/**
+ * Hourly ceilings on how many artists we will catalog, by what triggered it.
+ *
+ * Search is unauthenticated and far higher volume than saving, so it gets the smaller
+ * budget: a traffic spike must not turn into us hammering Bandcamp. A save is one person
+ * deliberately asking to follow an artist, so it gets a bigger budget and still gets through
+ * when searches are being dropped.
+ */
+const CATALOG_HOURLY_CAP = { searched: 60, saved: 240 } as const;
+
+export type CatalogTrigger = 'saved' | 'searched';
+
+/**
+ * May we catalog this artist right now — and if so, claim it.
+ *
+ * Cooldown, then hourly cap, then stamp `last_attempted_at`. The stamp is the claim: two
+ * near-simultaneous triggers for the same artist won't both do the work, because the second
+ * sees a fresh attempt timestamp.
+ *
+ * Returns false on any error. Cataloging is opportunistic — if we can't tell whether it's
+ * allowed, not crawling is the safe answer, and the next search or save tries again.
+ */
+export async function claimArtistForCatalog(
+  artistId: string,
+  trigger: CatalogTrigger
+): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    const { data: state, error: stateError } = await client
+      .from('release_catalog_state')
+      .select('last_catalogued_at, last_attempted_at, consecutive_failures')
+      .eq('artist_id', artistId)
+      .maybeSingle();
+
+    if (stateError) {
+      console.error('[DB] claimArtistForCatalog read failed:', stateError.message);
+      return false;
+    }
+
+    const now = Date.now();
+    const row = state as
+      | { last_catalogued_at: string | null; last_attempted_at: string; consecutive_failures: number }
+      | null;
+
+    if (row) {
+      // Already catalogued recently.
+      if (row.last_catalogued_at) {
+        const age = now - new Date(row.last_catalogued_at).getTime();
+        if (age < RECATALOG_COOLDOWN_HOURS * 3600_000) return false;
+      }
+
+      // Someone else claimed it moments ago, or a failing artist is backing off. The backoff
+      // doubles per consecutive failure so a permanently broken artist isn't retried on every
+      // single search, capped so it eventually recovers.
+      const attemptAge = now - new Date(row.last_attempted_at).getTime();
+      const backoffMs = Math.min(2 ** Math.min(row.consecutive_failures, 6), 64) * 15 * 60_000;
+      if (attemptAge < Math.max(backoffMs, 60_000)) return false;
+    }
+
+    // Hourly cap, counted across all artists.
+    const since = new Date(now - 3600_000).toISOString();
+    const { count, error: countError } = await client
+      .from('release_catalog_state')
+      .select('artist_id', { count: 'exact', head: true })
+      .gte('last_attempted_at', since);
+
+    if (countError) {
+      console.error('[DB] claimArtistForCatalog count failed:', countError.message);
+      return false;
+    }
+    if ((count ?? 0) >= CATALOG_HOURLY_CAP[trigger]) {
+      console.log(`[catalog] hourly cap reached for trigger=${trigger} (${count}) — skipping`);
+      return false;
+    }
+
+    const { error: claimError } = await client
+      .from('release_catalog_state')
+      .upsert(
+        { artist_id: artistId, last_attempted_at: new Date(now).toISOString(), last_trigger: trigger },
+        { onConflict: 'artist_id' }
+      );
+
+    if (claimError) {
+      console.error('[DB] claimArtistForCatalog claim failed:', claimError.message);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('[DB] claimArtistForCatalog error:', error);
+    return false;
+  }
+}
+
+/** Record the outcome of a catalog run. Failures increment the backoff counter. */
+export async function recordCatalogOutcome(
+  artistId: string,
+  outcome: { releasesFound: number } | { error: string }
+): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  const patch: Record<string, unknown> =
+    'error' in outcome
+      ? { last_error: outcome.error.slice(0, 500) }
+      : {
+          last_catalogued_at: new Date().toISOString(),
+          releases_found: outcome.releasesFound,
+          consecutive_failures: 0,
+          last_error: null,
+        };
+
+  try {
+    if ('error' in outcome) {
+      // Read-then-increment rather than a raw SQL expression, to stay within the JS client.
+      const { data } = await client
+        .from('release_catalog_state')
+        .select('consecutive_failures')
+        .eq('artist_id', artistId)
+        .maybeSingle();
+      const prev = (data as { consecutive_failures: number } | null)?.consecutive_failures ?? 0;
+      patch.consecutive_failures = prev + 1;
+    }
+
+    const { error } = await client
+      .from('release_catalog_state')
+      .update(patch)
+      .eq('artist_id', artistId);
+
+    if (error) console.error('[DB] recordCatalogOutcome failed:', error.message);
+  } catch (error) {
+    console.error('[DB] recordCatalogOutcome error:', error);
+  }
+}
+
+interface ReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  artworkUrl: string | null;
+  source: { platform: string; url: string; externalId: string | null };
+}
+
+/**
+ * Write a catalog run's releases, merging rather than replacing.
+ *
+ * Three rules that matter more than they look:
+ *
+ * 1. **Match on `(artist_id, release_type, match_key)`, not on slug.** A slug is derived from
+ *    a title and changes when the title does; the match key is what identity means here.
+ * 2. **Never overwrite a stored value with null.** A partial run — Bandcamp slow, artwork
+ *    missing — must not erase a date or artwork a previous run found. This is "never cache
+ *    uncertainty" in write form.
+ * 3. **Never touch a field an artist has edited.** `curated_fields` lists columns a verified
+ *    artist authored; ingest re-runs forever, so without this every crawl silently reverts
+ *    their corrections.
+ *
+ * Returns the number of releases written or updated.
+ */
+export async function persistReleases(
+  artistId: string,
+  releases: ReleaseToPersist[]
+): Promise<number> {
+  const client = getClient();
+  if (!client || releases.length === 0) return 0;
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, release_date, artwork_url, curated_fields')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistReleases read failed:', readError.message);
+      return 0;
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      artwork_url: string | null;
+      curated_fields: string[] | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
+    const takenSlugs = new Set(existing.map(r => r.slug));
+
+    let written = 0;
+
+    for (const release of releases) {
+      const identity = `${release.releaseType}:${release.matchKey}`;
+      const prior = byIdentity.get(identity);
+      const curated = new Set(prior?.curated_fields ?? []);
+
+      let releaseId: string;
+
+      if (prior) {
+        const patch: Record<string, unknown> = {};
+        // COALESCE semantics, applied in JS: only fill what's missing, never blank what's set,
+        // and never touch what the artist edited.
+        if (!curated.has('title')) patch.title = release.title;
+        if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
+          patch.artwork_url = release.artworkUrl;
+        }
+        if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
+          patch.release_date = release.releaseDate;
+          patch.date_precision = release.datePrecision;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        // Slug must not collide with anything already stored for this artist.
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            release_date: release.releaseDate,
+            date_precision: release.datePrecision,
+            status: release.status,
+            artwork_url: release.artworkUrl,
+            source: 'auto',
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        byIdentity.set(identity, {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          release_date: release.releaseDate,
+          artwork_url: release.artworkUrl,
+          curated_fields: [],
+        });
+      }
+
+      const { error: sourceError } = await client.from('release_sources').upsert(
+        {
+          release_id: releaseId,
+          platform: release.source.platform,
+          url: release.source.url,
+          external_id: release.source.externalId,
+          last_seen_at: new Date().toISOString(),
+        },
+        { onConflict: 'release_id,platform' }
+      );
+
+      if (sourceError) {
+        console.error('[DB] persistReleases source upsert failed:', sourceError.message);
+        continue;
+      }
+
+      written++;
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistReleases error:', error);
+    return 0;
+  }
+}
+
+/** The stored Bandcamp link for an artist, if we have one. */
+export async function getArtistBandcampUrl(artistId: string): Promise<string | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data, error } = await client
+      .from('artist_links')
+      .select('url')
+      .eq('artist_id', artistId)
+      .eq('platform', 'bandcamp')
+      .maybeSingle();
+
+    if (error) {
+      console.error('[DB] getArtistBandcampUrl failed:', error.message);
+      return null;
+    }
+    return (data as { url: string } | null)?.url ?? null;
+  } catch (error) {
+    console.error('[DB] getArtistBandcampUrl error:', error);
+    return null;
   }
 }
 
@@ -768,6 +1089,11 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
   const client = getClient();
   if (!client) return;
 
+  // Artists persisted in this run that have a Bandcamp link, collected so cataloging can be
+  // requested in a single call afterwards rather than once per artist. This function is
+  // awaited before the search response is sent, so wall-clock time here is user-visible.
+  const catalogCandidates: string[] = [];
+
   // This runs before the search response is sent, so wall-clock time matters:
   // artists persist concurrently, and each artist's links go up in one bulk
   // upsert instead of one round-trip per link.
@@ -852,10 +1178,21 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
       }
 
       console.log(`[DB] Persisted "${result.name}" with ${linkRows.length} links`);
+
+      // Only worth cataloging artists we can actually catalog — ingest is Bandcamp-only for
+      // now, so an artist without a Bandcamp link would just be a wasted claim.
+      if (linkRowsByPlatform.has('bandcamp')) catalogCandidates.push(artistId);
     } catch (error) {
       console.error(`[DB] Error persisting "${result.name}":`, error);
     }
   }));
+
+  // One request for the whole result set, after the writes, and only a 202 handshake is
+  // awaited. Cooldown and rate-cap checks happen inside the background function, so a search
+  // never pays a database round trip per artist to find out an artist was crawled last week.
+  if (catalogCandidates.length > 0) {
+    await requestArtistCatalog(catalogCandidates, 'searched');
+  }
 }
 
 /**

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -1,0 +1,142 @@
+// Turning a fetched Bandcamp /music page into release rows.
+//
+// The mapping is pure and lives here; the fetching and writing live in
+// catalog-artist-background.ts and db.ts. Same split as search-parsers/search-utils versus
+// search-sources, and for the same reason: this is the part with decisions in it, so it
+// should be testable without a network or a database.
+
+import {
+  parseBandcampGridReleases,
+  isBandcampChallenge,
+  type BandcampGridRelease,
+} from './search-parsers';
+import {
+  deriveStatus,
+  mapReleaseType,
+  releaseMatchKey,
+  uniqueReleaseSlug,
+  type ReleaseType,
+} from './release-utils';
+
+/** A release ready to be written, with its one known source. */
+export interface IngestedRelease {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  /** Null for Bandcamp grid ingest: dates live only on individual release pages. */
+  releaseDate: null;
+  datePrecision: 'unknown';
+  status: 'announced' | 'released';
+  artworkUrl: string | null;
+  source: {
+    platform: 'bandcamp';
+    url: string;
+    externalId: string | null;
+  };
+}
+
+export type IngestOutcome =
+  | { ok: true; releases: IngestedRelease[] }
+  | { ok: false; reason: 'bot_challenge' | 'no_releases' };
+
+/**
+ * Map a Bandcamp `/music` page into release rows.
+ *
+ * `pageUrl` is the URL we actually landed on after redirects, so relative hrefs resolve
+ * against the artist's real host (which may be a Bandcamp Pro custom domain).
+ *
+ * Two failures are reported distinctly rather than both looking like an empty catalog,
+ * because conflating them is the single most repeated bug class in this codebase:
+ *
+ * - `bot_challenge` — Fastly served an interstitial with HTTP 200. The upstream didn't
+ *   answer, so nothing may be concluded and nothing should be cached as a negative.
+ * - `no_releases` — the page parsed fine and genuinely has no releases (a parked account).
+ *
+ * A caller that treats these the same records "this artist has no releases" when the truth
+ * is "we were blocked".
+ */
+export function ingestBandcampGrid(html: string, pageUrl: string, now: Date = new Date()): IngestOutcome {
+  if (isBandcampChallenge(html)) return { ok: false, reason: 'bot_challenge' };
+
+  const parsed = parseBandcampGridReleases(html);
+  if (parsed.length === 0) return { ok: false, reason: 'no_releases' };
+
+  const releases: IngestedRelease[] = [];
+  const takenSlugs = new Set<string>();
+  const seenKeys = new Set<string>();
+
+  for (const entry of parsed) {
+    const url = resolveReleaseUrl(entry, pageUrl);
+    if (!url) continue;
+
+    const matchKey = releaseMatchKey(entry.title);
+    if (!matchKey) continue; // nothing identifiable to match on
+
+    // Within one page, the same normalized title at the same type is the same release —
+    // Bandcamp occasionally lists a release twice (featured plus in-sequence).
+    const dedupeKey = `${mapReleaseType(entry.type)}:${matchKey}`;
+    if (seenKeys.has(dedupeKey)) continue;
+    seenKeys.add(dedupeKey);
+
+    // Slug uniqueness has to account for what this run has already produced, not just what
+    // is already stored — two titles can slugify identically in one page.
+    const slug = uniqueReleaseSlug(entry.title, takenSlugs);
+    takenSlugs.add(slug);
+
+    releases.push({
+      title: entry.title,
+      slug,
+      matchKey,
+      releaseType: mapReleaseType(entry.type),
+      // The grid carries no dates at all — they exist only on individual release pages, at
+      // one extra request each. Left null rather than guessed; a later pass fills them in.
+      releaseDate: null,
+      datePrecision: 'unknown',
+      status: deriveStatus(null, false, now),
+      artworkUrl: entry.artworkUrl,
+      source: {
+        platform: 'bandcamp',
+        url,
+        externalId: entry.externalId,
+      },
+    });
+  }
+
+  if (releases.length === 0) return { ok: false, reason: 'no_releases' };
+  return { ok: true, releases };
+}
+
+/**
+ * Resolve a grid href, refusing anything that leaves the host we landed on.
+ *
+ * Same rule as the album-page fetch in check-releases: an href out of fetched markup is
+ * untrusted, and a release "source" URL pointing at someone else's domain would be stored
+ * and later shown to fans as a place to buy this artist's record.
+ */
+function resolveReleaseUrl(entry: BandcampGridRelease, pageUrl: string): string | null {
+  try {
+    const resolved = new URL(entry.href, pageUrl);
+    if (resolved.host !== new URL(pageUrl).host) return null;
+    if (resolved.protocol !== 'https:' && resolved.protocol !== 'http:') return null;
+    return resolved.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `/music` URL for an artist's Bandcamp page.
+ *
+ * Stored links point at all sorts of depths (`/`, `/music`, `/album/x`, with query strings),
+ * and the grid only exists at `/music`.
+ */
+export function bandcampMusicUrl(artistUrl: string): string | null {
+  try {
+    const u = new URL(artistUrl);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+    return `${u.origin}/music`;
+  } catch {
+    return null;
+  }
+}

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -1,0 +1,64 @@
+// Ask for artists to be catalogued, without waiting for it to happen.
+//
+// Both callers are on a user's critical path — saving an artist and running a search — so the
+// only work done here is one HTTP call to a Netlify Background Function, which returns 202 as
+// soon as it's accepted. All the gating (cooldown, hourly cap, claim) happens inside that
+// function rather than here, so the hot path never pays a database round trip per artist.
+//
+// This is the mistake the abandoned first attempt at Releases made: it did the release writes
+// inline in persistSearchResults, which is awaited during search, adding an estimated
+// 0.6–1.6s to every query after a long effort to get search down to ~1.8–3.0s.
+
+import type { CatalogTrigger } from './db';
+
+/** Matches MAX_ARTISTS_PER_RUN in catalog-artist-background.ts. */
+const MAX_ARTISTS_PER_REQUEST = 25;
+
+/**
+ * Request release cataloging for one or more artists.
+ *
+ * Awaited deliberately, despite being "fire and forget" in spirit: un-awaited work is killed
+ * when the Lambda freezes after the response, so a floating promise here would mean the
+ * invocation sometimes never leaves. What's awaited is only the 202 handshake, not the
+ * cataloging.
+ *
+ * Never throws and never blocks meaningfully — cataloging is opportunistic, and a fan saving
+ * an artist must not see an error because a crawl couldn't be scheduled.
+ */
+export async function requestArtistCatalog(
+  artistIds: string[],
+  trigger: CatalogTrigger
+): Promise<void> {
+  const ids = [...new Set(artistIds.filter(Boolean))].slice(0, MAX_ARTISTS_PER_REQUEST);
+  if (ids.length === 0) return;
+
+  const secret = process.env.INTERNAL_TASK_SECRET;
+  const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL;
+  if (!secret || !siteUrl) {
+    // Not an error worth surfacing: without configuration the feature is simply off.
+    console.log('[catalog] not requested — INTERNAL_TASK_SECRET or URL not configured');
+    return;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 3_000);
+    try {
+      await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${secret}`,
+        },
+        body: JSON.stringify({ artistIds: ids, trigger }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch (error) {
+    // A failed handshake means these artists don't get catalogued this time. The next search
+    // or save asks again, so there's nothing to retry and nothing a user should see.
+    console.warn('[catalog] request failed:', error instanceof Error ? error.message : String(error));
+  }
+}

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -37,7 +37,11 @@ export async function requestArtistCatalog(
   // crawl budget on behalf of traffic that isn't real. Netlify sets CONTEXT to
   // 'production' | 'deploy-preview' | 'branch-deploy' | 'dev'; it is undefined in tests and
   // under the plain Vite dev server, so a strict equality check also keeps local runs from
-  // touching production data. (To exercise this locally, set CONTEXT=production knowingly.)
+  // touching production data.
+  //
+  // Do NOT set CONTEXT=production to test locally — .env points at the production database,
+  // so that would have a laptop writing real rows. Use `npm run ingest:try <artist>` instead,
+  // which runs the real fetch, parse and mapping and prints what would be written.
   if (process.env.CONTEXT !== 'production') {
     console.log(`[catalog] not requested — context is ${process.env.CONTEXT ?? 'unset'}, not production`);
     return;

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -32,6 +32,17 @@ export async function requestArtistCatalog(
   const ids = [...new Set(artistIds.filter(Boolean))].slice(0, MAX_ARTISTS_PER_REQUEST);
   if (ids.length === 0) return;
 
+  // Production only. Deploy previews and branch deploys run against the *production*
+  // Supabase, so cataloging from one would write real releases and spend the real hourly
+  // crawl budget on behalf of traffic that isn't real. Netlify sets CONTEXT to
+  // 'production' | 'deploy-preview' | 'branch-deploy' | 'dev'; it is undefined in tests and
+  // under the plain Vite dev server, so a strict equality check also keeps local runs from
+  // touching production data. (To exercise this locally, set CONTEXT=production knowingly.)
+  if (process.env.CONTEXT !== 'production') {
+    console.log(`[catalog] not requested — context is ${process.env.CONTEXT ?? 'unset'}, not production`);
+    return;
+  }
+
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
 
   // DEPLOY_PRIME_URL first, not URL. On Netlify, URL is the *production* address even during

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -32,11 +32,18 @@ export async function requestArtistCatalog(
   const ids = [...new Set(artistIds.filter(Boolean))].slice(0, MAX_ARTISTS_PER_REQUEST);
   if (ids.length === 0) return;
 
-  const secret = process.env.INTERNAL_TASK_SECRET;
-  const siteUrl = process.env.URL || process.env.DEPLOY_PRIME_URL;
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+
+  // DEPLOY_PRIME_URL first, not URL. On Netlify, URL is the *production* address even during
+  // a deploy preview, so preferring it would make a preview invoke the production function —
+  // running production code for a preview's traffic and spending the shared hourly crawl
+  // budget. DEPLOY_PRIME_URL is the current deploy (preview, branch, or production), which is
+  // what we want in every context.
+  const siteUrl = process.env.DEPLOY_PRIME_URL || process.env.URL;
+
   if (!secret || !siteUrl) {
     // Not an error worth surfacing: without configuration the feature is simply off.
-    console.log('[catalog] not requested — INTERNAL_TASK_SECRET or URL not configured');
+    console.log('[catalog] not requested — INTERNAL_FUNCTION_SECRET or site URL not configured');
     return;
   }
 

--- a/api/functions/safe-fetch.ts
+++ b/api/functions/safe-fetch.ts
@@ -1,0 +1,121 @@
+// One outbound-fetch path for anything that retrieves a URL we didn't hardcode.
+//
+// Extracted from check-releases.ts so it can be shared. The reason it must be shared rather
+// than reimplemented: the checks here are not obvious, and each one exists because the
+// obvious version was wrong.
+//
+//   1. Validating the URL you were *given* says nothing about the URL you *retrieve*.
+//      Node's fetch follows redirects transparently, so redirects are resolved manually
+//      here and every hop is re-validated.
+//   2. A hostname string check is not an SSRF boundary. `169-254-169-254.nip.io` is an
+//      ordinary public name that resolves to the cloud metadata address, and wildcard-DNS
+//      services hand those out for free. Every hop is also resolved and every answer has to
+//      be public.
+//
+// Any code fetching a URL that came from a request body, a database row, or scraped markup
+// should use this. `isUrlHostnameAllowed` alone is not sufficient.
+
+import { lookup } from 'dns/promises';
+import { isPrivateIpAddress, isSafePublicHostname } from './middleware';
+
+export const FETCH_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+// Bandcamp Pro artists point custom domains at their store, so a single request can
+// legitimately redirect off *.bandcamp.com. Follow a few hops, validating each one.
+export const MAX_REDIRECTS = 5;
+
+/** Hostname for logging. The full URL may be caller-supplied, so it doesn't go in logs. */
+export function safeHostname(urlString: string): string {
+  try {
+    return new URL(urlString).hostname;
+  } catch {
+    return '<unparseable>';
+  }
+}
+
+/**
+ * Does every DNS answer for this hostname point at a public address?
+ *
+ * String checks on a hostname are not enough, and this is the gap that made them
+ * insufficient: `169-254-169-254.nip.io` is a perfectly ordinary public name that resolves
+ * to 169.254.169.254 — the cloud metadata endpoint. Wildcard-DNS services hand those out
+ * for free, and a Bandcamp Pro artist can point a custom domain anywhere, so an
+ * allowlisted `*.bandcamp.com` input can redirect to a name that resolves into private
+ * space. Nothing textual catches that; only resolution does.
+ *
+ * **All** answers must be public, so a dual-stack host can't smuggle a private AAAA past a
+ * public A record. Any resolver failure or NXDOMAIN returns false — for a security
+ * predicate, "couldn't check" has to mean "refuse".
+ *
+ * Residual risk, stated precisely rather than hand-waved: Node's `fetch` performs its own
+ * resolution when it connects, so a hostname whose DNS answers *change* between this check
+ * and that connect — rotating records or a very low TTL — can still slip through. Closing
+ * that needs the connection pinned to the address we validated, which means a custom
+ * undici dispatcher; `undici` isn't a declared dependency here (only transitively
+ * available), so pinning is deliberately left as a follow-up rather than built on a package
+ * that could vanish on any install. What this does close is the one-shot case, which is
+ * what was actually reachable.
+ */
+export async function resolvesToPublicAddress(hostname: string): Promise<boolean> {
+  if (!hostname || hostname === '<unparseable>') return false;
+  try {
+    const answers = await lookup(hostname, { all: true, verbatim: true });
+    if (answers.length === 0) return false;
+    return answers.every(a => !isPrivateIpAddress(a.address));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch with a timeout, validating **every** hop — both as a string and by resolution.
+ *
+ * Returns null when a target is refused or the redirect chain is too long. Callers treat
+ * that the same as an unreachable host.
+ *
+ * Note this answers "is this target safe to fetch", **not** "are we allowed to fetch this
+ * at all". Those are different questions and conflating them has already caused one bug:
+ * an allowlist check belongs at the point where the URL enters the system, and when you
+ * follow a link found inside fetched content you must additionally confine it (e.g. to the
+ * host you landed on). See `checkBandcamp` in check-releases.ts for that pattern.
+ */
+export async function safeFetch(url: string, timeoutMs: number = 5000): Promise<Response | null> {
+  let current = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (!isSafePublicHostname(current)) {
+      console.warn(`[safe-fetch] refused unsafe fetch target: ${safeHostname(current)}`);
+      return null;
+    }
+
+    if (!(await resolvesToPublicAddress(safeHostname(current)))) {
+      console.warn(`[safe-fetch] refused target resolving to private space: ${safeHostname(current)}`);
+      return null;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(current, {
+        headers: { 'User-Agent': FETCH_USER_AGENT },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (response.status < 300 || response.status >= 400) return response;
+
+    // A 3xx with no Location has nowhere to go. Returning it as-is is deliberate rather
+    // than unhandled: callers check `.ok`, which is false for a 3xx, so it fails closed.
+    const location = response.headers.get('location');
+    if (!location) return response;
+    current = new URL(location, current).toString();
+  }
+
+  console.warn(`[safe-fetch] too many redirects from ${safeHostname(url)}`);
+  return null;
+}

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -15,6 +15,7 @@
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { authenticateBearerFast } from './middleware';
+import { requestArtistCatalog } from './request-catalog';
 
 function getServiceClient() {
   return getClient();
@@ -251,6 +252,14 @@ async function handleSave(user: { userId: string; email: string }, body: Record<
     if (upsertError) {
       console.error('[saved-artists] Error saving artist:', upsertError);
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to save artist' }) };
+    }
+
+    // Saving is the strongest signal that someone wants this artist's releases — it's what
+    // feeds their release alerts and, later, their calendar. Catalog on the way through.
+    // 'saved' outranks 'searched' when the hourly cap is reached, so a deliberate save still
+    // gets through while opportunistic search-triggered crawls are dropped.
+    if (artistId) {
+      await requestArtistCatalog([artistId], 'saved');
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:data": "tsx scripts/generate-artist-data.ts",
     "generate:social": "tsx scripts/generate-social-posts.ts",
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
+    "ingest:try": "npx tsx scripts/ingest-releases.ts",
     "test:web": "cd apps/web && npx vitest run",
     "test:api": "npx vitest run api/functions/",
     "test": "npm run test:web && npm run test:api",

--- a/scripts/ingest-releases.ts
+++ b/scripts/ingest-releases.ts
@@ -1,0 +1,109 @@
+/**
+ * Try release ingest against a real Bandcamp page, locally, without writing anything.
+ *
+ * Usage:
+ *   npx tsx scripts/ingest-releases.ts <bandcamp-url-or-slug>
+ *   npx tsx scripts/ingest-releases.ts sufjanstevens
+ *   npx tsx scripts/ingest-releases.ts https://music.sufjan.com/music
+ *   npx tsx scripts/ingest-releases.ts sufjanstevens --json
+ *
+ * Exercises the whole ingest path that matters — fetch (with the same SSRF-safe fetcher
+ * production uses), parse, and map to release rows — and prints what *would* be written.
+ *
+ * DRY RUN ONLY, DELIBERATELY. There is no --write flag, because .env points at the
+ * production Supabase: a local write path would mean a laptop writing real `releases` rows,
+ * which is the exact thing the CONTEXT === 'production' gate exists to prevent. Everything
+ * interesting is upstream of the database anyway — the parse and the mapping are where the
+ * decisions live, and `persistReleases` is covered by unit tests and by the migration being
+ * validated against a real Postgres. To test the write path, point SUPABASE_URL at a branch
+ * database on purpose.
+ *
+ * One Bandcamp request per run (plus redirects). Be a good neighbour and don't loop it.
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
+
+const { safeFetch } = await import('../api/functions/safe-fetch.js');
+const { isUrlHostnameAllowed } = await import('../api/functions/middleware.js');
+const { ingestBandcampGrid, bandcampMusicUrl } = await import('../api/functions/release-ingest.js');
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const target = args.find(a => !a.startsWith('--'));
+
+if (!target) {
+  console.error('Usage: npx tsx scripts/ingest-releases.ts <bandcamp-url-or-slug> [--json]');
+  process.exit(1);
+}
+
+// A bare word is treated as a Bandcamp subdomain, which is how most artists are stored.
+const artistUrl = target.includes('://') ? target : `https://${target}.bandcamp.com`;
+
+const musicUrl = bandcampMusicUrl(artistUrl);
+if (!musicUrl) {
+  console.error(`Could not derive a /music URL from ${artistUrl}`);
+  process.exit(1);
+}
+
+// Same two checks production applies, in the same order, so this exercises the real gates
+// rather than a convenient shortcut around them.
+if (!isUrlHostnameAllowed(musicUrl)) {
+  console.error(`Refused: ${musicUrl} is not on the outbound allowlist.`);
+  console.error('A custom domain will fail here, exactly as it would in production — ingest');
+  console.error('resolves those by following a redirect from the *.bandcamp.com URL.');
+  process.exit(1);
+}
+
+if (!asJson) console.log(`\nFetching ${musicUrl} …`);
+
+const response = await safeFetch(musicUrl, 15_000);
+if (!response) {
+  console.error('Fetch refused (unsafe target or too many redirects).');
+  process.exit(1);
+}
+if (!response.ok) {
+  console.error(`Bandcamp responded ${response.status}.`);
+  process.exit(1);
+}
+
+const landedUrl = response.url || musicUrl;
+const html = await response.text();
+const outcome = ingestBandcampGrid(html, landedUrl);
+
+if (!outcome.ok) {
+  // The distinction matters: 'bot_challenge' means Bandcamp declined to answer (production
+  // treats it as a failure and backs off), while 'no_releases' is a real empty catalog.
+  console.error(`\nNothing ingested — reason: ${outcome.reason}`);
+  if (outcome.reason === 'bot_challenge') {
+    console.error('Fastly served a bot challenge with HTTP 200. Not an empty artist.');
+  }
+  process.exit(2);
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ landedUrl, releases: outcome.releases }, null, 2));
+  process.exit(0);
+}
+
+if (landedUrl !== musicUrl) console.log(`Redirected to ${landedUrl}`);
+console.log(`\nWould write ${outcome.releases.length} release(s). Nothing was saved.\n`);
+
+// Always leave a trailing space, so a value that exactly fills the column doesn't run into
+// the next one.
+const pad = (s: string, n: number) => (s.length >= n ? s.slice(0, n - 2) + '… ' : s.padEnd(n));
+console.log(pad('TYPE', 12) + pad('TITLE', 42) + pad('SLUG', 34) + 'ART');
+console.log('-'.repeat(92));
+for (const r of outcome.releases) {
+  console.log(pad(r.releaseType, 12) + pad(r.title, 42) + pad(r.slug, 34) + (r.artworkUrl ? 'yes' : 'NO'));
+}
+
+// Surfaced because they're the things most likely to be quietly wrong, and a count is easier
+// to sanity-check at a glance than reading every row.
+const missingArt = outcome.releases.filter(r => !r.artworkUrl).length;
+const missingId = outcome.releases.filter(r => !r.source.externalId).length;
+console.log(`\nsummary: ${outcome.releases.length} releases, ${missingArt} without artwork, ${missingId} without a stable id`);
+console.log('note: release dates are always null here — they live on individual release pages,');
+console.log('      at one extra request each, so grid ingest deliberately does not guess them.\n');

--- a/supabase/migrations/20260731180000_release-catalog-state.sql
+++ b/supabase/migrations/20260731180000_release-catalog-state.sql
@@ -1,0 +1,74 @@
+-- Migration: release_catalog_state
+--
+-- Bookkeeping for demand-driven release cataloging. One row per artist we have tried to
+-- catalog, which is what makes three guards possible:
+--
+--   1. Cooldown  — never re-crawl an artist within RECATALOG_COOLDOWN, so repeat searches
+--                  for the same artist cost nothing upstream.
+--   2. Rate cap  — count rows attempted in the last hour to bound how hard we hit Bandcamp
+--                  during a traffic spike. Cataloging is triggered by search as well as by
+--                  saving, and search is unauthenticated and far higher volume.
+--   3. Priority  — a save is a deliberate act by one person; a search is not. When the cap
+--                  is reached, saves still get through and searches are dropped.
+--
+-- Deliberately not a job queue. Cataloging is triggered by a user action and invoked
+-- immediately as a background function, so there is no scheduler to feed and nothing to
+-- drain. Dropping a searched artist when the cap is reached is fine — the next person to
+-- search or save them triggers it again. Add a queue only when something actually needs
+-- guaranteed eventual execution.
+
+CREATE TABLE IF NOT EXISTS release_catalog_state (
+  artist_id uuid PRIMARY KEY REFERENCES artists(id) ON DELETE CASCADE,
+
+  -- Last time cataloging *succeeded*. Drives the cooldown.
+  last_catalogued_at timestamptz,
+
+  -- Last time cataloging was *attempted*, set before the work starts. Doubles as a claim:
+  -- stamping it up front means two near-simultaneous triggers for the same artist don't both
+  -- run, and it's the column the hourly rate cap counts.
+  last_attempted_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Consecutive failures. Lets a permanently broken artist back off instead of being retried
+  -- on every search forever.
+  consecutive_failures integer NOT NULL DEFAULT 0,
+
+  -- Truncated on write; this is for debugging, not for display.
+  last_error text,
+
+  -- What triggered the most recent attempt. 'saved' outranks 'searched' under the cap.
+  last_trigger text NOT NULL DEFAULT 'searched'
+    CHECK (last_trigger IN ('saved', 'searched')),
+
+  -- How many releases the last successful run found. A run that suddenly finds 0 where it
+  -- previously found 20 is a parser or bot-challenge failure, not an artist deleting their
+  -- catalog — worth being able to see.
+  releases_found integer,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- The rate-cap query: how many artists were attempted in the last hour.
+CREATE INDEX IF NOT EXISTS idx_release_catalog_state_attempted
+  ON release_catalog_state (last_attempted_at DESC);
+
+-- The cooldown query.
+CREATE INDEX IF NOT EXISTS idx_release_catalog_state_catalogued
+  ON release_catalog_state (last_catalogued_at DESC NULLS FIRST);
+
+DROP TRIGGER IF EXISTS trg_release_catalog_state_updated_at ON release_catalog_state;
+CREATE TRIGGER trg_release_catalog_state_updated_at
+  BEFORE UPDATE ON release_catalog_state
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- Server-only: nothing in the client needs to read crawl bookkeeping. RLS on with no
+-- policies means the service-role client (which bypasses RLS) is the only reader or writer,
+-- and anon/authenticated get nothing. Deliberate, not an oversight — same pattern as
+-- bandcamp_slug_probes.
+ALTER TABLE release_catalog_state ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE release_catalog_state IS
+  'Per-artist release-cataloging bookkeeping: cooldown, hourly rate cap, and save-over-search priority. Server-only; no RLS policies by design.';
+COMMENT ON COLUMN release_catalog_state.last_attempted_at IS
+  'Stamped before work begins, so it also acts as a claim against concurrent triggers and as the rate-cap counter.';


### PR DESCRIPTION
> **Stacked on #358** (shared safe-fetch extraction) — base is `refactor/shared-safe-fetch`, so the diff shows only this work. Merge #358 first and GitHub will retarget this to `main` automatically.

Builds an artist's release catalog when a fan **saves** them or a **search resolves** them. No bulk backfill, no scheduler — per your decisions: *"the pages are generated solely based on demand"*, save **and** search, and no cron yet.

```
save / search  →  requestArtistCatalog()  →  catalog-artist-background
                                              →  one Bandcamp /music fetch
                                              →  releases + release_sources
```

## The three guards

Search is unauthenticated and far higher volume than saving, so this isn't left open-ended:

| Guard | Value | Why |
|---|---|---|
| **Cooldown** | 7 days | Repeat searches for the same artist cost nothing upstream |
| **Hourly cap** | `searched` 60/h, `saved` 240/h | A traffic spike can't turn into us hammering Bandcamp |
| **Priority** | falls out of the two budgets | When searches are being dropped, a deliberate save still gets through |

Plus per-artist exponential backoff on consecutive failures, so a permanently broken artist isn't retried on every single search forever.

## Nothing is on a user's critical path

Both call sites pay **one HTTP handshake** to a background function (returns 202, then runs up to 15 min on its own). All gating happens *inside* that function, so a search never does a DB round trip per artist just to learn that artist was crawled last week.

This is the specific mistake the abandoned first attempt made — it did release writes inline in `persistSearchResults`, which is awaited during search, adding an estimated **0.6–1.6s to every query** after a long effort to get search down to ~1.8–3.0s.

The search hook collects artist IDs during the existing fan-out and makes **one** call afterwards, rather than one per artist.

## Details that are load-bearing

- **A bot challenge is reported distinctly from an empty catalog**, and *throws* rather than recording success. Recording "0 releases" for a blocked fetch would poison the 7-day cooldown with a confident wrong answer. This is the never-cache-uncertainty rule applied to a crawl.
- **`persistReleases` merges and never writes null over a stored value**, so a partial run can't erase artwork or a date an earlier run found. It also **skips any column listed in `curated_fields`** — that's the provenance mechanism from #356 doing its job, so a re-crawl can't revert an artist's edits.
- **Identity is `(artist_id, release_type, match_key)`, not the slug.** A slug derives from a title and moves when the title does.
- **The stored Bandcamp URL isn't trusted just because it's ours.** A claimed artist can save any http(s) URL to their profile links, so it's checked against the allowlist (*"is this really Bandcamp"*) **in addition to** `safeFetch` (*"is this safe to fetch"*). Different questions — conflating them is what produced the second-hop finding in #355.
- **Grid hrefs are confined to the host we landed on.** A stored source URL is later shown to fans as a place to buy the record, so an href out of fetched markup must not point elsewhere. Works after a custom-domain redirect, where same-host means the custom domain.
- **The background function requires a shared secret** and refuses everything when `INTERNAL_TASK_SECRET` is unset (closed, not open). The Discord background function in this repo has no auth; copying that would create an open "make Unstream crawl Bandcamp" endpoint — the exact amplifier #355 existed to close.
- **Dates are left null.** They aren't in the grid at all — one request per release — so guessing would put a fabricated date into a chronology and into subscribers' calendars. A later pass fills them in, lazily and prioritised.

## Not a job queue, deliberately

Cataloging is triggered by a user action and invoked immediately, so there's no scheduler to feed and nothing to drain. Dropping a *searched* artist at the cap is fine — the next person to search or save them triggers it again. A queue is worth adding when something needs guaranteed eventual execution; this doesn't.

## Testing

- **13 tests** on the pure mapping: bot-challenge-vs-empty, cross-host href rejection, custom-domain acceptance, same-page dedup, album-vs-single *not* merging (under-merge, never over-merge), non-Latin titles surviving, colliding slugs, and never inventing a date.
- **Migration validated** by applying it twice to a throwaway `postgres:15-alpine` container: the `last_trigger` CHECK, the rate-cap query shape, the shared `updated_at` trigger, **RLS enabled with zero policies** (server-only, deliberate), and cascade from `artists`.
- `npm run test:api` — 318 passing (20 files)
- `npm run build` — clean
- The 8 `client is possibly null` errors in `saved-artists.ts` are **pre-existing** — verified identical against `origin/main` with a stash baseline, since `api/` isn't in the build's typecheck.

## Needs from you before this does anything

**A new env var: `INTERNAL_TASK_SECRET`** (any long random string) in Netlify. Without it the feature is simply off — `requestArtistCatalog` logs and returns, and the background function refuses all requests. Nothing breaks; cataloging just never starts.

## What this does not do yet

Release pages, feeds, alert rewiring, dates/formats/prices, and Discogs/MusicBrainz. This is the data foundation those sit on — the catalog now fills in as people use the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)