### PR TITLE
Show an artist's releases on their page

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -3,6 +3,27 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
 import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
 import { mainLinkDividerIndexes } from "../shared/link-dividers.ts";
+import { cheapestOfferSummary, formatReleaseDate } from "../shared/release-display.ts";
+
+/**
+ * How many releases to list before summarising the rest.
+ *
+ * Most catalogues fit: 16 for Sufjan Stevens, 13 for Explosions in the Sky. The cap exists for
+ * the artists who don't — one live Mirlo artist has 33 releases including *Inaction I–V* — where
+ * an unbounded list would bury the platform links this page exists to show.
+ */
+const MAX_RELEASES_SHOWN = 24;
+
+interface ReleaseRow {
+  slug: string;
+  title: string;
+  release_type: string;
+  release_date: string | null;
+  date_precision: string | null;
+  status: string;
+  artwork_url: string | null;
+  release_sources: { release_offers: { price: number | null; currency: string | null; availability: string }[] | null }[] | null;
+}
 
 // Allowed embed domains for featured releases (must match api/functions/artist-profile.ts)
 const ALLOWED_EMBED_DOMAINS = [
@@ -39,6 +60,47 @@ const SOCIAL_ICONS: Record<string, string> = {
 };
 
 const LOGO_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 110 110" aria-hidden="true"><defs><filter id="gs"><feColorMatrix type="saturate" values="0"/></filter></defs><g transform="translate(22,22) scale(1.8333)" filter="url(#gs)"><path fill="#50A5E6" d="M30 22c-3 0-6.688 7.094-7 10-.421 3.915 2 4 2 4h11V26s-3.438-4-6-4z"/><ellipse transform="rotate(-60 27.574 28.49)" fill="#1C6399" cx="27.574" cy="28.489" rx="5.848" ry="1.638"/><path fill="#F9CA55" d="M20.086 0c1.181 0 2.138.957 2.138 2.138 0 .789.668 10.824.668 10.824L17.948 18V2.138C17.948.957 18.905 0 20.086 0z"/><path fill="#FFDC5D" d="M18.875 4.323c0-1.099.852-1.989 1.903-1.989 1.051 0 1.903.891 1.903 1.989 0 0 .535 5.942 1.192 9.37.878 1.866 1.369 4.682 1.261 6.248.054.398 5.625 5.006 5.625 5.006-.281 1.813-2.259 6.155-4.759 8.159l-3.521-2.924c-2.885-.404-4.458-3.331-4.458-4.264 0-2.984.854-21.595.854-21.595z"/><path fill="#50A5E6" d="M6 22c3 0 6.688 7.094 7 10 .421 3.915-2 4-2 4H0V26s3.438-4 6-4z"/><ellipse transform="rotate(-30 8.424 28.489)" fill="#1C6399" cx="8.426" cy="28.489" rx="1.638" ry="5.848"/><path fill="#F9CA55" d="M16.061.011c-1.266-.127-2.333.864-2.333 2.103 0 .78-.184 10.319-.184 10.319L17.895 18l.062-15.765c0-1.106-.795-2.114-1.896-2.224z"/><path fill="#FFDC5D" d="M17.125 4.323c0-1.099-.852-1.989-1.903-1.989-1.051 0-1.903.891-1.903 1.989 0 0-.535 5.942-1.192 9.37-.878 1.866-1.369 4.682-1.261 6.248-.054.398-5.625 5.006-5.625 5.006C5.522 26.76 7.5 31.102 10 33.106l3.521-2.924c2.885-.404 4.458-3.331 4.458-4.264 0-2.984-.854-21.595-.854-21.595z"/><path fill="#F9CA55" d="M17.958 25.823c-.414 0-.75-.336-.75-.75V2.792c0-.414.336-.75.75-.75s.75.336.75.75v22.282c.001.413-.335.749-.75.749z"/></g><path d="M14,52 A41,41 0 0,1 96,52" fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round"/><line x1="14" y1="52" x2="14" y2="64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/><line x1="96" y1="52" x2="96" y2="64" stroke="currentColor" stroke-width="7" stroke-linecap="round"/><rect x="3" y="60" width="22" height="28" rx="9" fill="currentColor"/><rect x="85" y="60" width="22" height="28" rx="9" fill="currentColor"/></svg>';
+
+/**
+ * One release in the list: artwork, title, and the cheapest way to own it.
+ *
+ * The price is the point. A chronology of titles is something a dozen sites already have; "from
+ * $8" next to it is the thing that makes this list worth clicking, and it comes straight from
+ * the offers the release page shows in full.
+ */
+function renderReleaseRow(release: ReleaseRow, artistSlug: string): string {
+  const href = `/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release.slug)}`;
+  const title = escapeHtml(release.title);
+  const date = formatReleaseDate(release.release_date, release.date_precision);
+
+  // Capitalized here rather than with `text-transform: capitalize`, which applies to the whole
+  // line and would turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
+  const type = release.release_type === 'other'
+    ? ''
+    : release.release_type.charAt(0).toUpperCase() + release.release_type.slice(1);
+
+  const offers = (release.release_sources || []).flatMap(s => s.release_offers || []);
+  const meta = [type, date, cheapestOfferSummary(offers)].filter(Boolean).join(' · ');
+
+  const art = release.artwork_url
+    ? `<img src="${escapeHtml(release.artwork_url)}" alt="" loading="lazy" referrerpolicy="no-referrer" style="width:48px;height:48px;border-radius:6px;object-fit:cover;flex-shrink:0;background:var(--bg2)">`
+    : `<div style="width:48px;height:48px;border-radius:6px;flex-shrink:0;background:var(--bg2);display:flex;align-items:center;justify-content:center;font-size:20px">💿</div>`;
+
+  // An upcoming release is the most interesting row in the list and the easiest to miss when
+  // it's sorted to the top of a chronology that otherwise reads as history.
+  const upcoming = release.status === 'announced'
+    ? '<span style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--accent);flex-shrink:0">Coming</span>'
+    : '';
+
+  return `<a href="${href}" style="display:flex;align-items:center;gap:12px;padding:8px 12px;border-radius:12px;border:1px solid var(--border);text-decoration:none;color:var(--text)">
+    ${art}
+    <span style="flex:1;min-width:0">
+      <span style="display:block;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${title}</span>
+      ${meta ? `<span style="display:block;font-size:12px;color:var(--muted)">${escapeHtml(meta)}</span>` : ''}
+    </span>
+    ${upcoming}
+  </a>`;
+}
 
 function isEmbedDomainAllowed(url: string): boolean {
   try {
@@ -133,6 +195,8 @@ export default async function handler(request: Request, context: Context) {
     let artist: any;
     let profile: any;
     let links: any[];
+    let releases: ReleaseRow[] = [];
+    let releaseCount = 0;
 
     try {
       const { data: artistData } = await supabase
@@ -165,6 +229,29 @@ export default async function handler(request: Request, context: Context) {
         .abortSignal(controller.signal);
 
       links = linksData || [];
+
+      // Releases, newest first. `count: 'exact'` alongside a limit gives the full total in the
+      // same round trip, so the "and N more" line is a real number rather than a guess.
+      //
+      // Ordered to match idx_releases_artist_chrono: many releases have no date yet (grid ingest
+      // gets identity and artwork but no dates), and without the created_at tiebreaker those
+      // undated rows would shuffle between requests.
+      const { data: releasesData, count } = await supabase
+        .from('releases')
+        .select(
+          'slug, title, release_type, release_date, date_precision, status, artwork_url,' +
+          ' release_sources ( release_offers ( price, currency, availability ) )',
+          { count: 'exact' }
+        )
+        .eq('artist_id', artist.id)
+        .eq('is_hidden', false)
+        .order('release_date', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false })
+        .limit(MAX_RELEASES_SHOWN)
+        .abortSignal(controller.signal);
+
+      releases = (releasesData as ReleaseRow[]) || [];
+      releaseCount = count ?? releases.length;
     } catch (e: any) {
       // Timeout or error — fall through to SPA
       clearTimeout(timeoutId);
@@ -202,6 +289,29 @@ export default async function handler(request: Request, context: Context) {
     );
 
     const bcFriday = isBandcampFriday();
+
+    // Releases, shared by the claimed and unclaimed templates below.
+    //
+    // Rendered for every artist that has a catalogue, not only verified ones. The releases come
+    // from the artist's stored Bandcamp link — which this page is *already* showing as a place
+    // to buy — so listing what's behind that link asserts nothing the page doesn't already
+    // assert. Gating on verification would hide the feature from nearly every artist, since
+    // almost none are claimed.
+    //
+    // Nothing renders when there are no releases. An empty "Releases" heading reads as broken,
+    // while its absence reads as "nothing here yet" — which is the truth for any artist nobody
+    // has saved or searched, because cataloguing is demand-driven.
+    const releasesHtml = releases.length === 0 ? '' : `
+      <div style="margin-top:24px">
+        <h2 style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted);margin-bottom:12px">Releases</h2>
+        <div style="display:grid;gap:8px">
+          ${releases.map((r: ReleaseRow) => renderReleaseRow(r, slug)).join('')}
+        </div>
+        ${releaseCount > releases.length
+          ? `<p style="font-size:13px;color:var(--muted);margin-top:10px">and ${releaseCount - releases.length} more</p>`
+          : ''}
+      </div>
+    `;
 
     // Build platform links HTML (shared by both claimed and unclaimed)
     const platformLinksHtml = mainPlatforms.map((p: { platform: string; url: string; display_name?: string }, index: number) => {
@@ -332,6 +442,7 @@ export default async function handler(request: Request, context: Context) {
         <div style="display:grid;gap:8px">${platformLinksHtml}</div>
       ` : ''}
       ${socialLinksHtml}
+      ${releasesHtml}
     </div>
   </div>
 
@@ -430,6 +541,7 @@ export default async function handler(request: Request, context: Context) {
         <div style="display:grid;gap:8px">${platformLinksHtml}</div>
       ` : ''}
       ${socialLinksHtml}
+      ${releasesHtml}
       <div style="margin-top:24px;padding:16px;border-radius:12px;border:1px solid var(--border);text-align:center">
         <p style="font-size:14px;color:var(--muted)">Are you ${artistName}?</p>
         <a href="/claim?slug=${escapeHtml(slug)}" class="claim-cta">Claim this profile</a>

--- a/api/functions/__tests__/release-display.test.ts
+++ b/api/functions/__tests__/release-display.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  cheapestOfferSummary,
   formatMoney,
   formatOfferPrice,
   formatReleaseDate,
@@ -122,5 +123,32 @@ describe('formatOfferPrice', () => {
   it('renders a real price normally', () => {
     expect(formatOfferPrice(25, 'USD')).toBe('$25');
     expect(formatOfferPrice(8.5, 'GBP')).toBe('£8.50');
+  });
+});
+
+describe('cheapestOfferSummary', () => {
+  const offer = (price: number | null, availability = 'available') =>
+    ({ price, currency: 'USD', availability });
+
+  it('quotes the cheapest thing a fan can buy', () => {
+    expect(cheapestOfferSummary([offer(25), offer(8), offer(12)])).toBe('from $8');
+  });
+
+  // The one genuinely misleading number this list could show: a fan clicks expecting $8 vinyl
+  // and finds it gone. A release whose only offer is sold out summarises as nothing.
+  it('ignores sold-out formats when picking the cheapest', () => {
+    expect(cheapestOfferSummary([offer(25), offer(8, 'sold_out')])).toBe('from $25');
+    expect(cheapestOfferSummary([offer(8, 'sold_out')])).toBe('');
+  });
+
+  it('says name-your-price rather than "from $0"', () => {
+    expect(cheapestOfferSummary([offer(0)])).toBe('Name your price');
+  });
+
+  // The normal state for a release catalogued from the Bandcamp grid, whose own page hasn't
+  // been read for prices yet. Silence, not a zero.
+  it('says nothing when there are no offers or no prices', () => {
+    expect(cheapestOfferSummary([])).toBe('');
+    expect(cheapestOfferSummary([offer(null)])).toBe('');
   });
 });

--- a/api/shared/release-display.ts
+++ b/api/shared/release-display.ts
@@ -83,6 +83,31 @@ export function formatOfferPrice(price: number | null, currency: string | null):
 }
 
 /**
+ * "from $8", or "Name your price" — the cheapest thing a fan can actually buy, for a one-line
+ * summary in a list of releases.
+ *
+ * **Sold-out formats are excluded.** Quoting the price of a record nobody can buy would be the
+ * one genuinely misleading number in a discography list — a fan would click expecting $25 vinyl
+ * and find it gone. A release whose only offer is sold out summarises as nothing at all, which
+ * is the honest outcome.
+ *
+ * Returns '' when there are no offers, which is the normal state for a release catalogued from
+ * the Bandcamp grid whose own page hasn't been read for prices yet.
+ */
+export function cheapestOfferSummary(
+  offers: { price: number | null; currency: string | null; availability: string }[]
+): string {
+  const buyable = offers.filter(o => o.availability !== 'sold_out' && o.price !== null);
+  if (buyable.length === 0) return '';
+
+  const cheapest = buyable.reduce((low, o) => (o.price! < low.price! ? o : low));
+
+  // Bandcamp reports name-your-price as 0, and "from $0" reads as free.
+  if (cheapest.price === 0) return 'Name your price';
+  return `from ${formatMoney(cheapest.price!, cheapest.currency)}`;
+}
+
+/**
  * "≈$20–21.25 to the artist" — the emotional payload of the whole product, at the moment
  * someone is deciding where to buy.
  *


### PR DESCRIPTION
Release pages have been reachable only by typing the URL — nothing in the site linked to one. The artist page is their natural parent, so the section goes there.

```
RELEASES
  [art]  fruit is year 3 (honeycrush)              COMING
         Single · 5 September 2026
  [art]  infinite normal
         Album · 23 October 2025 · Name your price
  [art]  RUINED CASTLE
         Album · 1 June 2024 · from $7
  [art]  SOLO PIANO
         Album
  and 5 more
```

Placed **below Follow**: Support directly and Follow together form the links region whose order the artist controls via link dividers, and releases are a different kind of thing that shouldn't interrupt that ordering.

## Three calls worth recording

**Shown for every artist with a catalogue, not only verified ones.** The releases derive from the artist's stored Bandcamp link — which the page is *already* displaying as a place to buy. Listing what's behind that link asserts nothing the page doesn't already assert. Gating on verification would hide the feature from nearly every artist, since almost none are claimed.

**Nothing renders when there are no releases.** Not an empty box. An empty "Releases" heading reads as broken; its absence reads as "nothing here yet" — which is the truth for any artist nobody has saved or searched, because cataloguing is demand-driven.

**Sold-out formats don't set the price.** "from $8" pointing at a record nobody can buy is the one genuinely misleading number this list could show — a fan clicks expecting $8 vinyl and finds it gone. A release whose only offer is sold out summarises as nothing at all.

## Smaller things

- `count: 'exact'` rides along with the limit in the same round trip, so "and N more" is a real number rather than a guess. One extra query on the page total.
- Ordering matches `idx_releases_artist_chrono`. Many releases still have no date — grid ingest gets identity and artwork but no dates — and without the `created_at` tiebreaker those undated rows would shuffle between requests.
- Capped at 24. Most catalogues fit (16 for Sufjan Stevens, 13 for Explosions in the Sky); the cap is for the artists who don't, where an unbounded list would bury the platform links the page exists to show.
- An undated release shows no date rather than a fabricated one — `date_precision` earning its place again.
- Capitalising the release type happens in code, not via `text-transform: capitalize`, which applies to the whole line and turned "from $7" into "From $7" and "Name your price" into "Name Your Price".

## Testing

The price summary moved to `api/shared/release-display.ts` with tests rather than living inside the edge function — same reason as the rest of that module: code that makes claims about someone's money shouldn't be unverifiable. 21 tests there now, 365 across `api/functions`, full `npm run build` green.

Verified by rendering both templates locally against the real Kid Lightbulbs profile: claimed and unclaimed, section ordering (Support directly → Follow → Releases → claim CTA), the "Coming" badge on a future-dated release, an undated release, and the empty-catalogue case rendering no heading at all.

## What this doesn't do

Search results are unchanged — deliberately. Search is the hot path, and a release query per result would add database reads for data that's absent for nearly every artist today. Worth revisiting once the catalogue has real coverage.