### PR TITLE
Gate cataloging on a variable that exists at function runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,11 +163,17 @@ This is the lesson behind a run of bug fixes (#317–#328) and it applies to eve
 
 ### Testing release ingest locally
 
-Release cataloging only runs when `CONTEXT === 'production'`, because deploy previews and local
-runs both point at the **production** Supabase — so an ungated preview would write real
-`releases` rows and spend the real hourly crawl budget. That means ingest cannot be exercised
-on a deploy preview, and **`CONTEXT=production` is not a valid local workaround** — it would
-have your laptop writing production data.
+Release cataloging only runs where `RELEASE_CATALOG_ENABLED=true`, a custom env var scoped to
+Functions and set for the **Production context only**. Deploy previews and local runs both point
+at the **production** Supabase, so an ungated preview would write real `releases` rows and spend
+the real hourly crawl budget. Ingest therefore cannot be exercised on a deploy preview, and
+**setting the flag locally is not a valid workaround** — it would have your laptop writing
+production data.
+
+This used to gate on `CONTEXT === 'production'`, which silently disabled cataloging entirely:
+Netlify exposes only `URL`, `SITE_NAME` and `SITE_ID` to a serverless function at runtime, so
+`process.env.CONTEXT` is `undefined` in every deployed function. Don't reach for `CONTEXT` or
+`DEPLOY_PRIME_URL` in a function — neither exists there.
 
 Use the dry run instead:
 

--- a/api/functions/__tests__/admin-catalog-artist.test.ts
+++ b/api/functions/__tests__/admin-catalog-artist.test.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
   mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
   mocks.maybeSingle.mockResolvedValue({ data: null, error: null });
   vi.stubGlobal('fetch', mocks.fetch);
-  process.env.CONTEXT = 'production';
+  process.env.RELEASE_CATALOG_ENABLED = 'true';
   process.env.INTERNAL_FUNCTION_SECRET = 'secret';
   process.env.URL = 'https://unstream.stream';
 });
@@ -54,7 +54,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
-  delete process.env.CONTEXT;
+  delete process.env.RELEASE_CATALOG_ENABLED;
   delete process.env.INTERNAL_FUNCTION_SECRET;
   delete process.env.URL;
 });
@@ -112,11 +112,11 @@ describe('POST — starting a crawl', () => {
   // Netlify answers 202 to a background invocation the instant it is queued and discards the
   // handler's response — so any refusal we can predict has to be caught here, or it reaches the
   // UI as a crawl that simply never finishes.
-  it('refuses outside production rather than queuing a crawl that will be rejected', async () => {
-    process.env.CONTEXT = 'deploy-preview';
+  it('refuses where cataloging is disabled rather than queuing a crawl that will be rejected', async () => {
+    delete process.env.RELEASE_CATALOG_ENABLED;
     const response = await post();
     expect(response.statusCode).toBe(503);
-    expect(JSON.parse(response.body).error).toContain('production');
+    expect(JSON.parse(response.body).error).toContain('RELEASE_CATALOG_ENABLED');
     expect(mocks.fetch).not.toHaveBeenCalled();
   });
 

--- a/api/functions/__tests__/catalog-gating.test.ts
+++ b/api/functions/__tests__/catalog-gating.test.ts
@@ -51,8 +51,8 @@ const originalEnv = { ...process.env };
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.INTERNAL_FUNCTION_SECRET = SECRET;
-  process.env.CONTEXT = 'production';
-  process.env.DEPLOY_PRIME_URL = 'https://unstream.stream';
+  process.env.RELEASE_CATALOG_ENABLED = 'true';
+  process.env.URL = 'https://unstream.stream';
   mocks.claimArtistForCatalog.mockResolvedValue(false); // don't do real work by default
   vi.stubGlobal('fetch', mocks.fetch);
 });
@@ -98,9 +98,11 @@ describe('catalog-artist-background auth', () => {
   });
 });
 
-describe('catalog-artist-background is production-only', () => {
-  it.each(['deploy-preview', 'branch-deploy', 'dev'])('refuses in context %s', async context => {
-    process.env.CONTEXT = context;
+describe('catalog-artist-background refuses where cataloging is disabled', () => {
+  // Checked at the writer as well as the caller: the caller-side gate stops a preview asking,
+  // this one holds the guarantee no matter who asks, since this is what writes to production.
+  it('refuses when RELEASE_CATALOG_ENABLED is unset', async () => {
+    delete process.env.RELEASE_CATALOG_ENABLED;
 
     const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
 
@@ -108,13 +110,13 @@ describe('catalog-artist-background is production-only', () => {
     expect(mocks.claimArtistForCatalog).not.toHaveBeenCalled();
   });
 
-  it('refuses when CONTEXT is unset', async () => {
-    delete process.env.CONTEXT;
+  it.each(['false', 'yes', ''])('refuses when the flag is %o', async value => {
+    process.env.RELEASE_CATALOG_ENABLED = value;
     const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
     expect(r.statusCode).toBe(403);
   });
 
-  it('proceeds in production', async () => {
+  it('proceeds when enabled', async () => {
     const r = await post({ authorization: `Bearer ${SECRET}` }, { artistIds: [ARTIST] });
     expect(r.statusCode).toBe(200);
     expect(mocks.claimArtistForCatalog).toHaveBeenCalledWith(ARTIST, 'searched');
@@ -138,17 +140,21 @@ describe('catalog-artist-background is production-only', () => {
   });
 });
 
-describe('requestArtistCatalog is production-only', () => {
-  it.each(['deploy-preview', 'branch-deploy', 'dev'])('makes no request in context %s', async context => {
-    process.env.CONTEXT = context;
-
+describe('requestArtistCatalog only runs where cataloging is enabled', () => {
+  // The gate this replaced tested `CONTEXT !== 'production'`, which is unimplementable:
+  // Netlify exposes only URL, SITE_NAME and SITE_ID to a function at runtime, so CONTEXT is
+  // undefined in every deployed function and the check refused everything, in production,
+  // always. The test passed the whole time because it set CONTEXT itself.
+  it('makes no request when RELEASE_CATALOG_ENABLED is unset', async () => {
+    delete process.env.RELEASE_CATALOG_ENABLED;
     await requestArtistCatalog([ARTIST], 'saved');
-
     expect(mocks.fetch).not.toHaveBeenCalled();
   });
 
-  it('makes no request when CONTEXT is unset', async () => {
-    delete process.env.CONTEXT;
+  // Unset means off, and so does anything that isn't exactly 'true' — a crawl budget that fails
+  // open is worse than one that fails closed.
+  it.each(['false', '1', 'yes', ''])('makes no request when the flag is %o', async value => {
+    process.env.RELEASE_CATALOG_ENABLED = value;
     await requestArtistCatalog([ARTIST], 'saved');
     expect(mocks.fetch).not.toHaveBeenCalled();
   });

--- a/api/functions/admin-catalog-artist.ts
+++ b/api/functions/admin-catalog-artist.ts
@@ -20,6 +20,7 @@
 
 import { getClient, type CatalogTrigger } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { isCatalogEnabled } from './request-catalog';
 import { Sentry } from '../lib/sentry';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -145,18 +146,18 @@ export async function handler(event: {
   // accepts a background invocation and discards whatever the handler returns, so a 401 from a
   // bad secret and a 403 from a non-production context both reach us as 202. Anything not
   // checked up front is indistinguishable from a slow crawl.
-  if (process.env.CONTEXT !== 'production') {
+  if (!isCatalogEnabled()) {
     return {
       statusCode: 503,
       headers: CORS_HEADERS,
       body: JSON.stringify({
-        error: `Cataloging only runs in production (this deploy is "${process.env.CONTEXT ?? 'unset'}").`,
+        error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).',
       }),
     };
   }
 
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
-  const siteUrl = process.env.DEPLOY_PRIME_URL || process.env.URL;
+  const siteUrl = process.env.URL;
 
   if (!secret || !siteUrl) {
     // Said plainly rather than as a generic 500: this exact configuration gap silently stopped

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -23,6 +23,7 @@ import {
 import { isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
 import { bandcampMusicUrl, ingestBandcampDetail, ingestBandcampGrid } from './release-ingest';
+import { isCatalogEnabled } from './request-catalog';
 
 /** Ceiling on artists per invocation, so one call can't become an unbounded crawl. */
 const MAX_ARTISTS_PER_RUN = 25;
@@ -99,13 +100,12 @@ export async function handler(event: {
     return { statusCode: 401, body: '' };
   }
 
-  // Production only, checked here as well as in request-catalog.ts. The caller-side gate stops
-  // a preview from asking; this one means the guarantee holds no matter who asks, since this
-  // function is what actually writes to the production database. Cheap, and the alternative is
-  // a rule that's true only as long as every future caller remembers it.
-  if (process.env.CONTEXT !== 'production') {
-    console.log(`[catalog] refusing — context is ${process.env.CONTEXT ?? 'unset'}, not production`);
-    return { statusCode: 403, body: JSON.stringify({ skipped: 'non-production context' }) };
+  // Checked here as well as at the caller. The caller-side gate stops a preview from asking;
+  // this one means the guarantee holds no matter who asks, since this function is what actually
+  // writes to the production database.
+  if (!isCatalogEnabled()) {
+    console.log('[catalog] refusing — RELEASE_CATALOG_ENABLED is not set on this deploy');
+    return { statusCode: 403, body: JSON.stringify({ skipped: 'cataloging disabled on this deploy' }) };
   }
 
   let body: { artistIds?: unknown; trigger?: unknown };

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -15,6 +15,28 @@ import type { CatalogTrigger } from './db';
 const MAX_ARTISTS_PER_REQUEST = 25;
 
 /**
+ * Is this deploy allowed to catalog?
+ *
+ * **Not `CONTEXT`.** That gate was unimplementable: Netlify exposes only `URL`, `SITE_NAME` and
+ * `SITE_ID` to a serverless function at runtime — `CONTEXT` and `DEPLOY_PRIME_URL` are
+ * build-time variables. So `process.env.CONTEXT` is `undefined` in every deployed function, and
+ * the three `CONTEXT !== 'production'` checks this replaces refused *everything, in production,
+ * always*. Cataloging had never run once. It surfaced only when the admin button reported the
+ * refusal out loud — before that it was a `console.log` nobody reads.
+ *
+ * A custom variable is the documented way to get a per-context value into a function: set
+ * `RELEASE_CATALOG_ENABLED=true` scoped to Functions, for the **Production context only**.
+ * Deploy previews and branch deploys then get no value and stay off, which is the whole point —
+ * previews run against the *production* Supabase, so an ungated one would write real releases
+ * and spend the real hourly crawl budget on traffic that isn't real.
+ *
+ * Unset means off. A crawl budget that fails open is worse than one that fails closed.
+ */
+export function isCatalogEnabled(): boolean {
+  return process.env.RELEASE_CATALOG_ENABLED === 'true';
+}
+
+/**
  * Request release cataloging for one or more artists.
  *
  * Awaited deliberately, despite being "fire and forget" in spirit: un-awaited work is killed
@@ -32,29 +54,23 @@ export async function requestArtistCatalog(
   const ids = [...new Set(artistIds.filter(Boolean))].slice(0, MAX_ARTISTS_PER_REQUEST);
   if (ids.length === 0) return;
 
-  // Production only. Deploy previews and branch deploys run against the *production*
-  // Supabase, so cataloging from one would write real releases and spend the real hourly
-  // crawl budget on behalf of traffic that isn't real. Netlify sets CONTEXT to
-  // 'production' | 'deploy-preview' | 'branch-deploy' | 'dev'; it is undefined in tests and
-  // under the plain Vite dev server, so a strict equality check also keeps local runs from
-  // touching production data.
+  // Deploy previews and branch deploys share the *production* Supabase, so an ungated one would
+  // write real releases and spend the real hourly crawl budget on traffic that isn't real.
   //
-  // Do NOT set CONTEXT=production to test locally — .env points at the production database,
-  // so that would have a laptop writing real rows. Use `npm run ingest:try <artist>` instead,
-  // which runs the real fetch, parse and mapping and prints what would be written.
-  if (process.env.CONTEXT !== 'production') {
-    console.log(`[catalog] not requested — context is ${process.env.CONTEXT ?? 'unset'}, not production`);
+  // Do NOT set RELEASE_CATALOG_ENABLED locally to test — .env points at production, so that
+  // would have a laptop writing real rows. Use `npm run ingest:try <artist>` instead, which runs
+  // the real fetch, parse and mapping and prints what would be written.
+  if (!isCatalogEnabled()) {
+    console.log('[catalog] not requested — RELEASE_CATALOG_ENABLED is not set on this deploy');
     return;
   }
 
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
 
-  // DEPLOY_PRIME_URL first, not URL. On Netlify, URL is the *production* address even during
-  // a deploy preview, so preferring it would make a preview invoke the production function —
-  // running production code for a preview's traffic and spending the shared hourly crawl
-  // budget. DEPLOY_PRIME_URL is the current deploy (preview, branch, or production), which is
-  // what we want in every context.
-  const siteUrl = process.env.DEPLOY_PRIME_URL || process.env.URL;
+  // `URL` and not `DEPLOY_PRIME_URL`: only URL, SITE_NAME and SITE_ID reach a function at
+  // runtime, so DEPLOY_PRIME_URL is always undefined here. That means a preview would invoke the
+  // *production* background function — which is exactly why the gate above has to hold.
+  const siteUrl = process.env.URL;
 
   if (!secret || !siteUrl) {
     // Not an error worth surfacing: without configuration the feature is simply off.


### PR DESCRIPTION
**Release cataloging has never run. Not once, in production, since #359.**

All three gates tested `process.env.CONTEXT !== 'production'`. Netlify exposes **only `URL`, `SITE_NAME` and `SITE_ID`** to a serverless function at runtime — `CONTEXT` and `DEPLOY_PRIME_URL` are build-time variables ([docs](https://docs.netlify.com/build/functions/environment-variables/)). So `CONTEXT` is `undefined` in every deployed function, and every gate refused:

| Gate | Effect in production |
|---|---|
| `request-catalog.ts` | the save trigger and the search trigger never fired |
| `catalog-artist-background.ts` | refused every invocation it did receive |
| `admin-catalog-artist.ts` | the error you just saw |

So the empty `releases` table had **two** independent causes — the unset `INTERNAL_FUNCTION_SECRET`, and this. Fixing the first alone would not have helped.

## Why it hid for so long

Refusing looked exactly like working. Two of the three gates logged a line nobody reads, and an empty catalogue is precisely what a quiet week looks like — which is why I accepted "no traffic yet" as the explanation twice.

It surfaced only when the admin button reported the refusal out loud: *"this deploy is unset"*. That's the entire argument for the observability work in #370 — the same refusal had been happening silently for days.

**And the tests passed the whole time**, because they set `CONTEXT` themselves. They were testing a rule the runtime could never satisfy. That's the more uncomfortable lesson: a test that constructs the environment it asserts on can only ever confirm the author's model of it.

## The fix

`RELEASE_CATALOG_ENABLED`, a custom variable scoped to Functions and set for the **Production context only** — the documented way to get a per-context value into a function.

```ts
export function isCatalogEnabled(): boolean {
  return process.env.RELEASE_CATALOG_ENABLED === 'true';
}
```

Unset means off, and so does anything that isn't exactly `'true'`. A crawl budget that fails open is worse than one that fails closed. Deploy previews and branch deploys stay off, preserving the original intent — they run against the *production* Supabase, so an ungated one would write real releases and spend the real hourly budget.

Also drops `DEPLOY_PRIME_URL || URL` for plain `URL`, since the former is likewise undefined at runtime. The comment explaining why `DEPLOY_PRIME_URL` was preferred described build-time behaviour and was never true of this code path.

## ⚠️ Action needed

**Set `RELEASE_CATALOG_ENABLED=true` in Netlify — scoped to Functions, Production context only.** Without it cataloging stays off; same as today, but now for a visible reason.

## Testing

The gating tests now assert the real rule, including that a non-`'true'` value stays off. 32 tests across the two catalog test files, 25 API + 35 web files green, full build passes. CLAUDE.md updated with the runtime-variable constraint so nobody reaches for `CONTEXT` in a function again.