### PR TITLE
Serve real browsers the SPA on direct /u/:handle loads, not static HTML

### DIFF
--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -1,11 +1,13 @@
 // Edge function: /u/{handle}
 // Static HTML renderer for public saved-artists pages.
 // Models after api/edge/artist-page-static.ts — same pattern, same RLS-aware data fetching.
-// The edge function is the single renderer per CLAUDE.md "one route, one renderer".
-// React app hydrates client-side for the Copy URL button only (progressive enhancement).
+// Real browsers get the SPA (PublicSavedArtistsPage.tsx), same as a client-side <Link>
+// navigation would render, so a direct load and an in-app click produce the same UI (see
+// docs/retros/UNS-100-bifurcation-retro.md). Only crawlers get this static render.
 
 import { Context } from "https://edge.netlify.com";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.ts";
 
 function escapeHtml(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
@@ -49,6 +51,11 @@ export default async function handler(request: Request, context: Context) {
     const handle = url.pathname.replace(/^\/u\//, '').replace(/\/$/, '');
 
     if (!handle) return context.next();
+
+    const userAgent = request.headers.get('user-agent');
+    if (!isSocialCrawler(userAgent) && !isIndexingCrawler(userAgent)) {
+      return context.next();
+    }
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_KEY");


### PR DESCRIPTION
## Summary

- `/u/:handle` (public saved-artists pages) had the same two-renderers bug fixed for `/a/:slug` in #369: a direct page load hit `api/edge/u-handle.ts`'s hand-rolled static HTML with a stale header (no Login, plain search form) and footer (missing Dashboard/FAQ/Donate/Contact links) inside a 640px container, while client-side `<Link>` navigation rendered `PublicSavedArtistsPage.tsx` with the real, current `Header`/`Footer` components.
- Applied the same crawler gate used in `artist-page-static.ts`: real browsers now `context.next()` through to the SPA, so a direct load and an in-app click produce identical UI. Crawlers (Googlebot, facebookexternalhit, etc.) still get the fast static render for SEO/link previews.

## Why

Brandon reported `unstream.stream/u/brandon` was using an old header/footer and possibly the wrong layout. Root cause matched a bug already flagged (but left unfixed) after the original `/a/:slug` fix — same bifurcation pattern from `docs/retros/UNS-100-bifurcation-retro.md`.

## Test plan

- [x] `npm run test:api` — 389 tests passing
- [x] Verified in the dev server that `PublicSavedArtistsPage` (the path real browsers now take) renders with the current site-wide `Header`/`Footer` (Login, live search, full footer nav)
- [ ] Spot-check `unstream.stream/u/brandon` after deploy to confirm the header/footer now match the rest of the site