### PR TITLE
Make releases work on the React artist page (list + admin catalog button)

### DIFF
--- a/api/functions/__tests__/admin-catalog-artist.test.ts
+++ b/api/functions/__tests__/admin-catalog-artist.test.ts
@@ -1,0 +1,136 @@
+// The admin catalog endpoint.
+//
+// What's worth locking here is entirely about not reporting a confident wrong thing. This
+// endpoint exists to make cataloging observable, so the failure that matters isn't a crash —
+// it's answering "never catalogued" when the truth is "we couldn't ask", or "queued" when the
+// deploy can't run a crawl at all.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  maybeSingle: vi.fn(),
+  update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+  authenticateAdmin: vi.fn(),
+  fetch: vi.fn(() => Promise.resolve({ status: 202, ok: false } as Response)),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: mocks.maybeSingle }) }),
+      update: mocks.update,
+    }),
+  }),
+}));
+
+vi.mock('../middleware', () => ({
+  authenticateAdmin: mocks.authenticateAdmin,
+  buildCorsHeaders: () => ({ 'Content-Type': 'application/json' }),
+}));
+
+vi.mock('../../lib/sentry', () => ({ Sentry: { captureException: vi.fn() } }));
+
+const { handler } = await import('../admin-catalog-artist');
+
+const ARTIST = '11111111-2222-3333-4444-555555555555';
+const headers = { authorization: 'Bearer admin-token' };
+
+function get(artistId = ARTIST) {
+  return handler({ httpMethod: 'GET', headers, queryStringParameters: { artistId } });
+}
+function post(artistId = ARTIST) {
+  return handler({ httpMethod: 'POST', headers, body: JSON.stringify({ artistId }) });
+}
+
+beforeEach(() => {
+  mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
+  mocks.maybeSingle.mockResolvedValue({ data: null, error: null });
+  vi.stubGlobal('fetch', mocks.fetch);
+  process.env.CONTEXT = 'production';
+  process.env.INTERNAL_FUNCTION_SECRET = 'secret';
+  process.env.URL = 'https://unstream.stream';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  delete process.env.CONTEXT;
+  delete process.env.INTERNAL_FUNCTION_SECRET;
+  delete process.env.URL;
+});
+
+describe('auth', () => {
+  it('refuses anyone who is not an admin, including anonymous callers', async () => {
+    mocks.authenticateAdmin.mockResolvedValue(null);
+    expect((await get()).statusCode).toBe(403);
+    expect((await post()).statusCode).toBe(403);
+  });
+
+  it('rejects an artistId that is not a UUID', async () => {
+    expect((await get('../../etc/passwd')).statusCode).toBe(400);
+  });
+});
+
+describe('GET — reading the state', () => {
+  it('reports a genuinely never-catalogued artist as a null state, not an error', async () => {
+    const response = await get();
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ admin: true, state: null });
+  });
+
+  // The bug this exists to prevent: a failed read and "never catalogued" both arriving as null
+  // makes a broken database render as a confident fact about the artist.
+  it('does not report a failed read as a null state', async () => {
+    mocks.maybeSingle.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+    const response = await get();
+    expect(response.statusCode).toBe(503);
+    expect(JSON.parse(response.body).error).toBeTruthy();
+    expect(JSON.parse(response.body).state).toBeUndefined();
+  });
+
+  it('passes a real state through', async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { last_catalogued_at: '2026-07-31T00:00:00Z', releases_found: 16, releases_detailed: 16, last_error: null, consecutive_failures: 0 },
+      error: null,
+    });
+    const body = JSON.parse((await get()).body);
+    expect(body.state.releases_found).toBe(16);
+  });
+});
+
+describe('POST — starting a crawl', () => {
+  it('queues the crawl and clears the cooldown first', async () => {
+    const response = await post();
+    expect(response.statusCode).toBe(202);
+    // Without this the button appears to work and silently does nothing for a week.
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ last_catalogued_at: null, consecutive_failures: 0 })
+    );
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+  });
+
+  // Netlify answers 202 to a background invocation the instant it is queued and discards the
+  // handler's response — so any refusal we can predict has to be caught here, or it reaches the
+  // UI as a crawl that simply never finishes.
+  it('refuses outside production rather than queuing a crawl that will be rejected', async () => {
+    process.env.CONTEXT = 'deploy-preview';
+    const response = await post();
+    expect(response.statusCode).toBe(503);
+    expect(JSON.parse(response.body).error).toContain('production');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the internal secret is missing', async () => {
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    const response = await post();
+    expect(response.statusCode).toBe(503);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  // A boolean derived from that 202 would read as "the crawl was accepted" while being true
+  // even when it wasn't, so there deliberately isn't one.
+  it('does not claim the background function accepted the job', async () => {
+    const body = JSON.parse((await post()).body);
+    expect(body.started).toBeUndefined();
+  });
+});

--- a/api/functions/admin-catalog-artist.ts
+++ b/api/functions/admin-catalog-artist.ts
@@ -33,9 +33,22 @@ interface CatalogState {
   consecutive_failures: number;
 }
 
-async function readState(artistId: string): Promise<CatalogState | null> {
+/**
+ * Read this artist's catalog state.
+ *
+ * Deliberately three-valued, not two. "We couldn't ask" and "we asked and this artist has never
+ * been catalogued" are different facts, and collapsing them into one `null` makes a broken
+ * database read render as a confident "Never catalogued" — the same shape as the bug class the
+ * "never cache uncertainty" principle exists to prevent. This whole feature exists to give
+ * cataloging an observable surface, so an unreadable one has to say so.
+ */
+type StateResult =
+  | { ok: true; state: CatalogState | null }
+  | { ok: false; reason: string };
+
+async function readState(artistId: string): Promise<StateResult> {
   const client = getClient();
-  if (!client) return null;
+  if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
 
   const { data, error } = await client
     .from('release_catalog_state')
@@ -45,9 +58,9 @@ async function readState(artistId: string): Promise<CatalogState | null> {
 
   if (error) {
     console.error('[admin-catalog] state read failed:', error.message);
-    return null;
+    return { ok: false, reason: 'Could not read catalog state' };
   }
-  return (data as CatalogState | null) ?? null;
+  return { ok: true, state: (data as CatalogState | null) ?? null };
 }
 
 /**
@@ -106,15 +119,40 @@ export async function handler(event: {
   }
 
   if (event.httpMethod === 'GET') {
+    const result = await readState(artistId);
+    if (!result.ok) {
+      // 503, not a 200 carrying a null state: the caller must be able to tell "we couldn't ask"
+      // from "never catalogued", or it will report the second when the first is true.
+      return {
+        statusCode: 503,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: result.reason }),
+      };
+    }
     return {
       statusCode: 200,
       headers: CORS_HEADERS,
-      body: JSON.stringify({ admin: true, state: await readState(artistId) }),
+      body: JSON.stringify({ admin: true, state: result.state }),
     };
   }
 
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  // Every reason the background function would refuse, checked here instead — because its
+  // answer never comes back. Netlify's dispatcher returns 202 to the caller the instant it
+  // accepts a background invocation and discards whatever the handler returns, so a 401 from a
+  // bad secret and a 403 from a non-production context both reach us as 202. Anything not
+  // checked up front is indistinguishable from a slow crawl.
+  if (process.env.CONTEXT !== 'production') {
+    return {
+      statusCode: 503,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        error: `Cataloging only runs in production (this deploy is "${process.env.CONTEXT ?? 'unset'}").`,
+      }),
+    };
   }
 
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
@@ -135,20 +173,17 @@ export async function handler(event: {
 
   try {
     const trigger: CatalogTrigger = 'saved'; // the larger hourly budget — this is a deliberate act
-    const response = await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
+    await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
       body: JSON.stringify({ artistIds: [artistId], trigger }),
     });
 
-    // A background function answers 202 the moment it accepts the job — including when it is
-    // about to refuse on a bad secret. This status is a handshake, not an outcome, so the client
-    // polls the GET above for what actually happened.
-    return {
-      statusCode: 202,
-      headers: CORS_HEADERS,
-      body: JSON.stringify({ started: response.status === 202 || response.ok }),
-    };
+    // Nothing useful to report back from that response, and deliberately no `started` flag:
+    // the dispatcher's 202 says only that the request was queued, so any boolean derived from
+    // it would read as "the crawl was accepted" while being true even when it wasn't. The
+    // client polls the GET above, which reports what actually happened.
+    return { statusCode: 202, headers: CORS_HEADERS, body: JSON.stringify({ queued: true }) };
   } catch (error) {
     Sentry.captureException(error);
     return {

--- a/api/functions/admin-catalog-artist.ts
+++ b/api/functions/admin-catalog-artist.ts
@@ -1,0 +1,169 @@
+// API endpoint: GET/POST /api/admin/catalog-artist
+//
+// Admin-only. Catalogs one artist's releases on demand, from a button on their page.
+//
+// Cataloging is otherwise triggered only by a fan saving an artist or a search resolving one,
+// which is deliberate — it's what keeps the crawl small and the page count bounded. This is the
+// same escape hatch as `npm run catalog:artist`, reachable without a terminal.
+//
+// **The internal secret never leaves the server.** The browser authenticates as an admin with
+// its ordinary Supabase token; this function holds INTERNAL_FUNCTION_SECRET and uses it to
+// invoke the background function. Shipping that secret to the client would hand every visitor
+// the ability to make Unstream crawl Bandcamp on demand — the exact amplifier the check-releases
+// hardening existed to close.
+//
+//   GET  ?artistId=…  → is the caller an admin, and what is this artist's catalog state
+//   POST { artistId } → clear the cooldown and start a crawl
+//
+// The GET is what the button uses to decide whether to show itself: visibility follows the
+// server's real admin rule rather than a copy of it in page markup.
+
+import { getClient, type CatalogTrigger } from './db';
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { Sentry } from '../lib/sentry';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface CatalogState {
+  last_catalogued_at: string | null;
+  last_attempted_at: string;
+  releases_found: number | null;
+  releases_detailed: number | null;
+  last_error: string | null;
+  consecutive_failures: number;
+}
+
+async function readState(artistId: string): Promise<CatalogState | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  const { data, error } = await client
+    .from('release_catalog_state')
+    .select('last_catalogued_at, last_attempted_at, releases_found, releases_detailed, last_error, consecutive_failures')
+    .eq('artist_id', artistId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[admin-catalog] state read failed:', error.message);
+    return null;
+  }
+  return (data as CatalogState | null) ?? null;
+}
+
+/**
+ * Clear this artist's cooldown so the crawl actually runs.
+ *
+ * Without it the button would appear to work and do nothing for a week — `claimArtistForCatalog`
+ * refuses an artist catalogued in the last 7 days, which is right for demand-driven triggers and
+ * wrong for someone deliberately pressing "catalog now".
+ *
+ * Backdated rather than deleted: the row also carries the failure counter and the last error,
+ * which are worth keeping. Two hours clears both the cooldown and the exponential backoff.
+ */
+async function clearCooldown(artistId: string): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  const twoHoursAgo = new Date(Date.now() - 2 * 3600_000).toISOString();
+  const { error } = await client
+    .from('release_catalog_state')
+    .update({ last_catalogued_at: null, last_attempted_at: twoHoursAgo, consecutive_failures: 0 })
+    .eq('artist_id', artistId);
+
+  if (error) console.error('[admin-catalog] cooldown clear failed:', error.message);
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string> | null;
+  body?: string;
+}) {
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const admin = await authenticateAdmin(event.headers['authorization'] || event.headers['Authorization']);
+  if (!admin) {
+    // 403 for everyone who isn't an admin, including anonymous callers. The button treats any
+    // non-200 as "don't show me", so this is also what keeps it invisible to ordinary visitors.
+    return { statusCode: 403, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Forbidden' }) };
+  }
+
+  const artistId = (event.httpMethod === 'GET'
+    ? event.queryStringParameters?.artistId
+    : safeParseArtistId(event.body)) ?? '';
+
+  if (!UUID_REGEX.test(artistId)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'A valid artistId is required' }),
+    };
+  }
+
+  if (event.httpMethod === 'GET') {
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ admin: true, state: await readState(artistId) }),
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+  const siteUrl = process.env.DEPLOY_PRIME_URL || process.env.URL;
+
+  if (!secret || !siteUrl) {
+    // Said plainly rather than as a generic 500: this exact configuration gap silently stopped
+    // release cataloging from ever running, and "nothing happened" gave no clue why.
+    console.error('[admin-catalog] INTERNAL_FUNCTION_SECRET or site URL is not configured');
+    return {
+      statusCode: 503,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Cataloging is not configured on this deploy (INTERNAL_FUNCTION_SECRET).' }),
+    };
+  }
+
+  await clearCooldown(artistId);
+
+  try {
+    const trigger: CatalogTrigger = 'saved'; // the larger hourly budget — this is a deliberate act
+    const response = await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
+      body: JSON.stringify({ artistIds: [artistId], trigger }),
+    });
+
+    // A background function answers 202 the moment it accepts the job — including when it is
+    // about to refuse on a bad secret. This status is a handshake, not an outcome, so the client
+    // polls the GET above for what actually happened.
+    return {
+      statusCode: 202,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ started: response.status === 202 || response.ok }),
+    };
+  } catch (error) {
+    Sentry.captureException(error);
+    return {
+      statusCode: 502,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Could not reach the cataloging function' }),
+    };
+  }
+}
+
+function safeParseArtistId(body: string | undefined): string | undefined {
+  try {
+    const parsed = JSON.parse(body || '{}') as { artistId?: unknown };
+    return typeof parsed.artistId === 'string' ? parsed.artistId : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -2,7 +2,7 @@
 // Returns the full rich-profile payload for a claimed artist as JSON.
 // This is the data source for the React SPA artist page (UNS-102).
 
-import { getArtistProfileBySlug } from './db';
+import { getArtistProfileBySlug, getArtistReleases } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { PLATFORMS } from '../shared/platform-registry';
 import { isBandcampFriday } from '../shared/bandcamp-friday';
@@ -104,6 +104,11 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     // Build the image URL: custom > artist row > null
     const imageUrl = profile?.custom_image_url || artistRow.image_url || null;
 
+    // Releases. Capped because most catalogues fit well under it (16 for Sufjan Stevens, 13 for
+    // Explosions in the Sky) and the artists who don't would otherwise bury the platform links
+    // this page exists to show.
+    const { releases, total: releaseCount } = await getArtistReleases(artistRow.id, 24);
+
     const payload = {
       artist: {
         id: artistRow.id,
@@ -125,6 +130,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       // Indexes into `links` above which a horizontal divider is drawn.
       linkDividers: mainLinkDividerIndexes(allLinks, isMainLink, profile?.link_dividers),
       socialLinks: social,
+      releases,
+      releaseCount,
       bandcampFriday: bcFriday,
     };
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -1441,3 +1441,84 @@ export async function persistEnrichment(
     console.error(`[DB] Error enriching "${artistName}":`, error);
   }
 }
+
+// --- Releases for an artist page ---
+
+export interface ArtistPageRelease {
+  slug: string;
+  title: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  status: string;
+  artworkUrl: string | null;
+  offers: { price: number | null; currency: string | null; availability: string }[];
+}
+
+/**
+ * An artist's releases for their page, newest first, plus the total.
+ *
+ * `count: 'exact'` rides along with the limit in one round trip, so an "and N more" line is a
+ * real number rather than a guess. Ordering matches idx_releases_artist_chrono: many releases
+ * have no date yet — grid ingest gets identity and artwork but no dates — and without the
+ * created_at tiebreaker those undated rows would shuffle between requests.
+ *
+ * Hidden releases are filtered in the query rather than after, so a suppressed release is
+ * indistinguishable from one that was never catalogued. That's the point of the column.
+ */
+export async function getArtistReleases(
+  artistId: string,
+  limit: number
+): Promise<{ releases: ArtistPageRelease[]; total: number }> {
+  const client = getClient();
+  if (!client) return { releases: [], total: 0 };
+
+  try {
+    const { data, count, error } = await client
+      .from('releases')
+      .select(
+        'slug, title, release_type, release_date, date_precision, status, artwork_url,' +
+        ' release_sources ( release_offers ( price, currency, availability ) )',
+        { count: 'exact' }
+      )
+      .eq('artist_id', artistId)
+      .eq('is_hidden', false)
+      .order('release_date', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      console.error('[DB] getArtistReleases failed:', error.message);
+      return { releases: [], total: 0 };
+    }
+
+    type Row = {
+      slug: string;
+      title: string;
+      release_type: string;
+      release_date: string | null;
+      date_precision: string | null;
+      status: string;
+      artwork_url: string | null;
+      release_sources: { release_offers: { price: number | null; currency: string | null; availability: string }[] | null }[] | null;
+    };
+
+    // Through `unknown`: PostgREST types a nested select as a union that includes an error
+    // shape, so a direct cast is rejected. The runtime shape is checked by the query above.
+    const releases = ((data as unknown as Row[]) || []).map(r => ({
+      slug: r.slug,
+      title: r.title,
+      releaseType: r.release_type,
+      releaseDate: r.release_date,
+      datePrecision: r.date_precision,
+      status: r.status,
+      artworkUrl: r.artwork_url,
+      offers: (r.release_sources || []).flatMap(s => s.release_offers || []),
+    }));
+
+    return { releases, total: count ?? releases.length };
+  } catch (error) {
+    console.error('[DB] getArtistReleases error:', error);
+    return { releases: [], total: 0 };
+  }
+}

--- a/apps/web/src/components/AdminCatalogButton.tsx
+++ b/apps/web/src/components/AdminCatalogButton.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Admin-only "Catalog releases now" control on an artist page.
+ *
+ * Cataloguing is otherwise triggered only by a fan saving an artist or a search resolving one,
+ * which is deliberate — it's what keeps the crawl small. This is the same escape hatch as
+ * `npm run catalog:artist`, without a terminal.
+ *
+ * Lives in React rather than in the `artist-page-static` edge function because that function
+ * now serves **crawlers only** — real browsers get the SPA (PR #369). A control rendered there
+ * would be delivered to Googlebot and to nobody else.
+ *
+ * `isAdmin` decides whether this renders, matching how the rest of the app gates admin UI
+ * (App.tsx). That is presentation only: `/api/admin/catalog-artist` checks the caller against
+ * ADMIN_EMAIL server-side on every request, which is the check that actually matters.
+ */
+
+interface CatalogState {
+  last_catalogued_at: string | null;
+  releases_found: number | null;
+  releases_detailed: number | null;
+  last_error: string | null;
+}
+
+/** How long to keep asking before giving up. A full catalogue with prices takes a few minutes. */
+const MAX_POLLS = 24;
+const POLL_INTERVAL_MS = 5000;
+
+function describe(state: CatalogState | null): string {
+  if (state?.last_error) return `Last run failed: ${state.last_error}`;
+  // A state row exists as soon as a crawl is *claimed*, before it runs — so counts are only
+  // meaningful once one has finished. Otherwise "0 releases" would be a claim about the artist
+  // rather than the absence of an answer.
+  if (!state?.last_catalogued_at) return 'Never catalogued';
+  return `${state.releases_found ?? 0} releases, ${state.releases_detailed ?? 0} with prices`;
+}
+
+export function AdminCatalogButton({ artistId }: { artistId: string }) {
+  const { isAdmin, session } = useAuth();
+  const token = session?.access_token;
+
+  const [status, setStatus] = useState('');
+  const [running, setRunning] = useState(false);
+  const lastRunAt = useRef<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const readState = useCallback(async (): Promise<CatalogState | null> => {
+    const response = await fetch(`/api/admin/catalog-artist?artistId=${encodeURIComponent(artistId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) return null;
+    const data = await response.json();
+    return (data.state as CatalogState | null) ?? null;
+  }, [artistId, token]);
+
+  useEffect(() => {
+    if (!isAdmin || !token) return;
+    let cancelled = false;
+
+    readState()
+      .then(state => {
+        if (cancelled) return;
+        lastRunAt.current = state?.last_catalogued_at ?? null;
+        setStatus(describe(state));
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [isAdmin, token, readState]);
+
+  /**
+   * Ask for the outcome until it arrives.
+   *
+   * A hoisted function declaration rather than a self-referencing `const`, which would read its
+   * own binding inside its initializer — legal at runtime but genuinely confusing, and the
+   * linter is right to refuse it.
+   */
+  const poll = useCallback(() => {
+    let attempt = 0;
+
+    function scheduleNext() {
+      attempt += 1;
+      if (attempt > MAX_POLLS) {
+        setStatus('Still running — check back shortly');
+        setRunning(false);
+        return;
+      }
+      timer.current = setTimeout(async () => {
+        try {
+          const state = await readState();
+          if (state?.last_catalogued_at && state.last_catalogued_at !== lastRunAt.current) {
+            lastRunAt.current = state.last_catalogued_at;
+            setStatus(describe(state));
+            setRunning(false);
+            return;
+          }
+          if (state?.last_error) {
+            setStatus(describe(state));
+            setRunning(false);
+            return;
+          }
+        } catch {
+          // A dropped request mid-crawl isn't an answer; keep asking.
+        }
+        scheduleNext();
+      }, POLL_INTERVAL_MS);
+    }
+
+    scheduleNext();
+  }, [readState]);
+
+  const start = useCallback(async () => {
+    setRunning(true);
+    setStatus('Cataloguing…');
+    try {
+      const response = await fetch('/api/admin/catalog-artist', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ artistId }),
+      });
+      const body = await response.json().catch(() => ({}));
+
+      // 202 is only a handshake — a Netlify background function answers it the instant it
+      // accepts the job, including when it is about to refuse. Polling below reports what
+      // actually happened.
+      if (!response.ok && response.status !== 202) {
+        setStatus(body.error || 'Could not start');
+        setRunning(false);
+        return;
+      }
+      poll();
+    } catch {
+      setStatus('Could not start');
+      setRunning(false);
+    }
+  }, [artistId, token, poll]);
+
+  if (!isAdmin || !token) return null;
+
+  return (
+    <div className="mt-8 p-3 rounded-xl border border-dashed border-border text-center">
+      <button
+        onClick={start}
+        disabled={running}
+        className="px-4 py-2 rounded-lg border border-border text-sm text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-50"
+      >
+        Catalog releases now
+      </button>
+      <p className="mt-2 text-xs text-text-muted">{status || 'Admin only'}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/AdminCatalogButton.tsx
+++ b/apps/web/src/components/AdminCatalogButton.tsx
@@ -24,6 +24,8 @@ interface CatalogState {
   last_error: string | null;
 }
 
+type ReadResult = { ok: true; state: CatalogState | null } | { ok: false; reason: string };
+
 /** How long to keep asking before giving up. A full catalogue with prices takes a few minutes. */
 const MAX_POLLS = 24;
 const POLL_INTERVAL_MS = 5000;
@@ -44,15 +46,25 @@ export function AdminCatalogButton({ artistId }: { artistId: string }) {
   const [status, setStatus] = useState('');
   const [running, setRunning] = useState(false);
   const lastRunAt = useRef<string | null>(null);
+  /** Why the last read failed, so an exhausted poll can report that instead of guessing. */
+  const lastFailure = useRef<string | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const readState = useCallback(async (): Promise<CatalogState | null> => {
+  /**
+   * Three-valued on purpose. "We couldn't ask" and "this artist has never been catalogued" are
+   * different facts, and a single `null` for both makes a failed request render as a confident
+   * "Never catalogued" — the exact thing this control exists to stop being ambiguous.
+   */
+  const readState = useCallback(async (): Promise<ReadResult> => {
     const response = await fetch(`/api/admin/catalog-artist?artistId=${encodeURIComponent(artistId)}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      return { ok: false, reason: body.error || 'Could not read catalog state' };
+    }
     const data = await response.json();
-    return (data.state as CatalogState | null) ?? null;
+    return { ok: true, state: (data.state as CatalogState | null) ?? null };
   }, [artistId, token]);
 
   useEffect(() => {
@@ -60,12 +72,18 @@ export function AdminCatalogButton({ artistId }: { artistId: string }) {
     let cancelled = false;
 
     readState()
-      .then(state => {
+      .then(result => {
         if (cancelled) return;
-        lastRunAt.current = state?.last_catalogued_at ?? null;
-        setStatus(describe(state));
+        if (!result.ok) {
+          setStatus(result.reason);
+          return;
+        }
+        lastRunAt.current = result.state?.last_catalogued_at ?? null;
+        setStatus(describe(result.state));
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setStatus('Could not read catalog state');
+      });
 
     return () => {
       cancelled = true;
@@ -86,13 +104,24 @@ export function AdminCatalogButton({ artistId }: { artistId: string }) {
     function scheduleNext() {
       attempt += 1;
       if (attempt > MAX_POLLS) {
-        setStatus('Still running — check back shortly');
+        // Say which it was. "Still running" on top of a run of failed reads would be a guess
+        // about the crawl based on no information about the crawl.
+        setStatus(lastFailure.current ?? 'Still running — check back shortly');
         setRunning(false);
         return;
       }
       timer.current = setTimeout(async () => {
         try {
-          const state = await readState();
+          const result = await readState();
+          if (!result.ok) {
+            // A failed read is not "still running" — but it may be transient, so keep asking
+            // and let the message say which of the two we're looking at.
+            lastFailure.current = result.reason;
+            scheduleNext();
+            return;
+          }
+          lastFailure.current = null;
+          const { state } = result;
           if (state?.last_catalogued_at && state.last_catalogued_at !== lastRunAt.current) {
             lastRunAt.current = state.last_catalogued_at;
             setStatus(describe(state));
@@ -106,6 +135,7 @@ export function AdminCatalogButton({ artistId }: { artistId: string }) {
           }
         } catch {
           // A dropped request mid-crawl isn't an answer; keep asking.
+          lastFailure.current = 'Could not read catalog state';
         }
         scheduleNext();
       }, POLL_INTERVAL_MS);
@@ -125,9 +155,10 @@ export function AdminCatalogButton({ artistId }: { artistId: string }) {
       });
       const body = await response.json().catch(() => ({}));
 
-      // 202 is only a handshake — a Netlify background function answers it the instant it
-      // accepts the job, including when it is about to refuse. Polling below reports what
-      // actually happened.
+      // 202 means queued, nothing more: Netlify answers it the instant a background
+      // invocation is accepted and discards whatever the handler returns. The endpoint checks
+      // the refusals it can predict (non-production context, missing secret) and reports them
+      // as real errors above; everything else is settled by polling.
       if (!response.ok && response.status !== 202) {
         setStatus(body.error || 'Could not start');
         setRunning(false);

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -1,0 +1,92 @@
+import { Link } from 'react-router-dom';
+import { cheapestOfferSummary, formatReleaseDate } from '../../../../api/shared/release-display';
+import type { ArtistPagePayload } from '../types/artist-page';
+
+type Release = NonNullable<ArtistPagePayload['releases']>[number];
+
+/**
+ * An artist's releases, each linking to its buying guide at `/a/{artist}/{release}`.
+ *
+ * Placed below Follow: Support directly and Follow together form the links region whose order
+ * the artist controls with dividers, and releases are a different kind of thing that shouldn't
+ * interrupt that ordering.
+ *
+ * Renders nothing when there are no releases. An empty "Releases" heading reads as broken, while
+ * its absence reads as "nothing here yet" — the truth for any artist nobody has saved or
+ * searched, since cataloguing is demand-driven.
+ *
+ * The formatting helpers come from `api/shared/release-display.ts`, which the crawler-side edge
+ * renderer also uses, so the two can't drift on what a price or a partial date looks like.
+ */
+export function ReleasesSection({
+  releases,
+  total,
+  artistSlug,
+}: {
+  releases: Release[];
+  total: number;
+  artistSlug: string;
+}) {
+  if (releases.length === 0) return null;
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3">Releases</h2>
+      <div className="grid gap-2">
+        {releases.map(release => (
+          <ReleaseRow key={release.slug} release={release} artistSlug={artistSlug} />
+        ))}
+      </div>
+      {total > releases.length && (
+        <p className="mt-2.5 text-xs text-text-muted">and {total - releases.length} more</p>
+      )}
+    </div>
+  );
+}
+
+function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: string }) {
+  const date = formatReleaseDate(release.releaseDate, release.datePrecision);
+
+  // Capitalised here rather than with a `capitalize` class, which would apply to the whole line
+  // and turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
+  const type =
+    release.releaseType === 'other'
+      ? ''
+      : release.releaseType.charAt(0).toUpperCase() + release.releaseType.slice(1);
+
+  const meta = [type, date, cheapestOfferSummary(release.offers)].filter(Boolean).join(' · ');
+
+  return (
+    <Link
+      to={`/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release.slug)}`}
+      className="flex items-center gap-3 px-3 py-2 rounded-xl border border-border hover:bg-bg-hover transition-colors"
+    >
+      {release.artworkUrl ? (
+        <img
+          src={release.artworkUrl}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="w-12 h-12 rounded-md object-cover shrink-0 bg-bg-secondary"
+        />
+      ) : (
+        <div className="w-12 h-12 rounded-md shrink-0 bg-bg-secondary flex items-center justify-center text-xl">
+          💿
+        </div>
+      )}
+
+      <span className="flex-1 min-w-0">
+        <span className="block font-medium text-text-primary truncate">{release.title}</span>
+        {meta && <span className="block text-xs text-text-muted">{meta}</span>}
+      </span>
+
+      {/* An upcoming release is the most interesting row here and the easiest to miss at the top
+          of a list that otherwise reads as history. */}
+      {release.status === 'announced' && (
+        <span className="text-[10px] font-bold uppercase tracking-wide text-accent-primary shrink-0">
+          Coming
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/apps/web/src/components/RichArtistProfile.tsx
+++ b/apps/web/src/components/RichArtistProfile.tsx
@@ -3,6 +3,7 @@ import type { ArtistPagePayload } from '../types/artist-page';
 import { sources } from '../services/sources';
 import { analytics } from '../services/analytics';
 import { PlatformIcon } from './PlatformIcon';
+import { ReleasesSection } from './ReleasesSection';
 import { SocialIcon } from './SocialIcon';
 import type { SourceId } from '../types';
 
@@ -234,6 +235,12 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
             </div>
           </div>
         )}
+
+        <ReleasesSection
+          releases={payload.releases ?? []}
+          total={payload.releaseCount ?? 0}
+          artistSlug={slug}
+        />
 
         {/* Embed Widget */}
         <div className="mt-6">

--- a/apps/web/src/components/UnclaimedQuietCard.tsx
+++ b/apps/web/src/components/UnclaimedQuietCard.tsx
@@ -4,6 +4,7 @@ import type { ArtistPagePayload } from '../types/artist-page';
 import { sources } from '../services/sources';
 import { analytics } from '../services/analytics';
 import { PlatformIcon } from './PlatformIcon';
+import { ReleasesSection } from './ReleasesSection';
 import { SocialIcon } from './SocialIcon';
 import type { SourceId } from '../types';
 
@@ -173,6 +174,12 @@ export function UnclaimedQuietCard({ payload, slug, justClaimed, onSave, onUnsav
           </div>
         </div>
       )}
+
+      <ReleasesSection
+        releases={payload.releases ?? []}
+        total={payload.releaseCount ?? 0}
+        artistSlug={slug}
+      />
 
       {/* Claim nudge */}
       <div className="mt-6 p-4 rounded-lg border border-border bg-bg-secondary/50 text-center">

--- a/apps/web/src/pages/ArtistPage.tsx
+++ b/apps/web/src/pages/ArtistPage.tsx
@@ -8,6 +8,7 @@ import { NotFoundCard } from '../components/NotFoundCard';
 import { RichArtistProfile } from '../components/RichArtistProfile';
 import { UnclaimedQuietCard } from '../components/UnclaimedQuietCard';
 import { LoginInterstitial } from '../components/LoginInterstitial';
+import { AdminCatalogButton } from '../components/AdminCatalogButton';
 import { analytics } from '../services/analytics';
 import { useAuth } from '../contexts/AuthContext';
 import type { ArtistPagePayload } from '../types/artist-page';
@@ -124,6 +125,8 @@ export function ArtistPage() {
               disabledSave={!artistId}
             />
           )}
+          {/* Renders nothing unless a signed-in admin is looking. */}
+          {artistId && <AdminCatalogButton artistId={artistId} />}
         </div>
       </main>
       <Footer />

--- a/apps/web/src/types/artist-page.ts
+++ b/apps/web/src/types/artist-page.ts
@@ -30,5 +30,18 @@ export interface ArtistPagePayload {
     url: string;
     displayName: string | null;
   }>;
+  // Newest first, capped. Older cached responses omit both — treat as no releases.
+  releases?: Array<{
+    slug: string;
+    title: string;
+    releaseType: string;
+    releaseDate: string | null;
+    datePrecision: string | null;
+    status: string;
+    artworkUrl: string | null;
+    offers: Array<{ price: number | null; currency: string | null; availability: string }>;
+  }>;
+  /** Total before the cap, so the UI can say how many are not shown. */
+  releaseCount?: number;
   bandcampFriday: boolean;
 }

--- a/apps/web/tests/unit/ReleasesSection.test.tsx
+++ b/apps/web/tests/unit/ReleasesSection.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+// The releases list on an artist page.
+//
+// This section shipped once already into the wrong renderer — it went into the
+// artist-page-static edge function, which PR #369 had made crawler-only, so Googlebot saw an
+// artist's discography with prices and no human ever did. These tests exercise the component
+// real browsers actually render.
+//
+// What's worth locking is the set of things that would be quietly wrong rather than broken: a
+// fabricated date on a year-only release, a price quoted from a sold-out format, and a heading
+// with nothing under it.
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReleasesSection } from 'src/components/ReleasesSection';
+import type { ArtistPagePayload } from 'src/types/artist-page';
+
+type Release = NonNullable<ArtistPagePayload['releases']>[number];
+
+function release(overrides: Partial<Release> = {}): Release {
+  return {
+    slug: 'a-record',
+    title: 'A Record',
+    releaseType: 'album',
+    releaseDate: '2024-06-01',
+    datePrecision: 'day',
+    status: 'released',
+    artworkUrl: null,
+    offers: [],
+    ...overrides,
+  };
+}
+
+function show(releases: Release[], total = releases.length) {
+  return render(
+    <MemoryRouter>
+      <ReleasesSection releases={releases} total={total} artistSlug="kid-lightbulbs" />
+    </MemoryRouter>
+  );
+}
+
+afterEach(cleanup);
+
+describe('ReleasesSection', () => {
+  it('links each release to its buying guide', () => {
+    show([release({ slug: 'ruined-castle', title: 'RUINED CASTLE' })]);
+    expect(screen.getByRole('link', { name: /RUINED CASTLE/ }).getAttribute('href')).toBe(
+      '/a/kid-lightbulbs/ruined-castle'
+    );
+  });
+
+  // An empty "Releases" heading reads as broken; its absence reads as "nothing here yet", which
+  // is the truth for any artist nobody has saved or searched.
+  it('renders nothing at all when there are no releases', () => {
+    const { container } = show([]);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows type, date and the cheapest price together', () => {
+    show([
+      release({
+        offers: [
+          { price: 25, currency: 'USD', availability: 'available' },
+          { price: 7, currency: 'USD', availability: 'available' },
+        ],
+      }),
+    ]);
+    expect(screen.getByText('Album · 1 June 2024 · from $7')).toBeTruthy();
+  });
+
+  // Quoting the price of a record nobody can buy is the one genuinely misleading number this
+  // list could show.
+  it('never quotes a sold-out format as the price', () => {
+    show([
+      release({
+        offers: [
+          { price: 7, currency: 'USD', availability: 'sold_out' },
+          { price: 25, currency: 'USD', availability: 'available' },
+        ],
+      }),
+    ]);
+    expect(screen.getByText(/from \$25/)).toBeTruthy();
+    expect(screen.queryByText(/from \$7/)).toBeNull();
+  });
+
+  // Bandcamp reports name-your-price as 0, and "from $0" would tell a fan the record is free.
+  it('reads a zero price as name-your-price', () => {
+    show([release({ offers: [{ price: 0, currency: 'USD', availability: 'available' }] })]);
+    expect(screen.getByText(/Name your price/)).toBeTruthy();
+  });
+
+  // Grid ingest stores year-only and undated releases; rendering "1 January" would state a fact
+  // no source ever gave us.
+  it('does not invent a date it was not given', () => {
+    show([
+      release({ title: 'Year Only', releaseDate: '2024-01-01', datePrecision: 'year' }),
+      release({ slug: 'undated', title: 'Undated', releaseDate: null, datePrecision: 'unknown' }),
+    ]);
+    expect(screen.getByText('Album · 2024')).toBeTruthy();
+    expect(screen.getAllByText('Album').length).toBe(1);
+    expect(screen.queryByText(/January/)).toBeNull();
+  });
+
+  it('flags an upcoming release', () => {
+    show([release({ status: 'announced' })]);
+    expect(screen.getByText('Coming')).toBeTruthy();
+  });
+
+  it('says how many releases are not shown', () => {
+    show([release()], 9);
+    expect(screen.getByText('and 8 more')).toBeTruthy();
+  });
+
+  it('says nothing about a count when everything is shown', () => {
+    show([release()], 1);
+    expect(screen.queryByText(/more$/)).toBeNull();
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -180,6 +180,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/admin/catalog-artist"
+  to = "/.netlify/functions/admin-catalog-artist"
+  status = 200
+
+[[redirects]]
   from = "/api/discord/interaction"
   to = "/.netlify/functions/discord-interaction"
   status = 200


### PR DESCRIPTION
Two commits, both fixing the same root cause: **the Releases feature was built on the artist-page renderer #369 retired for humans.**

#366 put the releases list in `artist-page-static`, and #369 — landing hours later — made that edge function crawler-only. So Googlebot has been seeing artists' discographies with prices and no human ever has. My first version of the admin button had the same flaw.

## 1. The releases list, on the renderer real browsers get

- `getArtistReleases` in `db.ts` — one shape, used once. `count: 'exact'` rides along with the limit so "and N more" is a real number rather than a guess, and the ordering matches `idx_releases_artist_chrono` (many releases still have no date; without the `created_at` tiebreaker those rows shuffle between requests).
- `/api/artist-page` now carries `releases` and `releaseCount`. Both optional in the type, since cached responses predate them.
- `ReleasesSection` renders in `RichArtistProfile` and `UnclaimedQuietCard`, **below Follow** — Support directly and Follow are one artist-ordered region that releases shouldn't interrupt.

```
RELEASES
  [art]  fruit is year 3 (honeycrush)              COMING
         Single · 5 September 2026
  [art]  RUINED CASTLE
         Album · 1 June 2024 · from $7
  and 8 more
```

**One implementation of the formatting.** `ReleasesSection` imports `cheapestOfferSummary` and `formatReleaseDate` from `api/shared/release-display.ts` — the same module the crawler-side renderer uses, so the two can't drift on what a price or a partial date looks like. This is the first import from `api/shared` into the web app; it builds and typechecks. The alternative was a third hand-maintained copy of code that makes claims about someone's money, which `sources.ts` already shows the cost of.

The edge function keeps its own copy for crawlers. That's what it's for now.

## 2. The admin "Catalog releases now" button

Also React, for the same reason. `isAdmin` from `useAuth()` decides whether it renders, matching how the rest of the app gates admin UI.

**The internal secret never reaches the browser** — you authenticate with your ordinary Supabase token, and `/api/admin/catalog-artist` holds `INTERNAL_FUNCTION_SECRET` server-side. `isAdmin` is presentation only; the endpoint checks `ADMIN_EMAIL` on every request.

Two details worth keeping: the endpoint **clears the 7-day cooldown** first (otherwise the button appears to work and silently does nothing for a week), and it **polls `release_catalog_state`** rather than trusting the 202, which a background function returns even when it's about to refuse.

## Testing

Nine component tests on the things that would be quietly wrong rather than broken — a fabricated day on a year-only release, a price quoted from a sold-out format, a zero price reading as free rather than name-your-price, and a heading with nothing under it. 35 web test files and 24 API files pass; lint is at the pre-existing baseline; full `npm run build` green.

## Requires `ADMIN_EMAIL`

`authenticateAdmin` returns null when it's unset, so the endpoint 403s everyone and the button never appears. Worth confirming alongside `INTERNAL_FUNCTION_SECRET`.