### PR TITLE
Read Bandcamp release pages for dates, formats and prices

### DIFF
--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -5,7 +5,13 @@
 // points at someone else's domain, and not letting two same-slug titles in one page collide.
 
 import { describe, it, expect } from 'vitest';
-import { ingestBandcampGrid, bandcampMusicUrl } from '../release-ingest';
+import {
+  ingestBandcampGrid,
+  ingestBandcampDetail,
+  bandcampMusicUrl,
+  mapAvailability,
+  mapOfferFormat,
+} from '../release-ingest';
 
 function item(opts: { id?: string; href: string; title: string; img?: string }): string {
   return `<li ${opts.id ? `data-item-id="${opts.id}"` : ''} class="music-grid-item">
@@ -160,6 +166,202 @@ describe('ingestBandcampGrid', () => {
       PAGE_URL
     );
     expect(out).toEqual({ ok: false, reason: 'no_releases' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release pages — the date, the formats and the prices
+// ---------------------------------------------------------------------------
+
+/** A Bandcamp release page's JSON-LD, in the shape the live pages actually publish. */
+function detailPage(opts: {
+  datePublished?: string | null;
+  packages?: Array<{
+    format?: string;
+    typeName?: string;
+    price?: number | string;
+    currency?: string;
+    availability?: string;
+  }>;
+  extraScript?: string;
+}): string {
+  const graph: Record<string, unknown> = { '@type': 'MusicAlbum', name: 'A Record' };
+  if (opts.datePublished !== null) graph.datePublished = opts.datePublished ?? '06 Oct 2023 00:00:00 GMT';
+  if (opts.packages) {
+    graph.albumRelease = opts.packages.map(p => ({
+      '@type': ['MusicRelease', 'Product'],
+      musicReleaseFormat: p.format,
+      additionalProperty: [{ '@type': 'PropertyValue', name: 'type_name', value: p.typeName }],
+      offers: {
+        '@type': 'Offer',
+        price: p.price,
+        priceCurrency: p.currency ?? 'USD',
+        availability: p.availability ?? 'InStock',
+      },
+    }));
+  }
+  return `<html><head>${opts.extraScript ?? ''}
+    <script type="application/ld+json">${JSON.stringify(graph)}</script>
+  </head><body></body></html>`;
+}
+
+describe('ingestBandcampDetail', () => {
+  it('reads the date and every purchasable format', () => {
+    const out = ingestBandcampDetail(
+      detailPage({
+        datePublished: '15 Sep 2023 00:00:00 GMT',
+        packages: [
+          { format: 'DigitalFormat', typeName: 'Digital', price: 10, availability: 'OnlineOnly' },
+          { format: 'VinylFormat', typeName: '2 x Vinyl LP', price: 25 },
+          { format: 'CDFormat', typeName: 'Compact Disc (CD)', price: 12 },
+        ],
+      }),
+      new Date('2026-07-31T00:00:00Z')
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.releaseDate).toBe('2023-09-15');
+    expect(out.detail.datePrecision).toBe('day');
+    expect(out.detail.status).toBe('released');
+    expect(out.detail.offers).toEqual([
+      { format: 'digital', price: 10, currency: 'USD', availability: 'available' },
+      { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+      { format: 'cd', price: 12, currency: 'USD', availability: 'available' },
+    ]);
+  });
+
+  // One row per (source, format) is a schema constraint, and Bandcamp routinely sells several
+  // variants of one format. Quoting the deluxe box as "the price of the vinyl" would be a
+  // straightforwardly wrong number in front of someone deciding whether to buy.
+  it('collapses variants of one format to the cheapest available', () => {
+    const out = ingestBandcampDetail(
+      detailPage({
+        packages: [
+          { format: 'VinylFormat', typeName: 'Deluxe Box Set', price: 60, availability: 'SoldOut' },
+          { format: 'VinylFormat', typeName: 'Vinyl LP', price: 25, availability: 'InStock' },
+        ],
+      })
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([
+      { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+    ]);
+  });
+
+  it('keeps a sold-out format rather than dropping it', () => {
+    // A fan is better served by "vinyl — sold out" than by a page that silently omits the
+    // format, which reads as "this was never pressed".
+    const out = ingestBandcampDetail(
+      detailPage({ packages: [{ format: 'VinylFormat', price: 35, availability: 'SoldOut' }] })
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers[0].availability).toBe('sold_out');
+  });
+
+  it('treats a pre-order as announced', () => {
+    const out = ingestBandcampDetail(
+      detailPage({
+        datePublished: '01 Mar 2027 00:00:00 GMT',
+        packages: [{ format: 'VinylFormat', price: 30, availability: 'https://schema.org/PreOrder' }],
+      }),
+      new Date('2026-07-31T00:00:00Z')
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.status).toBe('announced');
+    expect(out.detail.offers[0].availability).toBe('preorder');
+  });
+
+  // Mirlo has a live release dated 2925-11-02. Unbounded, one typo sorts to the top of every
+  // chronology and lands in every calendar subscriber's feed.
+  it('refuses an implausible date instead of storing it', () => {
+    const out = ingestBandcampDetail(
+      detailPage({ datePublished: '2925-11-02' }),
+      new Date('2026-07-31T00:00:00Z')
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.releaseDate).toBeNull();
+    expect(out.detail.datePrecision).toBe('unknown');
+  });
+
+  // Standalone track pages are MusicRecording: a real date, and no offer anywhere in the
+  // JSON-LD. "No offers" here is a fact about the page, not a failure to read it.
+  it('accepts a page with a date and no offers', () => {
+    const out = ingestBandcampDetail(detailPage({ datePublished: '05 Aug 2014 00:00:00 GMT' }));
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.releaseDate).toBe('2014-08-05');
+    expect(out.detail.offers).toEqual([]);
+  });
+
+  // The distinction the rest of this codebase keeps getting wrong: an upstream that declined
+  // to answer is not an upstream that answered "nothing". Only the first should back off, and
+  // neither may be written down as "this release has no price".
+  it('separates a bot challenge from a page it could not read', () => {
+    const challenge = '<html><head><script src="/_fs-ch-abc/main.js"></script></head><body></body></html>';
+    expect(ingestBandcampDetail(challenge)).toEqual({ ok: false, reason: 'bot_challenge' });
+    expect(ingestBandcampDetail('<html><body>a real page, no structured data</body></html>')).toEqual({
+      ok: false,
+      reason: 'unreadable',
+    });
+  });
+
+  it('survives a broken JSON-LD block earlier in the page', () => {
+    const out = ingestBandcampDetail(
+      detailPage({
+        datePublished: '06 Oct 2023 00:00:00 GMT',
+        extraScript: '<script type="application/ld+json">{ not json </script>',
+      })
+    );
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.releaseDate).toBe('2023-10-06');
+  });
+});
+
+describe('mapOfferFormat', () => {
+  it('trusts musicReleaseFormat where it maps cleanly', () => {
+    expect(mapOfferFormat('DigitalFormat', 'Digital')).toBe('digital');
+    expect(mapOfferFormat('VinylFormat', '2 x Vinyl LP')).toBe('vinyl');
+    expect(mapOfferFormat('CDFormat', 'Compact Disc (CD)')).toBe('cd');
+    expect(mapOfferFormat('CassetteFormat', 'Cassette')).toBe('cassette');
+  });
+
+  // Bandcamp sells shirts and books alongside records, and schema.org has no music format for
+  // those — so the package label is the only signal left.
+  it('falls back to the package label for things schema.org has no format for', () => {
+    expect(mapOfferFormat(null, 'T-Shirt/Apparel')).toBe('merch');
+    expect(mapOfferFormat(null, 'Book/Magazine')).toBe('book');
+    expect(mapOfferFormat('OtherFormat', 'Cassette + zine')).toBe('cassette');
+  });
+
+  it('says other rather than guessing', () => {
+    expect(mapOfferFormat(null, null)).toBe('other');
+    expect(mapOfferFormat('MysteryFormat', 'Something new')).toBe('other');
+  });
+});
+
+describe('mapAvailability', () => {
+  it('maps the states Bandcamp actually publishes', () => {
+    expect(mapAvailability('InStock')).toBe('available');
+    expect(mapAvailability('OnlineOnly')).toBe('available'); // digital downloads
+    expect(mapAvailability('SoldOut')).toBe('sold_out');
+    expect(mapAvailability('PreOrder')).toBe('preorder');
+    // The "https://schema.org/…" spelling is folded by the parser, not here — the pre-order
+    // case above goes through the full path with that form.
+  });
+
+  // Optimism is the dangerous default here: telling someone a sold-out record is in stock is
+  // the one availability error that wastes their time.
+  it('leaves anything unrecognized unknown', () => {
+    expect(mapAvailability('Backordered')).toBe('unknown');
+    expect(mapAvailability(null)).toBe('unknown');
+    expect(mapAvailability('')).toBe('unknown');
   });
 });
 

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -14,19 +14,56 @@ import { timingSafeEqual } from 'crypto';
 import {
   claimArtistForCatalog,
   getArtistBandcampUrl,
+  persistReleaseDetail,
   persistReleases,
   recordCatalogOutcome,
   type CatalogTrigger,
+  type PersistedRelease,
 } from './db';
 import { isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
-import { bandcampMusicUrl, ingestBandcampGrid } from './release-ingest';
+import { bandcampMusicUrl, ingestBandcampDetail, ingestBandcampGrid } from './release-ingest';
 
 /** Ceiling on artists per invocation, so one call can't become an unbounded crawl. */
 const MAX_ARTISTS_PER_RUN = 25;
 
 /** Pause between artists. One Bandcamp request each, spaced out rather than in a burst. */
 const DELAY_BETWEEN_ARTISTS_MS = 1_000;
+
+// --- Detail-pass budgets -----------------------------------------------------
+//
+// The grid is one request for a whole discography. Dates, formats and prices are one request
+// *per release*, and they're the data the feature actually rests on, so the pass has to happen
+// — but a blanket sweep of ~800 artists × ~20 releases would be 16,000 requests, which is a
+// crawl programme, not a parser change. Four limits keep it a trickle:
+
+/** Newest-first, so a large discography gets its recent releases priced on the first run. */
+const MAX_DETAIL_FETCHES_PER_ARTIST = 20;
+
+/** Invocation-wide, so a 25-artist batch can't multiply into hundreds of requests. */
+const MAX_DETAIL_FETCHES_PER_RUN = 100;
+
+/** Roughly one request per second sustained — far below what one browser page load costs. */
+const DELAY_BETWEEN_DETAIL_FETCHES_MS = 1_000;
+
+/**
+ * Stop starting detail fetches this long into the invocation. Netlify background functions get
+ * 15 minutes; leaving headroom means a run ends by finishing rather than by being killed
+ * mid-write.
+ */
+const DETAIL_BUDGET_MS = 9 * 60_000;
+
+/**
+ * Re-read a release page after this long. Prices change and vinyl sells out, so an offer is a
+ * claim with an age — but re-reading weekly would triple the crawl for data that rarely moves.
+ */
+const DETAIL_REFRESH_DAYS = 30;
+
+/** What's left of the invocation's detail allowance. Shared across every artist in the batch. */
+interface DetailBudget {
+  fetchesLeft: number;
+  deadline: number;
+}
 
 function isAuthorized(header: string | undefined): boolean {
   // Reuses the secret this repo already has for internal function-to-function calls
@@ -87,6 +124,10 @@ export async function handler(event: {
 
   let catalogued = 0;
   let skipped = 0;
+  const budget: DetailBudget = {
+    fetchesLeft: MAX_DETAIL_FETCHES_PER_RUN,
+    deadline: Date.now() + DETAIL_BUDGET_MS,
+  };
 
   for (const [index, artistId] of artistIds.entries()) {
     // Cooldown, hourly cap and claim all happen here rather than at the call site, so the
@@ -99,7 +140,7 @@ export async function handler(event: {
     if (index > 0) await sleep(DELAY_BETWEEN_ARTISTS_MS);
 
     try {
-      const found = await catalogArtist(artistId);
+      const found = await catalogArtist(artistId, budget);
       if (found === null) {
         skipped++;
       } else {
@@ -121,7 +162,7 @@ export async function handler(event: {
  *
  * @throws on a genuine failure, so the caller records it against the backoff counter.
  */
-async function catalogArtist(artistId: string): Promise<number | null> {
+async function catalogArtist(artistId: string, budget: DetailBudget): Promise<number | null> {
   const storedUrl = await getArtistBandcampUrl(artistId);
   if (!storedUrl) {
     await recordCatalogOutcome(artistId, { error: 'no bandcamp link stored' });
@@ -147,8 +188,9 @@ async function catalogArtist(artistId: string): Promise<number | null> {
   if (!response) throw new Error('fetch refused or too many redirects');
   if (!response.ok) throw new Error(`bandcamp responded ${response.status}`);
 
+  const landedUrl = response.url || musicUrl;
   const html = await response.text();
-  const outcome = ingestBandcampGrid(html, response.url || musicUrl);
+  const outcome = ingestBandcampGrid(html, landedUrl);
 
   if (!outcome.ok) {
     // A bot challenge is the upstream declining to answer, not an artist with no releases.
@@ -161,8 +203,121 @@ async function catalogArtist(artistId: string): Promise<number | null> {
   }
 
   const written = await persistReleases(artistId, outcome.releases);
-  await recordCatalogOutcome(artistId, { releasesFound: written });
-  return written;
+  const detailed = await catalogDetails(written, landedUrl, budget);
+
+  await recordCatalogOutcome(artistId, {
+    releasesFound: written.length,
+    releasesDetailed: detailed,
+  });
+  return written.length;
+}
+
+/**
+ * Read individual release pages for dates, formats and prices.
+ *
+ * This is where the differentiator's data comes from — *"vinyl $25 · CD $12 · digital $10, ≈$21
+ * to the artist"* exists nowhere in the grid — so it can't be skipped, and it can't be
+ * unbounded either. It's the one part of ingest whose cost scales with catalog size rather
+ * than artist count.
+ *
+ * Returns how many pages were read successfully. Never throws: a release page failing is not a
+ * reason to fail the artist's whole catalog, which is already written by this point.
+ */
+async function catalogDetails(
+  releases: PersistedRelease[],
+  landedUrl: string,
+  budget: DetailBudget
+): Promise<number> {
+  const due = releases.filter(needsDetail).slice(0, MAX_DETAIL_FETCHES_PER_ARTIST);
+  if (due.length === 0) return 0;
+
+  let landedHost: string;
+  try {
+    landedHost = new URL(landedUrl).host;
+  } catch {
+    return 0;
+  }
+
+  let read = 0;
+  let attempted = 0;
+
+  for (const release of due) {
+    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+      // Said out loud rather than returning quietly: a silent cap reads as "we checked
+      // everything and there were no prices", which is the wrong conclusion to hand anyone
+      // looking at why a release page is bare.
+      console.log(`[catalog] detail budget spent — ${due.length - attempted} release(s) left for a later run`);
+      break;
+    }
+
+    if (!isFetchableReleaseUrl(release.url, landedHost)) {
+      console.warn(`[catalog] skipped release url: ${safeHostname(release.url)}`);
+      continue;
+    }
+
+    // Spacing is per *request*, so a run of failures doesn't turn into a burst.
+    if (attempted > 0) await sleep(DELAY_BETWEEN_DETAIL_FETCHES_MS);
+    attempted++;
+    budget.fetchesLeft--;
+
+    try {
+      const detailResponse = await safeFetch(release.url, 10_000);
+      if (!detailResponse?.ok) continue;
+
+      const outcome = ingestBandcampDetail(await detailResponse.text());
+      if (!outcome.ok) {
+        // A challenge means every subsequent request in this run is likely to be challenged
+        // too. Stop asking rather than burning the budget being refused, and leave
+        // detail_checked_at unset so these releases are retried.
+        if (outcome.reason === 'bot_challenge') {
+          console.warn('[catalog] bandcamp bot challenge on a release page — stopping detail pass');
+          break;
+        }
+        console.warn(`[catalog] unreadable release page: ${safeHostname(release.url)}`);
+        continue;
+      }
+
+      if (await persistReleaseDetail(release, outcome.detail)) read++;
+    } catch (error) {
+      console.warn(
+        `[catalog] detail fetch failed for ${safeHostname(release.url)}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  return read;
+}
+
+/**
+ * May we fetch this stored release URL?
+ *
+ * Two ways to qualify, because there are two ways a legitimate release URL arises:
+ *
+ * - **Same host as the page we just read.** A URL parsed out of this run's grid, which is how
+ *   Bandcamp Pro custom domains (`music.sufjan.com`) get in at all — they're nowhere near the
+ *   outbound allowlist, and their legitimacy comes from Bandcamp having redirected us there.
+ * - **On the allowlist.** A row stored by an earlier run, from before the artist moved to a
+ *   custom domain. Without this the host check would refuse those rows forever and their
+ *   prices would never be read.
+ *
+ * Neither answers "is this safe to fetch" — `safeFetch` does that separately, on every
+ * redirect hop. Three different questions, deliberately not collapsed into one.
+ */
+function isFetchableReleaseUrl(url: string, landedHost: string): boolean {
+  try {
+    if (new URL(url).host === landedHost) return true;
+  } catch {
+    return false;
+  }
+  return isUrlHostnameAllowed(url);
+}
+
+/** Never read, or read long enough ago that its prices are worth refreshing. */
+function needsDetail(release: PersistedRelease): boolean {
+  if (!release.detailCheckedAt) return true;
+  const age = Date.now() - new Date(release.detailCheckedAt).getTime();
+  return age > DETAIL_REFRESH_DAYS * 24 * 3600_000;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -471,7 +471,7 @@ export async function claimArtistForCatalog(
 /** Record the outcome of a catalog run. Failures increment the backoff counter. */
 export async function recordCatalogOutcome(
   artistId: string,
-  outcome: { releasesFound: number } | { error: string }
+  outcome: { releasesFound: number; releasesDetailed?: number } | { error: string }
 ): Promise<void> {
   const client = getClient();
   if (!client) return;
@@ -482,6 +482,7 @@ export async function recordCatalogOutcome(
       : {
           last_catalogued_at: new Date().toISOString(),
           releases_found: outcome.releasesFound,
+          releases_detailed: outcome.releasesDetailed ?? 0,
           consecutive_failures: 0,
           last_error: null,
         };
@@ -522,6 +523,21 @@ interface ReleaseToPersist {
 }
 
 /**
+ * A release row and its source after a write, which is what the detail pass needs to decide
+ * whether to spend a request on this release's own page.
+ */
+export interface PersistedRelease {
+  releaseId: string;
+  sourceId: string;
+  /** The release page for this source — where the date, formats and prices live. */
+  url: string;
+  /** When that page was last read. Null means never. */
+  detailCheckedAt: string | null;
+  /** Columns on the release row a verified artist has authored. Ingest leaves these alone. */
+  curatedFields: string[];
+}
+
+/**
  * Write a catalog run's releases, merging rather than replacing.
  *
  * Three rules that matter more than they look:
@@ -535,14 +551,16 @@ interface ReleaseToPersist {
  *    artist authored; ingest re-runs forever, so without this every crawl silently reverts
  *    their corrections.
  *
- * Returns the number of releases written or updated.
+ * Returns the releases written or updated, in the order they were given — which for a
+ * Bandcamp grid is newest first, so a budgeted detail pass reading the front of the list
+ * spends its requests on the releases a fan is most likely to be looking at.
  */
 export async function persistReleases(
   artistId: string,
   releases: ReleaseToPersist[]
-): Promise<number> {
+): Promise<PersistedRelease[]> {
   const client = getClient();
-  if (!client || releases.length === 0) return 0;
+  if (!client || releases.length === 0) return [];
 
   try {
     const { data: existingRows, error: readError } = await client
@@ -552,7 +570,7 @@ export async function persistReleases(
 
     if (readError) {
       console.error('[DB] persistReleases read failed:', readError.message);
-      return 0;
+      return [];
     }
 
     type ExistingRow = {
@@ -568,7 +586,7 @@ export async function persistReleases(
     const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
 
-    let written = 0;
+    const written: PersistedRelease[] = [];
 
     for (const release of releases) {
       const identity = `${release.releaseType}:${release.matchKey}`;
@@ -637,29 +655,145 @@ export async function persistReleases(
         });
       }
 
-      const { error: sourceError } = await client.from('release_sources').upsert(
-        {
-          release_id: releaseId,
-          platform: release.source.platform,
-          url: release.source.url,
-          external_id: release.source.externalId,
-          last_seen_at: new Date().toISOString(),
-        },
-        { onConflict: 'release_id,platform' }
-      );
+      // detail_checked_at is read back rather than written: it belongs to the detail pass, and
+      // a grid re-crawl must not reset it or every crawl would re-fetch every release page.
+      const { data: sourceRow, error: sourceError } = await client
+        .from('release_sources')
+        .upsert(
+          {
+            release_id: releaseId,
+            platform: release.source.platform,
+            url: release.source.url,
+            external_id: release.source.externalId,
+            last_seen_at: new Date().toISOString(),
+          },
+          { onConflict: 'release_id,platform' }
+        )
+        .select('id, url, detail_checked_at')
+        .single();
 
-      if (sourceError) {
-        console.error('[DB] persistReleases source upsert failed:', sourceError.message);
+      if (sourceError || !sourceRow) {
+        console.error('[DB] persistReleases source upsert failed:', sourceError?.message);
         continue;
       }
 
-      written++;
+      const source = sourceRow as { id: string; url: string; detail_checked_at: string | null };
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields: [...curated],
+      });
     }
 
     return written;
   } catch (error) {
     console.error('[DB] persistReleases error:', error);
-    return 0;
+    return [];
+  }
+}
+
+interface DetailToPersist {
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  offers: Array<{
+    format: string;
+    price: number | null;
+    currency: string | null;
+    availability: string;
+  }>;
+}
+
+/**
+ * Write what a release's own page told us: its date, and what you can buy there.
+ *
+ * The order of operations is the interesting part. Offers are written **before** stale ones
+ * are pruned, and `detail_checked_at` is stamped **last**:
+ *
+ * - Writing before pruning means a failure part-way through leaves the old offers in place
+ *   rather than an empty offer list. This project has already destroyed an artist's links
+ *   once with a delete-before-a-fallible-write (PR #350); an empty release page is the same
+ *   shape of mistake.
+ * - Pruning only happens when the page actually offered something. Zero offers is the normal
+ *   state of a standalone track page, so treating it as "everything was withdrawn" would
+ *   erase real prices.
+ * - Stamping last means an interrupted run is retried next cycle instead of being recorded as
+ *   done.
+ *
+ * Returns false when nothing could be written, so the caller can count it as a failure.
+ */
+export async function persistReleaseDetail(
+  release: PersistedRelease,
+  detail: DetailToPersist
+): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    // A date the artist authored outranks anything upstream says, and status is derived from
+    // the date, so a curated date takes both columns out of ingest's hands.
+    if (!release.curatedFields.includes('release_date')) {
+      const patch: Record<string, unknown> = { status: detail.status };
+      if (detail.releaseDate) {
+        patch.release_date = detail.releaseDate;
+        patch.date_precision = detail.datePrecision;
+      }
+
+      const { error } = await client.from('releases').update(patch).eq('id', release.releaseId);
+      if (error) {
+        console.error('[DB] persistReleaseDetail release update failed:', error.message);
+        return false;
+      }
+    }
+
+    if (detail.offers.length > 0) {
+      const capturedAt = new Date().toISOString();
+      const { error: offerError } = await client.from('release_offers').upsert(
+        detail.offers.map(offer => ({
+          release_source_id: release.sourceId,
+          format: offer.format,
+          price: offer.price,
+          currency: offer.currency,
+          availability: offer.availability,
+          captured_at: capturedAt,
+        })),
+        { onConflict: 'release_source_id,format' }
+      );
+
+      if (offerError) {
+        console.error('[DB] persistReleaseDetail offer upsert failed:', offerError.message);
+        return false;
+      }
+
+      const { error: pruneError } = await client
+        .from('release_offers')
+        .delete()
+        .eq('release_source_id', release.sourceId)
+        .not('format', 'in', `(${detail.offers.map(o => o.format).join(',')})`);
+
+      // A failed prune leaves a stale format listed, which is worth logging but not worth
+      // failing the whole detail write over — the prices we did just refresh are still good.
+      if (pruneError) {
+        console.error('[DB] persistReleaseDetail offer prune failed:', pruneError.message);
+      }
+    }
+
+    const { error: stampError } = await client
+      .from('release_sources')
+      .update({ detail_checked_at: new Date().toISOString() })
+      .eq('id', release.sourceId);
+
+    if (stampError) {
+      console.error('[DB] persistReleaseDetail stamp failed:', stampError.message);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('[DB] persistReleaseDetail error:', error);
+    return false;
   }
 }
 

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -7,14 +7,19 @@
 
 import {
   parseBandcampGridReleases,
+  parseBandcampReleaseDetail,
   isBandcampChallenge,
+  type BandcampDetailOffer,
   type BandcampGridRelease,
 } from './search-parsers';
 import {
   deriveStatus,
   mapReleaseType,
+  parseReleaseDate,
   releaseMatchKey,
   uniqueReleaseSlug,
+  type DatePrecision,
+  type ReleaseStatus,
   type ReleaseType,
 } from './release-utils';
 
@@ -105,6 +110,168 @@ export function ingestBandcampGrid(html: string, pageUrl: string, now: Date = ne
 
   if (releases.length === 0) return { ok: false, reason: 'no_releases' };
   return { ok: true, releases };
+}
+
+// ---------------------------------------------------------------------------
+// Release pages — dates, formats, prices
+// ---------------------------------------------------------------------------
+
+/** Formats `release_offers.format` accepts. */
+export type OfferFormat = 'digital' | 'vinyl' | 'cassette' | 'cd' | 'book' | 'merch' | 'other';
+
+/** States `release_offers.availability` accepts. */
+export type OfferAvailability = 'available' | 'preorder' | 'sold_out' | 'unknown';
+
+export interface IngestedOffer {
+  format: OfferFormat;
+  price: number | null;
+  currency: string | null;
+  availability: OfferAvailability;
+}
+
+/** Everything a release page adds to what the grid already gave us. */
+export interface IngestedDetail {
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  offers: IngestedOffer[];
+}
+
+export type DetailOutcome =
+  | { ok: true; detail: IngestedDetail }
+  | { ok: false; reason: 'bot_challenge' | 'unreadable' };
+
+/**
+ * Map a Bandcamp release page into the date and offers for one release.
+ *
+ * Same two-failure discipline as the grid ingest: a bot challenge is the upstream declining
+ * to answer and must back off, while an unreadable page is a parse problem worth reporting —
+ * neither may be written down as "this release has no price".
+ */
+export function ingestBandcampDetail(html: string, now: Date = new Date()): DetailOutcome {
+  if (isBandcampChallenge(html)) return { ok: false, reason: 'bot_challenge' };
+
+  const detail = parseBandcampReleaseDetail(html);
+  if (!detail) return { ok: false, reason: 'unreadable' };
+
+  const { date, precision } = parseReleaseDate(detail.datePublished, now);
+  const offers = aggregateOffers(detail.offers);
+
+  return {
+    ok: true,
+    detail: {
+      releaseDate: date,
+      datePrecision: precision,
+      status: deriveStatus(date, offers.some(o => o.availability === 'preorder'), now),
+      offers,
+    },
+  };
+}
+
+/**
+ * Collapse a page's packages into one offer per format.
+ *
+ * `release_offers` is unique on `(release_source_id, format)`, and Bandcamp routinely sells
+ * several packages of the same format — a standard LP and a coloured variant, a CD and a CD
+ * bundled with a shirt. Rather than pick arbitrarily, keep the **cheapest** price and the
+ * **most available** state across the variants, which is what "vinyl from $25, in stock"
+ * honestly means. Picking the first entry instead would quote a $60 deluxe box as the price
+ * of the record.
+ */
+function aggregateOffers(raw: BandcampDetailOffer[]): IngestedOffer[] {
+  const byFormat = new Map<OfferFormat, IngestedOffer>();
+
+  for (const offer of raw) {
+    const format = mapOfferFormat(offer.format, offer.typeName);
+    const availability = mapAvailability(offer.availability);
+    const existing = byFormat.get(format);
+
+    if (!existing) {
+      byFormat.set(format, { format, price: offer.price, currency: offer.currency, availability });
+      continue;
+    }
+
+    // A missing price loses to a real one; between two real prices the lower wins.
+    if (offer.price !== null && (existing.price === null || offer.price < existing.price)) {
+      existing.price = offer.price;
+      existing.currency = offer.currency;
+    }
+    if (AVAILABILITY_RANK[availability] > AVAILABILITY_RANK[existing.availability]) {
+      existing.availability = availability;
+    }
+  }
+
+  return [...byFormat.values()];
+}
+
+/** Higher wins when variants of one format disagree. Something buyable beats something not. */
+const AVAILABILITY_RANK: Record<OfferAvailability, number> = {
+  available: 3,
+  preorder: 2,
+  sold_out: 1,
+  unknown: 0,
+};
+
+const SCHEMA_FORMATS: Record<string, OfferFormat> = {
+  digitalformat: 'digital',
+  vinylformat: 'vinyl',
+  cdformat: 'cd',
+  cassetteformat: 'cassette',
+};
+
+/**
+ * Which of our formats is this package?
+ *
+ * `musicReleaseFormat` is the authority where it maps cleanly. Bandcamp also sells shirts,
+ * books and bundles, which arrive as formats schema.org has no music equivalent for — so
+ * where the format is unrecognized we read Bandcamp's own package label instead. Anything
+ * still unidentified becomes 'other' rather than being guessed into 'digital': a fan told
+ * "digital $30" about a t-shirt is worse served than one told "other $30".
+ */
+export function mapOfferFormat(
+  schemaFormat: string | null | undefined,
+  typeName: string | null | undefined
+): OfferFormat {
+  const mapped = schemaFormat ? SCHEMA_FORMATS[schemaFormat.toLowerCase().trim()] : undefined;
+  if (mapped) return mapped;
+
+  const label = (typeName ?? '').toLowerCase();
+  if (!label) return 'other';
+
+  if (label.includes('vinyl') || label.includes(' lp')) return 'vinyl';
+  if (label.includes('cassette')) return 'cassette';
+  if (label.includes('compact disc') || /\bcd\b/.test(label)) return 'cd';
+  if (label.includes('book') || label.includes('zine')) return 'book';
+  if (label.includes('shirt') || label.includes('poster') || label.includes('merch')) return 'merch';
+  if (label.includes('digital')) return 'digital';
+
+  return 'other';
+}
+
+/**
+ * schema.org availability onto ours.
+ *
+ * `OnlineOnly` is what Bandcamp uses for a digital download — it means buyable, not
+ * restricted. An unrecognized value stays 'unknown' rather than optimistically 'available':
+ * telling a fan a sold-out record is in stock is the failure that matters here.
+ */
+export function mapAvailability(raw: string | null | undefined): OfferAvailability {
+  switch ((raw ?? '').toLowerCase().trim()) {
+    case 'instock':
+    case 'onlineonly':
+    case 'instoreonly':
+    case 'limitedavailability':
+      return 'available';
+    case 'preorder':
+    case 'presale':
+      return 'preorder';
+    case 'soldout':
+    case 'outofstock':
+    case 'discontinued':
+      return 'sold_out';
+    default:
+      return 'unknown';
+  }
 }
 
 /**

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -438,6 +438,140 @@ function artworkFrom(item: HTMLElement): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Bandcamp release pages — the date, the formats and the prices
+// ---------------------------------------------------------------------------
+
+/** One purchasable package on a Bandcamp release page, as the page states it. */
+export interface BandcampDetailOffer {
+  /** schema.org `musicReleaseFormat` with any URL prefix stripped: "VinylFormat", "CDFormat". */
+  format: string | null;
+  /** Bandcamp's own label for the package: "Digital", "2 x Vinyl LP", "Compact Disc (CD)". */
+  typeName: string | null;
+  price: number | null;
+  /** ISO 4217, as given. */
+  currency: string | null;
+  /** schema.org `ItemAvailability`, prefix stripped: "InStock", "SoldOut", "PreOrder". */
+  availability: string | null;
+}
+
+export interface BandcampReleaseDetail {
+  /**
+   * Exactly as the page writes it — "06 Oct 2023 00:00:00 GMT". Left unparsed here so the
+   * sanity bounds live in one place (`parseReleaseDate` in release-utils).
+   */
+  datePublished: string | null;
+  offers: BandcampDetailOffer[];
+}
+
+/**
+ * Read a Bandcamp release page's date and purchase options.
+ *
+ * This is the data the whole Releases feature rests on — *"vinyl $25 · CD $12 · digital $10"* —
+ * and it exists **only** here. The `/music` grid carries identity and artwork but no dates,
+ * formats or prices at all, so a catalog with offers costs one request per release. Nothing
+ * about that is avoidable; it's why the detail pass is budgeted rather than a blanket sweep.
+ *
+ * Read from the page's `application/ld+json` block, not the `data-tralbum` attribute that
+ * also sits in the markup. The tralbum blob is richer (it has stock counts) but it is
+ * Bandcamp's private page state, whereas the JSON-LD is a documented schema.org graph the
+ * site publishes *for machines to read* — a stabler contract, and one we're plainly invited
+ * to use. Where the two disagree in coverage we take the smaller honest answer: see the
+ * standalone-track note below.
+ *
+ * Returns null when there's no usable JSON-LD, which callers must not confuse with "this
+ * release has no offers" — one is us failing to read the page, the other is a fact about
+ * the release.
+ */
+export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail | null {
+  const graph = firstLdJsonWith(html, node => 'datePublished' in node || 'albumRelease' in node);
+  if (!graph) return null;
+
+  const datePublished = typeof graph.datePublished === 'string' ? graph.datePublished : null;
+
+  // Albums list every package (digital, vinyl, CD, cassette, merch) as an `albumRelease`
+  // entry, each with its own `offers`. Standalone track pages are `MusicRecording` and carry
+  // a date but no offers at all — their price lives only in the tralbum blob, and without a
+  // currency beside it. A price with a guessed currency is worse than no price, so a single
+  // ingests its date and no offer.
+  const releases = Array.isArray(graph.albumRelease) ? graph.albumRelease : [];
+  const offers: BandcampDetailOffer[] = [];
+
+  for (const entry of releases) {
+    if (!isRecord(entry)) continue;
+    for (const offer of asArray(entry.offers)) {
+      if (!isRecord(offer)) continue;
+      offers.push({
+        format: stripSchemaPrefix(entry.musicReleaseFormat),
+        typeName: additionalProperty(entry.additionalProperty, 'type_name'),
+        price: asPrice(offer.price),
+        currency: typeof offer.priceCurrency === 'string' ? offer.priceCurrency.toUpperCase() : null,
+        availability: stripSchemaPrefix(offer.availability),
+      });
+    }
+  }
+
+  return { datePublished, offers };
+}
+
+/** First JSON-LD object in the page that satisfies `predicate`. Malformed blocks are skipped. */
+function firstLdJsonWith(
+  html: string,
+  predicate: (node: Record<string, unknown>) => boolean
+): Record<string, unknown> | null {
+  const root = parse(html);
+  for (const script of root.querySelectorAll('script[type="application/ld+json"]')) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(script.textContent ?? '');
+    } catch {
+      continue; // a broken block on the page is not a reason to give up on the page
+    }
+    for (const node of asArray(parsed)) {
+      if (isRecord(node) && predicate(node)) return node;
+    }
+  }
+  return null;
+}
+
+/**
+ * "https://schema.org/InStock" and "InStock" mean the same thing, and JSON-LD publishers use
+ * both forms interchangeably. Fold them so callers match on one spelling.
+ */
+function stripSchemaPrefix(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/^https?:\/\/schema\.org\//, '');
+}
+
+/** Value of a named entry in a schema.org `additionalProperty` list. */
+function additionalProperty(list: unknown, name: string): string | null {
+  for (const entry of asArray(list)) {
+    if (!isRecord(entry)) continue;
+    if (entry.name === name && (typeof entry.value === 'string' || typeof entry.value === 'number')) {
+      return String(entry.value);
+    }
+  }
+  return null;
+}
+
+/** Prices arrive as numbers here, but JSON-LD permits strings, so accept both. */
+function asPrice(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** JSON-LD lets any property be a single value or an array of them. */
+function asArray(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+// ---------------------------------------------------------------------------
 // Bandwagon
 // ---------------------------------------------------------------------------
 

--- a/scripts/ingest-releases.ts
+++ b/scripts/ingest-releases.ts
@@ -6,9 +6,15 @@
  *   npx tsx scripts/ingest-releases.ts sufjanstevens
  *   npx tsx scripts/ingest-releases.ts https://music.sufjan.com/music
  *   npx tsx scripts/ingest-releases.ts sufjanstevens --json
+ *   npx tsx scripts/ingest-releases.ts sufjanstevens --detail      (newest 3 release pages)
+ *   npx tsx scripts/ingest-releases.ts sufjanstevens --detail=10
  *
  * Exercises the whole ingest path that matters — fetch (with the same SSRF-safe fetcher
  * production uses), parse, and map to release rows — and prints what *would* be written.
+ *
+ * `--detail` additionally reads individual release pages, which is where dates, formats and
+ * prices live. It costs one request per release, so it's opt-in and capped low here; in
+ * production the same pass is metered by budgets in catalog-artist-background.ts.
  *
  * DRY RUN ONLY, DELIBERATELY. There is no --write flag, because .env points at the
  * production Supabase: a local write path would mean a laptop writing real `releases` rows,
@@ -28,11 +34,16 @@ config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
 
 const { safeFetch } = await import('../api/functions/safe-fetch.js');
 const { isUrlHostnameAllowed } = await import('../api/functions/middleware.js');
-const { ingestBandcampGrid, bandcampMusicUrl } = await import('../api/functions/release-ingest.js');
+const { ingestBandcampGrid, ingestBandcampDetail, bandcampMusicUrl } =
+  await import('../api/functions/release-ingest.js');
 
 const args = process.argv.slice(2);
 const asJson = args.includes('--json');
 const target = args.find(a => !a.startsWith('--'));
+
+/** How many release pages to read. 0 = none, which is the default: they cost a request each. */
+const detailArg = args.find(a => a === '--detail' || a.startsWith('--detail='));
+const detailCount = !detailArg ? 0 : Number(detailArg.split('=')[1] ?? 3) || 3;
 
 if (!target) {
   console.error('Usage: npx tsx scripts/ingest-releases.ts <bandcamp-url-or-slug> [--json]');
@@ -83,8 +94,30 @@ if (!outcome.ok) {
   process.exit(2);
 }
 
+/**
+ * Read individual release pages for date, formats and prices — the same pass production runs,
+ * with the same fetcher and the same mapping, just capped at a handful of pages.
+ */
+async function readDetails(urls: string[]) {
+  const results: Array<{ url: string; detail: unknown }> = [];
+  for (const [index, url] of urls.entries()) {
+    if (index > 0) await new Promise(r => setTimeout(r, 1_000)); // be a good neighbour
+    const res = await safeFetch(url, 15_000);
+    if (!res?.ok) {
+      results.push({ url, detail: { error: res ? `HTTP ${res.status}` : 'fetch refused' } });
+      continue;
+    }
+    const detailOutcome = ingestBandcampDetail(await res.text());
+    results.push({ url, detail: detailOutcome.ok ? detailOutcome.detail : { error: detailOutcome.reason } });
+  }
+  return results;
+}
+
+const detailUrls = outcome.releases.slice(0, detailCount).map(r => r.source.url);
+
 if (asJson) {
-  console.log(JSON.stringify({ landedUrl, releases: outcome.releases }, null, 2));
+  const details = detailUrls.length > 0 ? await readDetails(detailUrls) : undefined;
+  console.log(JSON.stringify({ landedUrl, releases: outcome.releases, details }, null, 2));
   process.exit(0);
 }
 
@@ -105,5 +138,31 @@ for (const r of outcome.releases) {
 const missingArt = outcome.releases.filter(r => !r.artworkUrl).length;
 const missingId = outcome.releases.filter(r => !r.source.externalId).length;
 console.log(`\nsummary: ${outcome.releases.length} releases, ${missingArt} without artwork, ${missingId} without a stable id`);
-console.log('note: release dates are always null here — they live on individual release pages,');
-console.log('      at one extra request each, so grid ingest deliberately does not guess them.\n');
+
+if (detailUrls.length === 0) {
+  console.log('note: release dates are always null above — they live on individual release pages,');
+  console.log('      at one extra request each. Pass --detail to read the newest few.\n');
+} else {
+  console.log(`\nReading ${detailUrls.length} release page(s) for dates, formats and prices …\n`);
+  for (const { url, detail } of await readDetails(detailUrls)) {
+    console.log(url.replace(/^https?:\/\//, ''));
+    const d = detail as { releaseDate?: string | null; datePrecision?: string; status?: string;
+      offers?: Array<{ format: string; price: number | null; currency: string | null; availability: string }>;
+      error?: string };
+    if (d.error) {
+      console.log(`  could not read: ${d.error}\n`);
+      continue;
+    }
+    console.log(`  date: ${d.releaseDate ?? 'none'} (${d.datePrecision}) · status: ${d.status}`);
+    if (!d.offers?.length) {
+      // Expected on standalone tracks: their page has a date but no offer in its JSON-LD.
+      console.log('  offers: none listed\n');
+      continue;
+    }
+    for (const o of d.offers) {
+      const price = o.price === null ? 'no price' : `${o.price} ${o.currency ?? ''}`.trim();
+      console.log(`  ${o.format.padEnd(9)} ${price.padEnd(12)} ${o.availability}`);
+    }
+    console.log('');
+  }
+}

--- a/supabase/migrations/20260731210000_release-source-detail-checked.sql
+++ b/supabase/migrations/20260731210000_release-source-detail-checked.sql
@@ -1,0 +1,36 @@
+-- Migration: release_sources.detail_checked_at
+--
+-- Records when we last read a release's own page for its date, formats and prices.
+--
+-- The `/music` grid gives identity and artwork for a whole discography in one request but
+-- carries no dates, formats or prices at all — those exist only on individual release pages,
+-- at one request each. So the detail pass is metered, and it needs to know two things the
+-- rest of the schema can't tell it:
+--
+--   1. Which releases have never been read, so a bounded run can pick up where the last one
+--      stopped instead of re-reading the same newest few forever.
+--   2. Which were read long enough ago to be worth re-reading. Prices change and vinyl sells
+--      out; an offer is a claim with an age, not a fact.
+--
+-- Why not infer it from `releases.release_date IS NULL`: a standalone track page legitimately
+-- has a date and no offer, and plenty of releases have a date from the grid-era rows that
+-- predate this column. Inferring would re-fetch those every cycle and never converge.
+
+ALTER TABLE release_sources
+  ADD COLUMN IF NOT EXISTS detail_checked_at timestamptz;
+
+COMMENT ON COLUMN release_sources.detail_checked_at IS
+  'When this source''s own release page was last read for date/formats/prices. NULL means never. Drives both the initial detail pass and offer-freshness refresh.';
+
+-- Observability for the detail pass, beside the grid pass's own count.
+--
+-- These two numbers fail independently and for different reasons: the grid can parse fine
+-- while every release page returns a bot challenge, which shows up as releases_found = 20 and
+-- releases_detailed = 0. Without the second number that reads as a healthy run, and the
+-- symptom a fan sees — release pages with no prices on them — has no signal behind it.
+
+ALTER TABLE release_catalog_state
+  ADD COLUMN IF NOT EXISTS releases_detailed integer;
+
+COMMENT ON COLUMN release_catalog_state.releases_detailed IS
+  'Release pages successfully read for date/formats/prices in the last run. Much lower than releases_found is expected (the pass is budgeted); zero across many runs is a failure.';


### PR DESCRIPTION
Step 3 landed the catalog with identity and artwork only: Bandcamp's `/music` grid carries **no dates, formats or prices**, so every release stored so far has `release_date = null` and an empty `release_offers`. The differentiator the whole feature rests on — *"vinyl $25 · CD $12 · digital $10, and roughly this much reaches the artist"* — had a schema and no data. This closes that, and it belongs before the release page rather than after it.

## What it does

- **`parseBandcampReleaseDetail`** reads the release page's `application/ld+json` — the documented schema.org graph Bandcamp publishes for machines — rather than the private `data-tralbum` blob sitting next to it in the markup. Stabler contract, and one we're plainly invited to read.
- **`ingestBandcampDetail`** maps it to a sanity-bounded date, one offer per format, an availability state, and a pre-order becoming `announced`.
- **Variants of one format collapse to the cheapest available.** `release_offers` is unique on `(source, format)` and Bandcamp routinely sells a standard LP and a £60 deluxe box. Quoting the box as "the price of the vinyl" is a wrong number in front of someone deciding whether to buy.
- **Sold-out formats are kept, not dropped.** "Vinyl — sold out" serves a fan better than a page that silently omits the format, which reads as "never pressed".

## The crawl budget

This is the one part of ingest whose cost scales with catalog size rather than artist count, so it's metered rather than swept: newest-first, **20 pages per artist**, **100 per invocation**, ~**1 request/second**, and a **9-minute deadline** inside the 15-minute background function. Offers refresh after **30 days** — prices change and vinyl sells out, but re-reading weekly would triple the crawl for data that rarely moves. When the budget runs out it says so in the log; a silent cap reads as *"we checked and there were no prices"*.

`release_sources.detail_checked_at` (new column) records what's been read, so a bounded run resumes where the last one stopped instead of re-reading the same newest few forever.

## Failure modes, kept apart

A bot challenge on a release page stops the pass and leaves `detail_checked_at` unset so those releases retry; an unreadable page is logged and skipped; **neither is ever written down as "this release has no price"**. `release_catalog_state.releases_detailed` (new column) sits beside `releases_found` because the two fail independently — a grid can parse perfectly while every release page is challenged, and without the second number that looks like a healthy run.

## Write safety

Upsert offers → prune formats no longer offered → stamp `detail_checked_at`, in that order and never delete-first (PR #350's lesson). Pruning only runs when the page offered *something*: zero offers is the normal state of a standalone track page, not a withdrawal. A curated release date takes both the date and the derived status out of ingest's hands.

## Verified against live pages

`npm run ingest:try -- explosionsinthesky --detail=3` — real fetch, real parse, no writes:

```
explosionsinthesky.bandcamp.com/album/end
  date: 2023-09-15 (day) · status: released
  digital   10 USD       available
  vinyl     25 USD       available
  cd        12 USD       available

explosionsinthesky.bandcamp.com/album/how-strange-innocence-anniversary-edition
  date: 2019-08-16 (day) · status: released
  digital   10 USD       available
  vinyl     35 USD       sold_out
```

Robots checked: `/album/` is permitted on both `bandcamp.com` and artist subdomains; only `/search`, `/api/`, `/stream`, `/cart/` and friends are disallowed.

## Testing

26 tests on the ingest path (11 new), 353 across `api/functions`. Full `npm run build` green.

Nothing is user-visible yet — this fills the tables the release page will read.