### PR TITLE
Quote the MusicBrainz artist query as a Lucene phrase

### DIFF
--- a/api/functions/__tests__/musicbrainz-artist-query.test.ts
+++ b/api/functions/__tests__/musicbrainz-artist-query.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+// The bug this guards: MusicBrainz is Lucene-backed, and the artist search used to send
+// an unquoted field term — `artist:viagra boys`. Lucene reads that as `artist:viagra` OR
+// a bare `boys`, so the loose token pulls in whichever popular artist matches it best.
+// Measured against the live API on 2026-07-31:
+//
+//   artist:viagra boys    -> "The Beach Boys" (score 100)  <- wrong artist wins
+//   artist:"viagra boys"  -> "Viagra Boys"    (score 100)
+//
+// The wrong hit is then correctly rejected by the downstream name-similarity guard, so
+// the artist silently loses ALL enrichment (official site, socials, Discogs, location,
+// and Qobuz, which MB is now the only source of) and the search returns nothing.
+//
+// On a 20-artist sample from data/artists-manifest.json, 4 got the wrong top hit
+// unquoted and quoting fixed all 4. 543 of ~790 catalog artists are multi-word.
+
+import { musicBrainzArtistQuery } from '../search-utils';
+
+describe('musicBrainzArtistQuery', () => {
+  it('wraps multi-word names in a Lucene phrase', () => {
+    // The regression itself: without the quotes this is `artist:viagra boys`.
+    expect(musicBrainzArtistQuery('viagra boys')).toBe('artist:"viagra boys"');
+    expect(musicBrainzArtistQuery('Ian McDonald')).toBe('artist:"Ian McDonald"');
+    expect(musicBrainzArtistQuery('the mountain goats')).toBe('artist:"the mountain goats"');
+  });
+
+  it('quotes single-word names too, so there is one code path', () => {
+    expect(musicBrainzArtistQuery('Radiohead')).toBe('artist:"Radiohead"');
+  });
+
+  it('preserves case and accents for the phrase', () => {
+    // Callers normalize accents upstream where they want to; this helper must not
+    // silently change the term it is handed.
+    expect(musicBrainzArtistQuery('Tanerélle')).toBe('artist:"Tanerélle"');
+    expect(musicBrainzArtistQuery('Sigur Rós')).toBe('artist:"Sigur Rós"');
+  });
+
+  it('strips quotes and backslashes that would break out of the phrase', () => {
+    // A stray `"` would terminate the phrase and turn the remainder into loose
+    // tokens — reintroducing the exact bug. A trailing `\` would escape the
+    // closing quote.
+    expect(musicBrainzArtistQuery('Bar "Nine" Trio')).toBe('artist:"Bar Nine Trio"');
+    expect(musicBrainzArtistQuery('AC\\DC')).toBe('artist:"AC DC"');
+    expect(musicBrainzArtistQuery('trailing\\')).toBe('artist:"trailing"');
+  });
+
+  it('collapses whitespace so stripping cannot leave doubled spaces', () => {
+    expect(musicBrainzArtistQuery('  Big   Thief  ')).toBe('artist:"Big Thief"');
+    expect(musicBrainzArtistQuery('a "" b')).toBe('artist:"a b"');
+  });
+
+  it('keeps punctuation Lucene does not treat as phrase-breaking', () => {
+    // Inside a quoted phrase these are literal, and stripping them would loosen
+    // the match for no reason.
+    expect(musicBrainzArtistQuery('Ben-G!')).toBe('artist:"Ben-G!"');
+    expect(musicBrainzArtistQuery('Godspeed You! Black Emperor'))
+      .toBe('artist:"Godspeed You! Black Emperor"');
+  });
+
+  it('produces a URL-safe value once encoded', () => {
+    // The call sites encodeURIComponent the whole thing; the quotes must survive
+    // as %22 rather than being dropped.
+    expect(encodeURIComponent(musicBrainzArtistQuery('viagra boys')))
+      .toBe('artist%3A%22viagra%20boys%22');
+  });
+});

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -6,7 +6,7 @@ import { cacheGetOrFetch, artistCacheKey } from './cache';
 import { persistEnrichment, getLinkSuppressions } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery, isUrlHostnameAllowed } from './middleware';
-import { normalizeAccents, normalizeForComparison, normalizeSearchQuery, isUrlSuppressed, type LinkSuppression } from './search-utils';
+import { normalizeAccents, normalizeForComparison, normalizeSearchQuery, musicBrainzArtistQuery, isUrlSuppressed, type LinkSuppression } from './search-utils';
 
 // Import all shared enrichment functions and types
 import {
@@ -78,7 +78,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
 
   try {
     // Search for artist
-    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=1`;
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(musicBrainzArtistQuery(query))}&fmt=json&limit=1`;
 
     const response = await globalThis.fetch(searchUrl, {
       headers: {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -37,6 +37,7 @@ import {
   isBandcampSearchLink,
   bandcampSubdomainOf,
   bandcampSubdomainConflicts,
+  musicBrainzArtistQuery,
 } from './search-utils';
 
 // Import shared enrichment functions
@@ -417,7 +418,7 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
     // Search for artist. MB is Lucene-backed and its ranked list is the one real
     // search engine in the fan-out: the top hit drives enrichment (strict gates
     // below), the rest become discovery candidates via collectMbSuggestions.
-    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=5`;
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(musicBrainzArtistQuery(query))}&fmt=json&limit=5`;
 
     const response = await globalThis.fetch(searchUrl, {
       headers: {

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -366,6 +366,34 @@ export function normalizeSearchQuery(query: string): string {
   return normalizeAccents(query);
 }
 
+/**
+ * Build the `query` value for a MusicBrainz artist search: a quoted Lucene phrase.
+ *
+ * The quotes are load-bearing. MusicBrainz is Lucene-backed, so an unquoted
+ * `artist:viagra boys` parses as `artist:viagra` OR a bare `boys` — and the
+ * loose token drags in whichever popular artist matches it best. Measured
+ * against the live API on 2026-07-31:
+ *
+ *   artist:viagra boys     -> "The Beach Boys"  (score 100, wrong artist)
+ *   artist:"viagra boys"   -> "Viagra Boys"     (score 100, right artist)
+ *
+ * The wrong hit is then correctly rejected by the name-similarity guards
+ * downstream, so the whole artist silently loses enrichment — official site,
+ * socials, Discogs, location, and Qobuz, which MB is now the only source of.
+ * On a 20-artist sample from data/artists-manifest.json, 4 got the wrong top
+ * hit unquoted and all 4 were fixed by quoting; 543 of ~790 catalog artists
+ * have multi-word names.
+ *
+ * Embedded double quotes and backslashes would terminate or escape the phrase,
+ * so they are stripped rather than escaped — no artist name needs them, and a
+ * stripped character costs at most a slightly looser match, while a broken
+ * phrase costs the whole query.
+ */
+export function musicBrainzArtistQuery(query: string): string {
+  const phrase = query.replace(/["\\]/g, ' ').replace(/\s+/g, ' ').trim();
+  return `artist:"${phrase}"`;
+}
+
 // ---------------------------------------------------------------------------
 // Name matching
 // ---------------------------------------------------------------------------

--- a/apps/web/server/search/musicbrainz.ts
+++ b/apps/web/server/search/musicbrainz.ts
@@ -1,5 +1,5 @@
 import type { MusicBrainzEnrichmentResponse, PlatformResult, SocialLink, SocialPlatform } from '../shared-types';
-import { delay } from '../shared-utils';
+import { delay, musicBrainzArtistQuery } from '../shared-utils';
 import { fetchDiscogsSocialLinks, fetchOfficialSiteSocialLinks, mergeSocialLinks, parseSocialUrl } from '../social-links';
 
 const USER_AGENT = 'Unstream/1.0 (https://github.com/unstream - ethical music finder)';
@@ -12,7 +12,7 @@ export async function searchMusicBrainz(query: string): Promise<PlatformResult[]
   const results: PlatformResult[] = [];
 
   try {
-    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=1`;
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(musicBrainzArtistQuery(query))}&fmt=json&limit=1`;
 
     const response = await globalThis.fetch(searchUrl, {
       headers: { 'User-Agent': USER_AGENT },
@@ -130,7 +130,7 @@ export async function searchMusicBrainzEnrichment(query: string): Promise<MusicB
   };
 
   try {
-    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=artist:${encodeURIComponent(query)}&fmt=json&limit=1`;
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(musicBrainzArtistQuery(query))}&fmt=json&limit=1`;
 
     const response = await globalThis.fetch(searchUrl, {
       headers: { 'User-Agent': USER_AGENT },

--- a/apps/web/server/shared-utils.ts
+++ b/apps/web/server/shared-utils.ts
@@ -60,3 +60,16 @@ export function parseReleaseDate(dateStr: string | undefined): Date | undefined 
 
   return undefined;
 }
+
+/**
+ * Build the `query` value for a MusicBrainz artist search: a quoted Lucene phrase.
+ *
+ * Dev-only mirror of `musicBrainzArtistQuery` in api/functions/search-utils.ts, which
+ * is the canonical version — this tree cannot import from api/functions. Keep the two
+ * in step; without the quotes, `artist:viagra boys` parses as `artist:viagra` OR a bare
+ * `boys` and MusicBrainz returns "The Beach Boys".
+ */
+export function musicBrainzArtistQuery(query: string): string {
+  const phrase = query.replace(/["\\]/g, ' ').replace(/\s+/g, ' ').trim();
+  return `artist:"${phrase}"`;
+}


### PR DESCRIPTION
Reported as: **"viagra boys" returns no results in search.**

## Root cause

MusicBrainz is Lucene-backed, and the artist search sent an **unquoted** field term — `artist:viagra boys`. Lucene reads that as `artist:viagra` OR a bare `boys`, so the loose token drags in whichever popular artist matches it best. Measured against the live MB API:

| Query sent | Top hit |
|---|---|
| `artist:viagra boys` (before) | **The Beach Boys**, score 100 |
| `artist:"viagra boys"` (after) | **Viagra Boys**, score 100, MBID `9df0c0ec…` |

The wrong hit is then *correctly* rejected by the downstream name-similarity guard, so the artist silently loses all enrichment — official site, socials, Discogs, location, and Qobuz, which MusicBrainz is now the only source of. The failure presents as "MusicBrainz has nothing" when MB actually has a score-100 match: a bad **query** masquerading as a missing **record**.

Phase 1 (`limit=5`) had the right artist at index 1 (score 99) but only reads `artists[0]` for enrichment, so it lost too.

## Blast radius

Sampled 20 multi-word names from `data/artists-manifest.json`:

- **4/20 wrong** unquoted — `Ian McDonald`→Michael McDonald, `Bradley Joseph`→Joseph Haydn, `Dinah Jane`→[unknown], `Red One`→[unknown]
- **4/4 fixed** by quoting
- 543 of ~790 catalog artists are multi-word, so this was roughly **14% of the catalog** silently losing MB enrichment.

## The change

Adds `musicBrainzArtistQuery` to `search-utils.ts` (pure, unit-tested, per the "keep new logic out of search-sources.ts" guidance) and uses it at both live call sites. Embedded `"` and `\` are stripped rather than escaped — no artist name needs them, and a stripped character costs a slightly looser match while a broken phrase costs the whole query.

`apps/web/server` is the dev-only shim and cannot import from `api/functions`, so it gets a small mirrored helper with a pointer comment. Without it, `npm run dev` would keep showing the bug and mislead whoever debugs this next. The dead Vercel-era copies in `api/search/sources.ts` and `api/search/musicbrainz.ts` are deliberately untouched.

## Verification

Against the dev API — "viagra boys" goes from `artistName: null` / 0 results to:

```
artistName : Viagra Boys
officialUrl: https://vboysstockholm.com/
discogsUrl : https://www.discogs.com/artist/4861285
socials    : twitter, facebook, instagram, youtube, tiktok
```

UI renders "Found 1 result" with Discogs (marketplace), Official Site, and socials. No console errors.

- `Ian McDonald` and `Bradley Joseph` now resolve correctly; `Radiohead` unchanged (no regression on previously-working queries)
- `npm run build` passes (347 API tests, 22 files)
- Lint baseline unchanged: 77 problems before and after, none in touched files
- Explicit `tsc --strict` on the three `api/` files (which the build does **not** typecheck): same 3 pre-existing errors before and after, shifted one line by the added import

## Not a bug, for the record

The Bandcamp miss was correct. `viagraboys.bandcamp.com` exists and name-matches, but the account is genuinely empty — zero grid items and zero release links on both `/music` and root — so the probe's `rejected_empty` verdict is right. Controls fetched identically: radiohead 15 grid items, sufjanstevens 16. Their catalog isn't on their label's page either, and MB lists no Bandcamp relation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)