### PR TITLE
Fix FAQ card styling to match Changelog/Guides

### DIFF
--- a/apps/web/src/pages/FaqPage.tsx
+++ b/apps/web/src/pages/FaqPage.tsx
@@ -9,9 +9,9 @@ export function FaqPage() {
 
       <Header />
 
-      <div className="pt-8 pb-8 px-4">
+      <div className="pt-6 pb-8 px-4">
         <div className="max-w-4xl mx-auto text-center">
-          <h1 className="font-display text-3xl md:text-4xl font-semibold text-text-primary mb-4">Frequently Asked Questions</h1>
+          <h1 className="font-display text-3xl md:text-4xl font-semibold text-text-primary mb-2">Frequently Asked Questions</h1>
           <p className="text-text-secondary text-lg max-w-2xl mx-auto">
             Learn more about Unstream, streaming economics, and how to support artists directly.
           </p>
@@ -21,9 +21,9 @@ export function FaqPage() {
       <main className="px-4 pb-16">
         <div className="max-w-2xl mx-auto">
           {faqSections.length > 0 && (
-            <div className="space-y-6">
+            <div className="space-y-4">
               {faqSections.map((section, index) => (
-                <details key={index} className="group bg-bg-secondary rounded-xl border border-border-primary">
+                <details key={index} className="group bg-surface-secondary rounded-xl border border-border">
                   <summary className="flex items-center justify-between cursor-pointer p-4 text-text-primary font-medium hover:bg-bg-hover transition-colors rounded-xl">
                     {section.title}
                     <span className="ml-2 text-text-muted group-open:rotate-180 transition-transform">▼</span>

--- a/apps/web/src/pages/GuidePage.tsx
+++ b/apps/web/src/pages/GuidePage.tsx
@@ -59,7 +59,7 @@ export function GuidePage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-semibold text-text-primary mb-2">Not found</h1>
+          <h1 className="font-display text-2xl font-semibold text-text-primary mb-2">Not found</h1>
           <Link to="/guides" className="text-accent-primary hover:underline">Back to guides</Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- FAQ's accordion cards used `border-border-primary`, a Tailwind class that doesn't exist in the theme (only `--color-border`/`border-border` is defined), so cards rendered with a bright default border instead of the subtle one Changelog/Guides use. Switched to `bg-surface-secondary`/`border-border` and matched hero spacing (`pt-6`/`mb-2`) and item spacing (`space-y-4`) to those pages.
- Added the missing `font-display` (Darker Grotesque) to GuidePage's "Not found" heading — it was the only heading across FAQ/Changelog/Guides/GuidePage not using it.

## Test plan
- [x] Verified in-browser (dark + light) that FAQ card borders/spacing now match Changelog and Guides
- [x] Verified GuidePage's not-found state renders in Darker Grotesque
- [x] `npm run lint` clean on changed files
- [x] `npm run test:unit` — 492 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)