### PR TITLE
Stop silently discarding rejected featured-release embeds

### DIFF
--- a/api/functions/__tests__/artist-profile-embed.test.ts
+++ b/api/functions/__tests__/artist-profile-embed.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeEmbed } from '../artist-profile';
+
+// A rejected embed used to be saved as null and reported as a success, so a
+// pasted Faircamp/unsupported embed silently vanished on reload. These pin
+// down: trusted platforms still pass, an artist's own linked domain (e.g. a
+// self-hosted Faircamp site) is now accepted, and everything else is still
+// rejected rather than silently accepted.
+
+describe('sanitizeEmbed', () => {
+  it('accepts a Bandcamp embed', () => {
+    const html = '<iframe style="border: 0; width: 350px; height: 470px;" src="https://bandcamp.com/EmbeddedPlayer/album=123/size=large/" seamless></iframe>';
+    expect(sanitizeEmbed(html)).toContain('src="https://bandcamp.com/EmbeddedPlayer/album=123/size=large/"');
+  });
+
+  it('accepts a Spotify embed', () => {
+    const html = '<iframe src="https://open.spotify.com/embed/track/abc123" width="100%" height="152"></iframe>';
+    expect(sanitizeEmbed(html)).toContain('open.spotify.com');
+  });
+
+  it('rejects a self-hosted domain with no owned-link match', () => {
+    const html = '<iframe src="https://cult.example-artist.com/embed/release/"></iframe>';
+    expect(sanitizeEmbed(html)).toBeNull();
+  });
+
+  it('accepts a self-hosted domain that matches one of the artist\'s own links', () => {
+    const html = '<iframe src="https://cult.example-artist.com/embed/release/"></iframe>';
+    expect(sanitizeEmbed(html, ['cult.example-artist.com'])).toContain('cult.example-artist.com');
+  });
+
+  it('does not let an owned hostname bypass the https requirement', () => {
+    const html = '<iframe src="http://cult.example-artist.com/embed/release/"></iframe>';
+    expect(sanitizeEmbed(html, ['cult.example-artist.com'])).toBeNull();
+  });
+
+  it('rejects an unrelated domain even when the artist owns other links', () => {
+    const html = '<iframe src="https://evil.example.com/x"></iframe>';
+    expect(sanitizeEmbed(html, ['cult.example-artist.com'])).toBeNull();
+  });
+
+  it('returns null for empty input without throwing', () => {
+    expect(sanitizeEmbed(null)).toBeNull();
+    expect(sanitizeEmbed('')).toBeNull();
+    expect(sanitizeEmbed('   ')).toBeNull();
+  });
+
+  it('returns null when there is no iframe tag at all', () => {
+    expect(sanitizeEmbed('https://bandcamp.com/EmbeddedPlayer/album=123/')).toBeNull();
+  });
+});

--- a/api/functions/artist-profile.ts
+++ b/api/functions/artist-profile.ts
@@ -2,7 +2,7 @@
 // Authenticated endpoint for updating a claimed artist profile.
 // Handles: slug changes, bio updates, platform link edits.
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { getClient } from './db';
 import { cacheDeleteByArtist } from './cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
@@ -47,7 +47,7 @@ export const ALLOWED_EMBED_DOMAINS = [
   'embed.tidal.com',
 ];
 
-export function sanitizeEmbed(raw: string | null): string | null {
+export function sanitizeEmbed(raw: string | null, ownedHostnames: string[] = []): string | null {
   if (!raw || !raw.trim()) return null;
 
   // Extract iframe src and validate it's a proper URL
@@ -63,11 +63,13 @@ export function sanitizeEmbed(raw: string | null): string | null {
     return null;
   }
 
-  // Validate embed domain against allowlist
+  // Validate embed domain: either a trusted major platform, or a domain the
+  // artist already has a verified link to (e.g. a self-hosted Faircamp site,
+  // which has no single fixed domain to allowlist).
   const hostname = parsedUrl.hostname.toLowerCase();
   const domainAllowed = ALLOWED_EMBED_DOMAINS.some(
     d => hostname === d || hostname.endsWith('.' + d)
-  );
+  ) || ownedHostnames.includes(hostname);
   if (!domainAllowed) return null;
 
   // Rebuild iframe with only safe attributes (whitelist approach)
@@ -93,6 +95,40 @@ export function sanitizeEmbed(raw: string | null): string | null {
 
   // Cap at 2000 chars
   return iframe.slice(0, 2000);
+}
+
+// Hostnames the artist already has a verified link to, used to allow embeds
+// from self-hosted platforms (Faircamp and similar) that have no single
+// fixed domain to put in ALLOWED_EMBED_DOMAINS. `bodyLinks` is the editor's
+// full desired link list when provided (this save may add the link and embed
+// it in the same request); otherwise fall back to what's already stored.
+async function getOwnedLinkHostnames(
+  client: SupabaseClient,
+  artistId: string,
+  bodyLinks: LinkEntry[] | undefined
+): Promise<string[]> {
+  const hostnames = new Set<string>();
+  const urls: string[] = [];
+
+  if (bodyLinks) {
+    urls.push(...bodyLinks.map(l => l.url).filter((url): url is string => !!url));
+  } else {
+    const { data: links } = await client
+      .from('artist_links')
+      .select('url')
+      .eq('artist_id', artistId);
+    urls.push(...(links || []).map(l => l.url));
+  }
+
+  for (const url of urls) {
+    try {
+      hostnames.add(new URL(url).hostname.toLowerCase());
+    } catch {
+      // Invalid URLs are rejected elsewhere; just skip for hostname purposes.
+    }
+  }
+
+  return [...hostnames];
 }
 
 function slugify(text: string): string {
@@ -302,7 +338,26 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
 
   // --- Update featured embed ---
   if (body.featuredEmbed !== undefined) {
-    const embed = sanitizeEmbed(body.featuredEmbed);
+    let embed: string | null = null;
+
+    // A non-empty value that fails validation is a rejection, not a clear —
+    // report it instead of silently saving null under a "success" response
+    // (see the featured-embed persistence investigation, 2026-07-31).
+    if (body.featuredEmbed && body.featuredEmbed.trim()) {
+      const ownedHostnames = await getOwnedLinkHostnames(client, artist.id, body.links);
+      embed = sanitizeEmbed(body.featuredEmbed, ownedHostnames);
+
+      if (!embed) {
+        return {
+          statusCode: 400,
+          headers: CORS_HEADERS,
+          body: JSON.stringify({
+            error: "That embed code isn't supported. Use an embed from Bandcamp, YouTube, Spotify, SoundCloud, Apple Music, Vimeo, Tidal, or a platform you've linked on this profile.",
+          }),
+        };
+      }
+    }
+
     const { error: embedError } = await client
       .from('artist_profiles')
       .update({ featured_embed: embed, updated_at: new Date().toISOString() })


### PR DESCRIPTION
## Summary
- A pasted featured-release embed that failed the domain allowlist was saved as `null` while the endpoint still returned `success: true`, so the artist edit page showed "Changes saved!" for an embed that had actually been discarded — only visible on reload.
- `sanitizeEmbed()` now returns a 400 with a clear error instead of silently saving `null` when a non-empty embed is rejected.
- `sanitizeEmbed()` also accepts a domain that matches one of the artist's own already-linked platforms (via a new `getOwnedLinkHostnames()` helper), so self-hosted embeds — like Faircamp, which has no single fixed domain — work once that platform is linked to the profile. The fixed `ALLOWED_EMBED_DOMAINS` allowlist for major platforms (Bandcamp, YouTube, Spotify, SoundCloud, Apple Music, Vimeo, Tidal) is unchanged.

## Test plan
- [x] Added `api/functions/__tests__/artist-profile-embed.test.ts` (8 tests) covering: trusted-platform acceptance, owned-hostname acceptance, https-only enforcement on owned hostnames, rejection of unrelated domains, and empty/malformed input.
- [x] `npm run test:api` — 385/385 passing
- [x] `npm run test:unit` — 492/492 passing
- [x] `npm run lint` — no new failures (pre-existing failures confirmed unchanged via `git stash` baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)