### PR TITLE
Releases: Discogs + MusicBrainz + Faircamp sources, dedup review queues, and artist curation

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
 import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
 import { mainLinkDividerIndexes } from "../shared/link-dividers.ts";
-import { cheapestOfferSummary, formatReleaseDate } from "../shared/release-display.ts";
+import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate } from "../shared/release-display.ts";
 import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.ts";
 
 /**
@@ -23,7 +23,10 @@ interface ReleaseRow {
   date_precision: string | null;
   status: string;
   artwork_url: string | null;
-  release_sources: { release_offers: { price: number | null; currency: string | null; availability: string }[] | null }[] | null;
+  release_sources: {
+    platform: string;
+    release_offers: { price: number | null; currency: string | null; availability: string }[] | null;
+  }[] | null;
 }
 
 // Allowed embed domains for featured releases (must match api/functions/artist-profile.ts)
@@ -80,8 +83,19 @@ function renderReleaseRow(release: ReleaseRow, artistSlug: string): string {
     ? ''
     : release.release_type.charAt(0).toUpperCase() + release.release_type.slice(1);
 
-  const offers = (release.release_sources || []).flatMap(s => s.release_offers || []);
-  const meta = [type, date, cheapestOfferSummary(offers)].filter(Boolean).join(' · ');
+  const sources = (release.release_sources || []).map(s => ({ platform: s.platform, offers: s.release_offers || [] }));
+  // leadingOfferSummary, not the globally cheapest price across every source — see the
+  // function's own doc for why picking the absolute cheapest could rank a Discogs secondhand
+  // listing above a Bandcamp direct purchase.
+  const meta = [type, date, leadingOfferSummary(sources)].filter(Boolean).join(' · ');
+
+  // Same artist-paying-first order as the summary above and the release page itself.
+  const platformsHtml = orderedSourcePlatforms(sources)
+    .map(p => {
+      const info = PLATFORM_INFO[p];
+      return `<span title="${escapeHtml(info?.name || p)}" style="font-size:12px">${info?.icon || '🔗'}</span>`;
+    })
+    .join('');
 
   const art = release.artwork_url
     ? `<img src="${escapeHtml(release.artwork_url)}" alt="" loading="lazy" referrerpolicy="no-referrer" style="width:48px;height:48px;border-radius:6px;object-fit:cover;flex-shrink:0;background:var(--bg2)">`
@@ -98,6 +112,7 @@ function renderReleaseRow(release: ReleaseRow, artistSlug: string): string {
     <span style="flex:1;min-width:0">
       <span style="display:block;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${title}</span>
       ${meta ? `<span style="display:block;font-size:12px;color:var(--muted)">${escapeHtml(meta)}</span>` : ''}
+      ${platformsHtml ? `<span style="display:flex;gap:4px;margin-top:2px">${platformsHtml}</span>` : ''}
     </span>
     ${upcoming}
   </a>`;
@@ -251,7 +266,7 @@ export default async function handler(request: Request, context: Context) {
         .from('releases')
         .select(
           'slug, title, release_type, release_date, date_precision, status, artwork_url,' +
-          ' release_sources ( release_offers ( price, currency, availability ) )',
+          ' release_sources ( platform, release_offers ( price, currency, availability ) )',
           { count: 'exact' }
         )
         .eq('artist_id', artist.id)

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -339,7 +339,7 @@ export default async function handler(request: Request, context: Context) {
     <div class="container" style="padding-bottom:32px">
       <h2 style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted);margin-bottom:12px">Where to buy</h2>
       ${sourcesHtml || '<p style="font-size:14px;color:var(--muted)">We haven\'t found anywhere to buy this yet.</p>'}
-      ${oldestCapture ? `<p class="note">Prices checked ${escapeHtml(relativeDays(oldestCapture))}. Stock and prices change &mdash; the platform is the last word. Payout figures are estimates based on each platform's published rates.</p>` : ''}
+      ${oldestCapture ? `<p class="note">Prices last checked ${escapeHtml(relativeDays(oldestCapture))}. Stock and prices may change. Payout figures are estimates based on each platform's published rates.</p>` : ''}
     </div>
   </div>
 

--- a/api/functions/__tests__/admin-catalog-artist.test.ts
+++ b/api/functions/__tests__/admin-catalog-artist.test.ts
@@ -8,27 +8,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  maybeSingle: vi.fn(),
-  update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+  getCatalogState: vi.fn(),
+  clearCatalogCooldown: vi.fn(),
   authenticateAdmin: vi.fn(),
   fetch: vi.fn(() => Promise.resolve({ status: 202, ok: false } as Response)),
 }));
 
+// getCatalogState/clearCatalogCooldown are the real db.ts functions, shared with the
+// artist-facing endpoint. The shape of the cooldown patch is covered where it lives; what this
+// file asserts is that the endpoint *asks for* the clear before queuing — without which the
+// button appears to work and silently does nothing for a week.
 vi.mock('../db', () => ({
-  getClient: () => ({
-    from: () => ({
-      select: () => ({ eq: () => ({ maybeSingle: mocks.maybeSingle }) }),
-      update: mocks.update,
-    }),
-  }),
+  getCatalogState: mocks.getCatalogState,
+  clearCatalogCooldown: mocks.clearCatalogCooldown,
 }));
 
 vi.mock('../middleware', () => ({
   authenticateAdmin: mocks.authenticateAdmin,
   buildCorsHeaders: () => ({ 'Content-Type': 'application/json' }),
 }));
-
-vi.mock('../../lib/sentry', () => ({ Sentry: { captureException: vi.fn() } }));
 
 const { handler } = await import('../admin-catalog-artist');
 
@@ -44,7 +42,8 @@ function post(artistId = ARTIST) {
 
 beforeEach(() => {
   mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
-  mocks.maybeSingle.mockResolvedValue({ data: null, error: null });
+  mocks.getCatalogState.mockResolvedValue({ ok: true, state: null });
+  mocks.clearCatalogCooldown.mockResolvedValue(undefined);
   vi.stubGlobal('fetch', mocks.fetch);
   process.env.RELEASE_CATALOG_ENABLED = 'true';
   process.env.INTERNAL_FUNCTION_SECRET = 'secret';
@@ -81,7 +80,7 @@ describe('GET — reading the state', () => {
   // The bug this exists to prevent: a failed read and "never catalogued" both arriving as null
   // makes a broken database render as a confident fact about the artist.
   it('does not report a failed read as a null state', async () => {
-    mocks.maybeSingle.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+    mocks.getCatalogState.mockResolvedValue({ ok: false, reason: 'Could not read catalog state' });
     const response = await get();
     expect(response.statusCode).toBe(503);
     expect(JSON.parse(response.body).error).toBeTruthy();
@@ -89,9 +88,9 @@ describe('GET — reading the state', () => {
   });
 
   it('passes a real state through', async () => {
-    mocks.maybeSingle.mockResolvedValue({
-      data: { last_catalogued_at: '2026-07-31T00:00:00Z', releases_found: 16, releases_detailed: 16, last_error: null, consecutive_failures: 0 },
-      error: null,
+    mocks.getCatalogState.mockResolvedValue({
+      ok: true,
+      state: { last_catalogued_at: '2026-07-31T00:00:00Z', releases_found: 16, releases_detailed: 16, last_error: null, consecutive_failures: 0 },
     });
     const body = JSON.parse((await get()).body);
     expect(body.state.releases_found).toBe(16);
@@ -103,9 +102,7 @@ describe('POST — starting a crawl', () => {
     const response = await post();
     expect(response.statusCode).toBe(202);
     // Without this the button appears to work and silently does nothing for a week.
-    expect(mocks.update).toHaveBeenCalledWith(
-      expect.objectContaining({ last_catalogued_at: null, consecutive_failures: 0 })
-    );
+    expect(mocks.clearCatalogCooldown).toHaveBeenCalledWith(ARTIST);
     expect(mocks.fetch).toHaveBeenCalledOnce();
   });
 

--- a/api/functions/__tests__/admin-release-review.test.ts
+++ b/api/functions/__tests__/admin-release-review.test.ts
@@ -1,0 +1,134 @@
+// The admin release-review endpoint: the human backstop for tier-3 dedup.
+//
+// What's worth locking: the auth gate holds, actions validate their inputs before touching the
+// database, and a merge conflict is reported as a 409 rather than silently discarding a source.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateAdmin: vi.fn(),
+  getReleaseReviewQueue: vi.fn(),
+  dismissReleaseReview: vi.fn(),
+  mergeReleases: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({}),
+  getReleaseReviewQueue: mocks.getReleaseReviewQueue,
+  dismissReleaseReview: mocks.dismissReleaseReview,
+  mergeReleases: mocks.mergeReleases,
+}));
+
+vi.mock('../middleware', () => ({
+  authenticateAdmin: mocks.authenticateAdmin,
+  buildCorsHeaders: () => ({ 'Content-Type': 'application/json' }),
+}));
+
+vi.mock('../../lib/sentry', () => ({ Sentry: { captureMessage: vi.fn() } }));
+
+const { handler } = await import('../admin-release-review');
+
+const KEEP = '11111111-1111-1111-1111-111111111111';
+const DROP = '22222222-2222-2222-2222-222222222222';
+const headers = { authorization: 'Bearer admin-token' };
+
+function get() {
+  return handler({ httpMethod: 'GET', headers });
+}
+function post(body: unknown) {
+  return handler({ httpMethod: 'POST', headers, body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
+  mocks.getReleaseReviewQueue.mockResolvedValue([]);
+  mocks.dismissReleaseReview.mockResolvedValue(true);
+  mocks.mergeReleases.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('auth', () => {
+  it('refuses anyone who is not an admin', async () => {
+    mocks.authenticateAdmin.mockResolvedValue(null);
+    expect((await get()).statusCode).toBe(401);
+    expect((await post({ action: 'dismiss', releaseId: KEEP })).statusCode).toBe(401);
+  });
+
+  it('handles OPTIONS without requiring auth', async () => {
+    const r = await handler({ httpMethod: 'OPTIONS', headers: {} });
+    expect(r.statusCode).toBe(204);
+    expect(mocks.authenticateAdmin).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET — the queue', () => {
+  it('returns whatever the queue function reports', async () => {
+    mocks.getReleaseReviewQueue.mockResolvedValue([{ primary: { id: KEEP }, counterpart: null }]);
+    const body = JSON.parse((await get()).body);
+    expect(body.pairs).toHaveLength(1);
+  });
+});
+
+describe('POST — dismiss', () => {
+  it('validates releaseId is a UUID', async () => {
+    const r = await post({ action: 'dismiss', releaseId: '../../etc/passwd' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.dismissReleaseReview).not.toHaveBeenCalled();
+  });
+
+  it('dismisses and reports success', async () => {
+    const r = await post({ action: 'dismiss', releaseId: KEEP });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.dismissReleaseReview).toHaveBeenCalledWith(KEEP);
+  });
+
+  it('reports a failure as a 500, not a false success', async () => {
+    mocks.dismissReleaseReview.mockResolvedValue(false);
+    const r = await post({ action: 'dismiss', releaseId: KEEP });
+    expect(r.statusCode).toBe(500);
+  });
+});
+
+describe('POST — merge', () => {
+  it('validates both ids are UUIDs', async () => {
+    const r = await post({ action: 'merge', keepId: KEEP, dropId: 'nope' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.mergeReleases).not.toHaveBeenCalled();
+  });
+
+  it('merges and reports success', async () => {
+    const r = await post({ action: 'merge', keepId: KEEP, dropId: DROP });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.mergeReleases).toHaveBeenCalledWith(KEEP, DROP);
+  });
+
+  // A merge conflict (both sides already have a source on the same platform) is a real
+  // decision an admin needs to make, not a 500 — the request wasn't malformed, the outcome was
+  // ambiguous.
+  it('reports a merge conflict as 409 with the reason', async () => {
+    mocks.mergeReleases.mockResolvedValue({ ok: false, error: 'Both releases already have a source on: bandcamp' });
+    const r = await post({ action: 'merge', keepId: KEEP, dropId: DROP });
+    expect(r.statusCode).toBe(409);
+    expect(JSON.parse(r.body).error).toContain('bandcamp');
+  });
+});
+
+describe('validation', () => {
+  it('rejects an unrecognized action', async () => {
+    const r = await post({ action: 'delete-everything' });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects invalid JSON', async () => {
+    const r = await handler({ httpMethod: 'POST', headers, body: '{not json' });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects methods other than GET/POST/OPTIONS', async () => {
+    const r = await handler({ httpMethod: 'DELETE', headers });
+    expect(r.statusCode).toBe(405);
+  });
+});

--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -40,9 +40,21 @@ vi.mock('../db', () => ({
   clearCatalogCooldown: mocks.clearCatalogCooldown,
 }));
 
+// buildCorsHeaders is NOT stubbed to a constant — this endpoint performs writes, and one thing
+// worth asserting is that it no longer hands back a wildcard origin. Mirrors the real helper's
+// non-API-key behaviour (pin to the canonical origin).
 vi.mock('../middleware', () => ({
   authenticateBearer: mocks.authenticateBearer,
   authenticateAdmin: mocks.authenticateAdmin,
+  buildCorsHeaders: (origin: string | undefined, apiKeyPresent: boolean) => ({
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': apiKeyPresent
+      ? '*'
+      : origin === 'https://unstream.stream'
+        ? origin
+        : 'https://unstream.stream',
+    Vary: 'Origin',
+  }),
 }));
 
 vi.mock('../cache', () => ({
@@ -305,6 +317,80 @@ describe('GET — catalog state for the button', () => {
     const body = JSON.parse((await get()).body);
     expect(body.catalog.state).toBeNull();
     expect(body.catalog.stateError).toBe('Could not read catalog state');
+  });
+});
+
+describe('CORS', () => {
+  // A write endpoint should not advertise itself to every origin. Previously this file
+  // hand-rolled `Access-Control-Allow-Origin: '*'`; it now goes through the shared helper.
+  it('never returns a wildcard origin for an authenticated write surface', async () => {
+    const r = await post({ action: 'hide', slug: SLUG, releaseId: RELEASE_A });
+    expect(r.headers['Access-Control-Allow-Origin']).not.toBe('*');
+    expect(r.headers['Access-Control-Allow-Origin']).toBe('https://unstream.stream');
+  });
+
+  it('answers preflight with the same restricted headers', async () => {
+    const r = await handler({ httpMethod: 'OPTIONS', headers: {} });
+    expect(r.statusCode).toBe(204);
+    expect(r.headers['Access-Control-Allow-Origin']).not.toBe('*');
+  });
+});
+
+describe('input types — a malformed body must not reach the database layer', () => {
+  // The declared TS types are compile-time only. Without a runtime guard a non-string title
+  // reaches `patch.title.trim()` in db.ts and throws inside an async function with no
+  // try/catch, surfacing as a bare 500 instead of a 400.
+  it.each([123, {}, [], true])('rejects a non-string title (%o) with a 400', async bad => {
+    const r = await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, title: bad });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.updateArtistReleaseFields).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty or whitespace-only title', async () => {
+    for (const bad of ['', '   ']) {
+      const r = await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, title: bad });
+      expect(r.statusCode).toBe(400);
+    }
+    expect(mocks.updateArtistReleaseFields).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long title rather than silently truncating it', async () => {
+    const r = await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, title: 'x'.repeat(201) });
+    expect(r.statusCode).toBe(400);
+  });
+
+  // null is meaningful — it clears the date — so it must still be accepted.
+  it('accepts null releaseDate but rejects a non-string one', async () => {
+    expect((await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, releaseDate: null })).statusCode).toBe(200);
+    expect((await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, releaseDate: 99 })).statusCode).toBe(400);
+  });
+
+  it('rejects a non-string artworkUrl', async () => {
+    const r = await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, artworkUrl: 42 });
+    expect(r.statusCode).toBe(400);
+  });
+});
+
+describe('platform allowlist', () => {
+  // release_sources.platform is read back as a registry key for the icon, display name and
+  // payoutRank ordering — an arbitrary label renders as a generic badge that sorts last.
+  it('rejects a platform that is not in the registry', async () => {
+    for (const bad of ['not-a-platform', 'javascript', '', 123]) {
+      const r = await post({ action: 'addLink', slug: SLUG, releaseId: RELEASE_A, platform: bad, url: 'https://example.com/x' });
+      expect(r.statusCode).toBe(400);
+    }
+    expect(mocks.addArtistReleaseLink).not.toHaveBeenCalled();
+  });
+
+  it('accepts a real registry platform', async () => {
+    const r = await post({ action: 'addLink', slug: SLUG, releaseId: RELEASE_A, platform: 'bandcamp', url: 'https://x.bandcamp.com/album/y' });
+    expect(r.statusCode).toBe(200);
+  });
+
+  it('rejects an unknown platform on create too', async () => {
+    const r = await post({ action: 'create', slug: SLUG, title: 'Thing', platform: 'made-up', url: 'https://example.com/x' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.createArtistRelease).not.toHaveBeenCalled();
   });
 });
 

--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   authenticateBearer: vi.fn(),
+  authenticateAdmin: vi.fn(),
   resolveOwnedArtist: vi.fn(),
   verifyReleaseOwnership: vi.fn(),
   getArtistReleasesForOwner: vi.fn(),
@@ -18,7 +19,10 @@ const mocks = vi.hoisted(() => ({
   createArtistRelease: vi.fn(),
   dismissReleaseReview: vi.fn(),
   mergeReleases: vi.fn(),
+  getCatalogState: vi.fn(),
+  clearCatalogCooldown: vi.fn(),
   cacheDeleteByArtist: vi.fn(),
+  triggerCatalogNow: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -32,14 +36,21 @@ vi.mock('../db', () => ({
   createArtistRelease: mocks.createArtistRelease,
   dismissReleaseReview: mocks.dismissReleaseReview,
   mergeReleases: mocks.mergeReleases,
+  getCatalogState: mocks.getCatalogState,
+  clearCatalogCooldown: mocks.clearCatalogCooldown,
 }));
 
 vi.mock('../middleware', () => ({
   authenticateBearer: mocks.authenticateBearer,
+  authenticateAdmin: mocks.authenticateAdmin,
 }));
 
 vi.mock('../cache', () => ({
   cacheDeleteByArtist: mocks.cacheDeleteByArtist,
+}));
+
+vi.mock('../request-catalog', () => ({
+  triggerCatalogNow: mocks.triggerCatalogNow,
 }));
 
 vi.mock('../ratelimit', () => ({
@@ -63,6 +74,8 @@ function post(body: unknown) {
 
 beforeEach(() => {
   mocks.authenticateBearer.mockResolvedValue({ userId: 'u1', email: 'artist@example.com' });
+  // Admin by default so the catalog path is reachable; the gate has its own tests below.
+  mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
   mocks.resolveOwnedArtist.mockResolvedValue({ ok: true, status: 200, artistId: 'artist-1', artistName: 'Kid Lightbulbs' });
   mocks.verifyReleaseOwnership.mockResolvedValue(true);
   mocks.getArtistReleasesForOwner.mockResolvedValue([]);
@@ -72,6 +85,9 @@ beforeEach(() => {
   mocks.createArtistRelease.mockResolvedValue({ ok: true, releaseId: RELEASE_A });
   mocks.dismissReleaseReview.mockResolvedValue(true);
   mocks.mergeReleases.mockResolvedValue({ ok: true });
+  mocks.getCatalogState.mockResolvedValue({ ok: true, state: null });
+  mocks.clearCatalogCooldown.mockResolvedValue(undefined);
+  mocks.triggerCatalogNow.mockResolvedValue({ ok: true });
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -214,6 +230,81 @@ describe('POST — create', () => {
     mocks.createArtistRelease.mockResolvedValue({ ok: false, error: 'Title needs at least one letter or number' });
     const r = await post({ action: 'create', slug: SLUG, title: '!!!', platform: 'bandcamp', url: 'https://x.bandcamp.com' });
     expect(r.statusCode).toBe(400);
+  });
+});
+
+describe('POST — catalog (self-serve scan)', () => {
+  it('clears the cooldown before queuing, or the button silently does nothing for a week', async () => {
+    const r = await post({ action: 'catalog', slug: SLUG });
+    expect(r.statusCode).toBe(202);
+    expect(mocks.clearCatalogCooldown).toHaveBeenCalledWith('artist-1');
+    expect(mocks.triggerCatalogNow).toHaveBeenCalledWith('artist-1');
+  });
+
+  // The rollout gate. Ownership authorizes the action; this is a separate, temporary limit on
+  // who can reach it at all — so a verified non-admin owner is refused for now.
+  it('refuses a verified owner who is not an admin while the rollout gate is on', async () => {
+    mocks.authenticateAdmin.mockResolvedValue(null);
+    const r = await post({ action: 'catalog', slug: SLUG });
+    expect(r.statusCode).toBe(403);
+    expect(mocks.triggerCatalogNow).not.toHaveBeenCalled();
+  });
+
+  // Ownership still has to hold on top of the gate — an admin may not catalog a profile that
+  // isn't theirs through this endpoint (that's what /api/admin/catalog-artist is for).
+  it('still requires ownership even for an admin', async () => {
+    mocks.resolveOwnedArtist.mockResolvedValue({ ok: false, status: 403, error: 'You do not own this profile' });
+    const r = await post({ action: 'catalog', slug: SLUG });
+    expect(r.statusCode).toBe(403);
+    expect(mocks.triggerCatalogNow).not.toHaveBeenCalled();
+  });
+
+  // Netlify answers a background invocation with 202 the instant it's queued and discards the
+  // handler's response, so a predictable refusal has to surface here or it reaches the UI as a
+  // crawl that simply never finishes.
+  it('passes a predictable refusal through with its own status and reason', async () => {
+    mocks.triggerCatalogNow.mockResolvedValue({
+      ok: false,
+      status: 503,
+      error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).',
+    });
+    const r = await post({ action: 'catalog', slug: SLUG });
+    expect(r.statusCode).toBe(503);
+    expect(JSON.parse(r.body).error).toContain('RELEASE_CATALOG_ENABLED');
+  });
+
+  it('does not purge caches — nothing has been written yet', async () => {
+    await post({ action: 'catalog', slug: SLUG });
+    expect(mocks.cacheDeleteByArtist).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET — catalog state for the button', () => {
+  it('reports canTrigger true and the state for an admin', async () => {
+    mocks.getCatalogState.mockResolvedValue({
+      ok: true,
+      state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 12, releases_detailed: 9, last_error: null, consecutive_failures: 0 },
+    });
+    const body = JSON.parse((await get()).body);
+    expect(body.catalog.canTrigger).toBe(true);
+    expect(body.catalog.state.releases_found).toBe(12);
+    expect(body.catalog.stateError).toBeNull();
+  });
+
+  it('reports canTrigger false for a non-admin owner, and does not read state at all', async () => {
+    mocks.authenticateAdmin.mockResolvedValue(null);
+    const body = JSON.parse((await get()).body);
+    expect(body.catalog.canTrigger).toBe(false);
+    expect(mocks.getCatalogState).not.toHaveBeenCalled();
+  });
+
+  // A failed read must not arrive as a null state — that renders as a confident
+  // "Never catalogued" when the truth is "we couldn't ask".
+  it('reports an unreadable state distinctly from never-catalogued', async () => {
+    mocks.getCatalogState.mockResolvedValue({ ok: false, reason: 'Could not read catalog state' });
+    const body = JSON.parse((await get()).body);
+    expect(body.catalog.state).toBeNull();
+    expect(body.catalog.stateError).toBe('Could not read catalog state');
   });
 });
 

--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -1,0 +1,240 @@
+// The artist-facing release curation endpoint (spec §11).
+//
+// What's worth locking: ownership is checked before every write (not just that *some* artist is
+// owned, but that the specific release ids in the request belong to *this* artist — the
+// distinction that stops a claimed artist from hiding/merging someone else's releases), and a
+// merge/dismiss/hide of a release you don't own is refused rather than silently no-op'd.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authenticateBearer: vi.fn(),
+  resolveOwnedArtist: vi.fn(),
+  verifyReleaseOwnership: vi.fn(),
+  getArtistReleasesForOwner: vi.fn(),
+  setReleaseHidden: vi.fn(),
+  updateArtistReleaseFields: vi.fn(),
+  addArtistReleaseLink: vi.fn(),
+  createArtistRelease: vi.fn(),
+  dismissReleaseReview: vi.fn(),
+  mergeReleases: vi.fn(),
+  cacheDeleteByArtist: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({}),
+  resolveOwnedArtist: mocks.resolveOwnedArtist,
+  verifyReleaseOwnership: mocks.verifyReleaseOwnership,
+  getArtistReleasesForOwner: mocks.getArtistReleasesForOwner,
+  setReleaseHidden: mocks.setReleaseHidden,
+  updateArtistReleaseFields: mocks.updateArtistReleaseFields,
+  addArtistReleaseLink: mocks.addArtistReleaseLink,
+  createArtistRelease: mocks.createArtistRelease,
+  dismissReleaseReview: mocks.dismissReleaseReview,
+  mergeReleases: mocks.mergeReleases,
+}));
+
+vi.mock('../middleware', () => ({
+  authenticateBearer: mocks.authenticateBearer,
+}));
+
+vi.mock('../cache', () => ({
+  cacheDeleteByArtist: mocks.cacheDeleteByArtist,
+}));
+
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ limited: false }),
+  getClientIp: () => '127.0.0.1',
+}));
+
+const { handler } = await import('../artist-releases');
+
+const RELEASE_A = '11111111-1111-1111-1111-111111111111';
+const RELEASE_B = '22222222-2222-2222-2222-222222222222';
+const headers = { authorization: 'Bearer user-token' };
+const SLUG = 'kid-lightbulbs';
+
+function get(slug = SLUG) {
+  return handler({ httpMethod: 'GET', headers, queryStringParameters: { slug } });
+}
+function post(body: unknown) {
+  return handler({ httpMethod: 'POST', headers, body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  mocks.authenticateBearer.mockResolvedValue({ userId: 'u1', email: 'artist@example.com' });
+  mocks.resolveOwnedArtist.mockResolvedValue({ ok: true, status: 200, artistId: 'artist-1', artistName: 'Kid Lightbulbs' });
+  mocks.verifyReleaseOwnership.mockResolvedValue(true);
+  mocks.getArtistReleasesForOwner.mockResolvedValue([]);
+  mocks.setReleaseHidden.mockResolvedValue(true);
+  mocks.updateArtistReleaseFields.mockResolvedValue(true);
+  mocks.addArtistReleaseLink.mockResolvedValue(true);
+  mocks.createArtistRelease.mockResolvedValue({ ok: true, releaseId: RELEASE_A });
+  mocks.dismissReleaseReview.mockResolvedValue(true);
+  mocks.mergeReleases.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('auth', () => {
+  it('refuses an unauthenticated caller', async () => {
+    mocks.authenticateBearer.mockResolvedValue(null);
+    expect((await get()).statusCode).toBe(401);
+    expect((await post({ action: 'hide', slug: SLUG, releaseId: RELEASE_A })).statusCode).toBe(401);
+  });
+
+  it('handles OPTIONS without requiring auth', async () => {
+    const r = await handler({ httpMethod: 'OPTIONS', headers: {} });
+    expect(r.statusCode).toBe(204);
+    expect(mocks.authenticateBearer).not.toHaveBeenCalled();
+  });
+});
+
+describe('ownership', () => {
+  it('refuses a caller who does not own the profile', async () => {
+    mocks.resolveOwnedArtist.mockResolvedValue({ ok: false, status: 403, error: 'You do not own this profile' });
+    const r = await post({ action: 'hide', slug: SLUG, releaseId: RELEASE_A });
+    expect(r.statusCode).toBe(403);
+    expect(mocks.setReleaseHidden).not.toHaveBeenCalled();
+  });
+
+  it('refuses hide/dismiss/merge for a release id that is not this artist\'s', async () => {
+    mocks.verifyReleaseOwnership.mockResolvedValue(false);
+
+    const dismiss = await post({ action: 'dismiss', slug: SLUG, releaseId: RELEASE_A });
+    expect(dismiss.statusCode).toBe(403);
+    expect(mocks.dismissReleaseReview).not.toHaveBeenCalled();
+
+    const merge = await post({ action: 'merge', slug: SLUG, keepId: RELEASE_A, dropId: RELEASE_B });
+    expect(merge.statusCode).toBe(403);
+    expect(mocks.mergeReleases).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET — the owner\'s release list', () => {
+  it('requires a slug', async () => {
+    const r = await handler({ httpMethod: 'GET', headers, queryStringParameters: {} });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('returns whatever the query function reports', async () => {
+    mocks.getArtistReleasesForOwner.mockResolvedValue([{ id: RELEASE_A, title: 'A Record' }]);
+    const body = JSON.parse((await get()).body);
+    expect(body.releases).toHaveLength(1);
+  });
+});
+
+describe('POST — hide/unhide', () => {
+  it('validates releaseId is a UUID', async () => {
+    const r = await post({ action: 'hide', slug: SLUG, releaseId: 'nope' });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('hides and unhides', async () => {
+    await post({ action: 'hide', slug: SLUG, releaseId: RELEASE_A });
+    expect(mocks.setReleaseHidden).toHaveBeenCalledWith('artist-1', RELEASE_A, true);
+
+    await post({ action: 'unhide', slug: SLUG, releaseId: RELEASE_A });
+    expect(mocks.setReleaseHidden).toHaveBeenCalledWith('artist-1', RELEASE_A, false);
+  });
+});
+
+describe('POST — merge', () => {
+  it('sends the exact keepId/dropId through to mergeReleases', async () => {
+    const r = await post({ action: 'merge', slug: SLUG, keepId: RELEASE_A, dropId: RELEASE_B });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.mergeReleases).toHaveBeenCalledWith(RELEASE_A, RELEASE_B);
+  });
+
+  it('reports a merge conflict as 409', async () => {
+    mocks.mergeReleases.mockResolvedValue({ ok: false, error: 'Both releases already have a source on: bandcamp' });
+    const r = await post({ action: 'merge', slug: SLUG, keepId: RELEASE_A, dropId: RELEASE_B });
+    expect(r.statusCode).toBe(409);
+  });
+});
+
+describe('POST — update', () => {
+  it('passes through title/date/artwork fields', async () => {
+    await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, title: 'New Title' });
+    expect(mocks.updateArtistReleaseFields).toHaveBeenCalledWith('artist-1', RELEASE_A, {
+      title: 'New Title',
+      releaseDate: undefined,
+      artworkUrl: undefined,
+    });
+  });
+
+  it('rejects a non-HTTPS artwork URL', async () => {
+    const r = await post({ action: 'update', slug: SLUG, releaseId: RELEASE_A, artworkUrl: 'http://example.com/x.jpg' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.updateArtistReleaseFields).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST — addLink', () => {
+  it('rejects a non-http(s) url', async () => {
+    const r = await post({ action: 'addLink', slug: SLUG, releaseId: RELEASE_A, platform: 'bandcamp', url: 'not a url' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.addArtistReleaseLink).not.toHaveBeenCalled();
+  });
+
+  it('adds a link', async () => {
+    const r = await post({
+      action: 'addLink',
+      slug: SLUG,
+      releaseId: RELEASE_A,
+      platform: 'discogs',
+      url: 'https://discogs.com/release/1',
+    });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.addArtistReleaseLink).toHaveBeenCalledWith('artist-1', RELEASE_A, 'discogs', 'https://discogs.com/release/1');
+  });
+});
+
+describe('POST — create', () => {
+  it('requires title, platform, and a valid url', async () => {
+    const r = await post({ action: 'create', slug: SLUG, title: '', platform: 'bandcamp', url: 'https://x.bandcamp.com' });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.createArtistRelease).not.toHaveBeenCalled();
+  });
+
+  it('creates a release and reports its id', async () => {
+    const r = await post({
+      action: 'create',
+      slug: SLUG,
+      title: 'B-Sides',
+      releaseType: 'ep',
+      platform: 'bandcamp',
+      url: 'https://x.bandcamp.com/album/b-sides',
+    });
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).releaseId).toBe(RELEASE_A);
+  });
+
+  it('reports a creation failure without a false success', async () => {
+    mocks.createArtistRelease.mockResolvedValue({ ok: false, error: 'Title needs at least one letter or number' });
+    const r = await post({ action: 'create', slug: SLUG, title: '!!!', platform: 'bandcamp', url: 'https://x.bandcamp.com' });
+    expect(r.statusCode).toBe(400);
+  });
+});
+
+describe('validation', () => {
+  it('rejects an unrecognized action', async () => {
+    const r = await post({ action: 'delete-everything', slug: SLUG });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('requires a slug on POST', async () => {
+    const r = await post({ action: 'hide', releaseId: RELEASE_A });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects invalid JSON', async () => {
+    const r = await handler({ httpMethod: 'POST', headers, body: '{not json' });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects methods other than GET/POST/OPTIONS', async () => {
+    const r = await handler({ httpMethod: 'DELETE', headers });
+    expect(r.statusCode).toBe(405);
+  });
+});

--- a/api/functions/__tests__/catalog-gating.test.ts
+++ b/api/functions/__tests__/catalog-gating.test.ts
@@ -14,7 +14,9 @@ const mocks = vi.hoisted(() => ({
   getArtistForCatalog: vi.fn(),
   persistReleases: vi.fn(),
   persistDiscogsReleases: vi.fn(),
+  persistFaircampReleases: vi.fn(),
   persistMusicBrainzEnrichment: vi.fn(),
+  attachDiscoveredSource: vi.fn(),
   recordCatalogOutcome: vi.fn(),
   safeFetch: vi.fn(),
   fetch: vi.fn(),
@@ -25,7 +27,9 @@ vi.mock('../db', () => ({
   getArtistForCatalog: mocks.getArtistForCatalog,
   persistReleases: mocks.persistReleases,
   persistDiscogsReleases: mocks.persistDiscogsReleases,
+  persistFaircampReleases: mocks.persistFaircampReleases,
   persistMusicBrainzEnrichment: mocks.persistMusicBrainzEnrichment,
+  attachDiscoveredSource: mocks.attachDiscoveredSource,
   recordCatalogOutcome: mocks.recordCatalogOutcome,
 }));
 

--- a/api/functions/__tests__/catalog-gating.test.ts
+++ b/api/functions/__tests__/catalog-gating.test.ts
@@ -11,8 +11,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   claimArtistForCatalog: vi.fn(),
-  getArtistBandcampUrl: vi.fn(),
+  getArtistForCatalog: vi.fn(),
   persistReleases: vi.fn(),
+  persistDiscogsReleases: vi.fn(),
+  persistMusicBrainzEnrichment: vi.fn(),
   recordCatalogOutcome: vi.fn(),
   safeFetch: vi.fn(),
   fetch: vi.fn(),
@@ -20,8 +22,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({
   claimArtistForCatalog: mocks.claimArtistForCatalog,
-  getArtistBandcampUrl: mocks.getArtistBandcampUrl,
+  getArtistForCatalog: mocks.getArtistForCatalog,
   persistReleases: mocks.persistReleases,
+  persistDiscogsReleases: mocks.persistDiscogsReleases,
+  persistMusicBrainzEnrichment: mocks.persistMusicBrainzEnrichment,
   recordCatalogOutcome: mocks.recordCatalogOutcome,
 }));
 

--- a/api/functions/__tests__/merge-releases-guard.test.ts
+++ b/api/functions/__tests__/merge-releases-guard.test.ts
@@ -1,0 +1,139 @@
+// The same-artist guard on mergeReleases.
+//
+// A merge is close to irreversible — `release_sources` rows are moved onto the survivor and the
+// other release row is deleted. The artist-facing endpoint proves ownership of both ids before
+// calling; the admin endpoint passes ids straight from a request body. So the invariant has to
+// hold inside `mergeReleases` itself, and the property worth locking is not just "it returns an
+// error" but that **nothing was written before it decided** — a guard that refuses after moving
+// the sources would be worse than no guard at all.
+//
+// Driven against a recording fake Supabase client rather than the module mock every endpoint
+// test uses, because the whole point is to exercise the real function body.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Op {
+  table: string;
+  op: 'select' | 'update' | 'delete';
+}
+
+const ops: Op[] = [];
+
+/** Rows `releases.select('id, artist_id').in(...)` will return. Set per test. */
+let pairRows: { id: string; artist_id: string }[] = [];
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(_cols: string) {
+          const record = () => ops.push({ table, op: 'select' });
+          return {
+            // releases: .select('id, artist_id').in('id', [...])
+            in: (_col: string, _vals: string[]) => {
+              record();
+              return Promise.resolve({ data: pairRows, error: null });
+            },
+            // release_sources: .select(...).eq('release_id', x)
+            eq: (_col: string, _val: string) => {
+              record();
+              const p = Promise.resolve({ data: [], error: null }) as Promise<{ data: unknown; error: null }> & {
+                maybeSingle?: () => Promise<{ data: unknown; error: null }>;
+              };
+              p.maybeSingle = () => Promise.resolve({ data: null, error: null });
+              return p;
+            },
+          };
+        },
+        update(_patch: Record<string, unknown>) {
+          return {
+            eq: (_col: string, _val: string) => {
+              ops.push({ table, op: 'update' });
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+        delete() {
+          return {
+            eq: (_col: string, _val: string) => {
+              ops.push({ table, op: 'delete' });
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { mergeReleases } = await import('../db');
+
+const KEEP = '11111111-1111-1111-1111-111111111111';
+const DROP = '22222222-2222-2222-2222-222222222222';
+
+beforeEach(() => {
+  ops.length = 0;
+});
+
+describe('mergeReleases — same-artist guard', () => {
+  it('refuses a pair belonging to two different artists', async () => {
+    pairRows = [
+      { id: KEEP, artist_id: 'artist-a' },
+      { id: DROP, artist_id: 'artist-b' },
+    ];
+
+    const result = await mergeReleases(KEEP, DROP);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/different artists/i);
+  });
+
+  // The property that actually matters: refusing late would already have moved the sources.
+  it('writes nothing at all when it refuses a cross-artist pair', async () => {
+    pairRows = [
+      { id: KEEP, artist_id: 'artist-a' },
+      { id: DROP, artist_id: 'artist-b' },
+    ];
+
+    await mergeReleases(KEEP, DROP);
+
+    expect(ops.filter(o => o.op === 'update')).toEqual([]);
+    expect(ops.filter(o => o.op === 'delete')).toEqual([]);
+  });
+
+  it('refuses when either release cannot be found, rather than merging into a gap', async () => {
+    pairRows = [{ id: KEEP, artist_id: 'artist-a' }]; // dropId missing
+
+    const result = await mergeReleases(KEEP, DROP);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/could not be found/i);
+    expect(ops.some(o => o.op === 'delete')).toBe(false);
+  });
+
+  it('refuses merging a release into itself', async () => {
+    const result = await mergeReleases(KEEP, KEEP);
+    expect(result.ok).toBe(false);
+    // Refused before touching the database at all.
+    expect(ops).toEqual([]);
+  });
+
+  it('proceeds to the source-conflict check for a same-artist pair', async () => {
+    pairRows = [
+      { id: KEEP, artist_id: 'artist-a' },
+      { id: DROP, artist_id: 'artist-a' },
+    ];
+
+    const result = await mergeReleases(KEEP, DROP);
+
+    // The fake returns no sources and no rows to backfill from, so this reaches the delete —
+    // which is the point: a same-artist pair is *not* blocked by the new guard.
+    expect(result.ok).toBe(true);
+    expect(ops.some(o => o.table === 'releases' && o.op === 'delete')).toBe(true);
+  });
+});

--- a/api/functions/__tests__/release-display.test.ts
+++ b/api/functions/__tests__/release-display.test.ts
@@ -7,10 +7,11 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  cheapestOfferSummary,
   formatMoney,
   formatOfferPrice,
   formatReleaseDate,
+  leadingOfferSummary,
+  orderedSourcePlatforms,
   payoutEstimate,
   payoutRank,
   relativeDays,
@@ -126,29 +127,57 @@ describe('formatOfferPrice', () => {
   });
 });
 
-describe('cheapestOfferSummary', () => {
+describe('orderedSourcePlatforms', () => {
+  it('orders artist-paying-first, matching the release page itself', () => {
+    expect(orderedSourcePlatforms([{ platform: 'discogs', offers: [] }, { platform: 'bandcamp', offers: [] }]))
+      .toEqual(['bandcamp', 'discogs']);
+  });
+});
+
+describe('leadingOfferSummary', () => {
   const offer = (price: number | null, availability = 'available') =>
     ({ price, currency: 'USD', availability });
+  const source = (platform: string, offers: ReturnType<typeof offer>[]) => ({ platform, offers });
 
-  it('quotes the cheapest thing a fan can buy', () => {
-    expect(cheapestOfferSummary([offer(25), offer(8), offer(12)])).toBe('from $8');
+  it('quotes the cheapest buyable offer from a single source, with its payout estimate', () => {
+    expect(leadingOfferSummary([source('bandcamp', [offer(25), offer(8), offer(12)])]))
+      .toBe('from $8 · ≈$6.40–$6.80 to artist');
   });
 
-  // The one genuinely misleading number this list could show: a fan clicks expecting $8 vinyl
-  // and finds it gone. A release whose only offer is sold out summarises as nothing.
-  it('ignores sold-out formats when picking the cheapest', () => {
-    expect(cheapestOfferSummary([offer(25), offer(8, 'sold_out')])).toBe('from $25');
-    expect(cheapestOfferSummary([offer(8, 'sold_out')])).toBe('');
+  // The whole reason this isn't just "globally cheapest": once Discogs (no payout figure,
+  // secondhand) is a second source, picking the absolute cheapest price could rank a used
+  // copy above the artist's own store — exactly the anti-pattern the sourcing spec warns
+  // against ("used CD $2.64" above "vinyl direct from the artist $30").
+  it('prefers the artist-paying source even when a lower-payout source is cheaper', () => {
+    const out = leadingOfferSummary([
+      source('discogs', [offer(3)]),
+      source('bandcamp', [offer(25)]),
+    ]);
+    expect(out).toContain('$25');
+    expect(out).not.toContain('$3');
+  });
+
+  it('falls through to the next source when the leading one has nothing buyable', () => {
+    const out = leadingOfferSummary([
+      source('bandcamp', [offer(8, 'sold_out')]),
+      source('discogs', [offer(12)]),
+    ]);
+    expect(out).toBe('from $12'); // discogs has no payout percent, so no estimate is shown
+  });
+
+  it('ignores sold-out formats when picking the cheapest within a source', () => {
+    expect(leadingOfferSummary([source('bandcamp', [offer(25), offer(8, 'sold_out')])])).toContain('$25');
   });
 
   it('says name-your-price rather than "from $0"', () => {
-    expect(cheapestOfferSummary([offer(0)])).toBe('Name your price');
+    expect(leadingOfferSummary([source('bandcamp', [offer(0)])])).toBe('Name your price');
   });
 
   // The normal state for a release catalogued from the Bandcamp grid, whose own page hasn't
   // been read for prices yet. Silence, not a zero.
-  it('says nothing when there are no offers or no prices', () => {
-    expect(cheapestOfferSummary([])).toBe('');
-    expect(cheapestOfferSummary([offer(null)])).toBe('');
+  it('says nothing when there are no sources, no offers, or no prices', () => {
+    expect(leadingOfferSummary([])).toBe('');
+    expect(leadingOfferSummary([source('bandcamp', [])])).toBe('');
+    expect(leadingOfferSummary([source('bandcamp', [offer(null)])])).toBe('');
   });
 });

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -11,6 +11,12 @@ import {
   bandcampMusicUrl,
   mapAvailability,
   mapOfferFormat,
+  ingestDiscogsMasters,
+  mapDiscogsFormatToReleaseType,
+  ingestDiscogsReleaseDetail,
+  mapDiscogsFormatName,
+  ingestMusicBrainzReleaseGroups,
+  type DiscogsArtistReleaseEntry,
 } from '../release-ingest';
 
 function item(opts: { id?: string; href: string; title: string; img?: string }): string {
@@ -386,5 +392,195 @@ describe('bandcampMusicUrl', () => {
     expect(bandcampMusicUrl('not a url')).toBeNull();
     expect(bandcampMusicUrl('file:///etc/passwd')).toBeNull();
     expect(bandcampMusicUrl('')).toBeNull();
+  });
+});
+
+describe('mapDiscogsFormatToReleaseType', () => {
+  it('reads the format string first', () => {
+    expect(mapDiscogsFormatToReleaseType('Vinyl, LP, Album', 'Some Title')).toBe('album');
+    expect(mapDiscogsFormatToReleaseType('CD, Compilation', 'Some Title')).toBe('compilation');
+    expect(mapDiscogsFormatToReleaseType('Vinyl, 7", Single', 'Some Title')).toBe('single');
+  });
+
+  it('falls back to the title when the format string does not say', () => {
+    expect(mapDiscogsFormatToReleaseType(null, 'Live at the Fillmore')).toBe('live');
+    expect(mapDiscogsFormatToReleaseType('File, MP3', 'Acoustic Sessions EP')).toBe('ep');
+  });
+
+  it('defaults to other rather than guessing', () => {
+    expect(mapDiscogsFormatToReleaseType('Vinyl, 12"', 'Untitled')).toBe('other');
+    expect(mapDiscogsFormatToReleaseType(null, null)).toBe('other');
+  });
+});
+
+function discogsEntry(opts: Partial<DiscogsArtistReleaseEntry> & { title: string }): DiscogsArtistReleaseEntry {
+  return {
+    id: 1,
+    type: 'master',
+    role: 'Main',
+    main_release: 100,
+    ...opts,
+  } as DiscogsArtistReleaseEntry;
+}
+
+describe('ingestDiscogsMasters', () => {
+  it('keeps only role=Main, type=master entries with a main_release', () => {
+    const out = ingestDiscogsMasters([
+      discogsEntry({ id: 1, main_release: 101, title: 'Real Album', format: 'Vinyl, LP, Album', year: 2015 }),
+      discogsEntry({ id: 2, type: 'release', title: 'A Specific Pressing' }),
+      discogsEntry({ id: 3, role: 'TrackAppearance', title: 'Featured On Someone Elses Comp' }),
+      discogsEntry({ id: 4, main_release: undefined, title: 'Master With No Representative Release' }),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      title: 'Real Album',
+      matchKey: 'realalbum',
+      releaseType: 'album',
+      releaseDate: '2015-01-01',
+      datePrecision: 'year',
+      masterId: '1',
+      mainReleaseId: '101',
+    });
+  });
+
+  it('drops a master repeated across pages rather than double-counting it', () => {
+    const out = ingestDiscogsMasters([
+      discogsEntry({ id: 5, title: 'Repeated Master' }),
+      discogsEntry({ id: 5, title: 'Repeated Master' }),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('assigns non-colliding slugs across two titles that would otherwise clash', () => {
+    const out = ingestDiscogsMasters([
+      discogsEntry({ id: 6, main_release: 201, title: 'A Record!' }),
+      discogsEntry({ id: 7, main_release: 202, title: 'A Record?' }),
+    ]);
+    expect(new Set(out.map(o => o.slug)).size).toBe(2);
+  });
+});
+
+describe('ingestDiscogsReleaseDetail', () => {
+  it('maps a full date, one offer, and available when listings exist', () => {
+    const out = ingestDiscogsReleaseDetail({
+      released: '2015-03-31',
+      formats: [{ name: 'Vinyl', descriptions: ['LP', 'Album'] }],
+      num_for_sale: 12,
+      lowest_price: 24.5,
+    });
+
+    expect(out.releaseDate).toBe('2015-03-31');
+    expect(out.datePrecision).toBe('day');
+    expect(out.offers).toEqual([
+      { format: 'vinyl', price: 24.5, currency: 'USD', availability: 'available' },
+    ]);
+  });
+
+  it('falls back to a year-only date when released is absent', () => {
+    const out = ingestDiscogsReleaseDetail({ year: 1998, formats: [{ name: 'CD' }] });
+    expect(out.releaseDate).toBe('1998-01-01');
+    expect(out.datePrecision).toBe('year');
+  });
+
+  // Zero current listings is not the same claim as "sold out" — that implies stock existed
+  // and ran out, but a release can simply have no active marketplace listings today.
+  it('reports zero listings as unknown, never sold_out', () => {
+    const out = ingestDiscogsReleaseDetail({
+      formats: [{ name: 'Vinyl' }],
+      num_for_sale: 0,
+      lowest_price: null,
+    });
+    expect(out.offers[0].availability).toBe('unknown');
+    expect(out.offers[0].price).toBeNull();
+    expect(out.offers[0].currency).toBeNull();
+  });
+
+  it('emits no offer at all when there is no format data', () => {
+    const out = ingestDiscogsReleaseDetail({ released: '2015' });
+    expect(out.offers).toEqual([]);
+  });
+
+  it('emits only one offer even for a multi-format bundle, keyed to the first format', () => {
+    // num_for_sale/lowest_price describe the whole release, not a per-format breakdown —
+    // repeating the same aggregate price across every format would misrepresent a bundle
+    // as several separately-buyable items at that price.
+    const out = ingestDiscogsReleaseDetail({
+      formats: [{ name: 'CD' }, { name: 'File' }],
+      num_for_sale: 3,
+      lowest_price: 9.99,
+    });
+    expect(out.offers).toHaveLength(1);
+    expect(out.offers[0].format).toBe('cd');
+  });
+});
+
+describe('mapDiscogsFormatName', () => {
+  it('maps known Discogs format names', () => {
+    expect(mapDiscogsFormatName('Vinyl')).toBe('vinyl');
+    expect(mapDiscogsFormatName('CD')).toBe('cd');
+    expect(mapDiscogsFormatName('Cassette')).toBe('cassette');
+    expect(mapDiscogsFormatName('File')).toBe('digital');
+  });
+
+  it('is case-insensitive', () => {
+    expect(mapDiscogsFormatName('vinyl')).toBe('vinyl');
+  });
+
+  it('reads descriptions when the name itself is unrecognized', () => {
+    expect(mapDiscogsFormatName('Box Set', ['Book'])).toBe('book');
+    expect(mapDiscogsFormatName('Box Set', ['Poster'])).toBe('merch');
+  });
+
+  it('defaults to other', () => {
+    expect(mapDiscogsFormatName(null, [])).toBe('other');
+    expect(mapDiscogsFormatName('8-Track Cartridge', [])).toBe('other');
+  });
+});
+
+describe('ingestMusicBrainzReleaseGroups', () => {
+  it('maps a release group into a matchable enrichment', () => {
+    const out = ingestMusicBrainzReleaseGroups([
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        title: 'Carrie & Lowell',
+        'primary-type': 'Album',
+        'secondary-types': [],
+        'first-release-date': '2015-03-31',
+      },
+    ]);
+
+    expect(out).toEqual([
+      {
+        matchKey: 'carrielowell',
+        releaseType: 'album',
+        releaseDate: '2015-03-31',
+        datePrecision: 'day',
+        mbid: '11111111-1111-1111-1111-111111111111',
+      },
+    ]);
+  });
+
+  it('keeps year-only precision rather than fabricating a day', () => {
+    const out = ingestMusicBrainzReleaseGroups([
+      { id: '22222222-2222-2222-2222-222222222222', title: 'Some Album', 'first-release-date': '1998' },
+    ]);
+    expect(out[0].releaseDate).toBe('1998-01-01');
+    expect(out[0].datePrecision).toBe('year');
+  });
+
+  it('drops a duplicate id rather than emitting it twice', () => {
+    const out = ingestMusicBrainzReleaseGroups([
+      { id: '33333333-3333-3333-3333-333333333333', title: 'Dup' },
+      { id: '33333333-3333-3333-3333-333333333333', title: 'Dup' },
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('skips a release group with no usable title', () => {
+    const out = ingestMusicBrainzReleaseGroups([
+      { id: '44444444-4444-4444-4444-444444444444', title: '...' },
+    ]);
+    expect(out).toHaveLength(0);
   });
 });

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -16,6 +16,10 @@ import {
   ingestDiscogsReleaseDetail,
   mapDiscogsFormatName,
   ingestMusicBrainzReleaseGroups,
+  ingestFaircampHomeLinks,
+  ingestFaircampReleasePage,
+  buildFaircampRelease,
+  findDiscoveredReleaseLinks,
   type DiscogsArtistReleaseEntry,
 } from '../release-ingest';
 
@@ -582,5 +586,150 @@ describe('ingestMusicBrainzReleaseGroups', () => {
       { id: '44444444-4444-4444-4444-444444444444', title: '...' },
     ]);
     expect(out).toHaveLength(0);
+  });
+});
+
+// Fixtures below are trimmed from a real, live Faircamp instance (verified 2026-08-01) rather
+// than guessed — Faircamp's own markup has no JSON-LD, no <time> tag, and no pubDate in its
+// RSS feed, so the parser is deliberately narrow: identity and artwork only.
+const FAIRCAMP_HOME_HTML = `<!doctype html><html><body>
+  <nav>
+    <a href="./">Home</a>
+    <a href="#content">Skip</a>
+    <a href="subscribe/">Subscribe</a>
+  </nav>
+  <ol>
+    <li><a href="ruined-castle/">RUINED CASTLE</a></li>
+    <li><a href="infinite-normal/">INFINITE NORMAL</a></li>
+    <li><a href="solo-piano/">SOLO PIANO</a></li>
+  </ol>
+  <a href="https://simonrepp.com/faircamp/">Powered by Faircamp</a>
+  <a href="favicon.png?H-w5zbrED30">icon</a>
+  <a href="feed.rss">RSS</a>
+  <a href="site.css?xwWmIbFHB50">styles</a>
+</body></html>`;
+
+const FAIRCAMP_RELEASE_HTML = `<!doctype html><html><head>
+  <meta property="og:title" content="RUINED CASTLE"/>
+  <meta property="og:image" content="https://music.kidlightbulbs.com/ruined-castle/cover_800.jpg?XZDh1t00IS8"/>
+  <meta property="og:description" content="The third album. A reflection on suffering."/>
+</head><body></body></html>`;
+
+describe('ingestFaircampHomeLinks', () => {
+  it('finds bare relative release links and resolves them against the page URL', () => {
+    const out = ingestFaircampHomeLinks(FAIRCAMP_HOME_HTML, 'https://music.kidlightbulbs.com/');
+    expect(out).toEqual([
+      { slug: 'ruined-castle', url: 'https://music.kidlightbulbs.com/ruined-castle/' },
+      { slug: 'infinite-normal', url: 'https://music.kidlightbulbs.com/infinite-normal/' },
+      { slug: 'solo-piano', url: 'https://music.kidlightbulbs.com/solo-piano/' },
+    ]);
+  });
+
+  it('excludes known non-release paths and anything with a query string or external host', () => {
+    const out = ingestFaircampHomeLinks(FAIRCAMP_HOME_HTML, 'https://music.kidlightbulbs.com/');
+    expect(out.map(o => o.slug)).not.toContain('subscribe');
+    expect(out.some(o => o.url.includes('simonrepp'))).toBe(false);
+    expect(out.some(o => o.url.includes('favicon'))).toBe(false);
+  });
+
+  it('deduplicates a repeated link and caps at the candidate ceiling', () => {
+    const manyLinks = Array.from({ length: 40 }, (_, i) => `<a href="release-${i}/">R${i}</a>`).join('');
+    const out = ingestFaircampHomeLinks(`<html>${manyLinks}</html>`, 'https://x.example.com/');
+    expect(out.length).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('ingestFaircampReleasePage', () => {
+  it('reads title and artwork from Open Graph tags', () => {
+    expect(ingestFaircampReleasePage(FAIRCAMP_RELEASE_HTML)).toEqual({
+      title: 'RUINED CASTLE',
+      artworkUrl: 'https://music.kidlightbulbs.com/ruined-castle/cover_800.jpg?XZDh1t00IS8',
+    });
+  });
+
+  it('decodes HTML entities in the title', () => {
+    const html = '<meta property="og:title" content="Rock &amp; Roll"/>';
+    expect(ingestFaircampReleasePage(html)?.title).toBe('Rock & Roll');
+  });
+
+  it('returns null when there is no og:title at all — likely not a release page', () => {
+    expect(ingestFaircampReleasePage('<html><body>nothing here</body></html>')).toBeNull();
+  });
+
+  it('accepts a missing artwork tag', () => {
+    expect(ingestFaircampReleasePage('<meta property="og:title" content="No Cover"/>')).toEqual({
+      title: 'No Cover',
+      artworkUrl: null,
+    });
+  });
+});
+
+describe('buildFaircampRelease', () => {
+  it('combines a release page into a persistable shape with an inferred type', () => {
+    const out = buildFaircampRelease(
+      { title: 'RUINED CASTLE', artworkUrl: 'https://example.com/cover.jpg' },
+      'https://music.kidlightbulbs.com/ruined-castle/',
+      new Set()
+    );
+    expect(out).toMatchObject({
+      title: 'RUINED CASTLE',
+      matchKey: 'ruinedcastle',
+      status: 'released',
+      artworkUrl: 'https://example.com/cover.jpg',
+      externalUrl: 'https://music.kidlightbulbs.com/ruined-castle/',
+    });
+  });
+
+  it('never has a date — Faircamp has none to give', () => {
+    const out = buildFaircampRelease({ title: 'Some Release', artworkUrl: null }, 'https://x.example.com/some-release/', new Set());
+    expect(out).not.toHaveProperty('releaseDate');
+  });
+
+  it('returns null for a title with no letters or numbers to match on', () => {
+    expect(buildFaircampRelease({ title: '...', artworkUrl: null }, 'https://x.example.com/dots/', new Set())).toBeNull();
+  });
+});
+
+describe('findDiscoveredReleaseLinks', () => {
+  // Real example: an artist's own official website linking directly to a specific Subvert
+  // release, verified 2026-08-01 (kidlightbulbs.com linking to
+  // subvert.fm/kid-lightbulbs/infinite-normal).
+  const OFFICIAL_SITE_HTML = `<html><body>
+    <a href="https://kidlightbulbs.bandcamp.com/album/infinite-normal">Bandcamp</a>
+    <a href="https://subvert.fm/kid-lightbulbs">Subvert profile</a>
+    <a href="https://www.subvert.fm/kid-lightbulbs/infinite-normal">Buy on Subvert</a>
+  </body></html>`;
+
+  it('finds a specific-release Subvert link but not the bare artist profile link', () => {
+    const out = findDiscoveredReleaseLinks(OFFICIAL_SITE_HTML, 'https://kidlightbulbs.com/');
+    expect(out).toEqual([
+      {
+        platform: 'subvert',
+        url: 'https://www.subvert.fm/kid-lightbulbs/infinite-normal',
+        matchKey: 'infinitenormal',
+      },
+    ]);
+  });
+
+  it('ignores links to hosts it does not recognize', () => {
+    const out = findDiscoveredReleaseLinks(
+      '<a href="https://kidlightbulbs.bandcamp.com/album/infinite-normal">Bandcamp</a>',
+      'https://kidlightbulbs.com/'
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('deduplicates the same link appearing twice', () => {
+    const html = `
+      <a href="https://subvert.fm/artist/release-one">A</a>
+      <a href="https://subvert.fm/artist/release-one">A again</a>
+    `;
+    const out = findDiscoveredReleaseLinks(html, 'https://example.com/');
+    expect(out).toHaveLength(1);
+  });
+
+  it('skips a slug with no letters or numbers to match on', () => {
+    const out = findDiscoveredReleaseLinks('<a href="https://subvert.fm/artist/---">A</a>', 'https://example.com/');
+    expect(out).toEqual([]);
   });
 });

--- a/api/functions/__tests__/release-review.test.ts
+++ b/api/functions/__tests__/release-review.test.ts
@@ -1,0 +1,65 @@
+// Folding a flat needs_review result set into pairs for the admin review queue.
+//
+// The property worth locking: a symmetric flag (A points at B, B points at A) must produce one
+// pair to review, not two — an admin re-deciding the same pair twice under two different rows
+// is the failure mode here.
+
+import { describe, it, expect } from 'vitest';
+import { pairReviewRows, type ReleaseReviewItem } from '../db';
+
+function item(id: string, overrides: Partial<ReleaseReviewItem> = {}): ReleaseReviewItem {
+  return {
+    id,
+    title: `Release ${id}`,
+    slug: `release-${id}`,
+    releaseType: 'album',
+    releaseDate: null,
+    datePrecision: null,
+    artworkUrl: null,
+    artistName: 'Some Artist',
+    artistSlug: 'some-artist',
+    platforms: ['bandcamp'],
+    ...overrides,
+  };
+}
+
+describe('pairReviewRows', () => {
+  it('collapses a symmetric pair into one entry', () => {
+    const rows = new Map([
+      ['a', { ...item('a'), flaggedAgainst: 'b' }],
+      ['b', { ...item('b'), flaggedAgainst: 'a' }],
+    ]);
+
+    const pairs = pairReviewRows(rows);
+    expect(pairs).toHaveLength(1);
+    expect([pairs[0].primary.id, pairs[0].counterpart?.id]).toEqual(['a', 'b']);
+  });
+
+  it('shows a row alone when its counterpart is not in the flagged set', () => {
+    const rows = new Map([['a', { ...item('a'), flaggedAgainst: 'ghost' }]]);
+
+    const pairs = pairReviewRows(rows);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].primary.id).toBe('a');
+    expect(pairs[0].counterpart).toBeNull();
+  });
+
+  it('shows a row with no flag target at all as an unpaired entry', () => {
+    const rows = new Map([['a', { ...item('a'), flaggedAgainst: null }]]);
+
+    const pairs = pairReviewRows(rows);
+    expect(pairs).toEqual([{ primary: rows.get('a'), counterpart: null }]);
+  });
+
+  it('handles multiple independent pairs for different artists', () => {
+    const rows = new Map([
+      ['a', { ...item('a'), flaggedAgainst: 'b' }],
+      ['b', { ...item('b'), flaggedAgainst: 'a' }],
+      ['c', { ...item('c', { artistName: 'Other Artist' }), flaggedAgainst: 'd' }],
+      ['d', { ...item('d', { artistName: 'Other Artist' }), flaggedAgainst: 'c' }],
+    ]);
+
+    const pairs = pairReviewRows(rows);
+    expect(pairs).toHaveLength(2);
+  });
+});

--- a/api/functions/__tests__/release-utils.test.ts
+++ b/api/functions/__tests__/release-utils.test.ts
@@ -13,6 +13,8 @@ import {
   shortHash,
   uniqueReleaseSlug,
   mapReleaseType,
+  mapMusicBrainzReleaseType,
+  isFuzzyReleaseMatch,
   parseReleaseDate,
   deriveStatus,
 } from '../release-utils';
@@ -251,5 +253,63 @@ describe('deriveStatus', () => {
     // Undated releases are overwhelmingly back-catalog; telling a fan something is coming
     // when we don't know is the worse error.
     expect(deriveStatus(null, false, now)).toBe('released');
+  });
+});
+
+describe('mapMusicBrainzReleaseType', () => {
+  it('maps primary types directly', () => {
+    expect(mapMusicBrainzReleaseType('Album', [])).toBe('album');
+    expect(mapMusicBrainzReleaseType('EP', [])).toBe('ep');
+    expect(mapMusicBrainzReleaseType('Single', [])).toBe('single');
+  });
+
+  it('is case-insensitive', () => {
+    expect(mapMusicBrainzReleaseType('album', [])).toBe('album');
+  });
+
+  it('lets a secondary type override the primary one', () => {
+    // A live album is more usefully typed 'live' than 'album' for dedup — the same
+    // granularity-over-collapsing philosophy mapReleaseType already applies to Bandcamp.
+    expect(mapMusicBrainzReleaseType('Album', ['Live'])).toBe('live');
+    expect(mapMusicBrainzReleaseType('Album', ['Compilation'])).toBe('compilation');
+    expect(mapMusicBrainzReleaseType('Album', ['Remix'])).toBe('remix');
+  });
+
+  it('falls back to other for unrecognized or missing primary types', () => {
+    expect(mapMusicBrainzReleaseType('Broadcast', [])).toBe('other');
+    expect(mapMusicBrainzReleaseType(null, null)).toBe('other');
+    expect(mapMusicBrainzReleaseType(undefined, undefined)).toBe('other');
+  });
+});
+
+describe('isFuzzyReleaseMatch', () => {
+  it('flags one key as a probable variant of a longer one containing it', () => {
+    expect(isFuzzyReleaseMatch('carrielowell', 'carrielowelldeluxeedition')).toBe(true);
+  });
+
+  it('is symmetric', () => {
+    expect(isFuzzyReleaseMatch('carrielowelldeluxeedition', 'carrielowell')).toBe(true);
+  });
+
+  it('never flags an exact match — that is tier 2, not tier 3', () => {
+    expect(isFuzzyReleaseMatch('carrielowell', 'carrielowell')).toBe(false);
+  });
+
+  it('does not flag titles that are simply different, even if similar in length', () => {
+    expect(isFuzzyReleaseMatch('redalbum', 'bluealbum')).toBe(false);
+  });
+
+  it('requires the shorter key to be a real substring, not just similar', () => {
+    expect(isFuzzyReleaseMatch('carrieandlowell', 'lowellandcarrie')).toBe(false);
+  });
+
+  it('ignores very short keys to avoid coincidental containment', () => {
+    expect(isFuzzyReleaseMatch('ep', 'thebigeprelease')).toBe(false);
+  });
+
+  it('requires the shorter key to cover most of the longer one, not just any amount', () => {
+    // "album" is contained in a much longer, unrelated title — containment alone isn't
+    // enough evidence without a length-ratio floor.
+    expect(isFuzzyReleaseMatch('album', 'thecompletealbumcollectionboxsetwithbonusdisc')).toBe(false);
   });
 });

--- a/api/functions/admin-catalog-artist.ts
+++ b/api/functions/admin-catalog-artist.ts
@@ -18,74 +18,11 @@
 // The GET is what the button uses to decide whether to show itself: visibility follows the
 // server's real admin rule rather than a copy of it in page markup.
 
-import { getClient, type CatalogTrigger } from './db';
+import { clearCatalogCooldown, getCatalogState } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
-import { isCatalogEnabled } from './request-catalog';
-import { Sentry } from '../lib/sentry';
+import { triggerCatalogNow } from './request-catalog';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-interface CatalogState {
-  last_catalogued_at: string | null;
-  last_attempted_at: string;
-  releases_found: number | null;
-  releases_detailed: number | null;
-  last_error: string | null;
-  consecutive_failures: number;
-}
-
-/**
- * Read this artist's catalog state.
- *
- * Deliberately three-valued, not two. "We couldn't ask" and "we asked and this artist has never
- * been catalogued" are different facts, and collapsing them into one `null` makes a broken
- * database read render as a confident "Never catalogued" — the same shape as the bug class the
- * "never cache uncertainty" principle exists to prevent. This whole feature exists to give
- * cataloging an observable surface, so an unreadable one has to say so.
- */
-type StateResult =
-  | { ok: true; state: CatalogState | null }
-  | { ok: false; reason: string };
-
-async function readState(artistId: string): Promise<StateResult> {
-  const client = getClient();
-  if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
-
-  const { data, error } = await client
-    .from('release_catalog_state')
-    .select('last_catalogued_at, last_attempted_at, releases_found, releases_detailed, last_error, consecutive_failures')
-    .eq('artist_id', artistId)
-    .maybeSingle();
-
-  if (error) {
-    console.error('[admin-catalog] state read failed:', error.message);
-    return { ok: false, reason: 'Could not read catalog state' };
-  }
-  return { ok: true, state: (data as CatalogState | null) ?? null };
-}
-
-/**
- * Clear this artist's cooldown so the crawl actually runs.
- *
- * Without it the button would appear to work and do nothing for a week — `claimArtistForCatalog`
- * refuses an artist catalogued in the last 7 days, which is right for demand-driven triggers and
- * wrong for someone deliberately pressing "catalog now".
- *
- * Backdated rather than deleted: the row also carries the failure counter and the last error,
- * which are worth keeping. Two hours clears both the cooldown and the exponential backoff.
- */
-async function clearCooldown(artistId: string): Promise<void> {
-  const client = getClient();
-  if (!client) return;
-
-  const twoHoursAgo = new Date(Date.now() - 2 * 3600_000).toISOString();
-  const { error } = await client
-    .from('release_catalog_state')
-    .update({ last_catalogued_at: null, last_attempted_at: twoHoursAgo, consecutive_failures: 0 })
-    .eq('artist_id', artistId);
-
-  if (error) console.error('[admin-catalog] cooldown clear failed:', error.message);
-}
 
 export async function handler(event: {
   httpMethod: string;
@@ -120,7 +57,7 @@ export async function handler(event: {
   }
 
   if (event.httpMethod === 'GET') {
-    const result = await readState(artistId);
+    const result = await getCatalogState(artistId);
     if (!result.ok) {
       // 503, not a 200 carrying a null state: the caller must be able to tell "we couldn't ask"
       // from "never catalogued", or it will report the second when the first is true.
@@ -141,58 +78,17 @@ export async function handler(event: {
     return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  // Every reason the background function would refuse, checked here instead — because its
-  // answer never comes back. Netlify's dispatcher returns 202 to the caller the instant it
-  // accepts a background invocation and discards whatever the handler returns, so a 401 from a
-  // bad secret and a 403 from a non-production context both reach us as 202. Anything not
-  // checked up front is indistinguishable from a slow crawl.
-  if (!isCatalogEnabled()) {
-    return {
-      statusCode: 503,
-      headers: CORS_HEADERS,
-      body: JSON.stringify({
-        error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).',
-      }),
-    };
+  await clearCatalogCooldown(artistId);
+  const queued = await triggerCatalogNow(artistId);
+
+  if (!queued.ok) {
+    return { statusCode: queued.status, headers: CORS_HEADERS, body: JSON.stringify({ error: queued.error }) };
   }
 
-  const secret = process.env.INTERNAL_FUNCTION_SECRET;
-  const siteUrl = process.env.URL;
-
-  if (!secret || !siteUrl) {
-    // Said plainly rather than as a generic 500: this exact configuration gap silently stopped
-    // release cataloging from ever running, and "nothing happened" gave no clue why.
-    console.error('[admin-catalog] INTERNAL_FUNCTION_SECRET or site URL is not configured');
-    return {
-      statusCode: 503,
-      headers: CORS_HEADERS,
-      body: JSON.stringify({ error: 'Cataloging is not configured on this deploy (INTERNAL_FUNCTION_SECRET).' }),
-    };
-  }
-
-  await clearCooldown(artistId);
-
-  try {
-    const trigger: CatalogTrigger = 'saved'; // the larger hourly budget — this is a deliberate act
-    await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
-      body: JSON.stringify({ artistIds: [artistId], trigger }),
-    });
-
-    // Nothing useful to report back from that response, and deliberately no `started` flag:
-    // the dispatcher's 202 says only that the request was queued, so any boolean derived from
-    // it would read as "the crawl was accepted" while being true even when it wasn't. The
-    // client polls the GET above, which reports what actually happened.
-    return { statusCode: 202, headers: CORS_HEADERS, body: JSON.stringify({ queued: true }) };
-  } catch (error) {
-    Sentry.captureException(error);
-    return {
-      statusCode: 502,
-      headers: CORS_HEADERS,
-      body: JSON.stringify({ error: 'Could not reach the cataloging function' }),
-    };
-  }
+  // Deliberately no `started` flag: the dispatcher's 202 says only that the request was queued,
+  // so any boolean derived from it would read as "the crawl was accepted" while being true even
+  // when it wasn't. The client polls the GET above, which reports what actually happened.
+  return { statusCode: 202, headers: CORS_HEADERS, body: JSON.stringify({ queued: true }) };
 }
 
 function safeParseArtistId(body: string | undefined): string | undefined {

--- a/api/functions/admin-release-review.ts
+++ b/api/functions/admin-release-review.ts
@@ -1,0 +1,147 @@
+// API endpoint: GET/POST /api/admin/release-review
+//
+// Admin-only endpoint for the tier-3 dedup backstop (spec §4, §11): ingest never auto-merges a
+// fuzzy title match, it only flags both sides via `needs_review` and asks a human. This is
+// where that human answers — "these are different" (dismiss) or "these are the same" (merge).
+
+import { getClient, getReleaseReviewQueue, dismissReleaseReview, mergeReleases } from './db';
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { Sentry } from '../lib/sentry';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body?: string;
+}) {
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const admin = await authenticateAdmin(event.headers['authorization'] || event.headers['Authorization'] || undefined);
+  if (!admin) {
+    return {
+      statusCode: 401,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return {
+      statusCode: 500,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Database not configured' }),
+    };
+  }
+
+  if (event.httpMethod === 'GET') {
+    const pairs = await getReleaseReviewQueue();
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ pairs }),
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  let body: {
+    action?: 'dismiss' | 'merge';
+    releaseId?: string;
+    keepId?: string;
+    dropId?: string;
+  };
+
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'Invalid JSON' }),
+    };
+  }
+
+  const { action } = body;
+
+  if (!action || !['dismiss', 'merge'].includes(action)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'action must be "dismiss" or "merge"' }),
+    };
+  }
+
+  if (action === 'dismiss') {
+    const { releaseId } = body;
+    if (!releaseId || !UUID_REGEX.test(releaseId)) {
+      return {
+        statusCode: 400,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'releaseId must be a UUID' }),
+      };
+    }
+
+    const ok = await dismissReleaseReview(releaseId);
+    if (!ok) {
+      return {
+        statusCode: 500,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Failed to dismiss review flag' }),
+      };
+    }
+
+    Sentry.captureMessage('Release review: dismissed', {
+      level: 'info',
+      extra: { releaseId, adminId: admin.userId },
+    });
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ success: true, action }),
+    };
+  }
+
+  // merge
+  const { keepId, dropId } = body;
+  if (!keepId || !UUID_REGEX.test(keepId) || !dropId || !UUID_REGEX.test(dropId)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: 'keepId and dropId must both be UUIDs' }),
+    };
+  }
+
+  const result = await mergeReleases(keepId, dropId);
+  if (!result.ok) {
+    return {
+      statusCode: 409,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: result.error || 'Failed to merge releases' }),
+    };
+  }
+
+  Sentry.captureMessage('Release review: merged', {
+    level: 'info',
+    extra: { keepId, dropId, adminId: admin.userId },
+  });
+
+  return {
+    statusCode: 200,
+    headers: CORS_HEADERS,
+    body: JSON.stringify({ success: true, action, keepId }),
+  };
+}

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -1,0 +1,241 @@
+// API endpoint: GET/POST /api/artist-releases
+//
+// The artist-facing half of release curation (spec §11): review what ingest catalogued, hide
+// what's wrong, fix a title/date/artwork, merge a release the tier-3 dedup pass flagged as a
+// possible duplicate (or one it didn't), add a platform link that's missing, or add a release
+// ingest never found at all.
+//
+// Ownership is the security boundary here, not an RLS policy — `releases`/`release_sources`
+// have no auth.uid()-keyed write policy (see the `releases` migration's own comment), so every
+// action below resolves the artist from `slug` and checks `resolveOwnedArtist` before touching
+// anything, exactly like `api/functions/artist-profile.ts` does for bio/link edits.
+
+import {
+  getClient,
+  resolveOwnedArtist,
+  verifyReleaseOwnership,
+  getArtistReleasesForOwner,
+  setReleaseHidden,
+  updateArtistReleaseFields,
+  addArtistReleaseLink,
+  createArtistRelease,
+  dismissReleaseReview,
+  mergeReleases,
+} from './db';
+import { authenticateBearer } from './middleware';
+import { cacheDeleteByArtist } from './cache';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+/** Same rule as artist-profile.ts's link validation: only a protocol check, no domain allowlist. */
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function purgeArtistCaches(artistName: string, slug: string): Promise<void> {
+  try {
+    await cacheDeleteByArtist(artistName);
+  } catch (e) {
+    console.error('[ArtistReleases] Redis cache purge failed:', e);
+  }
+
+  try {
+    const siteId = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
+    const token = process.env.NETLIFY_API_TOKEN;
+    if (siteId && token) {
+      await fetch('https://api.netlify.com/api/v1/purge', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ site_id: siteId, cache_tags: [`artist-${slug}`] }),
+      });
+    }
+  } catch (e) {
+    console.error('[ArtistReleases] CDN cache purge failed:', e);
+  }
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string>;
+  body?: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateBearer(event.headers.authorization || event.headers.Authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Authentication required' }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    const slug = event.queryStringParameters?.slug;
+    if (!slug) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'slug is required' }) };
+    }
+
+    const owned = await resolveOwnedArtist(slug, user.userId);
+    if (!owned.ok || !owned.artistId) {
+      return { statusCode: owned.status, headers: CORS_HEADERS, body: JSON.stringify({ error: owned.error }) };
+    }
+
+    const releases = await getArtistReleasesForOwner(owned.artistId);
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ releases }) };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  let body: {
+    slug?: string;
+    action?: 'hide' | 'unhide' | 'dismiss' | 'merge' | 'update' | 'addLink' | 'create';
+    releaseId?: string;
+    keepId?: string;
+    dropId?: string;
+    title?: string;
+    releaseDate?: string | null;
+    artworkUrl?: string | null;
+    releaseType?: string;
+    platform?: string;
+    url?: string;
+  };
+
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  }
+
+  const { slug, action } = body;
+  if (!slug) {
+    return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'slug is required' }) };
+  }
+
+  const owned = await resolveOwnedArtist(slug, user.userId);
+  if (!owned.ok || !owned.artistId || !owned.artistName) {
+    return { statusCode: owned.status, headers: CORS_HEADERS, body: JSON.stringify({ error: owned.error }) };
+  }
+  const artistId = owned.artistId;
+
+  const VALID_ACTIONS = ['hide', 'unhide', 'dismiss', 'merge', 'update', 'addLink', 'create'];
+  if (!action || !VALID_ACTIONS.includes(action)) {
+    return {
+      statusCode: 400,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ error: `action must be one of: ${VALID_ACTIONS.join(', ')}` }),
+    };
+  }
+
+  let ok = false;
+  let responseExtra: Record<string, unknown> = {};
+
+  if (action === 'hide' || action === 'unhide') {
+    const { releaseId } = body;
+    if (!releaseId || !UUID_REGEX.test(releaseId)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
+    }
+    ok = await setReleaseHidden(artistId, releaseId, action === 'hide');
+  } else if (action === 'dismiss') {
+    const { releaseId } = body;
+    if (!releaseId || !UUID_REGEX.test(releaseId)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
+    }
+    if (!(await verifyReleaseOwnership(artistId, [releaseId]))) {
+      return { statusCode: 403, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not your release' }) };
+    }
+    ok = await dismissReleaseReview(releaseId);
+  } else if (action === 'merge') {
+    const { keepId, dropId } = body;
+    if (!keepId || !UUID_REGEX.test(keepId) || !dropId || !UUID_REGEX.test(dropId)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'keepId and dropId must both be UUIDs' }) };
+    }
+    // Both sides, not just one — an artist could otherwise merge one of their own releases
+    // with someone else's by supplying a dropId (or keepId) they don't own.
+    if (!(await verifyReleaseOwnership(artistId, [keepId, dropId]))) {
+      return { statusCode: 403, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not your release' }) };
+    }
+    const result = await mergeReleases(keepId, dropId);
+    ok = result.ok;
+    if (!ok) {
+      return { statusCode: 409, headers: CORS_HEADERS, body: JSON.stringify({ error: result.error || 'Failed to merge releases' }) };
+    }
+  } else if (action === 'update') {
+    const { releaseId, title, releaseDate, artworkUrl } = body;
+    if (!releaseId || !UUID_REGEX.test(releaseId)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
+    }
+    if (artworkUrl !== undefined && artworkUrl !== null) {
+      try {
+        if (new URL(artworkUrl).protocol !== 'https:') {
+          return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Artwork URL must use HTTPS' }) };
+        }
+      } catch {
+        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid artwork URL' }) };
+      }
+    }
+    ok = await updateArtistReleaseFields(artistId, releaseId, { title, releaseDate, artworkUrl });
+  } else if (action === 'addLink') {
+    const { releaseId, platform, url } = body;
+    if (!releaseId || !UUID_REGEX.test(releaseId)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
+    }
+    if (!platform || !url || !isHttpUrl(url)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'platform and a valid http(s) url are required' }) };
+    }
+    ok = await addArtistReleaseLink(artistId, releaseId, platform, url);
+  } else {
+    // create
+    const { title, releaseType, releaseDate, platform, url } = body;
+    if (!title || !platform || !url || !isHttpUrl(url)) {
+      return {
+        statusCode: 400,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'title, platform, and a valid http(s) url are required' }),
+      };
+    }
+    const result = await createArtistRelease(artistId, {
+      title,
+      releaseType: releaseType || 'other',
+      releaseDate: releaseDate ?? null,
+      platform,
+      url,
+    });
+    ok = result.ok;
+    responseExtra = { releaseId: result.releaseId };
+    if (!ok) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: result.error || 'Failed to create release' }) };
+    }
+  }
+
+  if (!ok) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Action failed' }) };
+  }
+
+  await purgeArtistCaches(owned.artistName, slug);
+
+  return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ success: true, action, ...responseExtra }) };
+}

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -21,10 +21,13 @@ import {
   createArtistRelease,
   dismissReleaseReview,
   mergeReleases,
+  getCatalogState,
+  clearCatalogCooldown,
 } from './db';
-import { authenticateBearer } from './middleware';
+import { authenticateAdmin, authenticateBearer } from './middleware';
 import { cacheDeleteByArtist } from './cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
+import { triggerCatalogNow } from './request-catalog';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -43,6 +46,24 @@ function isHttpUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Is self-serve cataloguing available to this caller yet?
+ *
+ * **A rollout gate, deliberately separate from the permission model.** Ownership is what
+ * *authorizes* the `catalog` action — the artist asking is the artist whose catalog it is. This
+ * extra admin check is a temporary limit on who can reach it at all, while the crawl behaviour
+ * is watched on real traffic: an artist-triggered crawl spends the same shared hourly budget
+ * every fan-triggered one does, and the newer sources (Faircamp, discovered links) have never
+ * run against anything but one test instance.
+ *
+ * **To open this to all verified artists, delete this function and its two call sites.** Nothing
+ * about the ownership checks changes — which is the point of keeping the two ideas apart rather
+ * than folding the admin test into the authorization path.
+ */
+async function canTriggerCatalog(authHeader: string | undefined): Promise<boolean> {
+  return (await authenticateAdmin(authHeader)) !== null;
 }
 
 async function purgeArtistCaches(artistName: string, slug: string): Promise<void> {
@@ -86,7 +107,8 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateBearer(event.headers.authorization || event.headers.Authorization);
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  const user = await authenticateBearer(authHeader);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Authentication required' }) };
   }
@@ -103,7 +125,26 @@ export async function handler(event: {
     }
 
     const releases = await getArtistReleasesForOwner(owned.artistId);
-    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ releases }) };
+
+    // `canTrigger` comes from the server rather than being re-derived in the page, so the
+    // button's visibility follows the real rule instead of a copy of it — same reasoning as
+    // AdminCatalogButton. `state` is three-valued (see getCatalogState): a failed read must not
+    // render as a confident "never catalogued".
+    const canTrigger = await canTriggerCatalog(authHeader);
+    const stateResult = canTrigger ? await getCatalogState(owned.artistId) : null;
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        releases,
+        catalog: {
+          canTrigger,
+          state: stateResult?.ok ? stateResult.state : null,
+          stateError: stateResult && !stateResult.ok ? stateResult.reason : null,
+        },
+      }),
+    };
   }
 
   if (event.httpMethod !== 'POST') {
@@ -112,7 +153,7 @@ export async function handler(event: {
 
   let body: {
     slug?: string;
-    action?: 'hide' | 'unhide' | 'dismiss' | 'merge' | 'update' | 'addLink' | 'create';
+    action?: 'hide' | 'unhide' | 'dismiss' | 'merge' | 'update' | 'addLink' | 'create' | 'catalog';
     releaseId?: string;
     keepId?: string;
     dropId?: string;
@@ -141,13 +182,35 @@ export async function handler(event: {
   }
   const artistId = owned.artistId;
 
-  const VALID_ACTIONS = ['hide', 'unhide', 'dismiss', 'merge', 'update', 'addLink', 'create'];
+  const VALID_ACTIONS = ['hide', 'unhide', 'dismiss', 'merge', 'update', 'addLink', 'create', 'catalog'];
   if (!action || !VALID_ACTIONS.includes(action)) {
     return {
       statusCode: 400,
       headers: CORS_HEADERS,
       body: JSON.stringify({ error: `action must be one of: ${VALID_ACTIONS.join(', ')}` }),
     };
+  }
+
+  // Cataloguing returns 202 and is settled by polling the GET, so it doesn't fit the
+  // ok/responseExtra shape the editing actions share below — handled on its own here.
+  if (action === 'catalog') {
+    if (!(await canTriggerCatalog(authHeader))) {
+      return {
+        statusCode: 403,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Self-serve cataloguing is not available yet.' }),
+      };
+    }
+
+    await clearCatalogCooldown(artistId);
+    const queued = await triggerCatalogNow(artistId);
+    if (!queued.ok) {
+      return { statusCode: queued.status, headers: CORS_HEADERS, body: JSON.stringify({ error: queued.error }) };
+    }
+
+    // No cache purge here: nothing has been written yet. The crawl runs asynchronously, and the
+    // page polls the GET for its outcome.
+    return { statusCode: 202, headers: CORS_HEADERS, body: JSON.stringify({ queued: true }) };
   }
 
   let ok = false;

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -24,19 +24,16 @@ import {
   getCatalogState,
   clearCatalogCooldown,
 } from './db';
-import { authenticateAdmin, authenticateBearer } from './middleware';
+import { authenticateAdmin, authenticateBearer, buildCorsHeaders } from './middleware';
 import { cacheDeleteByArtist } from './cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { triggerCatalogNow } from './request-catalog';
+import { PLATFORMS } from '../shared/platform-registry';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const CORS_HEADERS = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
+/** Longest title we'll store. Matches the slice in `updateArtistReleaseFields`. */
+const MAX_TITLE_LENGTH = 200;
 
 /** Same rule as artist-profile.ts's link validation: only a protocol check, no domain allowlist. */
 function isHttpUrl(url: string): boolean {
@@ -46,6 +43,19 @@ function isHttpUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Is this a platform we can actually render?
+ *
+ * Unlike `artist_links` — which has an explicit `other_N` convention for freeform labels — a
+ * `release_sources.platform` value is read back as a key into the platform registry for the
+ * icon, the display name, and `payoutRank`'s ordering. An unrecognized string would render as a
+ * generic badge that ranks last, i.e. a worse answer for the fan than not showing it at all, so
+ * the registry is the allowlist rather than accepting any label.
+ */
+function isKnownPlatform(platform: string): boolean {
+  return Object.prototype.hasOwnProperty.call(PLATFORMS, platform);
 }
 
 /**
@@ -94,6 +104,13 @@ export async function handler(event: {
   queryStringParameters?: Record<string, string>;
   body?: string | null;
 }) {
+  // The shared helper rather than a hand-rolled wildcard: this endpoint performs writes
+  // (hide/merge/update/create/catalog), so it's restricted to unstream.stream like every other
+  // authenticated surface. Safe for deploy previews — the SPA calls `/api/...` as a same-origin
+  // relative request, and CORS doesn't apply to those at all.
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
@@ -251,7 +268,24 @@ export async function handler(event: {
     if (!releaseId || !UUID_REGEX.test(releaseId)) {
       return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
     }
+    // The declared types are compile-time only — a client can send `"title": 123`. Without
+    // this, a non-string reaches `patch.title.trim()` in db.ts and throws inside an async
+    // function with no try/catch around it, surfacing as a bare 500 rather than the 400 every
+    // other malformed field in this handler returns.
+    if (title !== undefined && (typeof title !== 'string' || !title.trim())) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'title must be a non-empty string' }) };
+    }
+    if (typeof title === 'string' && title.length > MAX_TITLE_LENGTH) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: `title must be ${MAX_TITLE_LENGTH} characters or fewer` }) };
+    }
+    // null is meaningful here — it clears the date. Anything other than null or a string is not.
+    if (releaseDate !== undefined && releaseDate !== null && typeof releaseDate !== 'string') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseDate must be a string or null' }) };
+    }
     if (artworkUrl !== undefined && artworkUrl !== null) {
+      if (typeof artworkUrl !== 'string') {
+        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'artworkUrl must be a string or null' }) };
+      }
       try {
         if (new URL(artworkUrl).protocol !== 'https:') {
           return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Artwork URL must use HTTPS' }) };
@@ -266,19 +300,37 @@ export async function handler(event: {
     if (!releaseId || !UUID_REGEX.test(releaseId)) {
       return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseId must be a UUID' }) };
     }
-    if (!platform || !url || !isHttpUrl(url)) {
-      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'platform and a valid http(s) url are required' }) };
+    if (typeof url !== 'string' || !isHttpUrl(url)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'A valid http(s) url is required' }) };
+    }
+    if (typeof platform !== 'string' || !isKnownPlatform(platform)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Unknown platform' }) };
     }
     ok = await addArtistReleaseLink(artistId, releaseId, platform, url);
   } else {
     // create
     const { title, releaseType, releaseDate, platform, url } = body;
-    if (!title || !platform || !url || !isHttpUrl(url)) {
+    if (typeof title !== 'string' || !title.trim() || typeof url !== 'string' || !isHttpUrl(url)) {
       return {
         statusCode: 400,
         headers: CORS_HEADERS,
-        body: JSON.stringify({ error: 'title, platform, and a valid http(s) url are required' }),
+        body: JSON.stringify({ error: 'title and a valid http(s) url are required' }),
       };
+    }
+    if (title.length > MAX_TITLE_LENGTH) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: `title must be ${MAX_TITLE_LENGTH} characters or fewer` }) };
+    }
+    if (typeof platform !== 'string' || !isKnownPlatform(platform)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Unknown platform' }) };
+    }
+    if (releaseDate !== undefined && releaseDate !== null && typeof releaseDate !== 'string') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseDate must be a string or null' }) };
+    }
+    // `releaseType` is mapped through `mapReleaseType`, which returns 'other' for anything it
+    // doesn't recognize — so a junk value degrades rather than needing its own rejection. Only
+    // its *type* matters here.
+    if (releaseType !== undefined && typeof releaseType !== 'string') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseType must be a string' }) };
     }
     const result = await createArtistRelease(artistId, {
       title,

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -13,7 +13,9 @@
 import { timingSafeEqual } from 'crypto';
 import {
   claimArtistForCatalog,
-  getArtistBandcampUrl,
+  getArtistForCatalog,
+  persistDiscogsReleases,
+  persistMusicBrainzEnrichment,
   persistReleaseDetail,
   persistReleases,
   recordCatalogOutcome,
@@ -22,8 +24,20 @@ import {
 } from './db';
 import { isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
-import { bandcampMusicUrl, ingestBandcampDetail, ingestBandcampGrid } from './release-ingest';
+import {
+  bandcampMusicUrl,
+  ingestBandcampDetail,
+  ingestBandcampGrid,
+  ingestDiscogsMasters,
+  ingestDiscogsReleaseDetail,
+  ingestMusicBrainzReleaseGroups,
+  type DiscogsArtistReleaseEntry,
+  type DiscogsReleaseDetailRaw,
+  type MusicBrainzReleaseGroupRaw,
+} from './release-ingest';
 import { isCatalogEnabled } from './request-catalog';
+import { musicBrainzArtistQuery, normalizeForComparison } from './search-utils';
+import { extractDiscogsArtistId } from '../search/enrichment';
 
 /** Ceiling on artists per invocation, so one call can't become an unbounded crawl. */
 const MAX_ARTISTS_PER_RUN = 25;
@@ -65,6 +79,43 @@ interface DetailBudget {
   fetchesLeft: number;
   deadline: number;
 }
+
+// --- Discogs + MusicBrainz enrichment budgets ---------------------------------
+//
+// Both ride along after Bandcamp within the same per-artist catalog run, sharing the
+// invocation's 15-minute Netlify ceiling with Bandcamp's own 9-minute detail budget above.
+// Neither ever fails the artist's run: a MusicBrainz hiccup or a Discogs rate-limit response
+// is worth logging, not worth discarding Bandcamp data this run already wrote.
+
+const DISCOGS_USER_AGENT = 'Unstream/1.0 (https://unstream.stream - ethical music finder)';
+const MUSICBRAINZ_USER_AGENT = 'Unstream/1.0 (https://unstream.stream - ethical music finder)';
+
+/** Sanity check before an MBID from MusicBrainz's own response is interpolated into a URL. */
+const MB_MBID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Discogs allows 25 req/min unauthenticated; paced well under that with margin to spare. */
+const DELAY_BETWEEN_DISCOGS_FETCHES_MS = 2_600;
+
+/** Filtered to `role: Main` + `type: master` per-artist, so this bounds priced releases, not raw listing rows. */
+const MAX_DISCOGS_MASTERS_PER_ARTIST = 5;
+
+/** Invocation-wide, list + detail requests combined. */
+const MAX_DISCOGS_FETCHES_PER_RUN = 30;
+
+/** How many raw (unfiltered) rows to read from `/artists/{id}/releases` before stopping. */
+const MAX_DISCOGS_LIST_PAGES = 2;
+
+interface DiscogsBudget {
+  fetchesLeft: number;
+  deadline: number;
+}
+
+/**
+ * Stop *starting* Discogs or MusicBrainz work for a new artist this long into the invocation —
+ * leaving headroom on top of Bandcamp's own 9-minute detail budget so a 25-artist batch ends
+ * by finishing rather than being killed mid-write.
+ */
+const ENRICHMENT_CUTOFF_MS = 13 * 60_000;
 
 function isAuthorized(header: string | undefined): boolean {
   // Reuses the secret this repo already has for internal function-to-function calls
@@ -128,6 +179,11 @@ export async function handler(event: {
     fetchesLeft: MAX_DETAIL_FETCHES_PER_RUN,
     deadline: Date.now() + DETAIL_BUDGET_MS,
   };
+  const discogsBudget: DiscogsBudget = {
+    fetchesLeft: MAX_DISCOGS_FETCHES_PER_RUN,
+    deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
+  };
+  const enrichmentDeadline = Date.now() + ENRICHMENT_CUTOFF_MS;
 
   for (const [index, artistId] of artistIds.entries()) {
     // Cooldown, hourly cap and claim all happen here rather than at the call site, so the
@@ -140,7 +196,7 @@ export async function handler(event: {
     if (index > 0) await sleep(DELAY_BETWEEN_ARTISTS_MS);
 
     try {
-      const found = await catalogArtist(artistId, budget);
+      const found = await catalogArtist(artistId, budget, discogsBudget, enrichmentDeadline);
       if (found === null) {
         skipped++;
       } else {
@@ -158,30 +214,93 @@ export async function handler(event: {
 }
 
 /**
- * Catalog one artist. Returns the release count, or null when there was nothing to do.
+ * Catalog one artist across every source we have a link for. Returns the total release count
+ * (Bandcamp + Discogs combined), or null when there was nothing to do at all.
  *
- * @throws on a genuine failure, so the caller records it against the backoff counter.
+ * The three sources are deliberately independent: Bandcamp remains the one whose own failures
+ * can still surface as a thrown error (see `catalogBandcamp`), but that error is caught here
+ * rather than left to unwind the whole function, because a Bandcamp bot challenge has nothing
+ * to do with whether Discogs or MusicBrainz can answer this run. Only when *nothing* came of
+ * the run — Bandcamp failed and Discogs/MusicBrainz found nothing to add — does the run count
+ * as a failure against the backoff counter.
  */
-async function catalogArtist(artistId: string, budget: DetailBudget): Promise<number | null> {
-  const storedUrl = await getArtistBandcampUrl(artistId);
-  if (!storedUrl) {
-    await recordCatalogOutcome(artistId, { error: 'no bandcamp link stored' });
+async function catalogArtist(
+  artistId: string,
+  budget: DetailBudget,
+  discogsBudget: DiscogsBudget,
+  enrichmentDeadline: number
+): Promise<number | null> {
+  const artist = await getArtistForCatalog(artistId);
+  if (!artist) {
+    await recordCatalogOutcome(artistId, { error: 'artist not found' });
+    return null;
+  }
+  if (!artist.bandcampUrl && !artist.discogsUrl) {
+    await recordCatalogOutcome(artistId, { error: 'no bandcamp or discogs link stored' });
     return null;
   }
 
+  let totalFound = 0;
+  let totalDetailed = 0;
+  let bandcampError: string | null = null;
+
+  if (artist.bandcampUrl) {
+    try {
+      const { found, detailed } = await catalogBandcamp(artistId, artist.bandcampUrl, budget);
+      totalFound += found;
+      totalDetailed += detailed;
+    } catch (error) {
+      bandcampError = error instanceof Error ? error.message : String(error);
+      console.error(`[catalog] bandcamp pass failed for artist ${artistId}:`, bandcampError);
+    }
+  }
+
+  // Stop *starting* new enrichment work once the invocation is close to Netlify's ceiling —
+  // an artist skipped here simply gets picked up by the artist's normal 7-day recatalog
+  // cooldown next time, rather than the whole batch being killed mid-write.
+  if (Date.now() < enrichmentDeadline) {
+    if (artist.discogsUrl) {
+      totalFound += await catalogDiscogs(artistId, artist.discogsUrl, discogsBudget);
+    }
+    await catalogMusicBrainz(artistId, artist.name);
+  }
+
+  if (bandcampError && totalFound === 0) {
+    await recordCatalogOutcome(artistId, { error: bandcampError });
+    return null;
+  }
+
+  await recordCatalogOutcome(artistId, {
+    releasesFound: totalFound,
+    releasesDetailed: totalDetailed,
+  });
+  return totalFound;
+}
+
+/**
+ * The Bandcamp pass: grid, then a budgeted detail pass over individual release pages.
+ *
+ * @throws on a genuine failure — a bot challenge or an unreachable fetch — so the caller can
+ * tell "Bandcamp declined to answer" apart from "Bandcamp said zero releases".
+ */
+async function catalogBandcamp(
+  artistId: string,
+  storedUrl: string,
+  budget: DetailBudget
+): Promise<{ found: number; detailed: number }> {
   // The stored URL is not automatically trustworthy: a claimed artist can save any http(s)
   // URL to their profile links, so a row labelled 'bandcamp' may not be Bandcamp at all.
   // The allowlist answers "is this really Bandcamp"; safeFetch separately answers "is this
   // safe to fetch". Both are needed — they are different questions.
   if (!isUrlHostnameAllowed(storedUrl)) {
-    await recordCatalogOutcome(artistId, { error: `stored bandcamp url not allowlisted: ${safeHostname(storedUrl)}` });
-    return null;
+    console.warn(`[catalog] stored bandcamp url not allowlisted: ${safeHostname(storedUrl)}`);
+    return { found: 0, detailed: 0 };
   }
 
   const musicUrl = bandcampMusicUrl(storedUrl);
   if (!musicUrl) {
-    await recordCatalogOutcome(artistId, { error: 'could not derive /music url' });
-    return null;
+    console.warn(`[catalog] could not derive /music url for artist ${artistId}`);
+    return { found: 0, detailed: 0 };
   }
 
   const response = await safeFetch(musicUrl, 10_000);
@@ -197,19 +316,145 @@ async function catalogArtist(artistId: string, budget: DetailBudget): Promise<nu
     // Throwing marks it a failure so it backs off and retries; recording it as a successful
     // zero would poison the cooldown with a false negative for a week.
     if (outcome.reason === 'bot_challenge') throw new Error('bandcamp bot challenge');
-
-    await recordCatalogOutcome(artistId, { releasesFound: 0 });
-    return 0;
+    return { found: 0, detailed: 0 };
   }
 
   const written = await persistReleases(artistId, outcome.releases);
   const detailed = await catalogDetails(written, landedUrl, budget);
+  return { found: written.length, detailed };
+}
 
-  await recordCatalogOutcome(artistId, {
-    releasesFound: written.length,
-    releasesDetailed: detailed,
-  });
-  return written.length;
+/**
+ * The Discogs pass: a cheap paginated listing (filtered to `role: Main` + `type: master`),
+ * then a budgeted detail pass over the newest masters for price and format data.
+ *
+ * Never throws — a Discogs hiccup is worth logging, not worth failing an artist whose
+ * Bandcamp pass may have already succeeded this run.
+ */
+async function catalogDiscogs(artistId: string, discogsUrl: string, budget: DiscogsBudget): Promise<number> {
+  const discogsArtistId = extractDiscogsArtistId(discogsUrl);
+  if (!discogsArtistId) return 0;
+
+  try {
+    const entries: DiscogsArtistReleaseEntry[] = [];
+
+    for (let page = 1; page <= MAX_DISCOGS_LIST_PAGES; page++) {
+      if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) break;
+      if (page > 1) await sleep(DELAY_BETWEEN_DISCOGS_FETCHES_MS);
+      budget.fetchesLeft--;
+
+      const listUrl = `https://api.discogs.com/artists/${discogsArtistId}/releases?per_page=100&page=${page}&sort=year&sort_order=desc`;
+      const response = await globalThis.fetch(listUrl, { headers: { 'User-Agent': DISCOGS_USER_AGENT } });
+      if (!response.ok) {
+        console.warn(`[catalog] discogs artist-releases responded ${response.status} for artist ${artistId}`);
+        break;
+      }
+
+      const data = (await response.json()) as {
+        releases?: DiscogsArtistReleaseEntry[];
+        pagination?: { pages?: number };
+      };
+      entries.push(...(data.releases ?? []));
+      if (page >= (data.pagination?.pages ?? 1)) break;
+    }
+
+    const masters = ingestDiscogsMasters(entries).slice(0, MAX_DISCOGS_MASTERS_PER_ARTIST);
+    if (masters.length === 0) return 0;
+
+    const written = await persistDiscogsReleases(
+      artistId,
+      masters.map(m => ({
+        title: m.title,
+        slug: m.slug,
+        matchKey: m.matchKey,
+        releaseType: m.releaseType,
+        releaseDate: m.releaseDate,
+        datePrecision: m.datePrecision,
+        status: m.status,
+        masterId: m.masterId,
+        mainReleaseId: m.mainReleaseId,
+      }))
+    );
+
+    for (const release of written) {
+      // Only price a master once; re-pricing rides the same cooldown as the rest of this
+      // artist's catalog rather than its own schedule.
+      if (release.detailCheckedAt) continue;
+
+      if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+        console.log(`[catalog] discogs detail budget spent for artist ${artistId}`);
+        break;
+      }
+      await sleep(DELAY_BETWEEN_DISCOGS_FETCHES_MS);
+      budget.fetchesLeft--;
+
+      try {
+        const releaseId = release.url.split('/').pop();
+        const detailResponse = await globalThis.fetch(`https://api.discogs.com/releases/${releaseId}`, {
+          headers: { 'User-Agent': DISCOGS_USER_AGENT },
+        });
+        if (!detailResponse.ok) continue;
+
+        const detail = ingestDiscogsReleaseDetail((await detailResponse.json()) as DiscogsReleaseDetailRaw);
+        await persistReleaseDetail(release, detail);
+      } catch (error) {
+        console.warn(
+          '[catalog] discogs detail fetch failed:',
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    return written.length;
+  } catch (error) {
+    console.warn('[catalog] discogs ingest failed:', error instanceof Error ? error.message : String(error));
+    return 0;
+  }
+}
+
+/**
+ * The MusicBrainz pass: enrichment only. Finds this artist's release groups and merges in
+ * whatever they add to releases we already have — never creates a new one, since MusicBrainz
+ * has no purchase link to offer (see `persistMusicBrainzEnrichment`).
+ *
+ * Two requests, spaced by MusicBrainz's mandatory ~1/sec rate limit — the same pacing
+ * `search-musicbrainz.ts` already uses against the same API. Never throws.
+ */
+async function catalogMusicBrainz(artistId: string, artistName: string): Promise<void> {
+  try {
+    const searchUrl = `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(musicBrainzArtistQuery(artistName))}&fmt=json&limit=1`;
+    const searchResponse = await globalThis.fetch(searchUrl, { headers: { 'User-Agent': MUSICBRAINZ_USER_AGENT } });
+    if (!searchResponse.ok) return;
+
+    const searchData = (await searchResponse.json()) as { artists?: { id: string; name: string; score: number }[] };
+    const artist = searchData.artists?.[0];
+    if (!artist || artist.score < 95 || !MB_MBID_PATTERN.test(artist.id)) return;
+
+    // Same over-eager-match guard as search-musicbrainz.ts: a low-confidence name match would
+    // attach some other artist's release dates and MBIDs to this one's catalog.
+    const queryNormalized = normalizeForComparison(artistName);
+    const artistNormalized = normalizeForComparison(artist.name);
+    const isNameMatch =
+      queryNormalized === artistNormalized ||
+      (queryNormalized.includes(artistNormalized) && artistNormalized.length > queryNormalized.length * 0.7) ||
+      (artistNormalized.includes(queryNormalized) && queryNormalized.length > artistNormalized.length * 0.7);
+    if (!isNameMatch) return;
+
+    await sleep(1_100); // MusicBrainz's mandatory ~1 req/sec
+
+    const rgUrl = `https://musicbrainz.org/ws/2/release-group?artist=${artist.id}&fmt=json&limit=100`;
+    const rgResponse = await globalThis.fetch(rgUrl, { headers: { 'User-Agent': MUSICBRAINZ_USER_AGENT } });
+    if (!rgResponse.ok) return;
+
+    const rgData = (await rgResponse.json()) as { 'release-groups'?: MusicBrainzReleaseGroupRaw[] };
+    const groups = ingestMusicBrainzReleaseGroups(rgData['release-groups'] ?? []);
+    if (groups.length === 0) return;
+
+    const touched = await persistMusicBrainzEnrichment(artistId, groups);
+    if (touched > 0) console.log(`[catalog] musicbrainz enriched ${touched} release(s) for artist ${artistId}`);
+  } catch (error) {
+    console.warn('[catalog] musicbrainz enrichment failed:', error instanceof Error ? error.message : String(error));
+  }
 }
 
 /**

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -15,10 +15,12 @@ import {
   claimArtistForCatalog,
   getArtistForCatalog,
   persistDiscogsReleases,
+  persistFaircampReleases,
   persistMusicBrainzEnrichment,
   persistReleaseDetail,
   persistReleases,
   recordCatalogOutcome,
+  attachDiscoveredSource,
   type CatalogTrigger,
   type PersistedRelease,
 } from './db';
@@ -26,10 +28,14 @@ import { isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
 import {
   bandcampMusicUrl,
+  buildFaircampRelease,
+  findDiscoveredReleaseLinks,
   ingestBandcampDetail,
   ingestBandcampGrid,
   ingestDiscogsMasters,
   ingestDiscogsReleaseDetail,
+  ingestFaircampHomeLinks,
+  ingestFaircampReleasePage,
   ingestMusicBrainzReleaseGroups,
   type DiscogsArtistReleaseEntry,
   type DiscogsReleaseDetailRaw,
@@ -111,11 +117,31 @@ interface DiscogsBudget {
 }
 
 /**
- * Stop *starting* Discogs or MusicBrainz work for a new artist this long into the invocation —
- * leaving headroom on top of Bandcamp's own 9-minute detail budget so a 25-artist batch ends
- * by finishing rather than being killed mid-write.
+ * Stop *starting* Discogs, MusicBrainz, Faircamp or official-site work for a new artist this
+ * long into the invocation — leaving headroom on top of Bandcamp's own 9-minute detail budget
+ * so a 25-artist batch ends by finishing rather than being killed mid-write.
  */
 const ENRICHMENT_CUTOFF_MS = 13 * 60_000;
+
+// --- Faircamp + discovered-link budgets ---------------------------------------
+//
+// Unlike Discogs and MusicBrainz, Faircamp has no centralized rate limit to respect — every
+// instance is a different self-hosted domain — so the ceiling here is about not fetching an
+// unbounded number of pages per artist, not about a shared API's tolerance.
+
+/** One request per candidate release page, spaced out rather than in a burst. */
+const DELAY_BETWEEN_FAIRCAMP_FETCHES_MS = 1_000;
+
+/** Bounds cost for an artist with an unusually large Faircamp archive. */
+const MAX_FAIRCAMP_RELEASES_PER_ARTIST = 20;
+
+/** Invocation-wide, homepage + release-page requests combined, across every artist in the batch. */
+const MAX_FAIRCAMP_FETCHES_PER_RUN = 100;
+
+interface FaircampBudget {
+  fetchesLeft: number;
+  deadline: number;
+}
 
 function isAuthorized(header: string | undefined): boolean {
   // Reuses the secret this repo already has for internal function-to-function calls
@@ -183,6 +209,10 @@ export async function handler(event: {
     fetchesLeft: MAX_DISCOGS_FETCHES_PER_RUN,
     deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
   };
+  const faircampBudget: FaircampBudget = {
+    fetchesLeft: MAX_FAIRCAMP_FETCHES_PER_RUN,
+    deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
+  };
   const enrichmentDeadline = Date.now() + ENRICHMENT_CUTOFF_MS;
 
   for (const [index, artistId] of artistIds.entries()) {
@@ -196,7 +226,7 @@ export async function handler(event: {
     if (index > 0) await sleep(DELAY_BETWEEN_ARTISTS_MS);
 
     try {
-      const found = await catalogArtist(artistId, budget, discogsBudget, enrichmentDeadline);
+      const found = await catalogArtist(artistId, budget, discogsBudget, faircampBudget, enrichmentDeadline);
       if (found === null) {
         skipped++;
       } else {
@@ -214,20 +244,20 @@ export async function handler(event: {
 }
 
 /**
- * Catalog one artist across every source we have a link for. Returns the total release count
- * (Bandcamp + Discogs combined), or null when there was nothing to do at all.
+ * Catalog one artist across every source we have a link for. Returns the total release count,
+ * or null when there was nothing to do at all.
  *
- * The three sources are deliberately independent: Bandcamp remains the one whose own failures
- * can still surface as a thrown error (see `catalogBandcamp`), but that error is caught here
- * rather than left to unwind the whole function, because a Bandcamp bot challenge has nothing
- * to do with whether Discogs or MusicBrainz can answer this run. Only when *nothing* came of
- * the run — Bandcamp failed and Discogs/MusicBrainz found nothing to add — does the run count
- * as a failure against the backoff counter.
+ * Bandcamp remains the one source whose own failures can still surface as a thrown error (see
+ * `catalogBandcamp`), but that error is caught here rather than left to unwind the whole
+ * function — a Bandcamp bot challenge has nothing to do with whether the other sources can
+ * answer this run. Only when *nothing* came of the run — Bandcamp failed and nothing else
+ * added anything — does the run count as a failure against the backoff counter.
  */
 async function catalogArtist(
   artistId: string,
   budget: DetailBudget,
   discogsBudget: DiscogsBudget,
+  faircampBudget: FaircampBudget,
   enrichmentDeadline: number
 ): Promise<number | null> {
   const artist = await getArtistForCatalog(artistId);
@@ -235,8 +265,8 @@ async function catalogArtist(
     await recordCatalogOutcome(artistId, { error: 'artist not found' });
     return null;
   }
-  if (!artist.bandcampUrl && !artist.discogsUrl) {
-    await recordCatalogOutcome(artistId, { error: 'no bandcamp or discogs link stored' });
+  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl) {
+    await recordCatalogOutcome(artistId, { error: 'no bandcamp, discogs, or faircamp link stored' });
     return null;
   }
 
@@ -263,6 +293,12 @@ async function catalogArtist(
       totalFound += await catalogDiscogs(artistId, artist.discogsUrl, discogsBudget);
     }
     await catalogMusicBrainz(artistId, artist.name);
+    if (artist.faircampUrl) {
+      totalFound += await catalogFaircamp(artistId, artist.faircampUrl, faircampBudget);
+    }
+    if (artist.officialSiteUrl) {
+      await catalogOfficialSite(artistId, artist.officialSiteUrl);
+    }
   }
 
   if (bandcampError && totalFound === 0) {
@@ -454,6 +490,109 @@ async function catalogMusicBrainz(artistId: string, artistName: string): Promise
     if (touched > 0) console.log(`[catalog] musicbrainz enriched ${touched} release(s) for artist ${artistId}`);
   } catch (error) {
     console.warn('[catalog] musicbrainz enrichment failed:', error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * The Faircamp pass: fetch the artist's homepage, discover candidate release links, then fetch
+ * each one (budgeted) for title and artwork via `ingestFaircampReleasePage`. Every page fetched
+ * along the way is also scanned for discovered links to platforms we can't fetch directly
+ * (Subvert today) — an artist's Faircamp page is exactly the kind of place a "buy this
+ * elsewhere" link shows up.
+ *
+ * Never throws — an unreachable or oddly-themed Faircamp instance is worth logging, not worth
+ * failing an artist whose Bandcamp pass may have already succeeded this run.
+ */
+async function catalogFaircamp(artistId: string, faircampUrl: string, budget: FaircampBudget): Promise<number> {
+  try {
+    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) return 0;
+    budget.fetchesLeft--;
+
+    const homeResponse = await safeFetch(faircampUrl, 10_000);
+    if (!homeResponse?.ok) return 0;
+
+    const landedUrl = homeResponse.url || faircampUrl;
+    const homeHtml = await homeResponse.text();
+    await scanForDiscoveredLinks(artistId, homeHtml, landedUrl);
+
+    const candidates = ingestFaircampHomeLinks(homeHtml, landedUrl).slice(0, MAX_FAIRCAMP_RELEASES_PER_ARTIST);
+    if (candidates.length === 0) return 0;
+
+    const takenSlugs = new Set<string>();
+    const toPersist: Parameters<typeof persistFaircampReleases>[1] = [];
+
+    for (const candidate of candidates) {
+      if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+        console.log(`[catalog] faircamp budget spent for artist ${artistId}`);
+        break;
+      }
+      if (toPersist.length > 0) await sleep(DELAY_BETWEEN_FAIRCAMP_FETCHES_MS);
+      budget.fetchesLeft--;
+
+      try {
+        const response = await safeFetch(candidate.url, 10_000);
+        if (!response?.ok) continue;
+
+        const html = await response.text();
+        const page = ingestFaircampReleasePage(html);
+        if (page) {
+          const release = buildFaircampRelease(page, candidate.url, takenSlugs);
+          if (release) {
+            takenSlugs.add(release.slug);
+            toPersist.push(release);
+          }
+        }
+
+        await scanForDiscoveredLinks(artistId, html, response.url || candidate.url);
+      } catch (error) {
+        console.warn(
+          `[catalog] faircamp release fetch failed for ${safeHostname(candidate.url)}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    if (toPersist.length === 0) return 0;
+
+    const written = await persistFaircampReleases(artistId, toPersist);
+    return written.length;
+  } catch (error) {
+    console.warn('[catalog] faircamp ingest failed:', error instanceof Error ? error.message : String(error));
+    return 0;
+  }
+}
+
+/**
+ * Scan already-fetched HTML for discovered links (Subvert today — see
+ * `findDiscoveredReleaseLinks`) and attach any confident, exact-title match. Never throws, and
+ * never fetches anything itself — the whole point is surfacing links from pages fetched for a
+ * different reason.
+ */
+async function scanForDiscoveredLinks(artistId: string, html: string, pageUrl: string): Promise<void> {
+  try {
+    for (const link of findDiscoveredReleaseLinks(html, pageUrl)) {
+      const attached = await attachDiscoveredSource(artistId, link.platform, link.url, link.matchKey);
+      if (attached) console.log(`[catalog] discovered ${link.platform} link attached for artist ${artistId}`);
+    }
+  } catch (error) {
+    console.warn('[catalog] discovered-link scan failed:', error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * The official-site pass: one fetch, scanned only for discovered links. An arbitrary personal
+ * website has no structure reliable enough to parse a whole release from directly — unlike
+ * Faircamp, this never creates a release on its own, only adds a source to one that already
+ * exists.
+ */
+async function catalogOfficialSite(artistId: string, officialSiteUrl: string): Promise<void> {
+  try {
+    const response = await safeFetch(officialSiteUrl, 10_000);
+    if (!response?.ok) return;
+    const html = await response.text();
+    await scanForDiscoveredLinks(artistId, html, response.url || officialSiteUrl);
+  } catch (error) {
+    console.warn('[catalog] official-site scan failed:', error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -920,19 +920,13 @@ export async function persistDiscogsReleases(
         }
       }
 
-      if (!prior) {
-        // Tier 3: nothing exact, but something close enough to warrant a human look. Never
-        // merge — insert a new row below and flag both sides, rather than guessing.
-        const candidates = byType.get(release.releaseType) ?? [];
-        const fuzzy = candidates.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
-        if (fuzzy) {
-          const { error: flagError } = await client
-            .from('releases')
-            .update({ needs_review: true })
-            .eq('id', fuzzy.id);
-          if (flagError) console.error('[DB] persistDiscogsReleases fuzzy-flag failed:', flagError.message);
-        }
-      }
+      // Tier 3: nothing exact, but something close enough to warrant a human look. Never
+      // merge — insert a new row below and flag both sides, with each pointing at the other
+      // via `flagged_against_release_id` so an admin queue can show the pair without having
+      // to re-run the fuzzy match to reconstruct what triggered it.
+      const fuzzy = prior
+        ? null
+        : (byType.get(release.releaseType) ?? []).find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey)) ?? null;
 
       let releaseId: string;
       let curatedFields: string[];
@@ -979,6 +973,9 @@ export async function persistDiscogsReleases(
             status: release.status,
             discogs_master_id: release.masterId,
             source: 'auto',
+            // fuzzy.id is already known here, unlike the reverse direction below — this row
+            // can point at its suspected duplicate in the same write that creates it.
+            ...(fuzzy && { needs_review: true, flagged_against_release_id: fuzzy.id }),
           })
           .select('id')
           .single();
@@ -1003,6 +1000,17 @@ export async function persistDiscogsReleases(
         const bucket = byType.get(release.releaseType);
         if (bucket) bucket.push(createdRow);
         else byType.set(release.releaseType, [createdRow]);
+
+        // The reverse direction: fuzzy's own id wasn't known until the new row above existed,
+        // so this side is written second. Never merge — flagging both sides is the whole
+        // point of tier 3.
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true, flagged_against_release_id: releaseId })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistDiscogsReleases fuzzy-flag failed:', flagError.message);
+        }
       }
 
       const { data: sourceRow, error: sourceError } = await client
@@ -1137,6 +1145,259 @@ export async function persistMusicBrainzEnrichment(
   }
 }
 
+// --- Tier-3 dedup admin review queue ---
+//
+// The backstop the dedup scheme (spec §4) leans on once claiming is optional: ingest never
+// auto-merges a fuzzy match, it only flags both sides via `needs_review` and
+// `flagged_against_release_id`. These functions are the read side (list flagged pairs) and the
+// two things an admin can do about one: say they're different (dismiss) or say they're the
+// same (merge).
+
+export interface ReleaseReviewItem {
+  id: string;
+  title: string;
+  slug: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  artworkUrl: string | null;
+  artistName: string;
+  artistSlug: string;
+  platforms: string[];
+}
+
+/**
+ * Fold a flat needs_review result set into pairs, deduplicating the two rows a symmetric flag
+ * always produces (A flagged against B, and B flagged against A, are one pair to review, not
+ * two). Pure and exported for tests — no network, no database.
+ *
+ * A row whose counterpart isn't in the set (already resolved from the other side, or deleted)
+ * is still shown, alone, rather than dropped — something about it looked ambiguous enough to
+ * flag, and silently hiding that is worse than showing it with nothing to compare against.
+ */
+export function pairReviewRows(
+  rows: Map<string, ReleaseReviewItem & { flaggedAgainst: string | null }>
+): { primary: ReleaseReviewItem; counterpart: ReleaseReviewItem | null }[] {
+  const seen = new Set<string>();
+  const pairs: { primary: ReleaseReviewItem; counterpart: ReleaseReviewItem | null }[] = [];
+
+  for (const row of rows.values()) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+
+    const counterpart = row.flaggedAgainst ? rows.get(row.flaggedAgainst) ?? null : null;
+    if (counterpart) seen.add(counterpart.id);
+
+    pairs.push({ primary: row, counterpart });
+  }
+
+  return pairs;
+}
+
+/**
+ * Every release currently flagged for review, paired with its suspected duplicate where one is
+ * still on file. Hidden releases are excluded — an admin has already ruled on those.
+ */
+export async function getReleaseReviewQueue(): Promise<
+  { primary: ReleaseReviewItem; counterpart: ReleaseReviewItem | null }[]
+> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const { data, error } = await client
+      .from('releases')
+      .select(
+        'id, title, slug, release_type, release_date, date_precision, artwork_url, flagged_against_release_id,' +
+        ' artists ( name, slug ), release_sources ( platform )'
+      )
+      .eq('needs_review', true)
+      .eq('is_hidden', false)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      console.error('[DB] getReleaseReviewQueue failed:', error.message);
+      return [];
+    }
+
+    type Row = {
+      id: string;
+      title: string;
+      slug: string;
+      release_type: string;
+      release_date: string | null;
+      date_precision: string | null;
+      artwork_url: string | null;
+      flagged_against_release_id: string | null;
+      artists: { name: string; slug: string } | { name: string; slug: string }[] | null;
+      release_sources: { platform: string }[] | null;
+    };
+
+    const rows = new Map<string, ReleaseReviewItem & { flaggedAgainst: string | null }>();
+
+    for (const r of (data as unknown as Row[]) || []) {
+      const artist = Array.isArray(r.artists) ? r.artists[0] : r.artists;
+      rows.set(r.id, {
+        id: r.id,
+        title: r.title,
+        slug: r.slug,
+        releaseType: r.release_type,
+        releaseDate: r.release_date,
+        datePrecision: r.date_precision,
+        artworkUrl: r.artwork_url,
+        artistName: artist?.name ?? '(unknown)',
+        artistSlug: artist?.slug ?? '',
+        platforms: (r.release_sources || []).map(s => s.platform),
+        flaggedAgainst: r.flagged_against_release_id,
+      });
+    }
+
+    return pairReviewRows(rows);
+  } catch (error) {
+    console.error('[DB] getReleaseReviewQueue error:', error);
+    return [];
+  }
+}
+
+/**
+ * "These are different releases." Clears the flag on both sides of the pair — including the
+ * counterpart, looked up here rather than trusted from the client, since flagged_against_
+ * release_id is what makes them a pair and both must stop pointing at the resolved question.
+ */
+export async function dismissReleaseReview(releaseId: string): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    const { data: row, error: readError } = await client
+      .from('releases')
+      .select('id, flagged_against_release_id')
+      .eq('id', releaseId)
+      .maybeSingle();
+
+    if (readError || !row) {
+      console.error('[DB] dismissReleaseReview read failed:', readError?.message ?? 'not found');
+      return false;
+    }
+
+    const counterpartId = (row as { flagged_against_release_id: string | null }).flagged_against_release_id;
+    const ids = counterpartId ? [releaseId, counterpartId] : [releaseId];
+
+    const { error } = await client
+      .from('releases')
+      .update({ needs_review: false, flagged_against_release_id: null })
+      .in('id', ids);
+
+    if (error) {
+      console.error('[DB] dismissReleaseReview update failed:', error.message);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[DB] dismissReleaseReview error:', error);
+    return false;
+  }
+}
+
+export interface MergeReleasesResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * "These are the same release." Moves every source off `dropId` onto `keepId`, fills in
+ * whatever `keepId` is missing (date, artwork) without overwriting anything it already has or
+ * anything an artist curated, then deletes the now-empty `dropId` row.
+ *
+ * Sources are moved **before** the duplicate row is deleted, and the delete is only attempted
+ * once that move has succeeded — this project has already lost data once to a delete-before-a-
+ * fallible-write (PR #350, an artist's links wiped by a preview), and a release merge is the
+ * same shape of risk.
+ *
+ * Refuses the merge outright if both releases already carry a source on the same platform,
+ * rather than silently dropping one — a merge with an ambiguous outcome should stop and ask,
+ * not guess which of two conflicting sources to keep.
+ */
+export async function mergeReleases(keepId: string, dropId: string): Promise<MergeReleasesResult> {
+  const client = getClient();
+  if (!client) return { ok: false, error: 'Database not configured' };
+  if (keepId === dropId) return { ok: false, error: 'Cannot merge a release into itself' };
+
+  try {
+    const [{ data: keepSources, error: keepError }, { data: dropSources, error: dropError }] = await Promise.all([
+      client.from('release_sources').select('platform').eq('release_id', keepId),
+      client.from('release_sources').select('id, platform').eq('release_id', dropId),
+    ]);
+
+    if (keepError || dropError) {
+      console.error('[DB] mergeReleases read failed:', keepError?.message, dropError?.message);
+      return { ok: false, error: 'Failed to read sources' };
+    }
+
+    const keepPlatforms = new Set((keepSources as { platform: string }[] | null || []).map(s => s.platform));
+    const drop = (dropSources as { id: string; platform: string }[] | null) || [];
+    const conflicting = drop.filter(s => keepPlatforms.has(s.platform));
+
+    if (conflicting.length > 0) {
+      const platforms = conflicting.map(c => c.platform).join(', ');
+      return { ok: false, error: `Both releases already have a source on: ${platforms} — resolve manually` };
+    }
+
+    if (drop.length > 0) {
+      const { error: moveError } = await client
+        .from('release_sources')
+        .update({ release_id: keepId })
+        .eq('release_id', dropId);
+
+      if (moveError) {
+        console.error('[DB] mergeReleases move failed:', moveError.message);
+        return { ok: false, error: 'Failed to move sources' };
+      }
+    }
+
+    const [{ data: keepRow }, { data: dropRow }] = await Promise.all([
+      client.from('releases').select('release_date, artwork_url, curated_fields').eq('id', keepId).maybeSingle(),
+      client.from('releases').select('release_date, date_precision, artwork_url').eq('id', dropId).maybeSingle(),
+    ]);
+
+    if (keepRow && dropRow) {
+      const curated = new Set((keepRow as { curated_fields: string[] | null }).curated_fields ?? []);
+      const patch: Record<string, unknown> = {};
+      const keep = keepRow as { release_date: string | null; artwork_url: string | null };
+      const drop2 = dropRow as { release_date: string | null; date_precision: string | null; artwork_url: string | null };
+
+      if (!curated.has('release_date') && drop2.release_date && !keep.release_date) {
+        patch.release_date = drop2.release_date;
+        patch.date_precision = drop2.date_precision;
+      }
+      if (!curated.has('artwork_url') && drop2.artwork_url && !keep.artwork_url) {
+        patch.artwork_url = drop2.artwork_url;
+      }
+      if (Object.keys(patch).length > 0) {
+        await client.from('releases').update(patch).eq('id', keepId);
+      }
+    }
+
+    // Safe now: every source under dropId has been moved (or there were none), and the
+    // conflict check above means nothing was left behind to lose.
+    const { error: deleteError } = await client.from('releases').delete().eq('id', dropId);
+    if (deleteError) {
+      console.error('[DB] mergeReleases delete failed:', deleteError.message);
+      return { ok: false, error: 'Sources moved, but failed to remove the duplicate row' };
+    }
+
+    const { error: clearError } = await client
+      .from('releases')
+      .update({ needs_review: false, flagged_against_release_id: null })
+      .eq('id', keepId);
+    if (clearError) console.error('[DB] mergeReleases clear-flag failed:', clearError.message);
+
+    return { ok: true };
+  } catch (error) {
+    console.error('[DB] mergeReleases error:', error);
+    return { ok: false, error: 'Unexpected error' };
+  }
+}
 
 // --- Bandcamp slug-probe cache (UNS-152) ---
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -1769,7 +1769,9 @@ export interface ArtistPageRelease {
   datePrecision: string | null;
   status: string;
   artworkUrl: string | null;
-  offers: { price: number | null; currency: string | null; availability: string }[];
+  // Platform attribution kept per-source (not flattened) so the UI can show *where* a release
+  // is available, not just the cheapest number across everywhere it happens to be sold.
+  sources: { platform: string; offers: { price: number | null; currency: string | null; availability: string }[] }[];
 }
 
 /**
@@ -1795,7 +1797,7 @@ export async function getArtistReleases(
       .from('releases')
       .select(
         'slug, title, release_type, release_date, date_precision, status, artwork_url,' +
-        ' release_sources ( release_offers ( price, currency, availability ) )',
+        ' release_sources ( platform, release_offers ( price, currency, availability ) )',
         { count: 'exact' }
       )
       .eq('artist_id', artistId)
@@ -1817,7 +1819,10 @@ export async function getArtistReleases(
       date_precision: string | null;
       status: string;
       artwork_url: string | null;
-      release_sources: { release_offers: { price: number | null; currency: string | null; availability: string }[] | null }[] | null;
+      release_sources: {
+        platform: string;
+        release_offers: { price: number | null; currency: string | null; availability: string }[] | null;
+      }[] | null;
     };
 
     // Through `unknown`: PostgREST types a nested select as a union that includes an error
@@ -1830,7 +1835,7 @@ export async function getArtistReleases(
       datePrecision: r.date_precision,
       status: r.status,
       artworkUrl: r.artwork_url,
-      offers: (r.release_sources || []).flatMap(s => s.release_offers || []),
+      sources: (r.release_sources || []).map(s => ({ platform: s.platform, offers: s.release_offers || [] })),
     }));
 
     return { releases, total: count ?? releases.length };

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3,6 +3,7 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
+import { isFuzzyReleaseMatch } from './release-utils';
 import { requestArtistCatalog } from './request-catalog';
 
 let supabase: SupabaseClient | null = null;
@@ -797,29 +798,345 @@ export async function persistReleaseDetail(
   }
 }
 
-/** The stored Bandcamp link for an artist, if we have one. */
-export async function getArtistBandcampUrl(artistId: string): Promise<string | null> {
+/** What the Discogs and MusicBrainz catalog passes need before they can start. */
+export interface ArtistForCatalog {
+  name: string;
+  bandcampUrl: string | null;
+  discogsUrl: string | null;
+}
+
+/**
+ * One read for everything cataloging needs to know about an artist: the display name
+ * (Discogs and MusicBrainz are both looked up by name, not by a stored id) plus whichever of
+ * the Bandcamp/Discogs links are on file. Returns null only when the artist row itself is
+ * missing — a source link being absent is a normal, independent per-source outcome, not a
+ * reason to fail the whole lookup.
+ */
+export async function getArtistForCatalog(artistId: string): Promise<ArtistForCatalog | null> {
   const client = getClient();
   if (!client) return null;
 
   try {
-    const { data, error } = await client
-      .from('artist_links')
-      .select('url')
-      .eq('artist_id', artistId)
-      .eq('platform', 'bandcamp')
-      .maybeSingle();
+    const [{ data: artistRow, error: artistError }, { data: linkRows, error: linkError }] = await Promise.all([
+      client.from('artists').select('name').eq('id', artistId).maybeSingle(),
+      client.from('artist_links').select('platform, url').eq('artist_id', artistId).in('platform', ['bandcamp', 'discogs']),
+    ]);
 
-    if (error) {
-      console.error('[DB] getArtistBandcampUrl failed:', error.message);
+    if (artistError || !artistRow) {
+      if (artistError) console.error('[DB] getArtistForCatalog artist read failed:', artistError.message);
       return null;
     }
-    return (data as { url: string } | null)?.url ?? null;
+    if (linkError) console.error('[DB] getArtistForCatalog link read failed:', linkError.message);
+
+    const links = (linkRows as { platform: string; url: string }[] | null) || [];
+    return {
+      name: (artistRow as { name: string }).name,
+      bandcampUrl: links.find(l => l.platform === 'bandcamp')?.url ?? null,
+      discogsUrl: links.find(l => l.platform === 'discogs')?.url ?? null,
+    };
   } catch (error) {
-    console.error('[DB] getArtistBandcampUrl error:', error);
+    console.error('[DB] getArtistForCatalog error:', error);
     return null;
   }
 }
+
+interface DiscogsReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  masterId: string;
+  mainReleaseId: string;
+}
+
+/**
+ * Write a Discogs catalog pass, merging into whatever's already there rather than replacing
+ * it — same shape and same three rules as `persistReleases`, plus a fourth this source needs
+ * and Bandcamp didn't, because Bandcamp is the only source in the catalog:
+ *
+ * 4. **Prefer the hard identifier over the title guess.** `discogs_master_id` is Discogs'
+ *    own "these pressings are one album" conclusion — tier 1 in the dedup scheme (spec §4).
+ *    Only fall back to `(release_type, match_key)` — tier 2 — when this artist has no row
+ *    with that master id yet, and only when that tier-2 candidate doesn't already carry a
+ *    *different* master id (which would mean the title match is coincidental, not the same
+ *    release). And when nothing matches exactly but a title is merely *close* to an existing
+ *    one — `isFuzzyReleaseMatch` — this never merges either: it inserts a new row and flags
+ *    both `needs_review`, which is tier 3. A human decides; the catalog never silently
+ *    asserts two different albums are the same one.
+ */
+export async function persistDiscogsReleases(
+  artistId: string,
+  releases: DiscogsReleaseToPersist[]
+): Promise<PersistedRelease[]> {
+  const client = getClient();
+  if (!client || releases.length === 0) return [];
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, release_date, curated_fields, discogs_master_id')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistDiscogsReleases read failed:', readError.message);
+      return [];
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      curated_fields: string[] | null;
+      discogs_master_id: string | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMasterId = new Map(
+      existing.filter(r => r.discogs_master_id).map(r => [r.discogs_master_id as string, r])
+    );
+    const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
+    const byType = new Map<string, ExistingRow[]>();
+    for (const row of existing) {
+      const bucket = byType.get(row.release_type);
+      if (bucket) bucket.push(row);
+      else byType.set(row.release_type, [row]);
+    }
+    const takenSlugs = new Set(existing.map(r => r.slug));
+
+    const written: PersistedRelease[] = [];
+
+    for (const release of releases) {
+      let prior = byMasterId.get(release.masterId);
+      let matchedByMasterId = Boolean(prior);
+
+      if (!prior) {
+        const exact = byIdentity.get(`${release.releaseType}:${release.matchKey}`);
+        if (exact && (!exact.discogs_master_id || exact.discogs_master_id === release.masterId)) {
+          prior = exact;
+        }
+      }
+
+      if (!prior) {
+        // Tier 3: nothing exact, but something close enough to warrant a human look. Never
+        // merge — insert a new row below and flag both sides, rather than guessing.
+        const candidates = byType.get(release.releaseType) ?? [];
+        const fuzzy = candidates.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistDiscogsReleases fuzzy-flag failed:', flagError.message);
+        }
+      }
+
+      let releaseId: string;
+      let curatedFields: string[];
+
+      if (prior) {
+        const curated = new Set(prior.curated_fields ?? []);
+        curatedFields = [...curated];
+        const patch: Record<string, unknown> = {};
+
+        // Title is only ever taken from a hard-identifier match (a re-crawl of a release we
+        // already know is this one). A tier-2 title-equality match means the two titles
+        // already normalize the same — overwriting risks nothing informative and risks
+        // clobbering a display-quality title Bandcamp already got right.
+        if (!curated.has('title') && matchedByMasterId) patch.title = release.title;
+        if (!prior.discogs_master_id) patch.discogs_master_id = release.masterId;
+        if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
+          patch.release_date = release.releaseDate;
+          patch.date_precision = release.datePrecision;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistDiscogsReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            release_date: release.releaseDate,
+            date_precision: release.datePrecision,
+            status: release.status,
+            discogs_master_id: release.masterId,
+            source: 'auto',
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistDiscogsReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        curatedFields = [];
+
+        const createdRow: ExistingRow = {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          release_date: release.releaseDate,
+          curated_fields: [],
+          discogs_master_id: release.masterId,
+        };
+        byMasterId.set(release.masterId, createdRow);
+        const bucket = byType.get(release.releaseType);
+        if (bucket) bucket.push(createdRow);
+        else byType.set(release.releaseType, [createdRow]);
+      }
+
+      const { data: sourceRow, error: sourceError } = await client
+        .from('release_sources')
+        .upsert(
+          {
+            release_id: releaseId,
+            platform: 'discogs',
+            // The specific pressing Discogs treats as this master's representative release —
+            // a real listing page, unlike the abstract master page.
+            url: `https://www.discogs.com/release/${release.mainReleaseId}`,
+            external_id: release.masterId,
+            last_seen_at: new Date().toISOString(),
+          },
+          { onConflict: 'release_id,platform' }
+        )
+        .select('id, url, detail_checked_at')
+        .single();
+
+      if (sourceError || !sourceRow) {
+        console.error('[DB] persistDiscogsReleases source upsert failed:', sourceError?.message);
+        continue;
+      }
+
+      const source = sourceRow as { id: string; url: string; detail_checked_at: string | null };
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields,
+      });
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistDiscogsReleases error:', error);
+    return [];
+  }
+}
+
+interface MusicBrainzEnrichmentInput {
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  mbid: string;
+}
+
+/**
+ * Fill in what MusicBrainz knows about releases we already have: a date at whatever precision
+ * MusicBrainz actually carries, and the release-group MBID as a hard identity anchor for
+ * future dedup passes (including Discogs and Bandcamp re-crawls, once one of them also finds
+ * this MBID some other way).
+ *
+ * **Update-only, by design.** MusicBrainz has no purchase link to offer, so unlike Bandcamp
+ * and Discogs this never inserts a new release row — a release page with a date and nowhere
+ * to buy it would be a worse outcome than not having the page at all.
+ *
+ * Matches tier 1 (an existing `musicbrainz_release_group_id`) first, then tier 2
+ * (`release_type` + `match_key`) — and only when that tier-2 candidate doesn't already carry
+ * a *different* MBID, which would mean the title match is coincidental. Returns how many rows
+ * were touched.
+ */
+export async function persistMusicBrainzEnrichment(
+  artistId: string,
+  groups: MusicBrainzEnrichmentInput[]
+): Promise<number> {
+  const client = getClient();
+  if (!client || groups.length === 0) return 0;
+
+  try {
+    const { data: existingRows, error } = await client
+      .from('releases')
+      .select('id, match_key, release_type, release_date, curated_fields, musicbrainz_release_group_id')
+      .eq('artist_id', artistId);
+
+    if (error) {
+      console.error('[DB] persistMusicBrainzEnrichment read failed:', error.message);
+      return 0;
+    }
+
+    type ExistingRow = {
+      id: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      curated_fields: string[] | null;
+      musicbrainz_release_group_id: string | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMbid = new Map(
+      existing.filter(r => r.musicbrainz_release_group_id).map(r => [r.musicbrainz_release_group_id as string, r])
+    );
+    const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
+
+    let touched = 0;
+
+    for (const group of groups) {
+      let row = byMbid.get(group.mbid);
+      if (!row) {
+        const candidate = byIdentity.get(`${group.releaseType}:${group.matchKey}`);
+        if (candidate && (!candidate.musicbrainz_release_group_id || candidate.musicbrainz_release_group_id === group.mbid)) {
+          row = candidate;
+        }
+      }
+      // MusicBrainz alone never creates a row — if nothing here matches, there's nothing yet
+      // to attach this enrichment to.
+      if (!row) continue;
+
+      const curated = new Set(row.curated_fields ?? []);
+      const patch: Record<string, unknown> = {};
+      if (!row.musicbrainz_release_group_id) patch.musicbrainz_release_group_id = group.mbid;
+      if (!curated.has('release_date') && group.releaseDate && !row.release_date) {
+        patch.release_date = group.releaseDate;
+        patch.date_precision = group.datePrecision;
+      }
+      if (Object.keys(patch).length === 0) continue;
+
+      const { error: updateError } = await client.from('releases').update(patch).eq('id', row.id);
+      if (updateError) {
+        console.error('[DB] persistMusicBrainzEnrichment update failed:', updateError.message);
+        continue;
+      }
+      touched++;
+    }
+
+    return touched;
+  } catch (error) {
+    console.error('[DB] persistMusicBrainzEnrichment error:', error);
+    return 0;
+  }
+}
+
 
 // --- Bandcamp slug-probe cache (UNS-152) ---
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -860,19 +860,21 @@ export async function persistReleaseDetail(
   }
 }
 
-/** What the Discogs and MusicBrainz catalog passes need before they can start. */
+/** What the catalog passes need before they can start. */
 export interface ArtistForCatalog {
   name: string;
   bandcampUrl: string | null;
   discogsUrl: string | null;
+  faircampUrl: string | null;
+  officialSiteUrl: string | null;
 }
 
 /**
  * One read for everything cataloging needs to know about an artist: the display name
  * (Discogs and MusicBrainz are both looked up by name, not by a stored id) plus whichever of
- * the Bandcamp/Discogs links are on file. Returns null only when the artist row itself is
- * missing — a source link being absent is a normal, independent per-source outcome, not a
- * reason to fail the whole lookup.
+ * the known links are on file. Returns null only when the artist row itself is missing — a
+ * source link being absent is a normal, independent per-source outcome, not a reason to fail
+ * the whole lookup.
  */
 export async function getArtistForCatalog(artistId: string): Promise<ArtistForCatalog | null> {
   const client = getClient();
@@ -881,7 +883,11 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
   try {
     const [{ data: artistRow, error: artistError }, { data: linkRows, error: linkError }] = await Promise.all([
       client.from('artists').select('name').eq('id', artistId).maybeSingle(),
-      client.from('artist_links').select('platform, url').eq('artist_id', artistId).in('platform', ['bandcamp', 'discogs']),
+      client
+        .from('artist_links')
+        .select('platform, url')
+        .eq('artist_id', artistId)
+        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'officialsite']),
     ]);
 
     if (artistError || !artistRow) {
@@ -895,6 +901,8 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
       name: (artistRow as { name: string }).name,
       bandcampUrl: links.find(l => l.platform === 'bandcamp')?.url ?? null,
       discogsUrl: links.find(l => l.platform === 'discogs')?.url ?? null,
+      faircampUrl: links.find(l => l.platform === 'faircamp')?.url ?? null,
+      officialSiteUrl: links.find(l => l.platform === 'officialsite')?.url ?? null,
     };
   } catch (error) {
     console.error('[DB] getArtistForCatalog error:', error);
@@ -1198,6 +1206,211 @@ export async function persistMusicBrainzEnrichment(
   } catch (error) {
     console.error('[DB] persistMusicBrainzEnrichment error:', error);
     return 0;
+  }
+}
+
+/**
+ * Write a Faircamp catalog pass.
+ *
+ * Matches on `match_key` **alone**, not `(release_type, match_key)` like every other source —
+ * Faircamp's own release-type guess (`mapDiscogsFormatToReleaseType` reading just a title) is
+ * unreliable enough that partitioning by it would systematically block the one thing that
+ * makes Faircamp worth ingesting: merging into a release Bandcamp or Discogs already typed
+ * correctly, adding Faircamp as a second source on the *same* row instead of a duplicate. When
+ * nothing matches exactly, a title merely *close* to an existing one still only ever flags
+ * (tier 3, `isFuzzyReleaseMatch`) — never merges — same as Discogs.
+ *
+ * Release type is never overwritten on an existing row; whichever source typed it first stands.
+ */
+interface FaircampReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  status: string;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+export async function persistFaircampReleases(
+  artistId: string,
+  releases: FaircampReleaseToPersist[]
+): Promise<PersistedRelease[]> {
+  const client = getClient();
+  if (!client || releases.length === 0) return [];
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, artwork_url, curated_fields')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistFaircampReleases read failed:', readError.message);
+      return [];
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      artwork_url: string | null;
+      curated_fields: string[] | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
+    const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+
+    const written: PersistedRelease[] = [];
+
+    for (const release of releases) {
+      const prior = byMatchKey.get(release.matchKey);
+
+      let releaseId: string;
+      let curatedFields: string[];
+
+      if (prior) {
+        const curated = new Set(prior.curated_fields ?? []);
+        curatedFields = [...curated];
+        const patch: Record<string, unknown> = {};
+
+        if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
+          patch.artwork_url = release.artworkUrl;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistFaircampReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        const fuzzy = existing.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
+
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            status: release.status,
+            artwork_url: release.artworkUrl,
+            source: 'auto',
+            ...(fuzzy && { needs_review: true, flagged_against_release_id: fuzzy.id }),
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistFaircampReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        curatedFields = [];
+
+        const createdRow: ExistingRow = {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          artwork_url: release.artworkUrl,
+          curated_fields: [],
+        };
+        byMatchKey.set(release.matchKey, createdRow);
+        existing.push(createdRow);
+
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true, flagged_against_release_id: releaseId })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistFaircampReleases fuzzy-flag failed:', flagError.message);
+        }
+      }
+
+      const source = await upsertReleaseSource(client, releaseId, 'faircamp', release.externalUrl, release.externalUrl, claimedKeys);
+      if (!source) {
+        console.error('[DB] persistFaircampReleases source write failed for release', releaseId);
+        continue;
+      }
+
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields,
+      });
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistFaircampReleases error:', error);
+    return [];
+  }
+}
+
+/**
+ * Attach a source *discovered* on some other page (never fetched directly — see
+ * `findDiscoveredReleaseLinks`) to an existing release, matched by **exact** normalized title.
+ * Exact only, deliberately: a wrong attachment here would point a fan at a different record
+ * than the one they're looking at, which is worse than never finding the link at all. Refuses
+ * rather than guesses when the match key is ambiguous (two releases share it) or the release
+ * already has a source for this platform.
+ */
+export async function attachDiscoveredSource(
+  artistId: string,
+  platform: string,
+  url: string,
+  matchKey: string
+): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    const { data, error } = await client
+      .from('releases')
+      .select('id, release_sources ( platform )')
+      .eq('artist_id', artistId)
+      .eq('match_key', matchKey);
+
+    if (error) {
+      console.error('[DB] attachDiscoveredSource read failed:', error.message);
+      return false;
+    }
+
+    const matches = (data as { id: string; release_sources: { platform: string }[] | null }[]) || [];
+    if (matches.length !== 1) return false; // no match, or ambiguous — never guess
+
+    const release = matches[0];
+    if ((release.release_sources || []).some(s => s.platform === platform)) return false;
+
+    const { error: insertError } = await client.from('release_sources').insert({
+      release_id: release.id,
+      platform,
+      url,
+      external_id: null,
+      source: 'auto',
+    });
+
+    if (insertError) {
+      console.error('[DB] attachDiscoveredSource insert failed:', insertError.message);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[DB] attachDiscoveredSource error:', error);
+    return false;
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -518,6 +518,66 @@ export async function recordCatalogOutcome(
   }
 }
 
+export interface CatalogStateRow {
+  last_catalogued_at: string | null;
+  last_attempted_at: string;
+  releases_found: number | null;
+  releases_detailed: number | null;
+  last_error: string | null;
+  consecutive_failures: number;
+}
+
+/**
+ * Deliberately three-valued, not two. "We couldn't ask" and "we asked and this artist has never
+ * been catalogued" are different facts, and collapsing them into one `null` makes a broken
+ * database read render as a confident "Never catalogued" — the same shape as the bug class the
+ * "never cache uncertainty" principle exists to prevent. Every surface that reports cataloging
+ * exists to make it observable, so an unreadable state has to say so rather than guess.
+ */
+export type CatalogStateResult =
+  | { ok: true; state: CatalogStateRow | null }
+  | { ok: false; reason: string };
+
+export async function getCatalogState(artistId: string): Promise<CatalogStateResult> {
+  const client = getClient();
+  if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
+
+  const { data, error } = await client
+    .from('release_catalog_state')
+    .select('last_catalogued_at, last_attempted_at, releases_found, releases_detailed, last_error, consecutive_failures')
+    .eq('artist_id', artistId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[DB] getCatalogState failed:', error.message);
+    return { ok: false, reason: 'Could not read catalog state' };
+  }
+  return { ok: true, state: (data as CatalogStateRow | null) ?? null };
+}
+
+/**
+ * Clear an artist's cooldown so a deliberately-requested crawl actually runs.
+ *
+ * Without it a "catalog now" control would appear to work and do nothing for a week —
+ * `claimArtistForCatalog` refuses an artist catalogued in the last 7 days, which is right for
+ * demand-driven triggers and wrong for someone deliberately asking.
+ *
+ * Backdated rather than deleted: the row also carries the failure counter and the last error,
+ * which are worth keeping. Two hours clears both the cooldown and the exponential backoff.
+ */
+export async function clearCatalogCooldown(artistId: string): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  const twoHoursAgo = new Date(Date.now() - 2 * 3600_000).toISOString();
+  const { error } = await client
+    .from('release_catalog_state')
+    .update({ last_catalogued_at: null, last_attempted_at: twoHoursAgo, consecutive_failures: 0 })
+    .eq('artist_id', artistId);
+
+  if (error) console.error('[DB] clearCatalogCooldown failed:', error.message);
+}
+
 interface ReleaseToPersist {
   title: string;
   slug: string;

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -1653,6 +1653,33 @@ export async function mergeReleases(keepId: string, dropId: string): Promise<Mer
   if (keepId === dropId) return { ok: false, error: 'Cannot merge a release into itself' };
 
   try {
+    // Both releases must belong to the same artist. The invariant lives *here*, not only at the
+    // call sites, because a merge is close to irreversible — sources are moved and a row is
+    // deleted — and the two callers reach it by different routes: the artist endpoint proves
+    // ownership of both ids (`verifyReleaseOwnership`), while the admin endpoint passes ids
+    // straight from a request body. Today the admin UI only ever submits pairs from the review
+    // queue, which is same-artist by construction, but "no caller currently sends a mismatched
+    // pair" is not something the database should be relying on.
+    const { data: pair, error: pairError } = await client
+      .from('releases')
+      .select('id, artist_id')
+      .in('id', [keepId, dropId]);
+
+    if (pairError) {
+      console.error('[DB] mergeReleases identity read failed:', pairError.message);
+      return { ok: false, error: 'Failed to read releases' };
+    }
+
+    const rows = (pair as { id: string; artist_id: string }[] | null) || [];
+    if (rows.length !== 2) return { ok: false, error: 'One or both releases could not be found' };
+    if (rows[0].artist_id !== rows[1].artist_id) {
+      // Deliberately not reported back with the artist ids in it — the caller supplied a pair
+      // they had no business pairing, and echoing whose release the other one is would confirm
+      // the existence of a row they can't otherwise see.
+      console.error('[DB] mergeReleases refused a cross-artist merge');
+      return { ok: false, error: 'Those releases belong to different artists' };
+    }
+
     const [{ data: keepSources, error: keepError }, { data: dropSources, error: dropError }] = await Promise.all([
       client.from('release_sources').select('platform').eq('release_id', keepId),
       client.from('release_sources').select('id, platform').eq('release_id', dropId),

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3,7 +3,14 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
-import { isFuzzyReleaseMatch } from './release-utils';
+import {
+  deriveStatus,
+  isFuzzyReleaseMatch,
+  mapReleaseType,
+  parseReleaseDate,
+  releaseMatchKey,
+  uniqueReleaseSlug,
+} from './release-utils';
 import { requestArtistCatalog } from './request-catalog';
 
 let supabase: SupabaseClient | null = null;
@@ -556,6 +563,69 @@ export interface PersistedRelease {
  * Bandcamp grid is newest first, so a budgeted detail pass reading the front of the list
  * spends its requests on the releases a fan is most likely to be looking at.
  */
+/**
+ * Which `(release_id, platform)` source rows an artist has claimed — added or corrected
+ * themselves via the curation UI, rather than ingest. Every ingest path must read this before
+ * writing a source row: a re-crawl silently overwriting an artist's fix in 30 days would be the
+ * exact "ingest clobbers a curated edit" bug `curated_fields` exists to prevent on `releases`
+ * itself, just one table over.
+ */
+async function getClaimedSourceKeys(client: SupabaseClient, releaseIds: string[]): Promise<Set<string>> {
+  if (releaseIds.length === 0) return new Set();
+
+  const { data, error } = await client
+    .from('release_sources')
+    .select('release_id, platform')
+    .eq('source', 'claimed')
+    .in('release_id', releaseIds);
+
+  if (error) {
+    console.error('[DB] getClaimedSourceKeys failed:', error.message);
+    return new Set();
+  }
+
+  return new Set((data as { release_id: string; platform: string }[] || []).map(r => `${r.release_id}:${r.platform}`));
+}
+
+/**
+ * Write one release's source row — or, if an artist has claimed this exact release+platform,
+ * read the existing (untouched) row back instead. The one place every ingest path goes through
+ * to write `release_sources`, so "never overwrite a claimed URL" only has to be correct once.
+ */
+async function upsertReleaseSource(
+  client: SupabaseClient,
+  releaseId: string,
+  platform: string,
+  url: string,
+  externalId: string | null,
+  claimedKeys: Set<string>
+): Promise<{ id: string; url: string; detail_checked_at: string | null } | null> {
+  if (claimedKeys.has(`${releaseId}:${platform}`)) {
+    const { data, error } = await client
+      .from('release_sources')
+      .select('id, url, detail_checked_at')
+      .eq('release_id', releaseId)
+      .eq('platform', platform)
+      .maybeSingle();
+    if (error || !data) return null;
+    return data as { id: string; url: string; detail_checked_at: string | null };
+  }
+
+  // detail_checked_at is read back rather than written: it belongs to the detail pass, and a
+  // grid re-crawl must not reset it or every crawl would re-fetch every release page.
+  const { data, error } = await client
+    .from('release_sources')
+    .upsert(
+      { release_id: releaseId, platform, url, external_id: externalId, last_seen_at: new Date().toISOString() },
+      { onConflict: 'release_id,platform' }
+    )
+    .select('id, url, detail_checked_at')
+    .single();
+
+  if (error || !data) return null;
+  return data as { id: string; url: string; detail_checked_at: string | null };
+}
+
 export async function persistReleases(
   artistId: string,
   releases: ReleaseToPersist[]
@@ -586,6 +656,7 @@ export async function persistReleases(
     const existing = (existingRows as ExistingRow[]) || [];
     const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -656,29 +727,20 @@ export async function persistReleases(
         });
       }
 
-      // detail_checked_at is read back rather than written: it belongs to the detail pass, and
-      // a grid re-crawl must not reset it or every crawl would re-fetch every release page.
-      const { data: sourceRow, error: sourceError } = await client
-        .from('release_sources')
-        .upsert(
-          {
-            release_id: releaseId,
-            platform: release.source.platform,
-            url: release.source.url,
-            external_id: release.source.externalId,
-            last_seen_at: new Date().toISOString(),
-          },
-          { onConflict: 'release_id,platform' }
-        )
-        .select('id, url, detail_checked_at')
-        .single();
+      const source = await upsertReleaseSource(
+        client,
+        releaseId,
+        release.source.platform,
+        release.source.url,
+        release.source.externalId,
+        claimedKeys
+      );
 
-      if (sourceError || !sourceRow) {
-        console.error('[DB] persistReleases source upsert failed:', sourceError?.message);
+      if (!source) {
+        console.error('[DB] persistReleases source write failed for release', releaseId);
         continue;
       }
 
-      const source = sourceRow as { id: string; url: string; detail_checked_at: string | null };
       written.push({
         releaseId,
         sourceId: source.id,
@@ -906,6 +968,7 @@ export async function persistDiscogsReleases(
       else byType.set(row.release_type, [row]);
     }
     const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -1013,29 +1076,22 @@ export async function persistDiscogsReleases(
         }
       }
 
-      const { data: sourceRow, error: sourceError } = await client
-        .from('release_sources')
-        .upsert(
-          {
-            release_id: releaseId,
-            platform: 'discogs',
-            // The specific pressing Discogs treats as this master's representative release —
-            // a real listing page, unlike the abstract master page.
-            url: `https://www.discogs.com/release/${release.mainReleaseId}`,
-            external_id: release.masterId,
-            last_seen_at: new Date().toISOString(),
-          },
-          { onConflict: 'release_id,platform' }
-        )
-        .select('id, url, detail_checked_at')
-        .single();
+      const source = await upsertReleaseSource(
+        client,
+        releaseId,
+        'discogs',
+        // The specific pressing Discogs treats as this master's representative release — a
+        // real listing page, unlike the abstract master page.
+        `https://www.discogs.com/release/${release.mainReleaseId}`,
+        release.masterId,
+        claimedKeys
+      );
 
-      if (sourceError || !sourceRow) {
-        console.error('[DB] persistDiscogsReleases source upsert failed:', sourceError?.message);
+      if (!source) {
+        console.error('[DB] persistDiscogsReleases source write failed for release', releaseId);
         continue;
       }
 
-      const source = sourceRow as { id: string; url: string; detail_checked_at: string | null };
       written.push({
         releaseId,
         sourceId: source.id,
@@ -1395,6 +1451,374 @@ export async function mergeReleases(keepId: string, dropId: string): Promise<Mer
     return { ok: true };
   } catch (error) {
     console.error('[DB] mergeReleases error:', error);
+    return { ok: false, error: 'Unexpected error' };
+  }
+}
+
+// --- Artist release curation (spec §11) ---
+//
+// The artist-facing half of the dedup backstop, and the durable fix for whatever the ~4%
+// wrong-artist probe rate and under-merge bias leave behind: a verified artist reviewing their
+// own catalog is the one source of ground truth ingest can never have. Every write here goes
+// through the same "service role + server-side ownership check" convention as
+// `api/functions/artist-profile.ts` — there is no RLS policy keyed to auth.uid() for these
+// tables (see the comment on `releases` in the schema migration), so the ownership check below
+// *is* the security boundary, not a UI nicety.
+
+export interface OwnedArtistCheck {
+  ok: boolean;
+  status: number;
+  error?: string;
+  artistId?: string;
+  artistName?: string;
+}
+
+/**
+ * Resolve a slug to an artist and verify the given user owns a verified claim on it. The same
+ * check `artist-profile.ts` inlines for bio/link edits, factored out here so newer
+ * release-curation endpoints don't each carry their own copy of an auth-critical block.
+ */
+export async function resolveOwnedArtist(slug: string, userId: string): Promise<OwnedArtistCheck> {
+  const client = getClient();
+  if (!client) return { ok: false, status: 500, error: 'Database not configured' };
+
+  const { data: artist, error: findError } = await client
+    .from('artists')
+    .select('id, name')
+    .eq('slug', slug)
+    .single();
+
+  if (findError || !artist) return { ok: false, status: 404, error: 'Artist not found' };
+
+  const { data: profile, error: profileError } = await client
+    .from('artist_profiles')
+    .select('user_id, verified_at')
+    .eq('artist_id', artist.id)
+    .single();
+
+  if (profileError || !profile) return { ok: false, status: 404, error: 'Profile not found' };
+  if (profile.user_id !== userId) return { ok: false, status: 403, error: 'You do not own this profile' };
+  if (!profile.verified_at) return { ok: false, status: 403, error: 'Profile not yet verified' };
+
+  return { ok: true, status: 200, artistId: (artist as { id: string }).id, artistName: (artist as { name: string }).name };
+}
+
+/**
+ * Do all of these release ids actually belong to this artist? `resolveOwnedArtist` proves the
+ * caller owns *an* artist profile — it says nothing about whether the release ids they sent in
+ * the request body are that artist's. Every action that takes a release id from the client
+ * must check this before touching the row, or a claimed artist could hide/merge/edit another
+ * artist's releases by guessing UUIDs.
+ */
+export async function verifyReleaseOwnership(artistId: string, releaseIds: string[]): Promise<boolean> {
+  const client = getClient();
+  if (!client || releaseIds.length === 0) return false;
+
+  const unique = [...new Set(releaseIds)];
+  const { data, error } = await client
+    .from('releases')
+    .select('id')
+    .eq('artist_id', artistId)
+    .in('id', unique);
+
+  if (error) {
+    console.error('[DB] verifyReleaseOwnership failed:', error.message);
+    return false;
+  }
+  return (data || []).length === unique.length;
+}
+
+export interface OwnerReleaseItem {
+  id: string;
+  title: string;
+  slug: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  artworkUrl: string | null;
+  isHidden: boolean;
+  needsReview: boolean;
+  flaggedAgainst: { id: string; title: string } | null;
+  sources: { platform: string; url: string }[];
+}
+
+/**
+ * Every release under this artist — including hidden ones and needs_review ones, unlike the
+ * public `getArtistReleases`, because the whole point of this view is letting the artist see
+ * what ingest did (right or wrong) rather than only what a fan would see.
+ */
+export async function getArtistReleasesForOwner(artistId: string): Promise<OwnerReleaseItem[]> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const { data, error } = await client
+      .from('releases')
+      .select(
+        'id, title, slug, release_type, release_date, date_precision, artwork_url, is_hidden,' +
+        ' needs_review, flagged_against_release_id, release_sources ( platform, url )'
+      )
+      .eq('artist_id', artistId)
+      .order('release_date', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('[DB] getArtistReleasesForOwner failed:', error.message);
+      return [];
+    }
+
+    type Row = {
+      id: string;
+      title: string;
+      slug: string;
+      release_type: string;
+      release_date: string | null;
+      date_precision: string | null;
+      artwork_url: string | null;
+      is_hidden: boolean;
+      needs_review: boolean;
+      flagged_against_release_id: string | null;
+      release_sources: { platform: string; url: string }[] | null;
+    };
+
+    const rows = (data as unknown as Row[]) || [];
+    // The counterpart a release is flagged against is always another row in this same result
+    // set — tier-3 fuzzy matching only ever compares releases under one artist — so resolving
+    // its title costs nothing extra to fetch.
+    const titleById = new Map(rows.map(r => [r.id, r.title]));
+
+    return rows.map(r => ({
+      id: r.id,
+      title: r.title,
+      slug: r.slug,
+      releaseType: r.release_type,
+      releaseDate: r.release_date,
+      datePrecision: r.date_precision,
+      artworkUrl: r.artwork_url,
+      isHidden: r.is_hidden,
+      needsReview: r.needs_review,
+      flaggedAgainst:
+        r.flagged_against_release_id && titleById.has(r.flagged_against_release_id)
+          ? { id: r.flagged_against_release_id, title: titleById.get(r.flagged_against_release_id)! }
+          : null,
+      sources: (r.release_sources || []).map(s => ({ platform: s.platform, url: s.url })),
+    }));
+  } catch (error) {
+    console.error('[DB] getArtistReleasesForOwner error:', error);
+    return [];
+  }
+}
+
+/** "This shouldn't be on my page." Ingest must never write `is_hidden` — only this, or an admin. */
+export async function setReleaseHidden(artistId: string, releaseId: string, hidden: boolean): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+  if (!(await verifyReleaseOwnership(artistId, [releaseId]))) return false;
+
+  const { error } = await client.from('releases').update({ is_hidden: hidden }).eq('id', releaseId);
+  if (error) {
+    console.error('[DB] setReleaseHidden failed:', error.message);
+    return false;
+  }
+  return true;
+}
+
+export interface ReleaseFieldPatch {
+  title?: string;
+  /** null clears the date entirely; omit the key to leave it untouched. */
+  releaseDate?: string | null;
+  artworkUrl?: string | null;
+}
+
+/**
+ * "Fix" — correct a title, date, or artwork ingest got wrong. Every field touched here is
+ * added to `curated_fields`, the existing provenance mechanism that stops a later re-crawl from
+ * silently reverting the artist's correction (see the `releases` migration's own comment on
+ * why this had to ship in step 1, not be retrofitted later).
+ */
+export async function updateArtistReleaseFields(
+  artistId: string,
+  releaseId: string,
+  patch: ReleaseFieldPatch
+): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+  if (!(await verifyReleaseOwnership(artistId, [releaseId]))) return false;
+
+  const { data: row, error: readError } = await client
+    .from('releases')
+    .select('curated_fields')
+    .eq('id', releaseId)
+    .maybeSingle();
+
+  if (readError || !row) {
+    console.error('[DB] updateArtistReleaseFields read failed:', readError?.message ?? 'not found');
+    return false;
+  }
+
+  const curated = new Set((row as { curated_fields: string[] | null }).curated_fields ?? []);
+  const update: Record<string, unknown> = {};
+
+  if (patch.title !== undefined) {
+    const title = patch.title.trim().slice(0, 200);
+    if (!title) return false;
+    update.title = title;
+    curated.add('title');
+  }
+  if (patch.releaseDate !== undefined) {
+    if (patch.releaseDate === null) {
+      update.release_date = null;
+      update.date_precision = 'unknown';
+    } else {
+      const { date, precision } = parseReleaseDate(patch.releaseDate);
+      if (!date) return false;
+      update.release_date = date;
+      update.date_precision = precision;
+    }
+    curated.add('release_date');
+  }
+  if (patch.artworkUrl !== undefined) {
+    update.artwork_url = patch.artworkUrl;
+    curated.add('artwork_url');
+  }
+
+  if (Object.keys(update).length === 0) return true;
+  update.curated_fields = [...curated];
+
+  const { error } = await client.from('releases').update(update).eq('id', releaseId);
+  if (error) {
+    console.error('[DB] updateArtistReleaseFields update failed:', error.message);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * "Add a platform link we missed" — or correct one ingest got wrong. Written with
+ * `source: 'claimed'`, which `getClaimedSourceKeys` (used by every ingest path) checks before
+ * ever overwriting a source's URL — the same "never clobber a curated edit" rule `curated_fields`
+ * enforces on the release row itself, one table over.
+ */
+export async function addArtistReleaseLink(
+  artistId: string,
+  releaseId: string,
+  platform: string,
+  url: string
+): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+  if (!(await verifyReleaseOwnership(artistId, [releaseId]))) return false;
+
+  const { error } = await client.from('release_sources').upsert(
+    {
+      release_id: releaseId,
+      platform,
+      url,
+      external_id: null,
+      source: 'claimed',
+      last_seen_at: new Date().toISOString(),
+    },
+    { onConflict: 'release_id,platform' }
+  );
+
+  if (error) {
+    console.error('[DB] addArtistReleaseLink failed:', error.message);
+    return false;
+  }
+  return true;
+}
+
+export interface NewArtistRelease {
+  title: string;
+  releaseType: string;
+  releaseDate: string | null;
+  platform: string;
+  url: string;
+}
+
+export interface CreateReleaseResult {
+  ok: boolean;
+  error?: string;
+  releaseId?: string;
+}
+
+/**
+ * "Add a release we never found." A release row ingest has no idea exists, so unlike
+ * everything else in this file it is never matched against `existing` — it's simply created,
+ * fully curated from the start (ingest must never touch a hand-authored row).
+ */
+export async function createArtistRelease(artistId: string, input: NewArtistRelease): Promise<CreateReleaseResult> {
+  const client = getClient();
+  if (!client) return { ok: false, error: 'Database not configured' };
+
+  const title = input.title.trim().slice(0, 200);
+  if (!title) return { ok: false, error: 'Title is required' };
+
+  const matchKey = releaseMatchKey(title);
+  if (!matchKey) return { ok: false, error: 'Title needs at least one letter or number' };
+
+  const releaseType = mapReleaseType(input.releaseType);
+  const now = new Date();
+  const { date, precision } = input.releaseDate
+    ? parseReleaseDate(input.releaseDate, now)
+    : { date: null, precision: 'unknown' as const };
+
+  try {
+    const { data: existingSlugs, error: slugError } = await client
+      .from('releases')
+      .select('slug')
+      .eq('artist_id', artistId);
+
+    if (slugError) {
+      console.error('[DB] createArtistRelease slug read failed:', slugError.message);
+      return { ok: false, error: 'Failed to create release' };
+    }
+
+    const taken = new Set(((existingSlugs as { slug: string }[] | null) || []).map(r => r.slug));
+    const slug = uniqueReleaseSlug(title, taken);
+
+    const { data: inserted, error } = await client
+      .from('releases')
+      .insert({
+        artist_id: artistId,
+        title,
+        slug,
+        match_key: matchKey,
+        release_type: releaseType,
+        release_date: date,
+        date_precision: precision,
+        status: deriveStatus(date, false, now),
+        source: 'claimed',
+        curated_fields: ['title', 'release_date'],
+      })
+      .select('id')
+      .single();
+
+    if (error || !inserted) {
+      console.error('[DB] createArtistRelease insert failed:', error?.message);
+      return { ok: false, error: 'Failed to create release' };
+    }
+
+    const releaseId = (inserted as { id: string }).id;
+
+    const { error: sourceError } = await client.from('release_sources').insert({
+      release_id: releaseId,
+      platform: input.platform,
+      url: input.url,
+      external_id: null,
+      source: 'claimed',
+    });
+
+    if (sourceError) {
+      console.error('[DB] createArtistRelease source insert failed:', sourceError.message);
+      // The release itself was created — better to hand back a release missing its one link
+      // than to lose the title/date/type the artist just entered.
+      return { ok: true, releaseId };
+    }
+
+    return { ok: true, releaseId };
+  } catch (error) {
+    console.error('[DB] createArtistRelease error:', error);
     return { ok: false, error: 'Unexpected error' };
   }
 }

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -316,6 +316,9 @@ export const ALLOWED_OUTBOUND_HOSTNAMES = new Set([
   'www.beatport.com',
   'discogs.com',
   'www.discogs.com',
+  // Discogs' actual database API (releases, masters, artist discographies) lives on this
+  // subdomain, distinct from the www host used for social-link scraping above.
+  'api.discogs.com',
   // Music metadata
   'musicbrainz.org',
   'beta.musicbrainz.org',

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -567,3 +567,205 @@ export function ingestMusicBrainzReleaseGroups(
 
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Faircamp — self-hosted, no central API, no reliable date or price
+// ---------------------------------------------------------------------------
+//
+// Every Faircamp instance lives on whatever domain the artist chose (their own subdomain, in
+// the one example this was built against) — there is no directory or API to query, only the
+// same static site a fan lands on. Verified directly against a live instance rather than
+// guessed: the homepage doubles as the release list, since every release is a plain relative
+// link straight off it, and there is no reliable date or price anywhere in Faircamp's own
+// markup — no JSON-LD, no `<time>` tag, no `pubDate` in its own RSS feed. So unlike Bandcamp
+// and Discogs, this ingest only ever produces identity and artwork. A release with no date is
+// an honest "we don't know", not a guess — and this source's whole reason for existing is that
+// a partial, sometimes-wrong catalog beats no catalog at all, with curation (hide/fix) as the
+// backstop for whatever guess turns out wrong.
+
+/** Ceiling on how many relative links one homepage can offer as release candidates. */
+const FAIRCAMP_MAX_CANDIDATES = 30;
+
+/** Slugs that match the release-link shape but never are one, seen or anticipated across themes. */
+const FAIRCAMP_NON_RELEASE_SLUGS = new Set(['subscribe', 'about', 'support', 'contact', 'donate', 'feed', 'blog']);
+
+export interface FaircampReleaseCandidate {
+  slug: string;
+  url: string;
+}
+
+/**
+ * Find candidate release links on a Faircamp artist homepage.
+ *
+ * Deliberately permissive rather than exhaustive: any bare relative path (`slug/`, no query, no
+ * subpath) is a candidate. Some will be wrong — a theme page using an unrecognized slug, say —
+ * accepted per the "even a high failure rate beats nothing" call on this source specifically.
+ */
+export function ingestFaircampHomeLinks(html: string, pageUrl: string): FaircampReleaseCandidate[] {
+  const out: FaircampReleaseCandidate[] = [];
+  const seen = new Set<string>();
+
+  let base: URL;
+  try {
+    base = new URL(pageUrl);
+  } catch {
+    return out;
+  }
+
+  for (const match of html.matchAll(/href="([^"]+)"/g)) {
+    const raw = match[1];
+    if (!/^[a-z0-9][a-z0-9-]*\/$/i.test(raw)) continue;
+
+    const slug = raw.slice(0, -1).toLowerCase();
+    if (FAIRCAMP_NON_RELEASE_SLUGS.has(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+
+    let url: string;
+    try {
+      url = new URL(raw, base).toString();
+    } catch {
+      continue;
+    }
+
+    out.push({ slug, url });
+    if (out.length >= FAIRCAMP_MAX_CANDIDATES) break;
+  }
+
+  return out;
+}
+
+export interface FaircampReleasePage {
+  title: string;
+  artworkUrl: string | null;
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+/**
+ * Pull the two things a Faircamp release page reliably gives us — title and artwork — both
+ * from Open Graph tags, the only markup consistent enough across themes to trust. Returns null
+ * when there's no `og:title` at all, which usually means the candidate link wasn't a release
+ * page (a theme's "more" or "support" page, say) rather than a parse failure worth reporting.
+ */
+export function ingestFaircampReleasePage(html: string): FaircampReleasePage | null {
+  const titleMatch = html.match(/<meta\s+property="og:title"\s+content="([^"]*)"/i);
+  if (!titleMatch) return null;
+
+  const title = decodeHtmlEntities(titleMatch[1]).trim();
+  if (!title) return null;
+
+  const imageMatch = html.match(/<meta\s+property="og:image"\s+content="([^"]*)"/i);
+  const artworkUrl = imageMatch ? decodeHtmlEntities(imageMatch[1]).trim() || null : null;
+
+  return { title, artworkUrl };
+}
+
+export interface FaircampReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  status: ReleaseStatus;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+/**
+ * Combine a homepage candidate with its release page's title/artwork into something ready to
+ * persist. Release type is inferred from the title alone via the same fallback
+ * `mapDiscogsFormatToReleaseType` uses when Discogs' own format string doesn't say — Faircamp
+ * has no format field at all, so this is the same "read the title, otherwise 'other'" call,
+ * reused rather than duplicated.
+ *
+ * `takenSlugs` is read, not written — the caller must add the returned slug before the next
+ * call, since releases are fetched and combined one at a time here rather than as one batch
+ * (each one is its own network request), unlike Bandcamp's grid.
+ */
+export function buildFaircampRelease(
+  page: FaircampReleasePage,
+  releaseUrl: string,
+  takenSlugs: ReadonlySet<string>,
+  now: Date = new Date()
+): FaircampReleaseToPersist | null {
+  const matchKey = releaseMatchKey(page.title);
+  if (!matchKey) return null;
+
+  return {
+    title: page.title,
+    slug: uniqueReleaseSlug(page.title, takenSlugs),
+    matchKey,
+    releaseType: mapDiscogsFormatToReleaseType(null, page.title),
+    status: deriveStatus(null, false, now),
+    artworkUrl: page.artworkUrl,
+    externalUrl: releaseUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovered links — a specific release, spotted on a page we fetched for another reason
+// ---------------------------------------------------------------------------
+//
+// Some platforms (Subvert today) have no fetchable API or page of their own — but an artist's
+// other pages sometimes link directly to a specific release there anyway (their own website
+// linking "buy this on Subvert", say). This never fetches the target platform itself; it only
+// reads links already present in markup fetched for a different reason (a Faircamp page, an
+// official website), and only ever proposes a match — attaching it to an existing release
+// requires an exact title match at the database layer (see `attachDiscoveredSource`), never a
+// guess. A single unmatched slug becomes nothing, not a bare, metadata-less release row.
+
+export interface DiscoveredSourceLink {
+  platform: string;
+  url: string;
+  /** Normalized match key of the release slug, for an exact-match lookup against existing releases. */
+  matchKey: string;
+}
+
+/**
+ * Hosts worth checking, and the shape a link has to have to plausibly point at one specific
+ * release rather than just the artist's own page there. Adding a platform here is a deliberate,
+ * reviewed decision — this is not a generic link scanner.
+ */
+const DISCOVERED_LINK_HOSTS: { platform: string; hostSuffix: string }[] = [{ platform: 'subvert', hostSuffix: 'subvert.fm' }];
+
+export function findDiscoveredReleaseLinks(html: string, pageUrl: string): DiscoveredSourceLink[] {
+  const found: DiscoveredSourceLink[] = [];
+  const seen = new Set<string>();
+
+  for (const match of html.matchAll(/href="([^"]+)"/g)) {
+    let url: URL;
+    try {
+      url = new URL(match[1], pageUrl);
+    } catch {
+      continue;
+    }
+
+    const host = url.hostname.toLowerCase();
+    const platformEntry = DISCOVERED_LINK_HOSTS.find(p => host === p.hostSuffix || host.endsWith(`.${p.hostSuffix}`));
+    if (!platformEntry) continue;
+
+    // At least two path segments — {artist}/{release} — so the artist's own profile link
+    // (just {artist}) is never mistaken for a specific release.
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length < 2) continue;
+
+    const releaseSlug = segments[segments.length - 1];
+    const matchKey = releaseMatchKey(releaseSlug.replace(/-/g, ' '));
+    if (!matchKey) continue;
+
+    const normalized = url.toString();
+    const dedupeKey = `${platformEntry.platform}:${normalized}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    found.push({ platform: platformEntry.platform, url: normalized, matchKey });
+  }
+
+  return found;
+}

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -14,6 +14,7 @@ import {
 } from './search-parsers';
 import {
   deriveStatus,
+  mapMusicBrainzReleaseType,
   mapReleaseType,
   parseReleaseDate,
   releaseMatchKey,
@@ -306,4 +307,263 @@ export function bandcampMusicUrl(artistUrl: string): string | null {
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Discogs — physical formats, editions, real selling prices, master IDs for dedup
+// ---------------------------------------------------------------------------
+//
+// Two-tier pass, same shape as Bandcamp's grid-then-detail split, because the underlying cost
+// structure is the same: `/artists/{id}/releases` is cheap and gives a whole discography in a
+// couple of paginated requests, while price and format data live one request per release. The
+// difference from Bandcamp is *what* the cheap pass gives us for free: `main_release`, which
+// means the detail pass doesn't need a second lookup to find the release behind a master.
+//
+// Filtered to `role: 'Main'` and `type: 'master'` throughout — an artist's raw releases list
+// can run into the thousands once every pressing, region and reissue is counted individually
+// (docs/specs/unstream-releases-v1-scope.md §10 measured 3,241 for one artist), and Discogs
+// masters have already done the "these forty pressings are one album" work for us.
+
+/** One entry from `GET /artists/{id}/releases`. */
+export interface DiscogsArtistReleaseEntry {
+  id: number;
+  type?: string;
+  main_release?: number;
+  title: string;
+  year?: number;
+  role?: string;
+  format?: string;
+}
+
+/** A master release ready to become (or merge into) a catalog row. */
+export interface DiscogsMasterCandidate {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  masterId: string;
+  /** The specific release Discogs treats as this master's representative pressing — the id
+   *  the detail pass fetches for price and format data. */
+  mainReleaseId: string;
+}
+
+/**
+ * Map an artist's Discogs discography listing into master-release candidates.
+ *
+ * Masters lacking `main_release` are dropped rather than kept with no way to price them — a
+ * master row that can never gain an offer is a dead end, and Discogs omits this field only for
+ * malformed or withdrawn masters.
+ */
+export function ingestDiscogsMasters(
+  entries: DiscogsArtistReleaseEntry[],
+  now: Date = new Date()
+): DiscogsMasterCandidate[] {
+  const out: DiscogsMasterCandidate[] = [];
+  const takenSlugs = new Set<string>();
+  const seenMasters = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry.role !== 'Main' || entry.type !== 'master') continue;
+    if (!entry.main_release) continue;
+
+    const masterId = String(entry.id);
+    // Discogs' pagination has repeated an id across pages before; a page-boundary is not a
+    // guarantee the same master won't be seen twice in one run.
+    if (seenMasters.has(masterId)) continue;
+    seenMasters.add(masterId);
+
+    const matchKey = releaseMatchKey(entry.title);
+    if (!matchKey) continue;
+
+    const { date, precision } = entry.year
+      ? parseReleaseDate(String(entry.year), now)
+      : { date: null, precision: 'unknown' as DatePrecision };
+
+    const slug = uniqueReleaseSlug(entry.title, takenSlugs);
+    takenSlugs.add(slug);
+
+    out.push({
+      title: entry.title,
+      slug,
+      matchKey,
+      releaseType: mapDiscogsFormatToReleaseType(entry.format, entry.title),
+      releaseDate: date,
+      datePrecision: precision,
+      status: deriveStatus(date, false, now),
+      masterId,
+      mainReleaseId: String(entry.main_release),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Discogs' artist-releases listing carries no dedicated release-type field — only a free-text
+ * format string like "Vinyl, LP, Album" or "CD, Compilation". Parsed the same defensively as
+ * `mapOfferFormat`: known keywords win, anything unrecognized becomes 'other' rather than a
+ * guess. Falls back to scanning the title too, since compilations and live albums often say so
+ * in the format string but occasionally only in the title ("... (Live)").
+ */
+export function mapDiscogsFormatToReleaseType(
+  format: string | null | undefined,
+  title: string | null | undefined
+): ReleaseType {
+  const label = `${format ?? ''} ${title ?? ''}`.toLowerCase();
+  if (!label.trim()) return 'other';
+
+  if (/\bcompilation\b/.test(label)) return 'compilation';
+  if (/\blive\b/.test(label)) return 'live';
+  if (/\bremix/.test(label)) return 'remix';
+  if (/\bep\b/.test(label)) return 'ep';
+  if (/\bsingle\b/.test(label)) return 'single';
+  if (/\balbum\b/.test(label)) return 'album';
+
+  return 'other';
+}
+
+/** What `GET /releases/{id}` gives us for one master's representative pressing. */
+export interface DiscogsReleaseDetailRaw {
+  released?: string | null;
+  year?: number | null;
+  formats?: { name?: string; descriptions?: string[] }[] | null;
+  num_for_sale?: number | null;
+  lowest_price?: number | null;
+}
+
+export interface DiscogsReleaseDetail {
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  offers: IngestedOffer[];
+}
+
+/**
+ * Map one Discogs release's own page into a date and (at most one) offer.
+ *
+ * `num_for_sale` and `lowest_price` describe secondhand marketplace listings for the **whole
+ * release**, not broken down by format — unlike Bandcamp, which prices each format on its own
+ * release page. Only one offer is emitted, keyed to the release's first listed format, rather
+ * than repeating the same aggregate price across every format in a multi-format pressing (a
+ * CD+book bundle showing "CD $5" and "book $5" as if either were separately buyable for $5
+ * would be the false-precision mistake this codebase exists to avoid).
+ *
+ * Zero current listings is reported as `unknown`, not `sold_out` — "sold out" implies stock
+ * existed and ran out, but a release can simply have no active marketplace listings today
+ * without ever having been withdrawn.
+ */
+export function ingestDiscogsReleaseDetail(
+  raw: DiscogsReleaseDetailRaw,
+  now: Date = new Date()
+): DiscogsReleaseDetail {
+  const dateSource = raw.released || (raw.year ? String(raw.year) : null);
+  const { date, precision } = parseReleaseDate(dateSource, now);
+
+  const offers: IngestedOffer[] = [];
+  const primaryFormat = raw.formats?.[0];
+  if (primaryFormat) {
+    const price = typeof raw.lowest_price === 'number' ? raw.lowest_price : null;
+    const availability: OfferAvailability =
+      price !== null && (raw.num_for_sale ?? 0) > 0 ? 'available' : 'unknown';
+
+    offers.push({
+      format: mapDiscogsFormatName(primaryFormat.name, primaryFormat.descriptions),
+      price,
+      // Discogs' public (unauthenticated) release endpoint has no currency field to read;
+      // its marketplace figures default to USD for requests with no `curr_abbr` override.
+      currency: price !== null ? 'USD' : null,
+      availability,
+    });
+  }
+
+  return {
+    releaseDate: date,
+    datePrecision: precision,
+    status: deriveStatus(date, false, now),
+    offers,
+  };
+}
+
+const DISCOGS_FORMAT_NAMES: Record<string, OfferFormat> = {
+  vinyl: 'vinyl',
+  cd: 'cd',
+  'cd-r': 'cd',
+  cassette: 'cassette',
+  file: 'digital',
+};
+
+/** Discogs' `formats[].name` (plus its free-text descriptions) onto our offer formats. */
+export function mapDiscogsFormatName(
+  name: string | null | undefined,
+  descriptions?: string[] | null
+): OfferFormat {
+  const mapped = name ? DISCOGS_FORMAT_NAMES[name.toLowerCase().trim()] : undefined;
+  if (mapped) return mapped;
+
+  const label = (descriptions ?? []).join(' ').toLowerCase();
+  if (label.includes('book') || label.includes('zine')) return 'book';
+  if (label.includes('shirt') || label.includes('poster') || label.includes('box set')) return 'merch';
+
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// MusicBrainz — release groups, MBIDs, partial dates
+// ---------------------------------------------------------------------------
+//
+// Enrichment only: MusicBrainz never creates a release row on its own. It has no purchase
+// link to offer, and a release page with no source to buy from is a worse outcome than not
+// having the page at all. Its job is filling in what Bandcamp and Discogs can't give
+// precisely — a release-group MBID as a hard identity anchor for future dedup, plus dates at
+// whatever precision MusicBrainz actually has (year-only and month-only are common, and
+// `date_precision` exists specifically so this module never has to pad one into a fabricated
+// day).
+
+/** One entry from `GET /ws/2/release-group?artist={mbid}&inc=...`. */
+export interface MusicBrainzReleaseGroupRaw {
+  id: string;
+  title: string;
+  'primary-type'?: string | null;
+  'secondary-types'?: string[] | null;
+  'first-release-date'?: string | null;
+}
+
+/** An MBID-anchored enrichment for a release we may or may not already have. */
+export interface MusicBrainzReleaseGroupEnrichment {
+  matchKey: string;
+  releaseType: ReleaseType;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  mbid: string;
+}
+
+export function ingestMusicBrainzReleaseGroups(
+  groups: MusicBrainzReleaseGroupRaw[],
+  now: Date = new Date()
+): MusicBrainzReleaseGroupEnrichment[] {
+  const out: MusicBrainzReleaseGroupEnrichment[] = [];
+  const seen = new Set<string>();
+
+  for (const group of groups) {
+    if (!group.id || seen.has(group.id)) continue;
+    seen.add(group.id);
+
+    const matchKey = releaseMatchKey(group.title);
+    if (!matchKey) continue;
+
+    const { date, precision } = parseReleaseDate(group['first-release-date'], now);
+
+    out.push({
+      matchKey,
+      releaseType: mapMusicBrainzReleaseType(group['primary-type'], group['secondary-types']),
+      releaseDate: date,
+      datePrecision: precision,
+      mbid: group.id,
+    });
+  }
+
+  return out;
 }

--- a/api/functions/release-utils.ts
+++ b/api/functions/release-utils.ts
@@ -144,6 +144,71 @@ export function mapReleaseType(raw: string | null | undefined): ReleaseType {
   return 'other';
 }
 
+/**
+ * Map MusicBrainz's release-group typing onto ours.
+ *
+ * MusicBrainz splits type into one `primary-type` (Album/EP/Single/Broadcast/Other) plus zero
+ * or more `secondary-types` (Compilation/Live/Remix/Soundtrack/…). Secondary types win when
+ * present — a live album is more usefully typed 'live' than 'album' for dedup purposes, the
+ * same reasoning `mapReleaseType` already applies to Bandcamp's own type strings.
+ */
+export function mapMusicBrainzReleaseType(
+  primaryType: string | null | undefined,
+  secondaryTypes: string[] | null | undefined
+): ReleaseType {
+  const secondary = new Set((secondaryTypes ?? []).map(s => s.toLowerCase()));
+  if (secondary.has('compilation')) return 'compilation';
+  if (secondary.has('live')) return 'live';
+  if (secondary.has('remix')) return 'remix';
+
+  switch ((primaryType ?? '').toLowerCase()) {
+    case 'album': return 'album';
+    case 'ep': return 'ep';
+    case 'single': return 'single';
+    default: return 'other';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-source dedup — tier 3 (fuzzy, never auto-merged)
+// ---------------------------------------------------------------------------
+
+/**
+ * How much of the longer key the shorter one must cover to count as "probably the same".
+ *
+ * Low enough to catch the motivating case — an album plus its "(Deluxe Edition)" or
+ * "(Remastered)" reissue, where the suffix can be nearly as long as the original title — but
+ * still high enough that a short, common word contained inside an unrelated long title (both
+ * happen to have "album" somewhere) doesn't trip it.
+ */
+const MIN_FUZZY_MATCH_RATIO = 0.4;
+
+/** Below this length a match key is too short for containment to mean anything. */
+const MIN_FUZZY_MATCH_LENGTH = 4;
+
+/**
+ * A conservative signal that two match keys under the same release_type MIGHT be the same
+ * release without being exactly equal — e.g. `carrielowell` and
+ * `carrielowelldeluxeedition`.
+ *
+ * This is tier 3 from the spec: it never merges anything. It only flags a pair as
+ * `needs_review` so a human decides. "Under-merge, never over-merge" (§4) means a false
+ * positive here costs a checkbox in an admin queue; a false positive in an exact-match tier
+ * would silently assert two different albums are one, which nobody would ever catch.
+ *
+ * Deliberately narrow: one key must fully *contain* the other, not merely overlap, and the
+ * shorter key must cover most of the longer one's length — otherwise two short, unrelated
+ * titles that happen to share a substring ("EP" inside a longer title's match key, say) would
+ * trip it.
+ */
+export function isFuzzyReleaseMatch(a: string, b: string): boolean {
+  if (!a || !b || a === b) return false;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  if (shorter.length < MIN_FUZZY_MATCH_LENGTH) return false;
+  if (!longer.includes(shorter)) return false;
+  return shorter.length / longer.length >= MIN_FUZZY_MATCH_RATIO;
+}
+
 // ---------------------------------------------------------------------------
 // Dates
 // ---------------------------------------------------------------------------

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -100,3 +100,62 @@ export async function requestArtistCatalog(
     console.warn('[catalog] request failed:', error instanceof Error ? error.message : String(error));
   }
 }
+
+/**
+ * The result of a *deliberate* catalog request — someone pressed a button and is waiting for an
+ * answer, so unlike `requestArtistCatalog` above every refusal is reported rather than logged.
+ */
+export type TriggerCatalogResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Queue a crawl for one artist, on purpose, and say why not if it can't happen.
+ *
+ * **Every refusal the background function could make is checked here instead**, because its
+ * answer never comes back: Netlify's dispatcher returns 202 the instant it accepts a background
+ * invocation and discards whatever the handler returns, so a 401 from a bad secret and a 403
+ * from a disabled deploy both reach the caller as 202. Anything not checked up front is
+ * indistinguishable from a slow crawl — which is exactly how cataloging stayed silently broken
+ * for days before the admin button reported a refusal out loud.
+ *
+ * Callers are responsible for clearing the cooldown first (`clearCatalogCooldown` in db.ts) —
+ * kept separate so this module needs no database access, and therefore no import from db.ts,
+ * which imports from here.
+ */
+export async function triggerCatalogNow(artistId: string): Promise<TriggerCatalogResult> {
+  if (!isCatalogEnabled()) {
+    return {
+      ok: false,
+      status: 503,
+      error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).',
+    };
+  }
+
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+  const siteUrl = process.env.URL;
+
+  if (!secret || !siteUrl) {
+    // Said plainly rather than as a generic 500: this exact configuration gap silently stopped
+    // release cataloging from ever running, and "nothing happened" gave no clue why.
+    console.error('[catalog] INTERNAL_FUNCTION_SECRET or site URL is not configured');
+    return {
+      ok: false,
+      status: 503,
+      error: 'Cataloging is not configured on this deploy (INTERNAL_FUNCTION_SECRET).',
+    };
+  }
+
+  try {
+    // 'saved' is the larger hourly budget, which is right for a deliberate act by a person.
+    await fetch(`${siteUrl}/.netlify/functions/catalog-artist-background`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
+      body: JSON.stringify({ artistIds: [artistId], trigger: 'saved' satisfies CatalogTrigger }),
+    });
+    return { ok: true };
+  } catch (error) {
+    console.error('[catalog] deliberate trigger failed:', error instanceof Error ? error.message : String(error));
+    return { ok: false, status: 502, error: 'Could not reach the cataloging function' };
+  }
+}

--- a/api/shared/release-display.ts
+++ b/api/shared/release-display.ts
@@ -83,31 +83,6 @@ export function formatOfferPrice(price: number | null, currency: string | null):
 }
 
 /**
- * "from $8", or "Name your price" — the cheapest thing a fan can actually buy, for a one-line
- * summary in a list of releases.
- *
- * **Sold-out formats are excluded.** Quoting the price of a record nobody can buy would be the
- * one genuinely misleading number in a discography list — a fan would click expecting $25 vinyl
- * and find it gone. A release whose only offer is sold out summarises as nothing at all, which
- * is the honest outcome.
- *
- * Returns '' when there are no offers, which is the normal state for a release catalogued from
- * the Bandcamp grid whose own page hasn't been read for prices yet.
- */
-export function cheapestOfferSummary(
-  offers: { price: number | null; currency: string | null; availability: string }[]
-): string {
-  const buyable = offers.filter(o => o.availability !== 'sold_out' && o.price !== null);
-  if (buyable.length === 0) return '';
-
-  const cheapest = buyable.reduce((low, o) => (o.price! < low.price! ? o : low));
-
-  // Bandcamp reports name-your-price as 0, and "from $0" reads as free.
-  if (cheapest.price === 0) return 'Name your price';
-  return `from ${formatMoney(cheapest.price!, cheapest.currency)}`;
-}
-
-/**
  * "≈$20–21.25 to the artist" — the emotional payload of the whole product, at the moment
  * someone is deciding where to buy.
  *
@@ -188,4 +163,58 @@ export function payoutRank(platform: string): number {
   const percent = PLATFORMS[platform]?.payoutPercent;
   const first = percent?.match(/\d+(?:\.\d+)?/)?.[0];
   return first ? Number(first) : -1;
+}
+
+/** One release's source, with just enough offer data to summarize or badge with. */
+export interface ReleaseSourceSummary {
+  platform: string;
+  offers: { price: number | null; currency: string | null; availability: string }[];
+}
+
+/**
+ * Which platforms a release is available on, ordered artist-paying-first — the same ordering
+ * the release page itself uses (`payoutRank`). For a compact "where to buy" badge row in a
+ * release list, where a fan should see the best options first without having to click through.
+ */
+export function orderedSourcePlatforms(sources: ReleaseSourceSummary[]): string[] {
+  return [...sources]
+    .sort((a, b) => payoutRank(b.platform) - payoutRank(a.platform))
+    .map(s => s.platform);
+}
+
+/**
+ * "from $8 · ≈$6.80 to artist", or "Name your price" — the one line a release-list row shows,
+ * for the leading (artist-paying-first) source that actually has a buyable offer.
+ *
+ * **Deliberately not the globally cheapest price across every source.** Once a release has
+ * more than one source, picking the absolute cheapest price could promote a Discogs secondhand
+ * listing over a Bandcamp direct purchase — exactly the anti-pattern the sourcing spec warns
+ * against ("used CD $2.64" ranked above "vinyl direct from the artist $30" would be off-mission
+ * even though both facts are true). So sources are walked in the same artist-paying-first order
+ * the release page uses, and the first one with a real buyable offer wins, even if a
+ * lower-payout source further down the list happens to be cheaper.
+ *
+ * Same sold-out and name-your-price handling as the release page itself: a release whose only
+ * offer is sold out contributes nothing to the summary, and a price of exactly 0 means
+ * name-your-price, not free.
+ *
+ * Returns '' when no source has a buyable offer, which is the normal state for a release whose
+ * detail pages haven't been read for prices yet.
+ */
+export function leadingOfferSummary(sources: ReleaseSourceSummary[]): string {
+  const ordered = [...sources].sort((a, b) => payoutRank(b.platform) - payoutRank(a.platform));
+
+  for (const source of ordered) {
+    const buyable = source.offers.filter(o => o.availability !== 'sold_out' && o.price !== null);
+    if (buyable.length === 0) continue;
+
+    const cheapest = buyable.reduce((low, o) => (o.price! < low.price! ? o : low));
+    if (cheapest.price === 0) return 'Name your price';
+
+    const priceText = `from ${formatMoney(cheapest.price!, cheapest.currency)}`;
+    const payout = payoutEstimate(cheapest.price!, cheapest.currency, PLATFORMS[source.platform]?.payoutPercent);
+    return payout ? `${priceText} · ${payout}` : priceText;
+  }
+
+  return '';
 }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -42,6 +42,7 @@ export function Header() {
   const navigate = useNavigate();
   const { session, user, isAdmin, signOut } = useAuth();
   const [pendingVerifyCount, setPendingVerifyCount] = useState(0);
+  const [pendingReleaseReviewCount, setPendingReleaseReviewCount] = useState(0);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
   // Fetch pending verification count for admins — only on admin-relevant pages
@@ -63,6 +64,23 @@ export function Header() {
     return () => controller.abort();
   }, [isAdmin, session?.access_token]);
 
+  // Same shape as the verification count above — a queue waiting on the tier-3 dedup backstop
+  // should be just as visible without opening the menu.
+  useEffect(() => {
+    if (!isAdmin || !session?.access_token) return;
+    const controller = new AbortController();
+    fetch('/api/admin/release-review', {
+      headers: { 'Authorization': `Bearer ${session.access_token}` },
+      signal: controller.signal,
+    })
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data?.pairs) setPendingReleaseReviewCount(data.pairs.length);
+      })
+      .catch(() => { /* aborted or network error */ });
+    return () => controller.abort();
+  }, [isAdmin, session?.access_token]);
+
   async function handleSignOut() {
     await signOut();
     navigate('/login');
@@ -76,12 +94,17 @@ export function Header() {
   // review is still visible without opening the menu.
   const adminGroup: NavGroup = {
     label: 'Admin',
-    emphasis: pendingVerifyCount > 0,
+    emphasis: pendingVerifyCount > 0 || pendingReleaseReviewCount > 0,
     items: [
       {
         to: '/admin/verify',
         label: pendingVerifyCount > 0 ? `Verify (${pendingVerifyCount})` : 'Verify',
         emphasis: pendingVerifyCount > 0,
+      },
+      {
+        to: '/admin/release-review',
+        label: pendingReleaseReviewCount > 0 ? `Release review (${pendingReleaseReviewCount})` : 'Release review',
+        emphasis: pendingReleaseReviewCount > 0,
       },
       { to: '/admin/links', label: 'Removed links' },
       { to: '/admin/analytics', label: 'Analytics' },

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -1,5 +1,8 @@
-import { cheapestOfferSummary, formatReleaseDate } from '../../../../api/shared/release-display';
+import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate } from '../../../../api/shared/release-display';
+import { PLATFORMS } from '../../../../api/shared/platform-registry';
+import { PlatformIcon } from './PlatformIcon';
 import type { ArtistPagePayload } from '../types/artist-page';
+import type { SourceId } from '../types';
 
 type Release = NonNullable<ArtistPagePayload['releases']>[number];
 
@@ -60,7 +63,14 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
       ? ''
       : release.releaseType.charAt(0).toUpperCase() + release.releaseType.slice(1);
 
-  const meta = [type, date, cheapestOfferSummary(release.offers)].filter(Boolean).join(' · ');
+  // leadingOfferSummary, not the globally cheapest price: once a release has more than one
+  // source, picking the absolute cheapest could rank a Discogs secondhand copy above a
+  // Bandcamp direct purchase — see the function's own doc for why that's off-mission.
+  const meta = [type, date, leadingOfferSummary(release.sources)].filter(Boolean).join(' · ');
+
+  // Ordered the same artist-paying-first way as the summary above and the release page
+  // itself, so the platform a fan sees leading the row is also the one the price came from.
+  const platforms = orderedSourcePlatforms(release.sources);
 
   return (
     <a
@@ -84,6 +94,27 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
       <span className="flex-1 min-w-0">
         <span className="block font-medium text-text-primary truncate">{release.title}</span>
         {meta && <span className="block text-xs text-text-muted">{meta}</span>}
+        {platforms.length > 0 && (
+          <span className="flex items-center gap-1 mt-1">
+            {/* Icons alone don't convey the platform names to a screen reader; the text below
+                does, and is visually hidden since the meta line above already carries the
+                price/payout for the leading one. */}
+            <span className="sr-only">
+              Available on {platforms.map(p => PLATFORMS[p]?.name ?? p).join(', ')}
+            </span>
+            <span aria-hidden="true" className="flex items-center gap-1">
+              {platforms.map(p => (
+                <PlatformIcon
+                  key={p}
+                  sourceId={p as SourceId}
+                  color={PLATFORMS[p]?.color ?? '#888'}
+                  emoji={PLATFORMS[p]?.icon ?? '🔗'}
+                  className="w-3.5 h-3.5"
+                />
+              ))}
+            </span>
+          </span>
+        )}
       </span>
 
       {/* An upcoming release is the most interesting row here and the easiest to miss at the top

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -24,6 +24,7 @@ const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage.tsx').the
 const AdminMergePage = lazy(() => import('./pages/AdminMergePage.tsx').then(m => ({ default: m.AdminMergePage })))
 const AdminVerifyPage = lazy(() => import('./pages/AdminVerifyPage.tsx').then(m => ({ default: m.AdminVerifyPage })))
 const AdminLinksPage = lazy(() => import('./pages/AdminLinksPage.tsx').then(m => ({ default: m.AdminLinksPage })))
+const AdminReleaseReviewPage = lazy(() => import('./pages/AdminReleaseReviewPage.tsx').then(m => ({ default: m.AdminReleaseReviewPage })))
 const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage.tsx').then(m => ({ default: m.ResetPasswordPage })))
 const GuidesIndexPage = lazy(() => import('./pages/GuidesIndexPage.tsx').then(m => ({ default: m.GuidesIndexPage })))
 const GuidePage = lazy(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
@@ -72,6 +73,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="/admin/merge" element={<AdminMergePage />} />
               <Route path="/admin/verify" element={<AdminVerifyPage />} />
               <Route path="/admin/links" element={<AdminLinksPage />} />
+              <Route path="/admin/release-review" element={<AdminReleaseReviewPage />} />
               <Route path="/admin/analytics" element={<AdminAnalyticsPage />} />
               <Route path="/developers" element={<DevelopersPage />} />
               <Route path="/extension" element={<ExtensionPage />} />

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -17,6 +17,7 @@ const ClaimPage = lazy(() => import('./pages/ClaimPage.tsx').then(m => ({ defaul
 const LoginPage = lazy(() => import('./pages/LoginPage.tsx').then(m => ({ default: m.LoginPage })))
 const DashboardPage = lazy(() => import('./pages/DashboardPage.tsx').then(m => ({ default: m.DashboardPage })))
 const ArtistEditPage = lazy(() => import('./pages/ArtistEditPage.tsx').then(m => ({ default: m.ArtistEditPage })))
+const ArtistReleasesPage = lazy(() => import('./pages/ArtistReleasesPage.tsx').then(m => ({ default: m.ArtistReleasesPage })))
 const ArtistDirectoryPage = lazy(() => import('./pages/ArtistDirectoryPage.tsx').then(m => ({ default: m.ArtistDirectoryPage })))
 const RoadmapPage = lazy(() => import('./pages/RoadmapPage.tsx').then(m => ({ default: m.RoadmapPage })))
 const SupportPage = lazy(() => import('./pages/SupportPage.tsx').then(m => ({ default: m.SupportPage })))
@@ -64,6 +65,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="/reset-password" element={<ResetPasswordPage />} />
               <Route path="/dashboard" element={<DashboardPage />} />
               <Route path="/artist-edit/:slug" element={<ArtistEditPage />} />
+              <Route path="/artist-edit/:slug/releases" element={<ArtistReleasesPage />} />
               <Route path="/artists" element={<ArtistDirectoryPage />} />
               <Route path="/roadmap" element={<RoadmapPage />} />
               <Route path="/support" element={<SupportPage />} />

--- a/apps/web/src/pages/AdminReleaseReviewPage.tsx
+++ b/apps/web/src/pages/AdminReleaseReviewPage.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+import { Header } from '../components/Header';
+import { SkeletonScreen } from '../components/Skeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
+import { PlatformIcon } from '../components/PlatformIcon';
+import { PLATFORMS } from '../../../../api/shared/platform-registry';
+import { formatReleaseDate } from '../../../../api/shared/release-display';
+import type { SourceId } from '../types';
+
+interface ReleaseReviewItem {
+  id: string;
+  title: string;
+  slug: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  artworkUrl: string | null;
+  artistName: string;
+  artistSlug: string;
+  platforms: string[];
+}
+
+interface ReviewPair {
+  primary: ReleaseReviewItem;
+  counterpart: ReleaseReviewItem | null;
+}
+
+/**
+ * The human backstop for tier-3 dedup (spec §4, §11). Ingest never auto-merges a fuzzy title
+ * match — it flags both sides via `needs_review` and asks here instead, because a false merge
+ * would silently assert two different albums are one, and nobody would ever notice.
+ *
+ * Each pair gets three possible answers: "not a duplicate" (dismiss, both sides stop being
+ * flagged), or "same release" pointed at whichever side should survive (merge moves the other
+ * side's sources over, then removes the now-empty duplicate row).
+ */
+export function AdminReleaseReviewPage() {
+  const { isAdmin, session } = useAuth();
+  const [pairs, setPairs] = useState<ReviewPair[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const fetchQueue = useCallback(async () => {
+    if (!session?.access_token) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/release-review', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to fetch (${response.status})`);
+      }
+
+      const data = await response.json();
+      setPairs(data.pairs || []);
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'admin.releaseReview.fetchQueue' } });
+      setError(err instanceof Error ? err.message : 'Failed to load the review queue.');
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.access_token]);
+
+  useEffect(() => {
+    if (isAdmin) fetchQueue();
+  }, [isAdmin, fetchQueue]);
+
+  const runAction = async (key: string, body: Record<string, unknown>) => {
+    if (!session?.access_token) return;
+    setActionLoading(key);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/release-review', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Action failed (${response.status})`);
+      }
+
+      await fetchQueue();
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: `admin.releaseReview.${body.action}` } });
+      setError(err instanceof Error ? err.message : 'Action failed.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-text-muted">Not authorized.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <div className="px-4 py-8">
+        <div className="max-w-3xl mx-auto space-y-8">
+          <div>
+            <h1 className="font-display text-2xl font-bold text-text-primary">Release Review</h1>
+            <p className="text-text-muted text-sm mt-1">
+              Releases the catalog wasn't confident enough to merge on its own — a title close
+              enough to another one under the same artist to flag for a human, rather than guess.
+            </p>
+          </div>
+
+          {error && (
+            <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <SkeletonScreen label="Loading flagged releases">
+              <FormSkeleton sections={2} fields={2} />
+            </SkeletonScreen>
+          ) : pairs.length === 0 ? (
+            <p className="text-text-muted text-sm">Nothing flagged for review right now.</p>
+          ) : (
+            <div className="space-y-4">
+              {pairs.map(pair => (
+                <ReviewPairCard
+                  key={pair.primary.id}
+                  pair={pair}
+                  actionLoading={actionLoading}
+                  onDismiss={releaseId => runAction(`dismiss-${releaseId}`, { action: 'dismiss', releaseId })}
+                  onMerge={(keepId, dropId) => runAction(`merge-${keepId}`, { action: 'merge', keepId, dropId })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReleaseSummary({ item }: { item: ReleaseReviewItem }) {
+  const date = formatReleaseDate(item.releaseDate, item.datePrecision);
+  const type =
+    item.releaseType === 'other' ? '' : item.releaseType.charAt(0).toUpperCase() + item.releaseType.slice(1);
+  const meta = [type, date].filter(Boolean).join(' · ');
+
+  return (
+    <div className="flex items-start gap-3">
+      {item.artworkUrl ? (
+        <img
+          src={item.artworkUrl}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="w-12 h-12 rounded-md object-cover shrink-0 bg-bg-secondary"
+        />
+      ) : (
+        <div className="w-12 h-12 rounded-md shrink-0 bg-bg-secondary flex items-center justify-center text-xl">
+          💿
+        </div>
+      )}
+      <div className="min-w-0">
+        <a
+          href={`/a/${encodeURIComponent(item.artistSlug)}/${encodeURIComponent(item.slug)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-text-primary truncate hover:underline block"
+        >
+          {item.title}
+        </a>
+        {meta && <p className="text-xs text-text-muted">{meta}</p>}
+        {item.platforms.length > 0 && (
+          <div className="flex items-center gap-1 mt-1">
+            {item.platforms.map(p => (
+              <PlatformIcon
+                key={p}
+                sourceId={p as SourceId}
+                color={PLATFORMS[p]?.color ?? '#888'}
+                emoji={PLATFORMS[p]?.icon ?? '🔗'}
+                className="w-3.5 h-3.5"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ReviewPairCard({
+  pair,
+  actionLoading,
+  onDismiss,
+  onMerge,
+}: {
+  pair: ReviewPair;
+  actionLoading: string | null;
+  onDismiss: (releaseId: string) => void;
+  onMerge: (keepId: string, dropId: string) => void;
+}) {
+  const { primary, counterpart } = pair;
+  const busy = (key: string) => actionLoading === key;
+
+  return (
+    <div className="p-4 rounded-xl bg-surface border border-border space-y-4">
+      <p className="text-xs text-text-secondary font-medium">{primary.artistName}</p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <ReleaseSummary item={primary} />
+          {counterpart && (
+            <button
+              onClick={() => onMerge(primary.id, counterpart.id)}
+              disabled={busy(`merge-${primary.id}`) || busy(`merge-${counterpart.id}`)}
+              className="w-full px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy(`merge-${primary.id}`) ? 'Merging...' : 'Same release — keep this one'}
+            </button>
+          )}
+        </div>
+
+        {counterpart && (
+          <div className="space-y-2">
+            <ReleaseSummary item={counterpart} />
+            <button
+              onClick={() => onMerge(counterpart.id, primary.id)}
+              disabled={busy(`merge-${primary.id}`) || busy(`merge-${counterpart.id}`)}
+              className="w-full px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy(`merge-${counterpart.id}`) ? 'Merging...' : 'Same release — keep this one'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {!counterpart && (
+        <p className="text-xs text-text-muted">
+          Its suspected duplicate is no longer on file — nothing left to compare against.
+        </p>
+      )}
+
+      <button
+        onClick={() => onDismiss(primary.id)}
+        disabled={busy(`dismiss-${primary.id}`)}
+        className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-sm font-medium hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {busy(`dismiss-${primary.id}`) ? 'Working...' : 'Not a duplicate'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -407,6 +407,13 @@ export function ArtistEditPage() {
               >
                 View live profile
               </Link>
+              {' · '}
+              <Link
+                to={`/artist-edit/${form.currentSlug}/releases`}
+                className="text-sm text-accent-primary hover:underline"
+              >
+                Manage releases
+              </Link>
             </div>
             <Link
               to="/artist-dashboard"

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
@@ -32,6 +32,23 @@ interface OwnerRelease {
   sources: { platform: string; url: string }[];
 }
 
+interface CatalogState {
+  last_catalogued_at: string | null;
+  releases_found: number | null;
+  releases_detailed: number | null;
+  last_error: string | null;
+}
+
+interface CatalogInfo {
+  canTrigger: boolean;
+  state: CatalogState | null;
+  stateError: string | null;
+}
+
+/** How long to keep asking before giving up. A full catalogue with prices takes a few minutes. */
+const MAX_CATALOG_POLLS = 24;
+const CATALOG_POLL_INTERVAL_MS = 5000;
+
 /**
  * The artist-facing half of release curation (spec §11) — reachable from `ArtistEditPage` via
  * "Manage releases". Ingest never merges a suspected duplicate or overwrites a curated field
@@ -47,6 +64,7 @@ export function ArtistReleasesPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [catalog, setCatalog] = useState<CatalogInfo | null>(null);
 
   const fetchReleases = useCallback(async () => {
     if (!session?.access_token || !slug) return;
@@ -65,6 +83,7 @@ export function ArtistReleasesPage() {
 
       const data = await response.json();
       setReleases(data.releases || []);
+      setCatalog(data.catalog ?? null);
     } catch (err) {
       Sentry.captureException(err, { extra: { context: 'artistReleases.fetch' } });
       setError(err instanceof Error ? err.message : 'Failed to load releases.');
@@ -192,10 +211,182 @@ export function ArtistReleasesPage() {
                   ))}
                 </div>
               )}
+
+              {catalog?.canTrigger && (
+                <CatalogNowPanel
+                  slug={slug}
+                  token={session?.access_token}
+                  catalog={catalog}
+                  onFinished={fetchReleases}
+                />
+              )}
             </>
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function describeCatalogState(state: CatalogState | null): string {
+  if (state?.last_error) return `Last run failed: ${state.last_error}`;
+  // A state row exists as soon as a crawl is *claimed*, before it runs — so counts are only
+  // meaningful once one has finished. Otherwise "0 releases" would be a claim about the
+  // catalogue rather than the absence of an answer.
+  if (!state?.last_catalogued_at) return 'Never catalogued';
+  return `${state.releases_found ?? 0} releases found, ${state.releases_detailed ?? 0} with prices`;
+}
+
+/**
+ * "Scan my links for releases" — the self-serve version of the admin catalog button.
+ *
+ * Visibility is decided by the server (`catalog.canTrigger`), not re-derived here, so the
+ * rollout gate can't drift out of sync with a copy of the rule in page code. While that gate is
+ * admin-only the copy says so plainly rather than pretending to be generally available.
+ *
+ * Polls for the outcome the same way `AdminCatalogButton` does, and for the same reason: Netlify
+ * answers a background invocation with 202 the moment it's queued and discards the handler's
+ * response, so the only honest way to report what happened is to ask afterwards.
+ */
+function CatalogNowPanel({
+  slug,
+  token,
+  catalog,
+  onFinished,
+}: {
+  slug: string;
+  token: string | undefined;
+  catalog: CatalogInfo;
+  onFinished: () => Promise<void> | void;
+}) {
+  const [status, setStatus] = useState<string>(
+    catalog.stateError ?? describeCatalogState(catalog.state)
+  );
+  const [running, setRunning] = useState(false);
+  const lastRunAt = useRef<string | null>(catalog.state?.last_catalogued_at ?? null);
+  const lastFailure = useRef<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  /**
+   * Three-valued on purpose: "we couldn't ask" and "never catalogued" are different facts, and
+   * one `null` for both makes a failed request render as a confident "Never catalogued".
+   */
+  const readState = useCallback(async (): Promise<
+    { ok: true; state: CatalogState | null } | { ok: false; reason: string }
+  > => {
+    const response = await fetch(`/api/artist-releases?slug=${encodeURIComponent(slug)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      return { ok: false, reason: body.error || 'Could not read catalog state' };
+    }
+    const data = await response.json();
+    const info = (data.catalog ?? null) as CatalogInfo | null;
+    if (info?.stateError) return { ok: false, reason: info.stateError };
+    return { ok: true, state: info?.state ?? null };
+  }, [slug, token]);
+
+  const poll = useCallback(() => {
+    let attempt = 0;
+
+    function scheduleNext() {
+      attempt += 1;
+      if (attempt > MAX_CATALOG_POLLS) {
+        // Say which it was. "Still running" on top of a run of failed reads would be a guess
+        // about the crawl based on no information about the crawl.
+        setStatus(lastFailure.current ?? 'Still running — check back shortly');
+        setRunning(false);
+        return;
+      }
+      timer.current = setTimeout(async () => {
+        try {
+          const result = await readState();
+          if (!result.ok) {
+            // A failed read is not "still running" — but it may be transient, so keep asking
+            // and let the message say which of the two we're looking at.
+            lastFailure.current = result.reason;
+            scheduleNext();
+            return;
+          }
+          lastFailure.current = null;
+          const { state } = result;
+          if (state?.last_catalogued_at && state.last_catalogued_at !== lastRunAt.current) {
+            lastRunAt.current = state.last_catalogued_at;
+            setStatus(describeCatalogState(state));
+            setRunning(false);
+            await onFinished();
+            return;
+          }
+          if (state?.last_error) {
+            setStatus(describeCatalogState(state));
+            setRunning(false);
+            return;
+          }
+        } catch {
+          // A dropped request mid-crawl isn't an answer; keep asking.
+          lastFailure.current = 'Could not read catalog state';
+        }
+        scheduleNext();
+      }, CATALOG_POLL_INTERVAL_MS);
+    }
+
+    scheduleNext();
+  }, [readState, onFinished]);
+
+  const start = useCallback(async () => {
+    setRunning(true);
+    setStatus('Scanning your links…');
+    try {
+      const response = await fetch('/api/artist-releases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ slug, action: 'catalog' }),
+      });
+      const body = await response.json().catch(() => ({}));
+
+      // 202 means queued and nothing more. The endpoint reports the refusals it can predict
+      // (cataloging disabled, secret missing) as real errors; everything else is settled by
+      // polling.
+      if (!response.ok && response.status !== 202) {
+        setStatus(body.error || 'Could not start');
+        setRunning(false);
+        return;
+      }
+      poll();
+    } catch {
+      setStatus('Could not start');
+      setRunning(false);
+    }
+  }, [slug, token, poll]);
+
+  return (
+    <div className="mt-8 p-4 rounded-xl border border-dashed border-border space-y-2">
+      <h2 className="font-display text-base font-semibold text-text-primary">
+        Look for releases on your links
+      </h2>
+      <p className="text-xs text-text-muted">
+        Checks the platforms on your profile — Bandcamp, Discogs, Faircamp — and adds anything it
+        finds. Some platforms can't be read automatically, so this won't always find everything;
+        whatever it misses you can add by hand above.
+      </p>
+      <div className="flex flex-wrap items-center gap-3 pt-1">
+        <button
+          onClick={start}
+          disabled={running || !token}
+          className="px-4 py-2 rounded-lg bg-bg-secondary border border-border text-sm text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {running ? 'Scanning…' : 'Scan my links for releases'}
+        </button>
+        <span className="text-xs text-text-muted">{status}</span>
+      </div>
+      <p className="text-[11px] text-text-muted pt-1">
+        Admin only for now, while we watch how it behaves.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -1,0 +1,513 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+import { Header } from '../components/Header';
+import { PageSkeleton } from '../components/PageSkeleton';
+import { FormSkeleton } from '../components/LoadingSkeletons';
+import { PlatformIcon } from '../components/PlatformIcon';
+import { PLATFORMS } from '../../../../api/shared/platform-registry';
+import { formatReleaseDate } from '../../../../api/shared/release-display';
+import { sources } from '../services/sources';
+import type { SourceId } from '../types';
+
+const PLATFORM_OPTIONS = (Object.values(sources) as { id: SourceId; name: string }[])
+  .filter(s => s.id !== 'other')
+  .map(s => ({ id: s.id, name: s.name }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const RELEASE_TYPES = ['album', 'ep', 'single', 'compilation', 'live', 'remix', 'other'] as const;
+
+interface OwnerRelease {
+  id: string;
+  title: string;
+  slug: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  artworkUrl: string | null;
+  isHidden: boolean;
+  needsReview: boolean;
+  flaggedAgainst: { id: string; title: string } | null;
+  sources: { platform: string; url: string }[];
+}
+
+/**
+ * The artist-facing half of release curation (spec §11) — reachable from `ArtistEditPage` via
+ * "Manage releases". Ingest never merges a suspected duplicate or overwrites a curated field
+ * (see `db.ts`'s `updateArtistReleaseFields`/`addArtistReleaseLink`); this page is where an
+ * artist, who knows their own catalog better than any auto-matching ever will, corrects it.
+ */
+export function ArtistReleasesPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const { session } = useAuth();
+  const [releases, setReleases] = useState<OwnerRelease[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const fetchReleases = useCallback(async () => {
+    if (!session?.access_token || !slug) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/artist-releases?slug=${encodeURIComponent(slug)}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to fetch (${response.status})`);
+      }
+
+      const data = await response.json();
+      setReleases(data.releases || []);
+    } catch (err) {
+      Sentry.captureException(err, { extra: { context: 'artistReleases.fetch' } });
+      setError(err instanceof Error ? err.message : 'Failed to load releases.');
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.access_token, slug]);
+
+  useEffect(() => {
+    fetchReleases();
+  }, [fetchReleases]);
+
+  const runAction = useCallback(
+    async (key: string, body: Record<string, unknown>): Promise<boolean> => {
+      if (!session?.access_token || !slug) return false;
+      setActionLoading(key);
+      setError(null);
+
+      try {
+        const response = await fetch('/api/artist-releases', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+          body: JSON.stringify({ slug, ...body }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || `Action failed (${response.status})`);
+        }
+
+        await fetchReleases();
+        return true;
+      } catch (err) {
+        Sentry.captureException(err, { extra: { context: `artistReleases.${body.action}` } });
+        setError(err instanceof Error ? err.message : 'Action failed.');
+        return false;
+      } finally {
+        setActionLoading(null);
+      }
+    },
+    [session?.access_token, slug, fetchReleases]
+  );
+
+  if (!slug) return null;
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <div className="px-4 py-8">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <div>
+            <Link
+              to={`/artist-edit/${slug}`}
+              className="text-sm text-text-muted hover:text-text-primary transition-colors"
+            >
+              &larr; Back to profile
+            </Link>
+            <h1 className="font-display text-2xl font-bold text-text-primary mt-1">Manage Releases</h1>
+            <p className="text-text-muted text-sm mt-1">
+              Hide anything that isn't yours, fix a title or date, merge a duplicate, or add
+              something we missed.
+            </p>
+          </div>
+
+          {error && (
+            <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <PageSkeleton label="Loading releases">
+              <FormSkeleton sections={2} fields={2} />
+            </PageSkeleton>
+          ) : (
+            <>
+              <button
+                onClick={() => setShowAddForm(v => !v)}
+                className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-sm font-medium hover:bg-bg-hover transition-colors"
+              >
+                {showAddForm ? 'Cancel' : '+ Add a release we missed'}
+              </button>
+
+              {showAddForm && (
+                <AddReleaseForm
+                  busy={actionLoading === 'create'}
+                  onCreate={async input => {
+                    const created = await runAction('create', { action: 'create', ...input });
+                    if (created) setShowAddForm(false);
+                  }}
+                />
+              )}
+
+              {releases.length === 0 ? (
+                <p className="text-text-muted text-sm">No releases catalogued yet.</p>
+              ) : (
+                <div className="space-y-3">
+                  {releases.map(release => (
+                    <ReleaseCard
+                      key={release.id}
+                      release={release}
+                      editing={editingId === release.id}
+                      actionLoading={actionLoading}
+                      onToggleEdit={() => setEditingId(editingId === release.id ? null : release.id)}
+                      onHide={() =>
+                        runAction(`hide-${release.id}`, {
+                          action: release.isHidden ? 'unhide' : 'hide',
+                          releaseId: release.id,
+                        })
+                      }
+                      onDismiss={() => runAction(`dismiss-${release.id}`, { action: 'dismiss', releaseId: release.id })}
+                      onMerge={(keepId, dropId) => runAction(`merge-${keepId}`, { action: 'merge', keepId, dropId })}
+                      onUpdate={async patch => {
+                        const saved = await runAction(`update-${release.id}`, {
+                          action: 'update',
+                          releaseId: release.id,
+                          ...patch,
+                        });
+                        if (saved) setEditingId(null);
+                      }}
+                      onAddLink={(platform, url) =>
+                        runAction(`addlink-${release.id}`, { action: 'addLink', releaseId: release.id, platform, url })
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PlatformBadges({ items }: { items: { platform: string; url: string }[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex items-center gap-2 mt-1.5">
+      {items.map(s => (
+        <a
+          key={s.platform}
+          href={s.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={PLATFORMS[s.platform]?.name ?? s.platform}
+        >
+          <PlatformIcon
+            sourceId={s.platform as SourceId}
+            color={PLATFORMS[s.platform]?.color ?? '#888'}
+            emoji={PLATFORMS[s.platform]?.icon ?? '🔗'}
+            className="w-4 h-4"
+          />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function ReleaseCard({
+  release,
+  editing,
+  actionLoading,
+  onToggleEdit,
+  onHide,
+  onDismiss,
+  onMerge,
+  onUpdate,
+  onAddLink,
+}: {
+  release: OwnerRelease;
+  editing: boolean;
+  actionLoading: string | null;
+  onToggleEdit: () => void;
+  onHide: () => void;
+  onDismiss: () => void;
+  onMerge: (keepId: string, dropId: string) => void;
+  onUpdate: (patch: { title?: string; releaseDate?: string | null; artworkUrl?: string | null }) => void;
+  onAddLink: (platform: string, url: string) => void;
+}) {
+  const busy = (key: string) => actionLoading === key;
+  const date = formatReleaseDate(release.releaseDate, release.datePrecision);
+  const type = release.releaseType === 'other' ? '' : release.releaseType.charAt(0).toUpperCase() + release.releaseType.slice(1);
+  const meta = [type, date].filter(Boolean).join(' · ');
+
+  return (
+    <div className={`p-4 rounded-xl bg-surface border border-border space-y-3 ${release.isHidden ? 'opacity-60' : ''}`}>
+      <div className="flex items-start gap-3">
+        {release.artworkUrl ? (
+          <img
+            src={release.artworkUrl}
+            alt=""
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            className="w-12 h-12 rounded-md object-cover shrink-0 bg-bg-secondary"
+          />
+        ) : (
+          <div className="w-12 h-12 rounded-md shrink-0 bg-bg-secondary flex items-center justify-center text-xl">
+            💿
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="font-medium text-text-primary truncate">{release.title}</p>
+            {release.isHidden && (
+              <span className="text-[10px] font-bold uppercase tracking-wide text-text-muted shrink-0">Hidden</span>
+            )}
+            {release.needsReview && (
+              <span className="text-[10px] font-bold uppercase tracking-wide text-yellow-500 shrink-0">Needs review</span>
+            )}
+          </div>
+          {meta && <p className="text-xs text-text-muted">{meta}</p>}
+          <PlatformBadges items={release.sources} />
+        </div>
+      </div>
+
+      {release.needsReview && release.flaggedAgainst && (
+        <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm space-y-2">
+          <p className="text-text-secondary">
+            Possible duplicate of <span className="font-medium">{release.flaggedAgainst.title}</span>.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={onDismiss}
+              disabled={busy(`dismiss-${release.id}`)}
+              className="px-3 py-1 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors disabled:opacity-50"
+            >
+              {busy(`dismiss-${release.id}`) ? 'Working...' : 'Not a duplicate'}
+            </button>
+            <button
+              onClick={() => onMerge(release.id, release.flaggedAgainst!.id)}
+              disabled={busy(`merge-${release.id}`)}
+              className="px-3 py-1 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-500 transition-colors disabled:opacity-50"
+            >
+              {busy(`merge-${release.id}`) ? 'Merging...' : 'Same release — keep this one'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={onHide}
+          disabled={busy(`hide-${release.id}`)}
+          className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors disabled:opacity-50"
+        >
+          {busy(`hide-${release.id}`) ? 'Working...' : release.isHidden ? 'Unhide' : 'Hide'}
+        </button>
+        <button
+          onClick={onToggleEdit}
+          className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors"
+        >
+          {editing ? 'Cancel' : 'Edit / add link'}
+        </button>
+      </div>
+
+      {editing && (
+        <EditReleaseForm
+          release={release}
+          busy={busy(`update-${release.id}`)}
+          linkBusy={busy(`addlink-${release.id}`)}
+          onSave={onUpdate}
+          onAddLink={onAddLink}
+        />
+      )}
+    </div>
+  );
+}
+
+function EditReleaseForm({
+  release,
+  busy,
+  linkBusy,
+  onSave,
+  onAddLink,
+}: {
+  release: OwnerRelease;
+  busy: boolean;
+  linkBusy: boolean;
+  onSave: (patch: { title?: string; releaseDate?: string | null; artworkUrl?: string | null }) => void;
+  onAddLink: (platform: string, url: string) => void;
+}) {
+  const [title, setTitle] = useState(release.title);
+  const [releaseDate, setReleaseDate] = useState(release.releaseDate ?? '');
+  const [artworkUrl, setArtworkUrl] = useState(release.artworkUrl ?? '');
+  const [linkPlatform, setLinkPlatform] = useState<string>(PLATFORM_OPTIONS[0]?.id ?? '');
+  const [linkUrl, setLinkUrl] = useState('');
+
+  return (
+    <div className="pt-3 border-t border-border space-y-4">
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-text-muted">Title</label>
+        <input
+          type="text"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        />
+        <label className="block text-xs font-medium text-text-muted">Release date</label>
+        <input
+          type="date"
+          value={releaseDate}
+          onChange={e => setReleaseDate(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        />
+        <label className="block text-xs font-medium text-text-muted">Artwork URL</label>
+        <input
+          type="text"
+          value={artworkUrl}
+          onChange={e => setArtworkUrl(e.target.value)}
+          placeholder="https://..."
+          className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        />
+        <button
+          onClick={() =>
+            onSave({
+              title: title.trim() !== release.title ? title.trim() : undefined,
+              releaseDate: releaseDate !== (release.releaseDate ?? '') ? releaseDate || null : undefined,
+              artworkUrl: artworkUrl !== (release.artworkUrl ?? '') ? artworkUrl || null : undefined,
+            })
+          }
+          disabled={busy}
+          className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-500 transition-colors disabled:opacity-50"
+        >
+          {busy ? 'Saving...' : 'Save changes'}
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-text-muted">Add a platform link</label>
+        <div className="flex flex-wrap gap-2">
+          <select
+            value={linkPlatform}
+            onChange={e => setLinkPlatform(e.target.value)}
+            className="px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+          >
+            {PLATFORM_OPTIONS.map(p => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={linkUrl}
+            onChange={e => setLinkUrl(e.target.value)}
+            placeholder="https://..."
+            className="flex-1 min-w-[160px] px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+          />
+          <button
+            onClick={() => {
+              if (!linkUrl.trim()) return;
+              onAddLink(linkPlatform, linkUrl.trim());
+              setLinkUrl('');
+            }}
+            disabled={linkBusy || !linkUrl.trim()}
+            className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors disabled:opacity-50"
+          >
+            {linkBusy ? 'Adding...' : 'Add link'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AddReleaseForm({
+  busy,
+  onCreate,
+}: {
+  busy: boolean;
+  onCreate: (input: { title: string; releaseType: string; releaseDate: string | null; platform: string; url: string }) => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [releaseType, setReleaseType] = useState<string>('album');
+  const [releaseDate, setReleaseDate] = useState('');
+  const [platform, setPlatform] = useState<string>(PLATFORM_OPTIONS[0]?.id ?? '');
+  const [url, setUrl] = useState('');
+
+  const canSubmit = title.trim().length > 0 && url.trim().length > 0;
+
+  return (
+    <div className="p-4 rounded-xl bg-surface border border-border space-y-3">
+      <label className="block text-xs font-medium text-text-muted">Title</label>
+      <input
+        type="text"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="Release title"
+        className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+      />
+
+      <div className="flex flex-wrap gap-2">
+        <select
+          value={releaseType}
+          onChange={e => setReleaseType(e.target.value)}
+          className="px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        >
+          {RELEASE_TYPES.map(t => (
+            <option key={t} value={t}>
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </option>
+          ))}
+        </select>
+        <input
+          type="date"
+          value={releaseDate}
+          onChange={e => setReleaseDate(e.target.value)}
+          className="px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <select
+          value={platform}
+          onChange={e => setPlatform(e.target.value)}
+          className="px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        >
+          {PLATFORM_OPTIONS.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="https://..."
+          className="flex-1 min-w-[160px] px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
+        />
+      </div>
+
+      <button
+        onClick={() =>
+          onCreate({ title: title.trim(), releaseType, releaseDate: releaseDate || null, platform, url: url.trim() })
+        }
+        disabled={busy || !canSubmit}
+        className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-sm font-medium hover:bg-green-500 transition-colors disabled:opacity-50"
+      >
+        {busy ? 'Adding...' : 'Add release'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/types/artist-page.ts
+++ b/apps/web/src/types/artist-page.ts
@@ -39,7 +39,12 @@ export interface ArtistPagePayload {
     datePrecision: string | null;
     status: string;
     artworkUrl: string | null;
-    offers: Array<{ price: number | null; currency: string | null; availability: string }>;
+    // Kept per-source (not flattened) so the UI can show *where* a release is available, not
+    // just the cheapest price across everywhere it happens to be sold.
+    sources: Array<{
+      platform: string;
+      offers: Array<{ price: number | null; currency: string | null; availability: string }>;
+    }>;
   }>;
   /** Total before the cap, so the UI can say how many are not shown. */
   releaseCount?: number;

--- a/apps/web/tests/unit/AdminReleaseReviewPage.test.tsx
+++ b/apps/web/tests/unit/AdminReleaseReviewPage.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+// The admin backstop for tier-3 dedup: renders a queue of suspected-duplicate pairs and lets an
+// admin dismiss ("not a duplicate") or merge ("same release, keep this one").
+//
+// What's worth locking: both merge buttons send the right (keepId, dropId) pairing — a swap
+// here would merge the wrong release away — and a pair whose counterpart is gone still renders
+// instead of disappearing.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { AdminReleaseReviewPage } from 'src/pages/AdminReleaseReviewPage';
+
+const mockSession = { access_token: 'admin-token' };
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAdmin: true, session: mockSession }),
+}));
+
+vi.mock('src/components/Header', () => ({
+  Header: () => null,
+}));
+
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function releaseItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    title: 'Carrie & Lowell',
+    slug: 'carrie-lowell',
+    releaseType: 'album',
+    releaseDate: '2015-03-31',
+    datePrecision: 'day',
+    artworkUrl: null,
+    artistName: 'Sufjan Stevens',
+    artistSlug: 'sufjan-stevens',
+    platforms: ['bandcamp'],
+    ...overrides,
+  };
+}
+
+function setupFetchMock(pairs: unknown[]) {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ pairs }),
+  });
+}
+
+describe('AdminReleaseReviewPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it('shows nothing-to-review as an explicit message, not a blank page', async () => {
+    setupFetchMock([]);
+    render(<AdminReleaseReviewPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Nothing flagged for review right now.')).toBeTruthy();
+    });
+  });
+
+  it('renders both sides of a pair', async () => {
+    const primary = releaseItem();
+    const counterpart = releaseItem({
+      id: '22222222-2222-2222-2222-222222222222',
+      title: 'Carrie & Lowell (Deluxe Edition)',
+      slug: 'carrie-lowell-deluxe',
+      platforms: ['discogs'],
+    });
+    setupFetchMock([{ primary, counterpart }]);
+
+    render(<AdminReleaseReviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Carrie & Lowell')).toBeTruthy();
+      expect(screen.getByText('Carrie & Lowell (Deluxe Edition)')).toBeTruthy();
+    });
+  });
+
+  // The one bug that would matter here: swapping keep/drop merges the wrong release away.
+  it('sends the clicked card as keepId and the other as dropId', async () => {
+    const primary = releaseItem();
+    const counterpart = releaseItem({
+      id: '22222222-2222-2222-2222-222222222222',
+      title: 'Carrie & Lowell (Deluxe Edition)',
+      slug: 'carrie-lowell-deluxe',
+    });
+    setupFetchMock([{ primary, counterpart }]);
+
+    render(<AdminReleaseReviewPage />);
+    await waitFor(() => screen.getByText('Carrie & Lowell (Deluxe Edition)'));
+
+    const keepButtons = screen.getAllByText('Same release — keep this one');
+    expect(keepButtons).toHaveLength(2);
+
+    fireEvent.click(keepButtons[1]); // the counterpart's card
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall[1].body);
+      expect(body).toEqual({ action: 'merge', keepId: counterpart.id, dropId: primary.id });
+    });
+  });
+
+  it('dismisses by releaseId of the primary side', async () => {
+    setupFetchMock([{ primary: releaseItem(), counterpart: null }]);
+
+    render(<AdminReleaseReviewPage />);
+    await waitFor(() => screen.getByText('Carrie & Lowell'));
+
+    fireEvent.click(screen.getByText('Not a duplicate'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(postCall[1].body)).toEqual({
+        action: 'dismiss',
+        releaseId: releaseItem().id,
+      });
+    });
+  });
+
+  // A missing counterpart (already resolved from the other side, or deleted) must still show
+  // the flagged release rather than vanish — it was flagged for a reason.
+  it('renders a release alone when it has no counterpart, with no merge button', async () => {
+    setupFetchMock([{ primary: releaseItem(), counterpart: null }]);
+
+    render(<AdminReleaseReviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Carrie & Lowell')).toBeTruthy();
+      expect(screen.getByText(/no longer on file/)).toBeTruthy();
+    });
+    expect(screen.queryByText('Same release — keep this one')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/ArtistReleasesPage.test.tsx
+++ b/apps/web/tests/unit/ArtistReleasesPage.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+// The artist-facing release curation page (spec §11).
+//
+// What's worth locking: the merge button on a flagged pair sends the *current* release as
+// keepId and its flagged counterpart as dropId (never swapped — that would merge away the
+// release the artist is looking at), and the add-release form actually reaches the network
+// with the fields the artist typed.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ArtistReleasesPage } from 'src/pages/ArtistReleasesPage';
+
+const mockSession = { access_token: 'user-token' };
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({ session: mockSession }),
+}));
+
+vi.mock('src/components/Header', () => ({
+  Header: () => null,
+}));
+
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function releaseItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    title: 'Ruined Castle',
+    slug: 'ruined-castle',
+    releaseType: 'album',
+    releaseDate: '2024-06-01',
+    datePrecision: 'day',
+    artworkUrl: null,
+    isHidden: false,
+    needsReview: false,
+    flaggedAgainst: null,
+    sources: [{ platform: 'bandcamp', url: 'https://x.bandcamp.com/album/ruined-castle' }],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/artist-edit/kid-lightbulbs/releases']}>
+      <Routes>
+        <Route path="/artist-edit/:slug/releases" element={<ArtistReleasesPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function setupFetchMock(releases: unknown[]) {
+  mockFetch.mockReset();
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (!init || init.method === undefined) {
+      // GET
+      return Promise.resolve({ ok: true, json: async () => ({ releases }) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
+  });
+}
+
+describe('ArtistReleasesPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it('lists releases fetched for this artist', async () => {
+    setupFetchMock([releaseItem()]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Ruined Castle')).toBeTruthy());
+  });
+
+  it('shows a needs-review release with its flagged counterpart', async () => {
+    setupFetchMock([
+      releaseItem({
+        id: '11111111-1111-1111-1111-111111111111',
+        needsReview: true,
+        flaggedAgainst: { id: '22222222-2222-2222-2222-222222222222', title: 'Ruined Castle (Deluxe)' },
+      }),
+    ]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Possible duplicate of/)).toBeTruthy();
+      expect(screen.getByText('Ruined Castle (Deluxe)')).toBeTruthy();
+    });
+  });
+
+  // The one bug that would matter: the merge call must keep the release being viewed, not
+  // swap in its counterpart as the survivor.
+  it('merges keeping the current release, dropping its flagged counterpart', async () => {
+    setupFetchMock([
+      releaseItem({
+        id: '11111111-1111-1111-1111-111111111111',
+        needsReview: true,
+        flaggedAgainst: { id: '22222222-2222-2222-2222-222222222222', title: 'Ruined Castle (Deluxe)' },
+      }),
+    ]);
+    renderPage();
+
+    await waitFor(() => screen.getByText('Same release — keep this one'));
+    fireEvent.click(screen.getByText('Same release — keep this one'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body).toMatchObject({
+        action: 'merge',
+        keepId: '11111111-1111-1111-1111-111111111111',
+        dropId: '22222222-2222-2222-2222-222222222222',
+      });
+    });
+  });
+
+  it('toggles hide/unhide with the right release id', async () => {
+    setupFetchMock([releaseItem()]);
+    renderPage();
+
+    await waitFor(() => screen.getByText('Hide'));
+    fireEvent.click(screen.getByText('Hide'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(postCall![1].body)).toMatchObject({
+        action: 'hide',
+        releaseId: '11111111-1111-1111-1111-111111111111',
+      });
+    });
+  });
+
+  it('submits the add-release form with the typed fields', async () => {
+    setupFetchMock([]);
+    renderPage();
+
+    await waitFor(() => screen.getByText('+ Add a release we missed'));
+    fireEvent.click(screen.getByText('+ Add a release we missed'));
+
+    fireEvent.change(screen.getByPlaceholderText('Release title'), { target: { value: 'A New EP' } });
+    const urlInputs = screen.getAllByPlaceholderText('https://...');
+    fireEvent.change(urlInputs[urlInputs.length - 1], { target: { value: 'https://x.bandcamp.com/album/new-ep' } });
+
+    fireEvent.click(screen.getByText('Add release'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body.action).toBe('create');
+      expect(body.title).toBe('A New EP');
+      expect(body.url).toBe('https://x.bandcamp.com/album/new-ep');
+    });
+  });
+
+  it('shows an empty state when there is nothing catalogued', async () => {
+    setupFetchMock([]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('No releases catalogued yet.')).toBeTruthy());
+  });
+});

--- a/apps/web/tests/unit/ArtistReleasesPage.test.tsx
+++ b/apps/web/tests/unit/ArtistReleasesPage.test.tsx
@@ -53,12 +53,12 @@ function renderPage() {
   );
 }
 
-function setupFetchMock(releases: unknown[]) {
+function setupFetchMock(releases: unknown[], catalog?: unknown) {
   mockFetch.mockReset();
   mockFetch.mockImplementation((url: string, init?: RequestInit) => {
     if (!init || init.method === undefined) {
       // GET
-      return Promise.resolve({ ok: true, json: async () => ({ releases }) });
+      return Promise.resolve({ ok: true, json: async () => ({ releases, catalog }) });
     }
     return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
   });
@@ -161,5 +161,105 @@ describe('ArtistReleasesPage', () => {
     setupFetchMock([]);
     renderPage();
     await waitFor(() => expect(screen.getByText('No releases catalogued yet.')).toBeTruthy());
+  });
+});
+
+describe('ArtistReleasesPage — self-serve catalog scan', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  const SCAN_LABEL = 'Scan my links for releases';
+
+  // Visibility follows the server's `canTrigger`, not a copy of the rule in page code — so the
+  // rollout gate can't drift out of sync with the client.
+  it('hides the scan control when the server says the caller cannot trigger', async () => {
+    setupFetchMock([], { canTrigger: false, state: null, stateError: null });
+    renderPage();
+    await waitFor(() => screen.getByText('No releases catalogued yet.'));
+    expect(screen.queryByText(SCAN_LABEL)).toBeNull();
+  });
+
+  it('hides the scan control entirely when the response carries no catalog block at all', async () => {
+    setupFetchMock([]);
+    renderPage();
+    await waitFor(() => screen.getByText('No releases catalogued yet.'));
+    expect(screen.queryByText(SCAN_LABEL)).toBeNull();
+  });
+
+  it('shows the scan control, and says it is admin-only for now', async () => {
+    setupFetchMock([], { canTrigger: true, state: null, stateError: null });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(SCAN_LABEL)).toBeTruthy());
+    expect(screen.getByText(/Admin only for now/)).toBeTruthy();
+    expect(screen.getByText('Never catalogued')).toBeTruthy();
+  });
+
+  it('summarizes a previous run', async () => {
+    setupFetchMock([], {
+      canTrigger: true,
+      state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 12, releases_detailed: 9, last_error: null },
+      stateError: null,
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('12 releases found, 9 with prices')).toBeTruthy());
+  });
+
+  // "We couldn't ask" must not render as a confident "Never catalogued".
+  it('reports an unreadable state instead of claiming never-catalogued', async () => {
+    setupFetchMock([], { canTrigger: true, state: null, stateError: 'Could not read catalog state' });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Could not read catalog state')).toBeTruthy());
+    expect(screen.queryByText('Never catalogued')).toBeNull();
+  });
+
+  it('reports a failed previous run rather than a count', async () => {
+    setupFetchMock([], {
+      canTrigger: true,
+      state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 0, releases_detailed: 0, last_error: 'bandcamp bot challenge' },
+      stateError: null,
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Last run failed: bandcamp bot challenge/)).toBeTruthy());
+  });
+
+  it('posts the catalog action for this artist when clicked', async () => {
+    setupFetchMock([], { canTrigger: true, state: null, stateError: null });
+    renderPage();
+    await waitFor(() => screen.getByText(SCAN_LABEL));
+
+    fireEvent.click(screen.getByText(SCAN_LABEL));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(postCall![1].body)).toEqual({ slug: 'kid-lightbulbs', action: 'catalog' });
+    });
+  });
+
+  // The endpoint reports refusals it can predict (cataloging disabled, missing secret) as real
+  // errors; those must surface rather than leaving the UI stuck on "Scanning…".
+  it('surfaces a refusal from the endpoint', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ releases: [], catalog: { canTrigger: true, state: null, stateError: null } }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).' }),
+      });
+    });
+
+    renderPage();
+    await waitFor(() => screen.getByText(SCAN_LABEL));
+    fireEvent.click(screen.getByText(SCAN_LABEL));
+
+    await waitFor(() => expect(screen.getByText(/RELEASE_CATALOG_ENABLED/)).toBeTruthy());
+    // Re-enabled rather than stuck mid-scan, so it can be retried once configuration is fixed.
+    expect((screen.getByText(SCAN_LABEL) as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/apps/web/tests/unit/ReleasesSection.test.tsx
+++ b/apps/web/tests/unit/ReleasesSection.test.tsx
@@ -25,7 +25,7 @@ function release(overrides: Partial<Release> = {}): Release {
     datePrecision: 'day',
     status: 'released',
     artworkUrl: null,
-    offers: [],
+    sources: [],
     ...overrides,
   };
 }
@@ -64,16 +64,21 @@ describe('ReleasesSection', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('shows type, date and the cheapest price together', () => {
+  it('shows type, date, the cheapest price, and the payout estimate together', () => {
     show([
       release({
-        offers: [
-          { price: 25, currency: 'USD', availability: 'available' },
-          { price: 7, currency: 'USD', availability: 'available' },
+        sources: [
+          {
+            platform: 'bandcamp',
+            offers: [
+              { price: 25, currency: 'USD', availability: 'available' },
+              { price: 7, currency: 'USD', availability: 'available' },
+            ],
+          },
         ],
       }),
     ]);
-    expect(screen.getByText('Album · 1 June 2024 · from $7')).toBeTruthy();
+    expect(screen.getByText('Album · 1 June 2024 · from $7 · ≈$5.60–$5.95 to artist')).toBeTruthy();
   });
 
   // Quoting the price of a record nobody can buy is the one genuinely misleading number this
@@ -81,9 +86,14 @@ describe('ReleasesSection', () => {
   it('never quotes a sold-out format as the price', () => {
     show([
       release({
-        offers: [
-          { price: 7, currency: 'USD', availability: 'sold_out' },
-          { price: 25, currency: 'USD', availability: 'available' },
+        sources: [
+          {
+            platform: 'bandcamp',
+            offers: [
+              { price: 7, currency: 'USD', availability: 'sold_out' },
+              { price: 25, currency: 'USD', availability: 'available' },
+            ],
+          },
         ],
       }),
     ]);
@@ -93,8 +103,41 @@ describe('ReleasesSection', () => {
 
   // Bandcamp reports name-your-price as 0, and "from $0" would tell a fan the record is free.
   it('reads a zero price as name-your-price', () => {
-    show([release({ offers: [{ price: 0, currency: 'USD', availability: 'available' }] })]);
+    show([
+      release({
+        sources: [{ platform: 'bandcamp', offers: [{ price: 0, currency: 'USD', availability: 'available' }] }],
+      }),
+    ]);
     expect(screen.getByText(/Name your price/)).toBeTruthy();
+  });
+
+  // Where a fan can actually go to get it — the thing this whole task exists to surface.
+  it('shows which platforms the release is available on', () => {
+    show([
+      release({
+        sources: [
+          { platform: 'bandcamp', offers: [] },
+          { platform: 'discogs', offers: [] },
+        ],
+      }),
+    ]);
+    expect(screen.getByText('Available on Bandcamp, Discogs')).toBeTruthy();
+  });
+
+  // The whole reason this isn't just "cheapest price across every source": once Discogs (no
+  // payout figure, secondhand) is a second source, picking the absolute cheapest could rank a
+  // used copy above the artist's own store — see leadingOfferSummary's own doc.
+  it('prefers the artist-paying source even when a lower-payout source is cheaper', () => {
+    show([
+      release({
+        sources: [
+          { platform: 'discogs', offers: [{ price: 3, currency: 'USD', availability: 'available' }] },
+          { platform: 'bandcamp', offers: [{ price: 25, currency: 'USD', availability: 'available' }] },
+        ],
+      }),
+    ]);
+    expect(screen.getByText(/from \$25/)).toBeTruthy();
+    expect(screen.queryByText(/from \$3/)).toBeNull();
   });
 
   // Grid ingest stores year-only and undated releases; rendering "1 January" would state a fact

--- a/netlify.toml
+++ b/netlify.toml
@@ -185,6 +185,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/admin/release-review"
+  to = "/.netlify/functions/admin-release-review"
+  status = 200
+
+[[redirects]]
   from = "/api/discord/interaction"
   to = "/.netlify/functions/discord-interaction"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -140,6 +140,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/artist-releases"
+  to = "/.netlify/functions/artist-releases"
+  status = 200
+
+[[redirects]]
   from = "/api/desktop/version"
   to = "/.netlify/functions/desktop-version"
   status = 200

--- a/supabase/migrations/20260801000000_release-review-candidate.sql
+++ b/supabase/migrations/20260801000000_release-review-candidate.sql
@@ -1,0 +1,21 @@
+-- Migration: releases.flagged_against_release_id
+--
+-- The tier-3 fuzzy dedup pass (persistDiscogsReleases) sets `needs_review = true` on both
+-- sides of a suspected duplicate pair, but never recorded *which* other release triggered the
+-- flag — so an admin queue built on `needs_review` alone could show that a release was flagged
+-- without being able to show what it was flagged against, forcing a re-run of the fuzzy match
+-- just to reconstruct a fact ingest already knew when it wrote the flag.
+--
+-- Nullable, self-referencing, and best-effort: `ON DELETE SET NULL` rather than a hard block,
+-- because deleting one side of a pair (e.g. via the admin "hide" action) should not be
+-- prevented by the other side still pointing at it — it should just stop pointing at anything.
+
+ALTER TABLE releases
+  ADD COLUMN IF NOT EXISTS flagged_against_release_id uuid REFERENCES releases(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_releases_flagged_against
+  ON releases (flagged_against_release_id)
+  WHERE flagged_against_release_id IS NOT NULL;
+
+COMMENT ON COLUMN releases.flagged_against_release_id IS
+  'The other release this one was fuzzy-matched against when needs_review was set (tier 3 dedup). Null once resolved (dismissed or merged). Never used to auto-merge — only to show an admin what the suspected duplicate is.';


### PR DESCRIPTION
Picks up the Releases feature at spec steps 7–10, plus §11 curation. Bandcamp-only
release pages read as an undifferentiated Bandcamp mirror, so this adds sources, the
dedup logic to combine them safely, and the human surfaces to correct what automation
gets wrong.

## What a fan sees

The artist-page release list now shows **which platforms** a release is on and **what it
costs, with the payout estimate** — previously it showed a bare "cheapest price" with no
attribution, so a second source had nothing to show for itself until you clicked through.

The price shown is the **leading artist-paying source, not the globally cheapest**. Once
Discogs is in the mix, "cheapest" could rank a $3 secondhand listing above a $25 direct
purchase — exactly the off-mission ordering the sourcing spec warns about.

## Sources

- **Discogs** — two-tier like Bandcamp: a cheap `role=Main`/`type=master` listing, then a
  budgeted detail pass for price/format/availability. Its marketplace stats describe the
  whole release rather than per format, so only one offer is emitted; zero listings reports
  as `unknown`, never `sold_out`.
- **MusicBrainz** — enrichment only. Fills in release-group MBIDs and partial dates on
  releases that already exist; never creates one, since it has no purchase link to attach.
- **Faircamp** — verified against a real live instance. Its homepage doubles as the release
  list, and it has no reliable date or price anywhere in its markup (no JSON-LD, no `<time>`,
  no RSS `pubDate`), so this ingest honestly produces identity and artwork only.
- **Discovered links** — some platforms can't be fetched at all, but an artist's other pages
  sometimes link straight to a specific release there. This reads those out of markup already
  fetched for another reason and attaches them only on an **exact** title match.

**Mirlo is deliberately absent.** Its API is the best of any source — full discography in one
request, with prices — but `api.mirlo.space/robots.txt` disallows `/v1/` for every user agent
under a `# Disallow crawling the API` comment. Raising it with Mirlo directly instead.
**Subvert** is a hard wall: even a known-good artist URL returns HTTP 429 from a bot
checkpoint, for any path. **Bandwagon** sets `Crawl-delay: 1000` seconds, and its discography
appears to be client-rendered anyway.

## Dedup, and the two review surfaces

Three tiers, using identity columns the step-1 schema already had but nothing populated:

1. Hard identifiers (`discogs_master_id`, `musicbrainz_release_group_id`)
2. Exact normalized title within release type
3. **Fuzzy — never merges.** Flags both sides `needs_review` and records which release
   triggered it, via a new nullable self-reference.

Tier 3 needs a human, so this adds both:

- **`/admin/release-review`** — flagged pairs, deduplicated so a symmetric flag is one
  decision rather than two. Dismiss, or merge keeping either side.
- **`/artist-edit/:slug/releases`** — the artist's own version, plus hide, fix
  title/date/artwork, add a missing platform link, and add a release ingest never found.

Merges move `release_sources` onto the survivor **before** deleting the duplicate, and only
delete once that has succeeded — this project has lost data to the reverse order before
(#350). A same-platform conflict refuses the merge rather than silently dropping a source.

## "Scan my links for releases" — admin-only for now

The self-serve trigger, on the artist's curation page. **Ownership authorizes it; the admin
check is a separate rollout gate** — one function, two call sites, and a comment saying that
opening it to all verified artists means deleting exactly that, with no change to the
ownership path. Ownership is still enforced on top, so an admin can't catalog someone else's
profile through this endpoint.

Ready to test in production behind that gate.

## Notes for review

- **Ingest can no longer clobber a curated edit.** Sources an artist added or corrected are
  written `source: 'claimed'`, and every ingest path checks that before touching a source's
  URL — the same rule `curated_fields` already enforced on the release row, extended to the
  sources table. Without it a re-crawl would have silently reverted an artist's fix in 30 days.
- **Catalog state is three-valued end to end.** "We couldn't ask" never renders as a confident
  "Never catalogued".
- One migration: `releases.flagged_against_release_id` (nullable, `ON DELETE SET NULL`).
- New env requirement: none beyond what cataloging already needs.

491 API tests, 523 web unit tests, clean typecheck. No new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)