### PR TITLE
Treat a MusicBrainz identity match as verification

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1353,6 +1353,7 @@ async function attachNameOnlyPlatforms(
         type: 'artist',
         platforms: toAttach.map(p => ({ sourceId: p.sourceId as SourceId, url: p.url })),
         matchConfidence: 'unverified',
+        unverifiedReason: 'no-release-data',
       };
 
       // If we have Faircamp, fetch releases to seed the result
@@ -1362,6 +1363,7 @@ async function attachNameOnlyPlatforms(
           const fcPlatform = newResult.platforms.find(p => p.sourceId === 'faircamp');
           if (fcPlatform) fcPlatform.allReleaseTitles = titles;
           newResult.matchConfidence = 'verified';
+          newResult.unverifiedReason = undefined;
         }
       }
 
@@ -1435,6 +1437,7 @@ async function attachNameOnlyPlatforms(
           type: 'artist',
           platforms: toAttach.map(p => ({ sourceId: p.sourceId as SourceId, url: p.url })),
           matchConfidence: 'unverified',
+          unverifiedReason: 'no-release-data',
         };
         merged.push(newResult);
         console.log(`[Deferred Attach] Ambiguous "${displayName}" with no Faircamp data — created separate result with ${toAttach.map(p => p.sourceId).join(', ')}`);
@@ -1443,6 +1446,26 @@ async function attachNameOnlyPlatforms(
       }
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+/**
+ * Did MusicBrainz give us a rich answer for this artist — a confirmed name plus at
+ * least one real destination?
+ *
+ * A name-only hit isn't enough: the card it produces is nothing but search links,
+ * and calling that verified would overclaim. But once MB hands over an official
+ * site, a Discogs page, a Qobuz page or a social profile, it has told us who the
+ * artist is and where to find them, which is the question "verified" answers.
+ */
+function musicBrainzConfirmsIdentity(mbData: EnrichedMusicBrainzResult): boolean {
+  if (!mbData.artistName) return false;
+  return Boolean(
+    mbData.officialUrl ||
+    mbData.discogsUrl ||
+    mbData.qobuzUrl ||
+    (mbData.socialLinks && mbData.socialLinks.length > 0)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1528,6 +1551,11 @@ function applyEnrichmentToResults(
   if (bestMatchIndex === -1) return;
 
   const result = aggregated[bestMatchIndex];
+  // MB picked this result out of the same-name candidates and is about to attach
+  // the artist's real links to it — that is an identity match, not a guess.
+  if (musicBrainzConfirmsIdentity(mbData)) {
+    result.musicBrainzConfirmed = true;
+  }
   const newPlatforms = [...result.platforms];
 
   // Add official site if available and not already present
@@ -1816,12 +1844,18 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
         return aSearch - bSearch;
       });
 
+      // This card exists because MusicBrainz knows the artist and our platforms
+      // don't. When MB also handed over their real links, that is the verification
+      // — there are no releases to cross-check and nothing to cross-check against.
+      const mbConfirmed = musicBrainzConfirmsIdentity(mbData);
       const mbResult: AggregatedResult = {
         id: `mb-${mbNorm}`,
         name: mbData.artistName,
         type: 'artist',
         platforms: mbPlatforms,
-        matchConfidence: 'unverified',
+        matchConfidence: mbConfirmed ? 'verified' : 'unverified',
+        unverifiedReason: mbConfirmed ? undefined : 'no-release-data',
+        musicBrainzConfirmed: mbConfirmed,
         location: mbData.location,
         wikipediaSummary: mbData.wikipediaSummary || undefined,
         wikipediaUrl: mbData.wikipediaUrl || undefined,

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -65,10 +65,27 @@ export interface AggregatedResult {
     latestRelease?: LatestRelease;
     allReleaseTitles?: string[]; // For disambiguation - all release titles (normalized)
   }[];
-  // Match confidence: 'verified' means releases match across platforms,
-  // 'unverified' means name-only match (no release data to compare)
-  // 'claimed' means artist has verified ownership of this profile
+  // Match confidence: 'verified' means we know who this is — releases match across
+  // platforms, a curated platform lists them, or MusicBrainz identified them (see
+  // musicBrainzConfirmed); 'unverified' means a name-only match we couldn't confirm;
+  // 'claimed' means the artist has verified ownership of this profile.
   matchConfidence?: 'verified' | 'unverified' | 'claimed';
+  // Why an 'unverified' result is unverified. These are different claims and the
+  // UI must not conflate them: 'conflicting-releases' means we compared this
+  // platform's releases against a verified set and they didn't match (there is
+  // always a sibling verified result), so it may be a different artist with the
+  // same name. 'no-release-data' means we had nothing to compare against at all
+  // — absence of evidence, not evidence of a mismatch, and often the only result
+  // on the page. Absent on results restored from the DB, which only persists the
+  // confidence itself; treat that like 'no-release-data'.
+  unverifiedReason?: 'conflicting-releases' | 'no-release-data';
+  // MusicBrainz matched this artist and supplied real destinations for them
+  // (official site, Discogs, Qobuz, socials). That confirms identity the same way
+  // a curated platform does, and more directly than release-title overlap, so it
+  // counts as verification on its own. Without it, artists MusicBrainz knows
+  // perfectly well — Nine Inch Nails, Viagra Boys — were labelled "Unverified"
+  // purely because nothing we could parse releases from had listed them.
+  musicBrainzConfirmed?: boolean;
   // Slug for claimed artist page (/a/{slug})
   claimedSlug?: string;
   // Set to true when this result was merged via a manual override — protects it from later splitting
@@ -853,9 +870,13 @@ export function splitSuspiciousPlatforms(aggregated: AggregatedResult[]): Aggreg
     const hasCurated = result.platforms.some(p => CURATED_PLATFORMS.has(p.sourceId));
     const suspicious = withoutReleases.filter(p => RELIABLE_RELEASE_PLATFORMS.has(p.sourceId));
 
-    // No platforms have releases
+    // No platforms have releases — nothing to compare, so nothing is in conflict.
+    // A curated platform or a MusicBrainz identity match vouches for the artist
+    // without needing release overlap.
+    const vouchedFor = hasCurated || result.musicBrainzConfirmed === true;
     if (withReleases.length === 0) {
-      result.matchConfidence = hasCurated ? 'verified' : 'unverified';
+      result.matchConfidence = vouchedFor ? 'verified' : 'unverified';
+      result.unverifiedReason = vouchedFor ? undefined : 'no-release-data';
       disambiguated.push(result);
       continue;
     }
@@ -910,6 +931,7 @@ export function splitSuspiciousPlatforms(aggregated: AggregatedResult[]): Aggreg
             imageUrl: result.imageUrl,
             platforms: [platform],
             matchConfidence: 'unverified',
+            unverifiedReason: 'conflicting-releases',
           });
         }
         continue;
@@ -918,12 +940,14 @@ export function splitSuspiciousPlatforms(aggregated: AggregatedResult[]): Aggreg
       // All suspicious platforms verified or kept due to no data
       result.platforms = [...withReleases, ...withoutReleases.filter(p => !RELIABLE_RELEASE_PLATFORMS.has(p.sourceId))];
       result.matchConfidence = 'verified';
+      result.unverifiedReason = undefined;
       disambiguated.push(result);
       continue;
     }
 
     // No suspicious platforms — keep as verified
     result.matchConfidence = 'verified';
+    result.unverifiedReason = undefined;
     disambiguated.push(result);
   }
 

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -119,8 +119,12 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect, onLink
       />
 
         <div className="px-4 pb-4 pt-2 border-t border-border space-y-4">
-          {/* Unverified match warning */}
-          {result.matchConfidence === 'unverified' && (
+          {/* Unverified match warning. Only shown for a real conflict — a result
+              split off because its releases didn't match a verified sibling. The
+              other way to be unverified is having no release data to compare at
+              all, which is not a warning about this result and, for a
+              MusicBrainz-only card, has no "other results" to compare with. */}
+          {result.matchConfidence === 'unverified' && result.unverifiedReason === 'conflicting-releases' && (
             <div className="flex items-start gap-2 p-2 rounded bg-yellow-500/5 border border-yellow-500/20 text-yellow-600 text-xs">
               <svg className="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />

--- a/apps/web/src/components/ResultCardHeader.tsx
+++ b/apps/web/src/components/ResultCardHeader.tsx
@@ -66,7 +66,12 @@ export function ResultCardHeader({
               {typeLabel[result.type]}
             </span>
             {result.matchConfidence === 'unverified' && (
-              <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-500 flex items-center gap-1 whitespace-nowrap" title="Could not verify this is the same artist - no matching releases found">
+              <span
+                className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-500 flex items-center gap-1 whitespace-nowrap"
+                title={result.unverifiedReason === 'conflicting-releases'
+                  ? 'This may be a different artist with the same name — its releases don’t match the verified result'
+                  : 'We couldn’t cross-check this against release data on other platforms'}
+              >
                 <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -597,6 +597,26 @@ export async function fetchMusicBrainzData(query: string): Promise<import('../ty
   }
 }
 
+/**
+ * Did MusicBrainz give us a rich answer — a confirmed name plus at least one real
+ * destination? If so the artist's identity is settled and the result is verified,
+ * regardless of whether any platform we can parse releases from has listed them.
+ * A name-only hit is not enough; that card is nothing but search links.
+ *
+ * Mirrors musicBrainzConfirmsIdentity in api/functions/search-sources.ts, minus
+ * the Qobuz check — the client gets Qobuz from platformUrls via pickQobuzUrl
+ * rather than a qobuzUrl field, and a Qobuz relation with no official site, no
+ * Discogs and no socials isn't a case worth mirroring the plumbing for.
+ */
+function musicBrainzConfirmsIdentity(mbData: import('../types').MusicBrainzData): boolean {
+  if (!mbData.artistName) return false;
+  return Boolean(
+    mbData.officialUrl ||
+    mbData.discogsUrl ||
+    (mbData.socialLinks && mbData.socialLinks.length > 0)
+  );
+}
+
 // Build a result card from MusicBrainz data alone, for searches where no
 // platform returned anything. Mirrors the server-side Phase 2.2 fallback in
 // api/functions/search-sources.ts: a prominent artist who isn't on any indie
@@ -630,12 +650,20 @@ export function buildMusicBrainzFallbackResult(
     { sourceId: 'buymeacoffee', url: 'https://buymeacoffee.com/explore-creators' },
   );
 
+  // This card is built only when no platform returned anything, so it is always
+  // the only result on the page — there is nothing to cross-check it against and
+  // nothing for it to conflict with. MusicBrainz naming the artist and handing
+  // over their real links is the verification.
+  const confirmed = musicBrainzConfirmsIdentity(mbData);
+
   return {
     id: `mb-${normalizeForComparison(name)}`,
     name,
     type: 'artist',
     platforms,
-    matchConfidence: 'unverified',
+    matchConfidence: confirmed ? 'verified' : 'unverified',
+    unverifiedReason: confirmed ? undefined : 'no-release-data',
+    musicBrainzConfirmed: confirmed,
     location: mbData.location,
     wikipediaSummary: mbData.wikipediaSummary || undefined,
     wikipediaUrl: mbData.wikipediaUrl || undefined,
@@ -840,9 +868,26 @@ export function mergeWithMusicBrainzData(
       return 0;
     });
 
+    // MusicBrainz picked this result out of the same-name candidates and just
+    // attached the artist's real links to it. That settles identity, so a card
+    // still labelled "unverified" only for want of parseable releases is now
+    // verified. A claimed profile already outranks both and is left alone.
+    // A card split off for conflicting releases keeps its warning: that split came
+    // from comparing actual release titles, and a name-level match is not grounds
+    // to throw that evidence away.
+    const confirmed = musicBrainzConfirmsIdentity(mbData);
+    const upgradedConfidence = confirmed &&
+      result.matchConfidence !== 'claimed' &&
+      result.unverifiedReason !== 'conflicting-releases'
+      ? ('verified' as const)
+      : result.matchConfidence;
+
     return {
       ...result,
       platforms: newPlatforms,
+      matchConfidence: upgradedConfidence,
+      musicBrainzConfirmed: confirmed || result.musicBrainzConfirmed,
+      unverifiedReason: upgradedConfidence === 'unverified' ? result.unverifiedReason : undefined,
       wikipediaSummary: mbData.wikipediaSummary || undefined,
       wikipediaUrl: mbData.wikipediaUrl || undefined,
       location: mbData.location || result.location,

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -77,10 +77,21 @@ export interface SearchResult {
   type: 'artist' | 'album' | 'track';
   imageUrl?: string;
   platforms: PlatformLink[];
-  // Match confidence: 'verified' means releases match across platforms,
-  // 'unverified' means name-only match (no release data to compare)
-  // 'claimed' means artist has verified ownership of this profile
+  // Match confidence: 'verified' means we know who this is — releases match across
+  // platforms, a curated platform lists them, or MusicBrainz identified them (see
+  // musicBrainzConfirmed); 'unverified' means a name-only match we couldn't confirm;
+  // 'claimed' means the artist has verified ownership of this profile.
   matchConfidence?: 'verified' | 'unverified' | 'claimed';
+  // Why an 'unverified' result is unverified. 'conflicting-releases' means this
+  // platform's releases didn't match a verified sibling result — it may be a
+  // different artist with the same name, and that warrants a warning.
+  // 'no-release-data' means we had nothing to compare against, which is not a
+  // warning about the result. Absent for results restored from the DB; treat
+  // that like 'no-release-data'. Mirrors api/functions/search-utils.ts.
+  unverifiedReason?: 'conflicting-releases' | 'no-release-data';
+  // MusicBrainz matched this artist and supplied real destinations for them.
+  // Counts as verification on its own — see api/functions/search-utils.ts.
+  musicBrainzConfirmed?: boolean;
   // Slug for claimed artist page (/a/{slug})
   claimedSlug?: string;
   // Wikipedia bio summary from MusicBrainz enrichment

--- a/apps/web/tests/unit/UnverifiedBanner.test.tsx
+++ b/apps/web/tests/unit/UnverifiedBanner.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+// The "Unverified match" banner claims a comparison — "the same X as the other
+// results" — so it may only appear when a comparison actually happened.
+//
+// The bug this guards: searching "viagra boys" returned exactly one card, built
+// from MusicBrainz alone because no platform matched, and it carried that banner.
+// There were no other results to be the same or different from, so the copy read
+// as a warning about a result nothing was actually in doubt about.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render as renderComponent, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ResultCard } from 'src/components/ResultCard';
+import type { SearchResult } from 'src/types';
+
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    session: null,
+    isArtistSaved: () => false,
+    saveArtist: vi.fn(),
+    removeSavedArtist: vi.fn(),
+  }),
+}));
+
+vi.mock('src/services/analytics', () => ({
+  analytics: {
+    trackPlatformClick: vi.fn(),
+    trackArtistSearchAppearance: vi.fn(),
+    trackArtistLinkClick: vi.fn(),
+    trackSearch: vi.fn(),
+  },
+}));
+
+vi.mock('@sentry/react', () => ({ captureException: vi.fn() }));
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    id: 'viagraboys',
+    name: 'Viagra Boys',
+    type: 'artist',
+    platforms: [{ sourceId: 'officialsite', url: 'https://vboysstockholm.com/' }],
+    ...overrides,
+  };
+}
+
+const render = (ui: React.ReactElement) => renderComponent(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('ResultCard unverified banner', () => {
+  afterEach(cleanup);
+
+  it('warns when the result was split off for having conflicting releases', () => {
+    render(<ResultCard result={makeResult({
+      matchConfidence: 'unverified',
+      unverifiedReason: 'conflicting-releases',
+    })} />);
+
+    expect(screen.getByText('Unverified match:')).toBeTruthy();
+  });
+
+  it('stays quiet for a MusicBrainz-only card with nothing to compare against', () => {
+    render(<ResultCard result={makeResult({
+      matchConfidence: 'unverified',
+      unverifiedReason: 'no-release-data',
+    })} />);
+
+    expect(screen.queryByText('Unverified match:')).toBeNull();
+    // The header chip still marks the result as unverified — the point is that
+    // low confidence gets a quiet label, not a warning about a conflict.
+    expect(screen.getByText('Unverified')).toBeTruthy();
+  });
+
+  it('stays quiet when the reason is missing, as for artists restored from the DB', () => {
+    render(<ResultCard result={makeResult({ matchConfidence: 'unverified' })} />);
+
+    expect(screen.queryByText('Unverified match:')).toBeNull();
+  });
+
+  it('shows nothing for a verified result', () => {
+    render(<ResultCard result={makeResult({ matchConfidence: 'verified' })} />);
+
+    expect(screen.queryByText('Unverified match:')).toBeNull();
+    expect(screen.queryByText('Unverified')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/disambiguation.test.ts
+++ b/apps/web/tests/unit/disambiguation.test.ts
@@ -40,6 +40,9 @@ describe('splitSuspiciousPlatforms', () => {
     expect(verified).toBeDefined();
     expect(unverified).toBeDefined();
     expect(unverified!.platforms[0].sourceId).toBe('bandcamp');
+    // Only this branch actually compared releases, so only this branch may claim
+    // the result conflicts with another one. The UI warning keys off the reason.
+    expect(unverified!.unverifiedReason).toBe('conflicting-releases');
   });
 
   it('keeps Bandcamp with matching releases on the same result', () => {
@@ -74,6 +77,36 @@ describe('splitSuspiciousPlatforms', () => {
     const disambiguated = splitSuspiciousPlatforms(results);
 
     expect(disambiguated[0].matchConfidence).toBe('unverified');
+    // Nothing was compared, so this must not be reported as a conflict. A
+    // MusicBrainz-only card lands here and is usually the only result on the page.
+    expect(disambiguated[0].unverifiedReason).toBe('no-release-data');
+  });
+
+  it('verifies a result MusicBrainz confirmed, with no releases and no curated platform', () => {
+    // The Nine Inch Nails / Viagra Boys case: MusicBrainz knows exactly who this is
+    // and supplied their real links, but nothing we can parse releases from lists
+    // them. That is not grounds for a warning.
+    const results = [makeResult('Nine Inch Nails', [
+      { sourceId: 'officialsite', url: 'https://www.nin.com/' },
+      { sourceId: 'discogs', url: 'https://www.discogs.com/artist/4192' },
+    ], { musicBrainzConfirmed: true })];
+
+    const disambiguated = splitSuspiciousPlatforms(results);
+
+    expect(disambiguated[0].matchConfidence).toBe('verified');
+    expect(disambiguated[0].unverifiedReason).toBeUndefined();
+  });
+
+  it('clears the unverified reason when a result is upgraded to verified', () => {
+    const results = [makeResult('Artist', [
+      { sourceId: 'bandcamp', url: 'https://a.bandcamp.com', allReleaseTitles: ['shared album'] },
+      { sourceId: 'mirlo', url: 'https://mirlo.space/artist', latestRelease: { title: 'Shared Album', type: 'album', url: 'https://mirlo.space/artist/shared' }, allReleaseTitles: ['shared album'] },
+    ], { matchConfidence: 'unverified', unverifiedReason: 'no-release-data' })];
+
+    const disambiguated = splitSuspiciousPlatforms(results);
+
+    expect(disambiguated[0].matchConfidence).toBe('verified');
+    expect(disambiguated[0].unverifiedReason).toBeUndefined();
   });
 });
 

--- a/apps/web/tests/unit/sources-service.test.ts
+++ b/apps/web/tests/unit/sources-service.test.ts
@@ -258,6 +258,58 @@ describe('mergeWithMusicBrainzData', () => {
     expect(merged[0].platforms).toHaveLength(1);
   });
 
+  // A MusicBrainz identity match is verification in its own right. Nine Inch Nails
+  // was labelled "Unverified" while showing its real official site, Discogs, Qobuz
+  // and socials — every one of them sourced from the MB record doing the labelling.
+  it('upgrades an unverified result MusicBrainz identified to verified', () => {
+    const results = [{
+      ...makeArtistResult('Test Artist', [{ sourceId: 'bandcamp' as const, url: 'https://a.bandcamp.com' }]),
+      matchConfidence: 'unverified' as const,
+      unverifiedReason: 'no-release-data' as const,
+    }];
+    const mbData = makeMBData({ officialUrl: 'https://testartist.com' });
+
+    const merged = mergeWithMusicBrainzData(results, mbData);
+    expect(merged[0].matchConfidence).toBe('verified');
+    expect(merged[0].unverifiedReason).toBeUndefined();
+  });
+
+  it('leaves confidence alone when MusicBrainz only confirmed the name', () => {
+    const results = [{
+      ...makeArtistResult('Test Artist', [{ sourceId: 'bandcamp' as const, url: 'https://a.bandcamp.com' }]),
+      matchConfidence: 'unverified' as const,
+      unverifiedReason: 'no-release-data' as const,
+    }];
+
+    const merged = mergeWithMusicBrainzData(results, makeMBData());
+    expect(merged[0].matchConfidence).toBe('unverified');
+  });
+
+  it('keeps a conflicting-releases split unverified even when MusicBrainz matches', () => {
+    // That split came from comparing actual release titles. A name-level MB match
+    // is weaker evidence and must not quietly erase it.
+    const results = [{
+      ...makeArtistResult('Test Artist', [{ sourceId: 'bandcamp' as const, url: 'https://impostor.bandcamp.com' }]),
+      matchConfidence: 'unverified' as const,
+      unverifiedReason: 'conflicting-releases' as const,
+    }];
+    const mbData = makeMBData({ officialUrl: 'https://testartist.com' });
+
+    const merged = mergeWithMusicBrainzData(results, mbData);
+    expect(merged[0].matchConfidence).toBe('unverified');
+    expect(merged[0].unverifiedReason).toBe('conflicting-releases');
+  });
+
+  it('does not downgrade a claimed profile', () => {
+    const results = [{
+      ...makeArtistResult('Test Artist', [{ sourceId: 'bandcamp' as const, url: 'https://a.bandcamp.com' }]),
+      matchConfidence: 'claimed' as const,
+    }];
+    const mbData = makeMBData({ officialUrl: 'https://testartist.com' });
+
+    expect(mergeWithMusicBrainzData(results, mbData)[0].matchConfidence).toBe('claimed');
+  });
+
   it('adds official site when available', () => {
     const results = [makeArtistResult('Test Artist', [{ sourceId: 'bandcamp', url: 'https://a.bandcamp.com' }])];
     const mbData = makeMBData({ officialUrl: 'https://testartist.com' });
@@ -532,7 +584,11 @@ describe('buildMusicBrainzFallbackResult', () => {
     expect(result).not.toBeNull();
     expect(result!.name).toBe('Radiohead');
     expect(result!.type).toBe('artist');
-    expect(result!.matchConfidence).toBe('unverified');
+    // MusicBrainz named the artist and handed over their official site, Discogs
+    // and socials. Nothing is in doubt, so the card must not wear a warning — this
+    // is the only result on the page and there is nothing to compare it against.
+    expect(result!.matchConfidence).toBe('verified');
+    expect(result!.unverifiedReason).toBeUndefined();
     const ids = result!.platforms.map(p => p.sourceId);
     expect(ids.slice(0, 4)).toEqual(['officialsite', 'discogs', 'instagram', 'youtube']);
     expect(ids).toContain('bandcamp');
@@ -553,5 +609,27 @@ describe('buildMusicBrainzFallbackResult', () => {
     const ids = bare!.platforms.map(p => p.sourceId);
     expect(ids[0]).toBe('bandcamp');
     expect(ids).not.toContain('officialsite');
+  });
+
+  it('stays unverified when MusicBrainz only confirmed the name', () => {
+    // Nothing but search links: MB knows the name and nothing else, so there is
+    // genuinely no destination we can vouch for.
+    const bare = buildMusicBrainzFallbackResult({
+      ...mbData,
+      officialUrl: null,
+      discogsUrl: null,
+      socialLinks: [],
+    });
+    expect(bare!.matchConfidence).toBe('unverified');
+    expect(bare!.unverifiedReason).toBe('no-release-data');
+  });
+
+  it('is verified on socials alone', () => {
+    const socialsOnly = buildMusicBrainzFallbackResult({
+      ...mbData,
+      officialUrl: null,
+      discogsUrl: null,
+    });
+    expect(socialsOnly!.matchConfidence).toBe('verified');
   });
 });


### PR DESCRIPTION
Searching **nine inch nails** returned a card showing the band's real official site, Discogs, Qobuz and five socials — under a yellow warning:

> **Unverified match:** We couldn't confirm this is the same "Nine Inch Nails" as the other results.

Every link in that card came from the MusicBrainz record that supposedly couldn't confirm it. And for **viagra boys** the card was the only result on the page, so there were no "other results" to be the same as.

Two separate defects, both in how confidence is decided and described.

## 1. A MusicBrainz identity match didn't count as verification

`matchConfidence: 'verified'` only ever meant "release titles overlap across platforms" (or a curated platform — mirlo/faircamp/jamcoop — listed them). So an artist none of our parseable platforms carried stayed unverified no matter how well MusicBrainz knew them. Since MB is now our only source of Qobuz links and socials, that's a lot of cards showing real, correct links under a warning.

But MB naming the artist and handing over their official site, Discogs, Qobuz and socials answers the question the badge is actually asking — more directly than release-title overlap does.

`musicBrainzConfirmsIdentity()` now gates a `musicBrainzConfirmed` flag, set wherever MB identity data lands on a result: the Phase 2.2 fallback card, Phase 2.1 enrichment, and both client-side equivalents. It vouches for a result the same way a curated platform does.

A **name-only** MB hit deliberately does not qualify — that card is nothing but search links, and calling it verified would overclaim. "Rich" means MB gave us at least one real destination.

## 2. The warning claimed a comparison that often never happened

Two unrelated situations both produced `'unverified'`:

| Situation | Is it a warning? |
|---|---|
| Bandcamp page split off because its releases contradicted a verified sibling | Yes — may be a different artist with the same name |
| No release data to compare at all | No — absence of evidence, not evidence of a mismatch |

The copy was written for the first and shown for both. `unverifiedReason` now records which, and the banner renders only for `'conflicting-releases'`. Absence of evidence gets the quiet header chip instead — whose tooltip made the same false claim and no longer does. Results restored from the DB carry no reason (only the confidence itself persists) and take the quiet path, which is the safe default.

An MB match does **not** override a conflicting-releases split, in either the server or client path: that split came from comparing actual release titles, and a name-level match is weaker evidence than the thing it would erase.

## Verification

Against the dev API on this branch (rebased onto #361, which is what makes these two queries resolve at all):

- `?q=viagra+boys` → 1 result, no banner, no chip
- `?q=nine+inch+nails` → 1 result, no banner, no chip

492 web unit tests + 347 API tests pass. Lint and an explicit `tsc` over the touched `api/` files are byte-identical to a stashed baseline (77 pre-existing lint problems, 3 pre-existing type errors — `api/` isn't in the typecheck include, so this was checked by hand).

New coverage: `apps/web/tests/unit/UnverifiedBanner.test.tsx`, plus cases in `disambiguation.test.ts` and `sources-service.test.ts` for the confidence rule, the reason split, and the conflicting-releases guard.

## Worth a second look

This widens what the public "Verified" badge means, and `db.ts` persists `match_confidence` — so newly-verified MB artists propagate to stored artists, the Apple app, and the artist pages. That's the intended effect, but it is the part with reach beyond search.

## Relationship to #361

Independent. #361 fixed the MusicBrainz Lucene quoting so these queries resolve; this fixes how the resulting card is labelled. The mislabelling predates #361 and affects any artist our platforms miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)