### PR TITLE
Add the release page at /a/{artist}/{release}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,8 +172,9 @@ have your laptop writing production data.
 Use the dry run instead:
 
 ```bash
-npm run ingest:try -- sufjanstevens          # table of what would be written
-npm run ingest:try -- sufjanstevens --json   # full row shapes
+npm run ingest:try -- sufjanstevens              # table of what would be written
+npm run ingest:try -- sufjanstevens --json       # full row shapes
+npm run ingest:try -- sufjanstevens --detail=3   # + dates, formats and prices for the newest 3
 ```
 
 It runs the real path — the same SSRF-safe fetcher, the same allowlist check, the same parser
@@ -183,6 +184,22 @@ request per run; don't loop it.
 There is deliberately no `--write` flag. Everything with a decision in it lives upstream of the
 database, and `persistReleases` is covered by unit tests plus a migration validated against a
 real Postgres. To test the write path, point `SUPABASE_URL` at a branch database on purpose.
+
+### Seeing the release page locally
+
+`npm run dev` **cannot** show you `/a/{artist}/{release}` — the Vite dev server doesn't run edge
+functions at all. `netlify dev` does, but it reads the production Supabase, where a release only
+exists once demand-driven cataloging has run for that artist. So the page you most want to look
+at is the one neither of those can render.
+
+```bash
+npm run preview:release -- explosionsinthesky    # then open http://localhost:8788
+```
+
+Fetches the real `/music` grid, lists the discography, and renders any release through the
+**real** `api/edge/release-page.ts` — same template, same payout maths — fetching that release's
+page from Bandcamp on demand. Only the two database reads are stubbed; there is no database
+connection, so nothing can be written. One Bandcamp request per release page you open.
 
 Once ingest is live, `release_catalog_state` is the observability surface:
 `last_attempted_at`, `releases_found`, `last_error`, `consecutive_failures`. A run that suddenly

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -23,7 +23,7 @@ import {
   AVAILABILITY_LABELS,
   AVAILABILITY_ORDER,
   FORMAT_LABELS,
-  formatMoney,
+  formatOfferPrice,
   formatReleaseDate,
   payoutEstimate,
   payoutRank,
@@ -64,9 +64,12 @@ const CSS = `
   .source { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin-bottom: 12px; }
   .source-head { display: flex; align-items: center; gap: 10px; padding: 12px 16px; background: var(--bg2); }
   .offer { display: flex; align-items: baseline; gap: 12px; padding: 10px 16px; border-top: 1px solid var(--border); font-size: 14px; }
-  .offer-format { width: 88px; flex-shrink: 0; font-weight: 500; text-transform: capitalize; }
-  .offer-price { width: 88px; flex-shrink: 0; }
-  .offer-payout { color: var(--muted); font-size: 13px; }
+  .offer-format { flex: 0 0 88px; font-weight: 500; text-transform: capitalize; }
+  /* Sized to content with a floor, not fixed: "$25" and "Name your price" both live in this
+     column, and a width that suits one wraps the other onto two lines. Rows within a card still
+     line up, because one artist's prices are all the same shape. */
+  .offer-price { flex: 0 0 auto; min-width: 88px; }
+  .offer-payout { flex: 1; color: var(--muted); font-size: 13px; }
   .offer.gone { color: var(--muted); }
   .buy { display: block; padding: 12px 16px; border-top: 1px solid var(--border); text-align: center; font-weight: 600; text-decoration: none; color: var(--accent); }
   .buy:hover { text-decoration: underline; }
@@ -83,8 +86,8 @@ const CSS = `
     .release-art, .release-art-fallback { width: 200px; height: 200px; }
     /* Narrower fixed columns so the payout estimate — the line this page exists for — stays on
        one line instead of wrapping under the price. */
-    .offer-format { width: 64px; }
-    .offer-price { width: 72px; }
+    .offer-format { flex-basis: 64px; }
+    .offer-price { min-width: 72px; }
   }
 `;
 
@@ -229,7 +232,7 @@ export default async function handler(request: Request, context: Context) {
         // means for the artist. The availability label rides in the third column rather than
         // beside the price — a sold-out row has no payout to show, and "$14 · Sold out"
         // crammed into the price column wraps onto two lines on every phone.
-        const priceText = offer.price !== null ? formatMoney(offer.price, offer.currency) : '—';
+        const priceText = formatOfferPrice(offer.price, offer.currency);
         const payout = gone ? '' : payoutEstimate(offer.price, offer.currency, payoutPercent);
         const note = [AVAILABILITY_LABELS[offer.availability] || '', payout]
           .filter(Boolean)

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -1,0 +1,380 @@
+// The release page: /a/{artist}/{release}
+//
+// A buying guide for one record — what formats exist, what they cost, and roughly how much
+// reaches the artist. Odesli, the distributor landing pages and feature.fm all answer "where
+// can I *stream* this", which is the opposite of what Unstream is for. Nobody answers this
+// question, which is the whole reason the feature exists.
+//
+// **Pure SSR, and only SSR.** This URL is rendered here and nowhere else. The SPA must never
+// try to take it over: one route with two renderers is the UNS-100 bifurcation class that
+// produced a run of back-button and bfcache bugs where every fix partially reverted the last
+// (see docs/retros/UNS-100-bifurcation-retro.md). Nothing on this page hydrates or re-renders
+// client-side — the only script anywhere in it is an inline image-error fallback.
+//
+// **Route precedence.** netlify.toml declares this *before* `/a/*`, because `/a/*` also matches
+// `/a/artist/release` and artist-page-static would otherwise answer first. The regex here
+// matches exactly two path segments so single-segment artist URLs never reach it.
+
+import { Context } from "https://edge.netlify.com";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { PLATFORMS } from "../shared/platform-registry.ts";
+import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
+import {
+  AVAILABILITY_LABELS,
+  AVAILABILITY_ORDER,
+  FORMAT_LABELS,
+  formatMoney,
+  formatReleaseDate,
+  payoutEstimate,
+  payoutRank,
+  relativeDays,
+} from "../shared/release-display.ts";
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+const LOGO_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 110 110" aria-hidden="true"><defs><filter id="gs"><feColorMatrix type="saturate" values="0"/></filter></defs><g transform="translate(22,22) scale(1.8333)" filter="url(#gs)"><path fill="#50A5E6" d="M30 22c-3 0-6.688 7.094-7 10-.421 3.915 2 4 2 4h11V26s-3.438-4-6-4z"/><ellipse transform="rotate(-60 27.574 28.49)" fill="#1C6399" cx="27.574" cy="28.489" rx="5.848" ry="1.638"/><path fill="#F9CA55" d="M20.086 0c1.181 0 2.138.957 2.138 2.138 0 .789.668 10.824.668 10.824L17.948 18V2.138C17.948.957 18.905 0 20.086 0z"/><path fill="#FFDC5D" d="M18.875 4.323c0-1.099.852-1.989 1.903-1.989 1.051 0 1.903.891 1.903 1.989 0 0 .535 5.942 1.192 9.37.878 1.866 1.369 4.682 1.261 6.248.054.398 5.625 5.006 5.625 5.006-.281 1.813-2.259 6.155-4.759 8.159l-3.521-2.924c-2.885-.404-4.458-3.331-4.458-4.264 0-2.984.854-21.595.854-21.595z"/><path fill="#50A5E6" d="M6 22c3 0 6.688 7.094 7 10 .421 3.915-2 4-2 4H0V26s3.438-4 6-4z"/><ellipse transform="rotate(-30 8.424 28.489)" fill="#1C6399" cx="8.426" cy="28.489" rx="1.638" ry="5.848"/><path fill="#F9CA55" d="M16.061.011c-1.266-.127-2.333.864-2.333 2.103 0 .78-.184 10.319-.184 10.319L17.895 18l.062-15.765c0-1.106-.795-2.114-1.896-2.224z"/><path fill="#FFDC5D" d="M17.125 4.323c0-1.099-.852-1.989-1.903-1.989-1.051 0-1.903.891-1.903 1.989 0 0-.535 5.942-1.192 9.37-.878 1.866-1.369 4.682-1.261 6.248-.054.398-5.625 5.006-5.625 5.006C5.522 26.76 7.5 31.102 10 33.106l3.521-2.924c2.885-.404 4.458-3.331 4.458-4.264 0-2.984-.854-21.595-.854-21.595z"/><path fill="#F9CA55" d="M17.958 25.823c-.414 0-.75-.336-.75-.75V2.792c0-.414.336-.75.75-.75s.75.336.75.75v22.282c.001.413-.335.749-.75.749z"/></g><path d="M14,52 A41,41 0 0,1 96,52" fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round"/><line x1="14" y1="52" x2="14" y2="64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/><line x1="96" y1="52" x2="96" y2="64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/><rect x="3" y="60" width="22" height="28" rx="9" fill="currentColor"/><rect x="85" y="60" width="22" height="28" rx="9" fill="currentColor"/></svg>';
+
+const CSS = `
+  :root { --bg: #0d0d0d; --bg2: #1a1a1a; --text: #f0f0f0; --muted: #999; --border: #2a2a2a; --accent: #ff6b35; --footer-border: #1a1a1a; }
+  @media (prefers-color-scheme: light) {
+    :root { --bg: #ffffff; --bg2: #f5f5f5; --text: #1a1a1a; --muted: #555; --border: #e0e0e0; --accent: #e55a2b; --footer-border: #e0e0e0; }
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Stack Sans Headline', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
+  h1, h2 { font-family: 'Darker Grotesque', 'Stack Sans Headline', system-ui, sans-serif; }
+  a { color: inherit; }
+  .container { max-width: 640px; margin: 0 auto; padding: 0 24px; width: 100%; }
+  .page-content { position: relative; flex: 1; display: flex; flex-direction: column; }
+  @keyframes bc-pulse { 0%, 100% { opacity: 0.7; } 50% { opacity: 1; } }
+  .site-header { padding: 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+  .site-header .brand { display: flex; align-items: center; gap: 8px; font-size: 20px; font-weight: 700; color: var(--text); text-decoration: none; flex-shrink: 0; }
+  .site-header .brand:hover { opacity: 0.8; }
+  .site-header .header-search { display: flex; gap: 8px; flex: 1; max-width: 420px; margin: 0 auto; }
+  .site-header .header-search input { flex: 1; min-width: 0; background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px; font-size: 14px; color: var(--text); font-family: inherit; }
+  .site-header .header-search input:focus { outline: none; border-color: var(--accent); }
+  .site-header .header-search button { border: 0; border-radius: 8px; padding: 8px 14px; background: var(--accent); color: #fff; font-size: 14px; font-weight: 500; cursor: pointer; font-family: inherit; }
+  @media (max-width: 640px) { .site-header .header-search { display: none; } }
+
+  .release-head { display: flex; gap: 20px; align-items: flex-start; }
+  .release-art { width: 160px; height: 160px; flex-shrink: 0; border-radius: 12px; border: 1px solid var(--border); background: var(--bg2); object-fit: cover; }
+  .release-art-fallback { width: 160px; height: 160px; flex-shrink: 0; border-radius: 12px; border: 1px solid var(--border); background: var(--bg2); display: flex; align-items: center; justify-content: center; font-size: 40px; }
+
+  .source { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin-bottom: 12px; }
+  .source-head { display: flex; align-items: center; gap: 10px; padding: 12px 16px; background: var(--bg2); }
+  .offer { display: flex; align-items: baseline; gap: 12px; padding: 10px 16px; border-top: 1px solid var(--border); font-size: 14px; }
+  .offer-format { width: 88px; flex-shrink: 0; font-weight: 500; text-transform: capitalize; }
+  .offer-price { width: 88px; flex-shrink: 0; }
+  .offer-payout { color: var(--muted); font-size: 13px; }
+  .offer.gone { color: var(--muted); }
+  .buy { display: block; padding: 12px 16px; border-top: 1px solid var(--border); text-align: center; font-weight: 600; text-decoration: none; color: var(--accent); }
+  .buy:hover { text-decoration: underline; }
+  .note { font-size: 13px; color: var(--muted); margin-top: 16px; }
+
+  /* Last, so these win over the base rules above — no media query beats a later rule of the
+     same specificity, and this block sat earlier in the file at first, which quietly did
+     nothing at all. */
+  @media (max-width: 520px) {
+    /* Stacked, but the art is capped rather than full-bleed: a square at 100% width fills the
+       entire first screen on a phone and pushes the title, the date and every price below the
+       fold — which is the whole reason someone opened the page. */
+    .release-head { flex-direction: column; }
+    .release-art, .release-art-fallback { width: 200px; height: 200px; }
+    /* Narrower fixed columns so the payout estimate — the line this page exists for — stays on
+       one line instead of wrapping under the price. */
+    .offer-format { width: 64px; }
+    .offer-price { width: 72px; }
+  }
+`;
+
+interface OfferRow {
+  format: string;
+  price: number | null;
+  currency: string | null;
+  availability: string;
+  captured_at: string;
+}
+
+interface SourceRow {
+  platform: string;
+  url: string;
+  detail_checked_at: string | null;
+  release_offers: OfferRow[] | null;
+}
+
+export default async function handler(request: Request, context: Context) {
+  try {
+    const url = new URL(request.url);
+    const segments = url.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+    // ['a', artistSlug, releaseSlug] — the route regex guarantees the shape, but this function
+    // is the thing that has to be right if that regex is ever loosened.
+    if (segments.length !== 3 || segments[0] !== 'a') return context.next();
+
+    const artistSlug = decodeURIComponent(segments[1]);
+    const releaseSlug = decodeURIComponent(segments[2]);
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_KEY");
+    if (!supabaseUrl || !supabaseKey) return context.next();
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    let artist: { id: string; name: string; image_url: string | null };
+    let release: {
+      title: string;
+      release_type: string;
+      release_date: string | null;
+      date_precision: string | null;
+      status: string;
+      artwork_url: string | null;
+      release_sources: SourceRow[] | null;
+    };
+
+    try {
+      const { data: artistData } = await supabase
+        .from('artists')
+        .select('id, name, image_url')
+        .eq('slug', artistSlug)
+        .maybeSingle()
+        .abortSignal(controller.signal);
+
+      if (!artistData) {
+        clearTimeout(timeoutId);
+        return context.next();
+      }
+      artist = artistData;
+
+      // One round trip for the release, its sources and their offers. `is_hidden` is filtered
+      // in the query rather than after: a suppressed release must be indistinguishable from one
+      // that was never catalogued, which is the point of having the column.
+      const { data: releaseData } = await supabase
+        .from('releases')
+        .select(`
+          title, release_type, release_date, date_precision, status, artwork_url,
+          release_sources ( platform, url, detail_checked_at,
+            release_offers ( format, price, currency, availability, captured_at )
+          )
+        `)
+        .eq('artist_id', artist.id)
+        .eq('slug', releaseSlug)
+        .eq('is_hidden', false)
+        .maybeSingle()
+        .abortSignal(controller.signal);
+
+      if (!releaseData) {
+        clearTimeout(timeoutId);
+        // The artist exists but this release doesn't — a stale link from an old alert, a
+        // mistyped slug, or a release an artist has since suppressed. Falling through would
+        // hand it to the SPA, which has no route for a two-segment /a/ path and renders a
+        // blank page. Send them somewhere useful instead. 302 rather than 301 because a
+        // suppressed release can come back, and this deliberately doesn't distinguish
+        // "hidden" from "never existed".
+        return Response.redirect(`${url.origin}/a/${encodeURIComponent(artistSlug)}`, 302);
+      }
+      release = releaseData;
+    } catch {
+      // Timeout or error — fall through to the SPA rather than showing a broken page.
+      clearTimeout(timeoutId);
+      return context.next();
+    }
+
+    clearTimeout(timeoutId);
+
+    const artistName = escapeHtml(artist.name);
+    const title = escapeHtml(release.title);
+    const pageUrl = `https://unstream.stream/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(releaseSlug)}`;
+    const artworkUrl = release.artwork_url || '';
+    const bcFriday = isBandcampFriday();
+
+    const dateText = formatReleaseDate(release.release_date, release.date_precision);
+    const typeLabel = release.release_type === 'other' ? '' : release.release_type.toUpperCase();
+    const statusText = release.status === 'announced'
+      ? (dateText ? `Coming ${dateText}` : 'Announced')
+      : dateText;
+
+    const sources = [...(release.release_sources || [])].sort(
+      (a, b) => payoutRank(b.platform) - payoutRank(a.platform)
+    );
+
+    // The oldest price on the page is the honest freshness claim: saying "checked today"
+    // because *one* source was re-read would overstate the rest.
+    const capturedTimes = sources
+      .flatMap(s => (s.release_offers || []).map(o => o.captured_at))
+      .filter(Boolean)
+      .sort();
+    const oldestCapture = capturedTimes[0] ?? null;
+
+    const sourcesHtml = sources.map(source => {
+      const info = PLATFORMS[source.platform];
+      const name = info?.name || source.platform;
+      const isBCFriday = source.platform === 'bandcamp' && bcFriday;
+      // On a Bandcamp Friday Bandcamp waives its revenue share, so the usual range is simply
+      // wrong for the next 24 hours. The rest of the product already models this; a page about
+      // where to buy would be a strange place to ignore it.
+      const payoutPercent = isBCFriday ? '~97%' : info?.payoutPercent;
+
+      const offers = [...(source.release_offers || [])].sort((a, b) => {
+        const availability = (AVAILABILITY_ORDER[a.availability] ?? 2) - (AVAILABILITY_ORDER[b.availability] ?? 2);
+        if (availability !== 0) return availability;
+        return (a.price ?? Infinity) - (b.price ?? Infinity);
+      });
+
+      const offersHtml = offers.map(offer => {
+        const gone = offer.availability === 'sold_out';
+        // Three columns, always the same three: what it is, what it costs, and what that
+        // means for the artist. The availability label rides in the third column rather than
+        // beside the price — a sold-out row has no payout to show, and "$14 · Sold out"
+        // crammed into the price column wraps onto two lines on every phone.
+        const priceText = offer.price !== null ? formatMoney(offer.price, offer.currency) : '—';
+        const payout = gone ? '' : payoutEstimate(offer.price, offer.currency, payoutPercent);
+        const note = [AVAILABILITY_LABELS[offer.availability] || '', payout]
+          .filter(Boolean)
+          .join(' · ');
+        return `<div class="offer${gone ? ' gone' : ''}">
+          <span class="offer-format">${escapeHtml(FORMAT_LABELS[offer.format] || offer.format)}</span>
+          <span class="offer-price">${escapeHtml(priceText)}</span>
+          <span class="offer-payout">${escapeHtml(note)}</span>
+        </div>`;
+      }).join('');
+
+      // An honest empty state. "We know it's here, we haven't read the prices yet" is a
+      // different statement from "there is nothing to buy", and a fan can act on the first.
+      const pendingHtml = offers.length === 0
+        ? `<div class="offer"><span style="color:var(--muted)">${
+            source.detail_checked_at
+              ? 'No formats listed on this page.'
+              : 'Still gathering formats and prices.'
+          }</span></div>`
+        : '';
+
+      return `<div class="source">
+        <div class="source-head">
+          <span style="font-size:18px">${info?.icon || '🔗'}</span>
+          <span style="flex:1;font-weight:600">${escapeHtml(name)}</span>
+          ${payoutPercent ? `<span style="font-size:12px;color:var(--muted)">${escapeHtml(payoutPercent)} to artist</span>` : ''}
+          ${isBCFriday ? '<span style="font-size:11px;font-weight:700;color:#1da0c3;animation:bc-pulse 2s ease-in-out infinite">Bandcamp Friday!</span>' : ''}
+        </div>
+        ${offersHtml}${pendingHtml}
+        <a class="buy" href="${escapeHtml(source.url)}" target="_blank" rel="noopener noreferrer">Buy on ${escapeHtml(name)} &rarr;</a>
+      </div>`;
+    }).join('');
+
+    const description = `Where to buy ${release.title} by ${artist.name} — formats, prices, and how much reaches the artist.`;
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title} by ${artistName} - Unstream | Where to buy</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <!-- noindex by design, not by oversight. Release pages are generated from a crawl, so a
+       wrong one would mint a durable URL asserting an artist made a record they didn't, and a
+       catalog of thin auto-generated pages is textbook scaled-content abuse — the penalty for
+       which is site-wide, putting the artist-page and guide rankings already earned at risk.
+       These pages exist as a destination for a release alert, not as a landing page for a
+       stranger. Indexation is a later, deliberate decision for pages that clear a quality bar.
+       "follow" so the links out to artists and platforms still count.
+
+       There is deliberately no MusicRelease JSON-LD here for the same reason: structured data
+       does nothing on a noindex page except make a machine-readable claim we aren't yet
+       confident enough to publish. -->
+  <meta name="robots" content="noindex, follow">
+  <meta property="og:title" content="${title} by ${artistName}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:url" content="${pageUrl}">
+  <meta property="og:type" content="music.album">
+  <meta property="og:site_name" content="Unstream">
+  ${artworkUrl ? `<meta property="og:image" content="${escapeHtml(artworkUrl)}">
+  <meta property="og:image:alt" content="${title}">` : ''}
+  <meta name="twitter:card" content="${artworkUrl ? 'summary_large_image' : 'summary'}">
+  <link rel="canonical" href="${pageUrl}">
+  <link href="https://fonts.googleapis.com/css2?family=Darker+Grotesque:wght@300..900&family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>${CSS}</style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="brand">${LOGO_SVG} Unstream</a>
+    <!-- Plain GET form, no JS: this page is pure SSR, so it can't render the React
+         HeaderSearch. Submitting lands on /?q=… where the SPA renders results. Never point
+         this at /search — that URL belongs to the noscript-search edge function. -->
+    <form class="header-search" action="/" method="get" role="search">
+      <input type="text" name="q" placeholder="Search artists..." aria-label="Search artists" enterkeyhint="search">
+      <button type="submit">Search</button>
+    </form>
+  </header>
+
+  <div class="page-content">
+    <div class="container" style="padding-top:32px;padding-bottom:32px">
+      <a href="/a/${escapeHtml(encodeURIComponent(artistSlug))}" style="font-size:14px;color:var(--muted);text-decoration:none">&larr; ${artistName}</a>
+
+      <div class="release-head" style="margin-top:20px">
+        <!-- Artwork is hotlinked from the platform's CDN, so a dead or blocked image is a
+             normal outcome, not an edge case — and an empty bordered box on a buying page
+             reads as broken. Same onerror swap artist-page-static uses. -->
+        ${artworkUrl
+          ? `<img class="release-art" src="${escapeHtml(artworkUrl)}" alt="${title}" loading="lazy" referrerpolicy="no-referrer" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+             <div class="release-art-fallback" style="display:none">💿</div>`
+          : `<div class="release-art-fallback">💿</div>`}
+        <div>
+          ${typeLabel ? `<div style="font-size:11px;letter-spacing:0.08em;color:var(--muted)">${escapeHtml(typeLabel)}</div>` : ''}
+          <h1 style="font-size:32px;font-weight:700;line-height:1.1;margin-top:4px">${title}</h1>
+          <div style="margin-top:6px;font-size:15px;color:var(--muted)">${artistName}</div>
+          ${statusText ? `<div style="margin-top:10px;font-size:14px;color:var(--muted)">${escapeHtml(statusText)}</div>` : ''}
+        </div>
+      </div>
+    </div>
+
+    <div class="container" style="padding-bottom:32px">
+      <h2 style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted);margin-bottom:12px">Where to buy</h2>
+      ${sourcesHtml || '<p style="font-size:14px;color:var(--muted)">We haven\'t found anywhere to buy this yet.</p>'}
+      ${oldestCapture ? `<p class="note">Prices checked ${escapeHtml(relativeDays(oldestCapture))}. Stock and prices change &mdash; the platform is the last word. Payout figures are estimates based on each platform's published rates.</p>` : ''}
+    </div>
+  </div>
+
+  <div style="padding:24px 16px;text-align:center">
+    <a href="https://unstream.stream" style="color:var(--text);text-decoration:none;font-weight:700;font-size:18px">Powered by Unstream</a>
+    <p style="font-size:14px;color:var(--muted);margin-top:4px">Find music on platforms that pay artists fairly.</p>
+  </div>
+
+  <footer style="margin-top:auto;padding:24px 16px;border-top:1px solid var(--footer-border)">
+    <div style="max-width:896px;margin:0 auto;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;font-size:14px;color:var(--muted)">
+      <a href="https://bgreen.lol" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Made with love in Massachusetts, USA</a>
+      <nav style="display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:12px">
+        <a href="/artists" style="color:var(--muted);text-decoration:none">Indie Artist Index</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/guides" style="color:var(--muted);text-decoration:none">Guides</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/changelog" style="color:var(--muted);text-decoration:none">Changelog</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="https://github.com/users/brandonlucasgreen/projects/4" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Roadmap</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="https://github.com/brandonlucasgreen/unstream" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Codebase</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/support" style="color:var(--muted);text-decoration:none">Support</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="https://letterbird.co/hi-d2078591" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Contact</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/privacy-policy" style="color:var(--muted);text-decoration:none">Privacy policy</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>`;
+
+    return new Response(html, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
+        'Cache-Tag': `release-${artistSlug}-${releaseSlug}`,
+      },
+    });
+  } catch {
+    return context.next();
+  }
+}

--- a/api/functions/__tests__/release-display.test.ts
+++ b/api/functions/__tests__/release-display.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatMoney,
+  formatOfferPrice,
   formatReleaseDate,
   payoutEstimate,
   payoutRank,
@@ -102,5 +103,24 @@ describe('payoutRank', () => {
 
   it('ranks a platform we know nothing about last', () => {
     expect(payoutRank('not-a-platform')).toBeLessThan(payoutRank('bandcamp'));
+  });
+});
+
+describe('formatOfferPrice', () => {
+  // Bandcamp reports name-your-price as `price: 0` with no other signal. Rendering "$0" tells a
+  // fan the record is free when they're actually being asked to decide what to pay — close to
+  // the opposite message on a product about paying artists. Caught on Kid Lightbulbs' own
+  // catalog, where every release is name-your-price.
+  it('reads zero as name-your-price, not free', () => {
+    expect(formatOfferPrice(0, 'USD')).toBe('Name your price');
+  });
+
+  it('says nothing about cost when there is no figure', () => {
+    expect(formatOfferPrice(null, 'USD')).toBe('—');
+  });
+
+  it('renders a real price normally', () => {
+    expect(formatOfferPrice(25, 'USD')).toBe('$25');
+    expect(formatOfferPrice(8.5, 'GBP')).toBe('£8.50');
   });
 });

--- a/api/functions/__tests__/release-display.test.ts
+++ b/api/functions/__tests__/release-display.test.ts
@@ -1,0 +1,106 @@
+// Formatting for the release page.
+//
+// Everything here makes a claim about someone's money or a release date on a page whose whole
+// job is being accurate about both — so the properties worth locking are the ones where being
+// subtly wrong looks fine: a fabricated day on a year-only date, false precision on a payout,
+// a secondhand marketplace ranked above the artist's own store.
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatMoney,
+  formatReleaseDate,
+  payoutEstimate,
+  payoutRank,
+  relativeDays,
+} from '../../shared/release-display';
+
+describe('formatMoney', () => {
+  it('drops trailing zeros but keeps real cents', () => {
+    expect(formatMoney(25, 'USD')).toBe('$25');
+    expect(formatMoney(21.25, 'USD')).toBe('$21.25');
+    expect(formatMoney(8.5, 'USD')).toBe('$8.50');
+  });
+
+  it('uses the currency the platform actually quoted', () => {
+    expect(formatMoney(20, 'GBP')).toBe('£20');
+    expect(formatMoney(20, 'EUR')).toBe('€20');
+  });
+
+  // A wrong symbol asserts the wrong price. A currency code in front of the number doesn't.
+  it('degrades to something honest for a currency it does not know', () => {
+    const out = formatMoney(20, 'ZZZ');
+    expect(out).toContain('20');
+    expect(out).not.toContain('$');
+  });
+
+  it('falls back to USD when a source gave no currency', () => {
+    expect(formatMoney(10, null)).toBe('$10');
+  });
+});
+
+describe('payoutEstimate', () => {
+  // The number the whole product is built to show, at the moment someone decides where to buy.
+  it('turns a payout range and a price into a money range', () => {
+    expect(payoutEstimate(30, 'USD', '80-85%')).toBe('≈$24–$25.50 to artist');
+    expect(payoutEstimate(10, 'USD', '80-85%')).toBe('≈$8–$8.50 to artist');
+  });
+
+  it('collapses to a single figure when the platform publishes one', () => {
+    expect(payoutEstimate(20, 'USD', '~70%')).toBe('≈$14 to artist');
+    expect(payoutEstimate(20, 'USD', '100%')).toBe('≈$20 to artist');
+  });
+
+  // Silence beats a made-up number. A missing price or an unknown payout are both cases where
+  // any output at all would be an invention.
+  it('says nothing rather than guessing', () => {
+    expect(payoutEstimate(null, 'USD', '80-85%')).toBe('');
+    expect(payoutEstimate(25, 'USD', undefined)).toBe('');
+    expect(payoutEstimate(25, 'USD', 'varies')).toBe('');
+    expect(payoutEstimate(0, 'USD', '80-85%')).toBe(''); // name-your-price at zero
+  });
+});
+
+describe('formatReleaseDate', () => {
+  it('renders a full date only when the source gave one', () => {
+    expect(formatReleaseDate('2023-09-15', 'day')).toBe('15 September 2023');
+  });
+
+  // The fabrication `date_precision` exists to prevent: MusicBrainz year-only dates are stored
+  // padded to 1 January, and printing that day states a fact no source ever gave us.
+  it('never invents a day or a month it was not given', () => {
+    expect(formatReleaseDate('2023-01-01', 'year')).toBe('2023');
+    expect(formatReleaseDate('2023-09-01', 'month')).toBe('September 2023');
+    expect(formatReleaseDate('2023-01-01', 'unknown')).toBe('');
+  });
+
+  it('renders nothing for a missing date', () => {
+    expect(formatReleaseDate(null, 'day')).toBe('');
+    expect(formatReleaseDate('', 'day')).toBe('');
+  });
+});
+
+describe('relativeDays', () => {
+  const now = new Date('2026-07-31T12:00:00Z');
+
+  it('reads as words rather than a timestamp', () => {
+    expect(relativeDays('2026-07-31T09:00:00Z', now)).toBe('today');
+    expect(relativeDays('2026-07-30T09:00:00Z', now)).toBe('yesterday');
+    expect(relativeDays('2026-07-28T09:00:00Z', now)).toBe('3 days ago');
+  });
+
+  it('does not claim a price was checked in the future', () => {
+    expect(relativeDays('2026-08-02T09:00:00Z', now)).toBe('just now');
+  });
+});
+
+describe('payoutRank', () => {
+  // Artist-paying options lead, always. Once Discogs and its secondhand marketplace join the
+  // catalog, any other ordering puts "used CD $2.64" above "vinyl direct from the artist $25".
+  it('orders platforms by the bottom of their payout range', () => {
+    expect(payoutRank('mirlo')).toBeGreaterThan(payoutRank('bandcamp'));
+  });
+
+  it('ranks a platform we know nothing about last', () => {
+    expect(payoutRank('not-a-platform')).toBeLessThan(payoutRank('bandcamp'));
+  });
+});

--- a/api/shared/release-display.ts
+++ b/api/shared/release-display.ts
@@ -1,0 +1,148 @@
+/**
+ * Formatting for the release page: money, payout estimates, dates, freshness, ordering.
+ *
+ * Split out of the edge function so it can be tested. Edge functions run on Deno and import
+ * from URLs, which puts them out of reach of vitest — the existing workaround for that has
+ * been to copy the function into the test file and keep the copy in sync by hand. Everything
+ * here makes a claim about someone's money or a release date, which is exactly the code that
+ * shouldn't be verified against a copy of itself.
+ *
+ * Imported with an explicit `.ts` extension by the edge function (Deno requires it) and
+ * without one by node — the same arrangement `bandcamp-friday.ts` already uses.
+ */
+
+import { PLATFORMS } from './platform-registry.ts';
+
+/** Display order within a source: cheapest first, and anything you can't buy at the bottom. */
+export const AVAILABILITY_ORDER: Record<string, number> = {
+  available: 0,
+  preorder: 1,
+  unknown: 2,
+  sold_out: 3,
+};
+
+export const FORMAT_LABELS: Record<string, string> = {
+  digital: 'Digital',
+  vinyl: 'Vinyl',
+  cassette: 'Cassette',
+  cd: 'CD',
+  book: 'Book',
+  merch: 'Merch',
+  other: 'Other',
+};
+
+/** Only the states worth saying out loud — 'available' needs no label beside a price. */
+export const AVAILABILITY_LABELS: Record<string, string> = {
+  preorder: 'Pre-order',
+  sold_out: 'Sold out',
+  unknown: 'Price unknown',
+};
+
+/**
+ * Money, in the currency the platform quoted.
+ *
+ * `Intl` rather than a symbol table: it already knows every currency, and an unrecognized code
+ * degrades to "CAD 25" instead of a confidently wrong symbol.
+ *
+ * Two decimals or none — never one. A whole price reads "$25" rather than "$25.00", but
+ * anything with cents reads in full: "$8.50", not "$8.5". Letting Intl choose the minimum
+ * produces the second, which looks like a typo in a price. Cents are never rounded away,
+ * because tidying someone's money is a small lie on a page whose entire job is being accurate
+ * about it.
+ */
+export function formatMoney(amount: number, currency: string | null): string {
+  const digits = Number.isInteger(amount) ? 0 : 2;
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency || 'USD',
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(amount);
+  } catch {
+    return `${amount} ${currency ?? ''}`.trim();
+  }
+}
+
+/**
+ * "≈$20–21.25 to the artist" — the emotional payload of the whole product, at the moment
+ * someone is deciding where to buy.
+ *
+ * Deliberately a **range**, because the registry's payout figures are ranges ('80-85%', '~70%')
+ * and they're honest about it: Bandcamp's real take differs between digital and physical,
+ * payment processing comes off the top, and on a Bandcamp Friday it's ~97%. Asserting a single
+ * precise figure about someone's income would be worse than saying "roughly". The string form
+ * of `payoutPercent` makes false precision impossible by construction — keep it that way.
+ *
+ * Returns '' when there's no percentage or no price, rather than inventing either.
+ */
+export function payoutEstimate(
+  price: number | null,
+  currency: string | null,
+  payoutPercent?: string
+): string {
+  if (price === null || price <= 0 || !payoutPercent) return '';
+
+  const numbers = payoutPercent.match(/\d+(?:\.\d+)?/g);
+  if (!numbers || numbers.length === 0) return '';
+
+  const low = Number(numbers[0]) / 100;
+  const high = Number(numbers[numbers.length - 1]) / 100;
+  if (!Number.isFinite(low) || !Number.isFinite(high)) return '';
+
+  const lowAmount = formatMoney(price * low, currency);
+  const highAmount = formatMoney(price * high, currency);
+
+  return lowAmount === highAmount
+    ? `≈${lowAmount} to artist`
+    : `≈${lowAmount}–${highAmount} to artist`;
+}
+
+/**
+ * A release date rendered only as precisely as we actually know it.
+ *
+ * MusicBrainz returns year-only and month-only dates, and printing "1 January 2023" for a
+ * year-only date states a fact no source ever gave us. `date_precision` exists for this, and
+ * this is the one place it pays off.
+ */
+export function formatReleaseDate(date: string | null, precision: string | null): string {
+  if (!date) return '';
+  const [year, month, day] = date.split('-').map(Number);
+  if (!Number.isFinite(year)) return '';
+
+  const monthName = new Date(Date.UTC(year, (month || 1) - 1, 1))
+    .toLocaleDateString('en-GB', { month: 'long', timeZone: 'UTC' });
+
+  if (precision === 'year') return String(year);
+  if (precision === 'month') return `${monthName} ${year}`;
+  if (precision === 'day') return `${day} ${monthName} ${year}`;
+  // 'unknown' precision on a stored date means we padded it ourselves. Say nothing rather
+  // than pick a shape.
+  return '';
+}
+
+/** "today" / "yesterday" / "3 days ago" — how old a price is, in words a person reads. */
+export function relativeDays(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return '';
+  const days = Math.floor((now.getTime() - new Date(iso).getTime()) / 86_400_000);
+  if (!Number.isFinite(days) || days < 0) return 'just now';
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return `${days} days ago`;
+}
+
+/**
+ * The lower bound of a platform's payout range, for ordering sources on the page.
+ *
+ * Artist-paying options lead, always. A page that put "used CD, $2.64" above "vinyl direct from
+ * the artist, $25" would be off-mission even though both facts are true — and once Discogs and
+ * its secondhand marketplace join the catalog, that is exactly the page any other ordering
+ * produces. Search already sorts this way; this is the same rule in a second place.
+ *
+ * Unknown platforms rank last rather than first.
+ */
+export function payoutRank(platform: string): number {
+  const percent = PLATFORMS[platform]?.payoutPercent;
+  const first = percent?.match(/\d+(?:\.\d+)?/)?.[0];
+  return first ? Number(first) : -1;
+}

--- a/api/shared/release-display.ts
+++ b/api/shared/release-display.ts
@@ -65,6 +65,24 @@ export function formatMoney(amount: number, currency: string | null): string {
 }
 
 /**
+ * What goes in the price column.
+ *
+ * **Zero means name-your-price, not free.** Bandcamp reports a name-your-price release as
+ * `price: 0` with no other signal, and rendering that as "$0" tells a fan the record costs
+ * nothing — when in fact they're being invited to decide what to pay, which on a product about
+ * paying artists is close to the opposite message. Caught on Kid Lightbulbs' own catalog, where
+ * every release is name-your-price.
+ *
+ * A null price is a format we know exists but have no figure for; an em dash says that without
+ * claiming it's free.
+ */
+export function formatOfferPrice(price: number | null, currency: string | null): string {
+  if (price === null) return '—';
+  if (price === 0) return 'Name your price';
+  return formatMoney(price, currency);
+}
+
+/**
  * "≈$20–21.25 to the artist" — the emotional payload of the whole product, at the moment
  * someone is deciding where to buy.
  *

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,17 @@
   path = "/"
   function = "og-metadata"
 
+# MUST stay above the /a/* entry below. Edge functions run in declaration order, and `/a/*`
+# matches /a/{artist}/{release} too — declared first, artist-page-static would look up an
+# artist whose slug is "artist/release", find nothing, and fall through. It would still work,
+# but only by accident, and it would cost a database query on every release page view.
+#
+# A regex rather than a path glob because the distinction that matters here is the number of
+# path segments: exactly two under /a/. Netlify's `path` globs can't express that.
+[[edge_functions]]
+  pattern = "^/a/[^/]+/[^/]+/?$"
+  function = "release-page"
+
 [[edge_functions]]
   path = "/artist/*"
   function = "artist-page-static"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate:social": "tsx scripts/generate-social-posts.ts",
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
     "ingest:try": "npx tsx scripts/ingest-releases.ts",
+    "preview:release": "npx tsx scripts/preview-release-page.ts",
     "test:web": "cd apps/web && npx vitest run",
     "test:api": "npx vitest run api/functions/",
     "test": "npm run test:web && npm run test:api",

--- a/scripts/preview-release-page.ts
+++ b/scripts/preview-release-page.ts
@@ -1,0 +1,237 @@
+/**
+ * See the release page locally, with real data, without a database.
+ *
+ * Usage:
+ *   npm run preview:release -- explosionsinthesky
+ *   npm run preview:release -- sufjanstevens --port=8123
+ *
+ * Then open the printed URL. The index lists the artist's whole discography; clicking a
+ * release fetches that release's page from Bandcamp and renders it through the **real**
+ * `api/edge/release-page.ts` — the same template, the same formatting, the same payout maths
+ * that production will run.
+ *
+ * WHY THIS EXISTS
+ *
+ * `npm run dev` cannot show you this page. The Vite dev server doesn't run edge functions at
+ * all (see "Local dev API vs production API" in CLAUDE.md), and `netlify dev` — which does —
+ * reads the production Supabase, where the `releases` table is empty until demand-driven
+ * cataloging has run for an artist. So the one thing you'd want to look at is the one thing
+ * neither of those can show you.
+ *
+ * WHAT IS AND ISN'T REAL
+ *
+ * Real: the fetch (the production SSRF-safe fetcher), the grid parse, the release-page parse,
+ * the type/date/offer mapping, and the entire rendered page including payout estimates and
+ * Bandcamp Friday handling.
+ *
+ * Faked: only the two database reads. Nothing is written anywhere — there is no database
+ * connection at all, which is the point.
+ *
+ * One Bandcamp request for the grid, then one per release page you open. Be a good neighbour.
+ */
+
+import { config } from 'dotenv';
+import { createServer } from 'http';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
+
+const REPO_ROOT = resolve(import.meta.dirname ?? '.', '..');
+
+const { safeFetch } = await import('../api/functions/safe-fetch.js');
+const { isUrlHostnameAllowed } = await import('../api/functions/middleware.js');
+const { ingestBandcampGrid, ingestBandcampDetail, bandcampMusicUrl } =
+  await import('../api/functions/release-ingest.js');
+
+const args = process.argv.slice(2);
+const target = args.find(a => !a.startsWith('--'));
+const port = Number(args.find(a => a.startsWith('--port='))?.split('=')[1] ?? 8788);
+
+if (!target) {
+  console.error('Usage: npm run preview:release -- <bandcamp-url-or-slug> [--port=8788]');
+  process.exit(1);
+}
+
+const artistUrl = target.includes('://') ? target : `https://${target}.bandcamp.com`;
+const musicUrl = bandcampMusicUrl(artistUrl);
+if (!musicUrl || !isUrlHostnameAllowed(musicUrl)) {
+  console.error(`Refused: ${artistUrl} is not a fetchable Bandcamp URL.`);
+  process.exit(1);
+}
+
+console.log(`\nFetching ${musicUrl} …`);
+const gridResponse = await safeFetch(musicUrl, 15_000);
+if (!gridResponse?.ok) {
+  console.error(`Bandcamp responded ${gridResponse ? gridResponse.status : 'not at all'}.`);
+  process.exit(1);
+}
+
+const landedUrl = gridResponse.url || musicUrl;
+const outcome = ingestBandcampGrid(await gridResponse.text(), landedUrl);
+if (!outcome.ok) {
+  console.error(`\nNothing to preview — reason: ${outcome.reason}`);
+  process.exit(2);
+}
+
+const releases = outcome.releases;
+const artistSlug = target.includes('://') ? new URL(landedUrl).hostname.split('.')[0] : target;
+let artistName = artistSlug;
+
+// ---------------------------------------------------------------------------
+// Load the real edge function, with its three Deno-only imports redirected
+// ---------------------------------------------------------------------------
+
+const stubDir = mkdtempSync(join(tmpdir(), 'unstream-release-preview-'));
+
+writeFileSync(join(stubDir, 'edge.ts'), `export type Context = { next: () => Response };\n`);
+
+// The two database reads the edge function makes, answered from memory. `_table` is set by
+// from() and read by then(), which works because the function awaits each query before
+// starting the next one.
+writeFileSync(join(stubDir, 'supabase.ts'), `
+export let artist: any = null;
+export let release: any = null;
+export function setRows(a: any, r: any) { artist = a; release = r; }
+export function createClient() {
+  const q: any = {
+    _table: '',
+    select: () => q, eq: () => q, abortSignal: () => q, maybeSingle: () => q,
+    then: (resolve: any) => resolve({ data: q._table === 'artists' ? artist : release }),
+  };
+  return { from(table: string) { q._table = table; return q; } };
+}
+`);
+
+const source = (await import('fs')).readFileSync(join(REPO_ROOT, 'api/edge/release-page.ts'), 'utf8')
+  .replace('https://edge.netlify.com', join(stubDir, 'edge.ts'))
+  .replace('https://esm.sh/@supabase/supabase-js@2', join(stubDir, 'supabase.ts'))
+  // Relative shared imports would break from a temp directory.
+  .replace(/"\.\.\/shared\//g, `"${join(REPO_ROOT, 'api/shared')}/`);
+
+const modulePath = join(stubDir, 'release-page.ts');
+writeFileSync(modulePath, source);
+
+// The edge function reads env through Deno.env; it only checks that the two Supabase values
+// are present, since the client itself is stubbed above.
+(globalThis as Record<string, unknown>).Deno = {
+  env: { get: (key: string) => (key.startsWith('SUPABASE') ? 'preview' : undefined) },
+};
+
+const { setRows } = await import(modulePath.replace('release-page.ts', 'supabase.ts'));
+const { default: renderReleasePage } = await import(modulePath);
+
+// ---------------------------------------------------------------------------
+// Serve
+// ---------------------------------------------------------------------------
+
+/** Release pages already fetched, so clicking around doesn't re-request Bandcamp. */
+const detailCache = new Map<string, { detail: unknown; checkedAt: string }>();
+
+function escape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function indexPage(): string {
+  const rows = releases.map(r =>
+    `<li style="margin:6px 0"><a href="/a/${artistSlug}/${r.slug}">${escape(r.title)}</a>
+     <span style="color:#888;font-size:13px"> — ${r.releaseType}${detailCache.has(r.slug) ? ' · fetched' : ''}</span></li>`
+  ).join('');
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Release page preview</title>
+    <style>body{font-family:system-ui;max-width:640px;margin:40px auto;padding:0 24px;line-height:1.5}
+    a{color:#e55a2b}code{background:#eee;padding:1px 5px;border-radius:4px}</style></head><body>
+    <h1>${escape(artistName)}</h1>
+    <p style="color:#666">${releases.length} releases from <code>${escape(landedUrl)}</code>.
+    Opening one fetches its release page from Bandcamp (one request) and renders it through the
+    real edge function. Nothing is written anywhere.</p>
+    <ul style="padding-left:18px">${rows}</ul></body></html>`;
+}
+
+const server = createServer(async (req, res) => {
+  const path = decodeURIComponent((req.url || '/').split('?')[0]);
+
+  if (path === '/' || path === '/index.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(indexPage());
+    return;
+  }
+
+  const match = path.match(/^\/a\/[^/]+\/([^/]+)\/?$/);
+  const release = match ? releases.find(r => r.slug === match[1]) : undefined;
+  if (!release) {
+    res.writeHead(302, { Location: '/' });
+    res.end();
+    return;
+  }
+
+  if (!detailCache.has(release.slug)) {
+    console.log(`  fetching ${release.source.url}`);
+    const detailResponse = await safeFetch(release.source.url, 15_000);
+    const outcome = detailResponse?.ok
+      ? ingestBandcampDetail(await detailResponse.text())
+      : ({ ok: false, reason: 'fetch failed' } as const);
+    if (outcome.ok) {
+      detailCache.set(release.slug, { detail: outcome.detail, checkedAt: new Date().toISOString() });
+    } else {
+      // Left uncached deliberately: this previews the "still gathering" state, which is what
+      // every release in the real catalog currently shows.
+      console.warn(`  could not read detail (${'reason' in outcome ? outcome.reason : '?'})`);
+    }
+  }
+
+  const cached = detailCache.get(release.slug);
+  const detail = cached?.detail as
+    | { releaseDate: string | null; datePrecision: string; status: string; offers: Array<Record<string, unknown>> }
+    | undefined;
+
+  setRows(
+    { id: 'preview-artist', name: artistName, image_url: null },
+    {
+      title: release.title,
+      release_type: release.releaseType,
+      release_date: detail?.releaseDate ?? null,
+      date_precision: detail?.datePrecision ?? 'unknown',
+      status: detail?.status ?? 'released',
+      artwork_url: release.artworkUrl,
+      release_sources: [
+        {
+          platform: 'bandcamp',
+          url: release.source.url,
+          detail_checked_at: cached?.checkedAt ?? null,
+          release_offers: (detail?.offers ?? []).map(offer => ({
+            ...offer,
+            captured_at: cached?.checkedAt ?? new Date().toISOString(),
+          })),
+        },
+      ],
+    }
+  );
+
+  const response = await renderReleasePage(
+    new Request(`https://unstream.stream${path}`),
+    { next: () => new Response('fell through to the SPA', { status: 404 }) }
+  );
+
+  res.writeHead(response.status, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(await response.text());
+});
+
+// The artist's real name comes from the first release page we read; until then the slug does.
+const first = releases[0];
+if (first) {
+  const nameResponse = await safeFetch(first.source.url, 15_000);
+  if (nameResponse?.ok) {
+    const html = await nameResponse.text();
+    const outcome = ingestBandcampDetail(html);
+    if (outcome.ok) {
+      detailCache.set(first.slug, { detail: outcome.detail, checkedAt: new Date().toISOString() });
+    }
+    artistName = html.match(/"byArtist":\{[^}]*"name":"([^"]+)"/)?.[1] ?? artistSlug;
+  }
+}
+
+server.listen(port, () => {
+  console.log(`\n${releases.length} releases found. Preview at http://localhost:${port}\n`);
+  console.log('Nothing is written to any database. Ctrl-C to stop.\n');
+});


### PR DESCRIPTION
**Stacked on [#360](https://github.com/brandonlucasgreen/unstream/pull/360)** — it reads `release_sources.detail_checked_at`, which that PR's migration adds. Review #360 first; this diff is only the two new files plus the route.

Step 4 of the V1 scope. The first user-visible piece of Releases: a buying guide for one record — what formats exist, what they cost, and roughly how much reaches the artist. Odesli, the distributor landing pages and feature.fm all answer *"where can I stream this"*, which is the opposite of what Unstream is for.

```
Vinyl     $25   ≈$20–$21.25 to artist
CD        $12   ≈$9.60–$10.20 to artist
Digital   $10   ≈$8–$8.50 to artist
Cassette  $14   Sold out
```

## Decisions worth stating

**Pure SSR, and only SSR.** This URL renders here and nowhere else — the SPA never takes it over. One route with two renderers is the UNS-100 bifurcation class. Nothing hydrates; the only script on the page is an inline image-error fallback (the same one `artist-page-static` uses, because hotlinked CDN artwork failing is normal, and an empty bordered box on a buying page reads as broken).

**Route declared before `/a/*`**, since that glob also matches `/a/artist/release` and `artist-page-static` would otherwise answer first — it'd still work, but only by accident, and at the cost of a DB query per release page view. A regex rather than a path glob because what matters is the *number of path segments*, which Netlify's globs can't express. Netlify's docs confirm both that `pattern` is supported in `netlify.toml` and that declarations run top-to-bottom. The service worker's navigation denylist already covers `/^\/a\//`, so no change needed there.

**`noindex, follow`, and deliberately no JSON-LD.** These pages are generated from a crawl, so a wrong one mints a durable URL asserting an artist made a record they didn't — and a catalog of thin auto-generated pages is textbook scaled-content abuse, whose penalty is *site-wide*, putting the artist-page and guide rankings already earned at risk. Structured data on a noindex page does nothing except publish a machine-readable claim we aren't yet confident enough to make. Indexation stays a later, deliberate decision.

**Payouts are ranges, never point estimates.** The registry's figures are strings (`'80-85%'`, `'~70%'`), which makes false precision impossible by construction — keep it that way. Bandcamp Friday is honoured, because on those days the usual range is simply wrong.

**Sources order by payout; artist-paying options lead.** Moot with one source today, but it's the rule that stops Discogs' secondhand marketplace outranking the artist's own store once step 7 lands.

**Honest states, not empty ones.** *"Still gathering formats and prices"* is a different statement from *"there is nothing to buy"* — and it's what **every release currently in the catalog will show**, since grid ingest has no prices. A release that doesn't exist redirects to the artist page rather than falling through to a blank SPA route (there's no catch-all route for a two-segment `/a/` path).

**Prices are claims with an age.** The footer reports the *oldest* capture on the page; saying "checked today" because one source was refreshed would overstate the rest.

## Testing

The formatting — money, payout ranges, precision-aware dates, freshness, source ordering — lives in `api/shared/release-display.ts` rather than inside the edge function. Edge functions can't run under vitest, and the existing workaround has been to copy the function into the test file and keep the copy in sync by hand; code that makes claims about someone's money shouldn't be verified against a copy of itself. 14 tests, including the ones that matter most: a year-only date never renders a fabricated day, an unknown payout renders nothing rather than a guess, and an unknown currency degrades to a code rather than a wrong symbol.

Verified by running the real edge module against canned data and rendering it at desktop and mobile widths in both themes, including the no-offers state. Mobile initially put a full-bleed square of artwork above everything and wrapped the payout onto two lines — both fixed and measured, not eyeballed.

Full `npm run build` green; 367 tests across `api/functions`.

## Still not wired up

Nothing links here yet. Alerts still open the raw platform URL — that's step 5, and it's what makes this page reachable.