### PR TITLE
Fix artist pages rendering two different UIs depending on entry point

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -4,6 +4,7 @@ import { PLATFORMS } from "../shared/platform-registry.ts";
 import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
 import { mainLinkDividerIndexes } from "../shared/link-dividers.ts";
 import { cheapestOfferSummary, formatReleaseDate } from "../shared/release-display.ts";
+import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.ts";
 
 /**
  * How many releases to list before summarising the rest.
@@ -181,6 +182,16 @@ export default async function handler(request: Request, context: Context) {
     const slug = url.pathname.replace(/^\/(a|artist)\//, '').replace(/\/$/, '');
 
     if (!slug) return context.next();
+
+    // Real browsers get the SPA, same as a client-side <Link> navigation from /artists would
+    // render — so a direct load and an in-app click produce the same UI (see
+    // docs/retros/UNS-100-bifurcation-retro.md). Only crawlers, which either can't run JS
+    // (social previews) or benefit from content that doesn't wait on a client fetch (indexing),
+    // get this static render.
+    const userAgent = request.headers.get('user-agent');
+    if (!isSocialCrawler(userAgent) && !isIndexingCrawler(userAgent)) {
+      return context.next();
+    }
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_KEY");

--- a/api/edge/og-metadata.ts
+++ b/api/edge/og-metadata.ts
@@ -1,51 +1,5 @@
 import { Context } from "https://edge.netlify.com";
-
-// Social media crawler user agents (for OG tag previews only)
-const SOCIAL_CRAWLER_USER_AGENTS = [
-  'facebookexternalhit',
-  'Facebot',
-  'Twitterbot',
-  'LinkedInBot',
-  'Pinterest',
-  'Slackbot',
-  'TelegramBot',
-  'WhatsApp',
-  'Discordbot',
-  'Applebot',
-  'Mastodon',
-  'Pleroma',
-  'Misskey',
-  'Akkoma',
-  'Pixelfed',
-  'PeerTube',
-  'Lemmy',
-  'Bluesky',
-  'bsky.app',
-  'redditbot',
-];
-
-// Indexing crawlers (need actual page content, not just OG tags)
-const INDEXING_CRAWLERS = [
-  'Googlebot',
-  'bingbot',
-  'YandexBot',
-  'DuckDuckBot',
-  'Baiduspider',
-];
-
-// Check if request is from a social media crawler (OG previews only)
-function isSocialCrawler(userAgent: string | null): boolean {
-  if (!userAgent) return false;
-  const ua = userAgent.toLowerCase();
-  return SOCIAL_CRAWLER_USER_AGENTS.some(crawler => ua.includes(crawler.toLowerCase()));
-}
-
-// Check if request is from an indexing crawler (needs real page content)
-function isIndexingCrawler(userAgent: string | null): boolean {
-  if (!userAgent) return false;
-  const ua = userAgent.toLowerCase();
-  return INDEXING_CRAWLERS.some(crawler => ua.includes(crawler.toLowerCase()));
-}
+import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.ts";
 
 // Perform search to get first artist image
 async function getFirstArtistImage(query: string, baseUrl: string): Promise<{ imageUrl?: string; artistName?: string }> {

--- a/api/shared/crawler-detection.ts
+++ b/api/shared/crawler-detection.ts
@@ -1,0 +1,48 @@
+// Shared bot detection for edge functions that must serve real browsers the SPA (so a direct
+// load renders exactly the same UI as client-side navigation — see docs/retros/UNS-100-bifurcation-retro.md)
+// while still handing crawlers a fully populated, no-JS-required HTML page for SEO/link previews.
+
+// Social media crawlers: don't execute JS, only need OG/Twitter meta tags for link previews.
+const SOCIAL_CRAWLER_USER_AGENTS = [
+  'facebookexternalhit',
+  'Facebot',
+  'Twitterbot',
+  'LinkedInBot',
+  'Pinterest',
+  'Slackbot',
+  'TelegramBot',
+  'WhatsApp',
+  'Discordbot',
+  'Applebot',
+  'Mastodon',
+  'Pleroma',
+  'Misskey',
+  'Akkoma',
+  'Pixelfed',
+  'PeerTube',
+  'Lemmy',
+  'Bluesky',
+  'bsky.app',
+  'redditbot',
+];
+
+// Indexing crawlers: need real page content, not just meta tags.
+const INDEXING_CRAWLERS = [
+  'Googlebot',
+  'bingbot',
+  'YandexBot',
+  'DuckDuckBot',
+  'Baiduspider',
+];
+
+export function isSocialCrawler(userAgent: string | null): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+  return SOCIAL_CRAWLER_USER_AGENTS.some(crawler => ua.includes(crawler.toLowerCase()));
+}
+
+export function isIndexingCrawler(userAgent: string | null): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+  return INDEXING_CRAWLERS.some(crawler => ua.includes(crawler.toLowerCase()));
+}


### PR DESCRIPTION
## Summary

`/a/:slug` and `/artist/:slug` had two renderers for one URL — the exact "two renderers for one URL" anti-pattern called out in CLAUDE.md and `docs/retros/UNS-100-bifurcation-retro.md`:

- **Direct load** (typed URL, bookmark, external link, page refresh): the `artist-page-static` edge function unconditionally served a hand-written static page — 640px container, bare header with no Login link or auth state.
- **Client-side navigation** (clicking an artist from `/artists` while already in the app): React Router matched the SPA's own `/a/:slug` route, rendering the real `ArtistPage.tsx` — wide (`max-w-4xl`) container, full `Header` with Login.

Same URL, two different UIs depending on how you arrived — which is exactly what was reported: opening `/a/kid-lightbulbs` directly gives a narrower page missing the Login link.

## Fix

`api/edge/og-metadata.ts` (the `/` route) already solves this correctly: it checks the User-Agent and only serves crawlers a static page, letting real browsers (and JS-executing indexing crawlers) fall through to the SPA via `context.next()`. This PR applies the same gate to `artist-page-static.ts`:

- Real browsers → `context.next()` → Netlify's SPA catch-all → `index.html` → React Router → the same `ArtistPage.tsx` a client-side click would render. Direct load and in-app navigation are now identical.
- Social crawlers (Facebook, Twitter, Slack, etc., which don't execute JS) and indexing crawlers (Googlebot, etc.) still get the fully-populated static HTML with real OG tags and JSON-LD — unchanged for SEO/link previews.

Extracted the shared bot-detection lists/helpers (previously duplicated only in `og-metadata.ts`) to `api/shared/crawler-detection.ts` so both edge functions share one implementation.

## Verification

`npm run dev` doesn't run edge functions, and `netlify dev` in this environment fails to bundle unrelated functions (`jose` resolution error, pre-existing). Verified instead by executing the real `artist-page-static.ts` handler with its Deno-only imports rewritten to local stubs (same technique as `scripts/preview-release-page.ts`), covering:

- Regular browser UA → falls through to SPA ✅
- No UA header → falls through to SPA ✅
- Googlebot UA → still gets full static HTML, contains artist name ✅
- `facebookexternalhit` UA → still gets full static HTML ✅

Also confirmed via `deno check --allow-import` that no new type errors were introduced (the 3 pre-existing `.abortSignal`/Supabase typing errors are unrelated and predate this change).

## Test plan

- [x] `npm run test:unit` — 492 passed
- [x] `npm run test:api` — 389 passed
- [x] `npm run lint` — no new errors (77 pre-existing, confirmed identical via stash baseline)
- [x] Manual handler execution confirms routing behavior for both human and crawler UAs
- [ ] Spot-check `/a/kid-lightbulbs` on the deploy preview to confirm the Login link and wide layout now appear on a direct load

🤖 Generated with [Claude Code](https://claude.com/claude-code)