### PR TITLE
Navigate to release pages instead of client-side routing to them

### DIFF
--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { cheapestOfferSummary, formatReleaseDate } from '../../../../api/shared/release-display';
 import type { ArtistPagePayload } from '../types/artist-page';
 
@@ -17,6 +16,13 @@ type Release = NonNullable<ArtistPagePayload['releases']>[number];
  *
  * The formatting helpers come from `api/shared/release-display.ts`, which the crawler-side edge
  * renderer also uses, so the two can't drift on what a price or a partial date looks like.
+ *
+ * **Rows are plain `<a>`, never react-router `<Link>`.** `/a/{artist}/{release}` is rendered by
+ * the `release-page` edge function and by nothing else — the SPA has no route for a two-segment
+ * `/a/` path, and there is no catch-all `<Route>`, so a client-side navigation there matches
+ * nothing and renders a blank page. It also strands history: the URL changes, React renders
+ * nothing, and Back has nowhere sensible to go. A real navigation reaches the one renderer that
+ * exists, which is also what makes an in-app click and a pasted link produce the same page.
  */
 export function ReleasesSection({
   releases,
@@ -57,8 +63,8 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
   const meta = [type, date, cheapestOfferSummary(release.offers)].filter(Boolean).join(' · ');
 
   return (
-    <Link
-      to={`/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release.slug)}`}
+    <a
+      href={`/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release.slug)}`}
       className="flex items-center gap-3 px-3 py-2 rounded-xl border border-border hover:bg-bg-hover transition-colors"
     >
       {release.artworkUrl ? (
@@ -87,6 +93,6 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
           Coming
         </span>
       )}
-    </Link>
+    </a>
   );
 }

--- a/apps/web/tests/unit/ReleasesSection.test.tsx
+++ b/apps/web/tests/unit/ReleasesSection.test.tsx
@@ -11,7 +11,6 @@
 // with nothing under it.
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { ReleasesSection } from 'src/components/ReleasesSection';
 import type { ArtistPagePayload } from 'src/types/artist-page';
 
@@ -31,11 +30,13 @@ function release(overrides: Partial<Release> = {}): Release {
   };
 }
 
+// Rendered with **no Router on purpose**. A react-router <Link> throws without one, so this
+// harness is what keeps the rows real anchors: `/a/{artist}/{release}` is served only by the
+// release-page edge function, and a client-side navigation there matches no SPA route, renders
+// a blank page and strands the Back button.
 function show(releases: Release[], total = releases.length) {
   return render(
-    <MemoryRouter>
-      <ReleasesSection releases={releases} total={total} artistSlug="kid-lightbulbs" />
-    </MemoryRouter>
+    <ReleasesSection releases={releases} total={total} artistSlug="kid-lightbulbs" />
   );
 }
 
@@ -47,6 +48,13 @@ describe('ReleasesSection', () => {
     expect(screen.getByRole('link', { name: /RUINED CASTLE/ }).getAttribute('href')).toBe(
       '/a/kid-lightbulbs/ruined-castle'
     );
+  });
+
+  // The regression this file exists to prevent, spelled out: a <Link> here produced a blank
+  // page on click and a dead Back button, because that URL has no SPA route. Rendering without
+  // a Router is the assertion — <Link> cannot mount outside one.
+  it('navigates for real rather than client-side routing to a URL the SPA cannot render', () => {
+    expect(() => show([release()])).not.toThrow();
   });
 
   // An empty "Releases" heading reads as broken; its absence reads as "nothing here yet", which


### PR DESCRIPTION
Clicking a release from an artist page rendered a **blank page**. A hard refresh loaded it, and **Back was dead** afterwards.

## Cause

`ReleasesSection` linked with react-router's `<Link>`, but `/a/{artist}/{release}` is served by the `release-page` edge function **and by nothing else**:

```
main.tsx:  <Route path="/a/:slug" element={<ArtistPage />} />   ← one segment
           (no catch-all <Route>)
```

So a client-side navigation to a two-segment path matched no route and rendered nothing. That single cause explains all three symptoms:

| Symptom | Why |
|---|---|
| Blank page on click | React Router matched nothing, and there's no catch-all to render a 404 |
| Hard refresh works | Only a real request reaches the edge function |
| Back button dead | The URL had already changed while React rendered nothing, so history had nowhere sensible to return to |

## Fix

A plain `<a>`. A real navigation reaches the one renderer that exists, and it's the honest expression of what that URL is — it also means an in-app click and a pasted link produce the same page, the property #369 established for artist pages.

**This is the UNS-100 bifurcation class wearing a different hat.** The familiar shape is two renderers for one URL; this was one renderer plus a link asserting a second. Worth stating plainly, because it isn't obvious from the retro: **a `<Link>` is an assertion that the SPA can render the target.**

## Making it catchable

The test file now renders **without a Router**. `<Link>` can't mount outside one, so that harness is the assertion. Verified by reverting the fix — 9 of the 10 tests fail, rather than passing quietly:

```
with <Link> restored:  Tests  9 failed | 1 passed (10)
with the fix:          Tests  10 passed (10)
```

## Scope

Every other `to={/a/...}` in the app is a single-segment artist link, which *does* have an SPA route. Checked all eight; they stay as they are.

## Related, not fixed here

**There is no catch-all `<Route>`**, so *any* unmatched URL renders a blank page rather than a 404 — a typo'd link, an old bookmark, anything. That's pre-existing and unrelated to Releases, and what a 404 should look like is a product decision, so I've left it. Worth a follow-up: it's the reason this bug presented as "blank" instead of "not found", which cost more diagnosis than it should have.

25 API + 35 web test files pass, lint at baseline, build green.