### PR TITLE
Fix release catalog prices and Faircamp artist-page ingest

### DIFF
--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -248,13 +248,15 @@ export default async function handler(request: Request, context: Context) {
         </div>`;
       }).join('');
 
-      // An honest empty state. "We know it's here, we haven't read the prices yet" is a
-      // different statement from "there is nothing to buy", and a fan can act on the first.
+      // An honest empty state. Both branches say the same thing to a fan — we have no price to
+      // show you — and neither says "this is free" or "there is nothing to buy". The wording no
+      // longer promises that a price is on its way: a Faircamp release whose purchase page we
+      // can't read has no price coming, and "still gathering" would be a promise we don't keep.
       const pendingHtml = offers.length === 0
         ? `<div class="offer"><span style="color:var(--muted)">${
             source.detail_checked_at
               ? 'No formats listed on this page.'
-              : 'Still gathering formats and prices.'
+              : 'Price information not available.'
           }</span></div>`
         : '';
 

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -17,6 +17,7 @@ import {
   mapDiscogsFormatName,
   ingestMusicBrainzReleaseGroups,
   ingestFaircampHomeLinks,
+  ingestFaircampPurchasePage,
   ingestFaircampReleasePage,
   buildFaircampRelease,
   findDiscoveredReleaseLinks,
@@ -189,6 +190,8 @@ function detailPage(opts: {
   packages?: Array<{
     format?: string;
     typeName?: string;
+    /** Bandcamp's own product kind: 'a' album, 'p' package, 'b' discography, 'i' subscription. */
+    itemType?: string;
     price?: number | string;
     currency?: string;
     availability?: string;
@@ -201,7 +204,10 @@ function detailPage(opts: {
     graph.albumRelease = opts.packages.map(p => ({
       '@type': ['MusicRelease', 'Product'],
       musicReleaseFormat: p.format,
-      additionalProperty: [{ '@type': 'PropertyValue', name: 'type_name', value: p.typeName }],
+      additionalProperty: [
+        { '@type': 'PropertyValue', name: 'type_name', value: p.typeName },
+        ...(p.itemType ? [{ '@type': 'PropertyValue', name: 'item_type', value: p.itemType }] : []),
+      ],
       offers: {
         '@type': 'Offer',
         price: p.price,
@@ -254,6 +260,43 @@ describe('ingestBandcampDetail', () => {
       })
     );
 
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([
+      { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+    ]);
+  });
+
+  // The subscription and the discography bundle are typed DigitalFormat/Digital exactly like
+  // the album's own download, so nothing but item_type tells them apart — and being cheaper,
+  // the subscription wins the cheapest-variant rule and gets published as the album's price.
+  // Measured on kidlightbulbs.bandcamp.com: a $3.33/month subscription quoted as the album.
+  it('ignores the artist subscription and the discography bundle', () => {
+    const out = ingestBandcampDetail(
+      detailPage({
+        packages: [
+          { format: 'DigitalFormat', typeName: 'Digital', itemType: 'a', price: 5, availability: 'OnlineOnly' },
+          { format: 'DigitalFormat', typeName: 'Digital', itemType: 'i', price: 3.33 },
+          { format: 'DigitalFormat', typeName: 'Digital', itemType: 'b', price: 23.2, availability: 'OnlineOnly' },
+          { format: 'VinylFormat', typeName: 'Vinyl LP', itemType: 'p', price: 25, availability: 'InStock' },
+        ],
+      })
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([
+      { format: 'digital', price: 5, currency: 'USD', availability: 'available' },
+      { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+    ]);
+  });
+
+  it('keeps a package that carries no item_type at all', () => {
+    // Dropping the unlabelled would empty the offers on any page whose markup drifts — a worse
+    // failure than the one above, and a silent one.
+    const out = ingestBandcampDetail(
+      detailPage({ packages: [{ format: 'VinylFormat', typeName: 'Vinyl LP', price: 25 }] })
+    );
     expect(out.ok).toBe(true);
     if (!out.ok) return;
     expect(out.detail.offers).toEqual([
@@ -592,17 +635,31 @@ describe('ingestMusicBrainzReleaseGroups', () => {
 // Fixtures below are trimmed from a real, live Faircamp instance (verified 2026-08-01) rather
 // than guessed — Faircamp's own markup has no JSON-LD, no <time> tag, and no pubDate in its
 // RSS feed, so the parser is deliberately narrow: identity and artwork only.
+// A multi-artist instance, which is the case that broke: every release block carries its own
+// artist credits, as links indistinguishable in shape from the release links beside them.
 const FAIRCAMP_HOME_HTML = `<!doctype html><html><body>
   <nav>
     <a href="./">Home</a>
     <a href="#content">Skip</a>
     <a href="subscribe/">Subscribe</a>
   </nav>
-  <ol>
-    <li><a href="ruined-castle/">RUINED CASTLE</a></li>
-    <li><a href="infinite-normal/">INFINITE NORMAL</a></li>
-    <li><a href="solo-piano/">SOLO PIANO</a></li>
-  </ol>
+  <div class="page_grid">
+    <div class="release">
+      <a href="ruined-castle/"><img src="ruined-castle/cover_320.jpg?XZDh1t00IS8"></a>
+      <a href="ruined-castle/">RUINED CASTLE</a>
+      <div class="release_artists"><a href="kl/">Kid Lightbulbs</a></div>
+    </div>
+    <div class="release">
+      <a href="infinite-normal/"><img src="infinite-normal/cover_320.jpg?MYD15tAi5QI"></a>
+      <a href="infinite-normal/">INFINITE NORMAL</a>
+      <div class="release_artists"><a href="kl/">Kid Lightbulbs</a></div>
+    </div>
+    <div class="release">
+      <a href="solo-piano/"><img src="solo-piano/cover_320.jpg?_5Kuo0yq7XY"></a>
+      <a href="solo-piano/">SOLO PIANO</a>
+      <div class="release_artists"><a href="blg/">Brandon Lucas Green</a></div>
+    </div>
+  </div>
   <a href="https://simonrepp.com/faircamp/">Powered by Faircamp</a>
   <a href="favicon.png?H-w5zbrED30">icon</a>
   <a href="feed.rss">RSS</a>
@@ -613,7 +670,40 @@ const FAIRCAMP_RELEASE_HTML = `<!doctype html><html><head>
   <meta property="og:title" content="RUINED CASTLE"/>
   <meta property="og:image" content="https://music.kidlightbulbs.com/ruined-castle/cover_800.jpg?XZDh1t00IS8"/>
   <meta property="og:description" content="The third album. A reflection on suffering."/>
-</head><body></body></html>`;
+</head><body>
+  <a href="purchase/YV_jiM0Ks4o/">Buy</a>
+  <a href="embed/">Embed</a>
+</body></html>`;
+
+/**
+ * The purchase page's price block, copied from what Faircamp's generator emits
+ * (renderer/src/pages/multitrack_purchase.rs) and checked against the live page.
+ */
+function faircampPurchaseHtml(opts: { min?: string; max?: string; fixedText?: string }): string {
+  const priceBlock = opts.fixedText
+    ? opts.fixedText
+    : `<label for="price">Name your price</label><br><br>
+       <div style="align-items: center; column-gap: .5rem; display: flex; position: relative;">
+         <span style="position: absolute; left: .5rem;">$</span>
+         <input autocomplete="off"
+                ${opts.max ? `data-max="${opts.max}"` : ''}
+                data-min="${opts.min ?? '0'}"
+                id="price"
+                pattern="[0-9]+([.,][0-9]+)?"
+                placeholder="0 or more"
+                style="padding-left: 1.5rem; width: 8rem;"
+                type="text">
+         USD
+       </div>`;
+
+  return `<!doctype html><html><body>
+    <h1>Purchase downloads</h1>
+    <div id="confirm_price">
+      <div class="interactive"><form action="../../downloads/iKtmnNw4rCY/">${priceBlock}<button>Confirm</button></form></div>
+      <div style="font-size: .9rem; margin: 1rem 0;">Available formats: MP3, Ogg Vorbis, FLAC, WAV</div>
+    </div>
+  </body></html>`;
+}
 
 describe('ingestFaircampHomeLinks', () => {
   it('finds bare relative release links and resolves them against the page URL', () => {
@@ -632,6 +722,27 @@ describe('ingestFaircampHomeLinks', () => {
     expect(out.some(o => o.url.includes('favicon'))).toBe(false);
   });
 
+  // The bug this guards: on a site hosting more than one artist, the per-release artist credits
+  // were catalogued as records, so Kid Lightbulbs' page listed "Kid Lightbulbs" and "Brandon
+  // Lucas Green" as albums. Nothing on the linked page says otherwise — an artist page and a
+  // release page both publish an og:title — so it has to be caught here.
+  it('never treats a release block\'s artist credits as releases', () => {
+    const out = ingestFaircampHomeLinks(FAIRCAMP_HOME_HTML, 'https://music.kidlightbulbs.com/');
+    expect(out.map(o => o.slug)).not.toContain('kl');
+    expect(out.map(o => o.slug)).not.toContain('blg');
+  });
+
+  it('falls back to a whole-page scan when there are no release blocks, still minus credits', () => {
+    // A generator change should cost coverage, not correctness.
+    const noBlocks = `<html><body>
+      <ol>
+        <li><a href="in-winter/">in winter/borders</a><div class="release_artists"><a href="kl/">Kid Lightbulbs</a></div></li>
+      </ol>
+    </body></html>`;
+    const out = ingestFaircampHomeLinks(noBlocks, 'https://music.kidlightbulbs.com/');
+    expect(out.map(o => o.slug)).toEqual(['in-winter']);
+  });
+
   it('deduplicates a repeated link and caps at the candidate ceiling', () => {
     const manyLinks = Array.from({ length: 40 }, (_, i) => `<a href="release-${i}/">R${i}</a>`).join('');
     const out = ingestFaircampHomeLinks(`<html>${manyLinks}</html>`, 'https://x.example.com/');
@@ -640,10 +751,11 @@ describe('ingestFaircampHomeLinks', () => {
 });
 
 describe('ingestFaircampReleasePage', () => {
-  it('reads title and artwork from Open Graph tags', () => {
+  it('reads title, artwork and the purchase link', () => {
     expect(ingestFaircampReleasePage(FAIRCAMP_RELEASE_HTML)).toEqual({
       title: 'RUINED CASTLE',
       artworkUrl: 'https://music.kidlightbulbs.com/ruined-castle/cover_800.jpg?XZDh1t00IS8',
+      purchaseHref: 'purchase/YV_jiM0Ks4o/',
     });
   });
 
@@ -660,7 +772,48 @@ describe('ingestFaircampReleasePage', () => {
     expect(ingestFaircampReleasePage('<meta property="og:title" content="No Cover"/>')).toEqual({
       title: 'No Cover',
       artworkUrl: null,
+      purchaseHref: null,
     });
+  });
+
+  it('reports no purchase link for a release that has none', () => {
+    // A code-unlocked release links `unlock/…` instead, and has no price anywhere.
+    const html = '<meta property="og:title" content="ALTERNATE NORMAL"/><a href="unlock/vvsrj_sNEcc/">Unlock</a>';
+    expect(ingestFaircampReleasePage(html)?.purchaseHref).toBeNull();
+  });
+});
+
+describe('ingestFaircampPurchasePage', () => {
+  it('reads a name-your-price minimum and its currency', () => {
+    expect(ingestFaircampPurchasePage(faircampPurchaseHtml({ min: '0' }))).toEqual({
+      format: 'digital',
+      price: 0,
+      currency: 'USD',
+      availability: 'available',
+    });
+  });
+
+  // The floor of a range is the honest figure: it's what a fan can actually pay.
+  it('takes the floor of a bounded range', () => {
+    expect(ingestFaircampPurchasePage(faircampPurchaseHtml({ min: '5', max: '20' }))).toMatchObject({
+      price: 5,
+      currency: 'USD',
+    });
+  });
+
+  // A fixed price is rendered as text with no input at all, and the words around it are
+  // localized — only the amount-then-ISO-code adjacency is guaranteed by the generator.
+  it('reads a fixed price rendered as plain text', () => {
+    expect(ingestFaircampPurchasePage(faircampPurchaseHtml({ fixedText: 'Preis $12 USD' }))).toMatchObject({
+      price: 12,
+      currency: 'USD',
+    });
+  });
+
+  it('returns null rather than a price of zero when it cannot read one', () => {
+    // "We couldn't read it" and "you may pay nothing" are different claims about someone's
+    // income, and the second is the one that costs an artist money.
+    expect(ingestFaircampPurchasePage('<html><body><p>Sold out</p></body></html>')).toBeNull();
   });
 });
 

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -104,10 +104,11 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     // Build the image URL: custom > artist row > null
     const imageUrl = profile?.custom_image_url || artistRow.image_url || null;
 
-    // Releases. Capped because most catalogues fit well under it (16 for Sufjan Stevens, 13 for
-    // Explosions in the Sky) and the artists who don't would otherwise bury the platform links
-    // this page exists to show.
-    const { releases, total: releaseCount } = await getArtistReleases(artistRow.id, 24);
+    // Releases. The page paginates these ten at a time rather than listing them all, so the cap
+    // here bounds the payload, not what a fan can reach: six pages, which covers every catalogue
+    // measured so far (16 for Sufjan Stevens, 13 for Explosions in the Sky, 33 for the largest
+    // live Mirlo artist). Beyond it the list says how many more exist rather than fetching them.
+    const { releases, total: releaseCount } = await getArtistReleases(artistRow.id, 60);
 
     const payload = {
       artist: {

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -35,6 +35,7 @@ import {
   ingestDiscogsMasters,
   ingestDiscogsReleaseDetail,
   ingestFaircampHomeLinks,
+  ingestFaircampPurchasePage,
   ingestFaircampReleasePage,
   ingestMusicBrainzReleaseGroups,
   type DiscogsArtistReleaseEntry,
@@ -135,8 +136,12 @@ const DELAY_BETWEEN_FAIRCAMP_FETCHES_MS = 1_000;
 /** Bounds cost for an artist with an unusually large Faircamp archive. */
 const MAX_FAIRCAMP_RELEASES_PER_ARTIST = 20;
 
-/** Invocation-wide, homepage + release-page requests combined, across every artist in the batch. */
-const MAX_FAIRCAMP_FETCHES_PER_RUN = 100;
+/**
+ * Invocation-wide, across every artist in the batch: homepage, release pages and purchase
+ * pages combined. A release costs up to two requests, not one, because Faircamp keeps the price
+ * on a separate purchase page — hence the headroom over the old ceiling of 100.
+ */
+const MAX_FAIRCAMP_FETCHES_PER_RUN = 150;
 
 interface FaircampBudget {
   fetchesLeft: number;
@@ -520,6 +525,10 @@ async function catalogFaircamp(artistId: string, faircampUrl: string, budget: Fa
 
     const takenSlugs = new Set<string>();
     const toPersist: Parameters<typeof persistFaircampReleases>[1] = [];
+    // Where each release's price lives, keyed by the release URL that becomes its source URL.
+    // Read now, fetched after the write, so the 30-day refresh rule can be applied to a source
+    // whose `detail_checked_at` only exists once it has been persisted.
+    const purchaseUrls = new Map<string, string>();
 
     for (const candidate of candidates) {
       if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
@@ -540,6 +549,10 @@ async function catalogFaircamp(artistId: string, faircampUrl: string, budget: Fa
           if (release) {
             takenSlugs.add(release.slug);
             toPersist.push(release);
+            if (page.purchaseHref) {
+              const purchaseUrl = resolveSameHost(page.purchaseHref, response.url || candidate.url);
+              if (purchaseUrl) purchaseUrls.set(release.externalUrl, purchaseUrl);
+            }
           }
         }
 
@@ -555,10 +568,81 @@ async function catalogFaircamp(artistId: string, faircampUrl: string, budget: Fa
     if (toPersist.length === 0) return 0;
 
     const written = await persistFaircampReleases(artistId, toPersist);
+    await catalogFaircampPrices(written, purchaseUrls, budget);
     return written.length;
   } catch (error) {
     console.warn('[catalog] faircamp ingest failed:', error instanceof Error ? error.message : String(error));
     return 0;
+  }
+}
+
+/**
+ * Read Faircamp prices, one purchase page per release that's due one.
+ *
+ * Separate from the release-page pass above because it can only run after the write: whether a
+ * release is due a refresh is a fact about its stored source (`detail_checked_at`), and that
+ * doesn't exist until `persistFaircampReleases` has created it. Same 30-day rule as Bandcamp's
+ * detail pass, so a re-catalog of an unchanged Faircamp site costs nothing extra.
+ *
+ * Never throws — a purchase page that won't load leaves the release with no price, which is what
+ * it already had.
+ */
+async function catalogFaircampPrices(
+  written: PersistedRelease[],
+  purchaseUrls: Map<string, string>,
+  budget: FaircampBudget
+): Promise<void> {
+  for (const release of written) {
+    const purchaseUrl = purchaseUrls.get(release.url);
+    if (!purchaseUrl || !needsDetail(release)) continue;
+
+    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+      console.log('[catalog] faircamp budget spent before prices were read');
+      return;
+    }
+    await sleep(DELAY_BETWEEN_FAIRCAMP_FETCHES_MS);
+    budget.fetchesLeft--;
+
+    try {
+      const response = await safeFetch(purchaseUrl, 10_000);
+      if (!response?.ok) continue;
+
+      const offer = ingestFaircampPurchasePage(await response.text());
+      if (!offer) {
+        console.warn(`[catalog] no readable price on ${safeHostname(purchaseUrl)} purchase page`);
+        continue;
+      }
+
+      // status null: Faircamp knows nothing about the release's date, so it must not restate
+      // the row's status — only the offer is written. See `DetailToPersist`.
+      await persistReleaseDetail(release, {
+        releaseDate: null,
+        datePrecision: 'unknown',
+        status: null,
+        offers: [offer],
+      });
+    } catch (error) {
+      console.warn(
+        `[catalog] faircamp purchase fetch failed for ${safeHostname(purchaseUrl)}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+}
+
+/**
+ * Resolve a relative href from fetched markup, refusing anything that leaves the host it came
+ * from. Same rule, and same reason, as `resolveReleaseUrl` in release-ingest: an href out of
+ * fetched markup is untrusted.
+ */
+function resolveSameHost(href: string, pageUrl: string): string | null {
+  try {
+    const resolved = new URL(href, pageUrl);
+    if (resolved.host !== new URL(pageUrl).host) return null;
+    if (resolved.protocol !== 'https:' && resolved.protocol !== 'http:') return null;
+    return resolved.toString();
+  } catch {
+    return null;
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2015,12 +2015,15 @@ export async function addArtistReleaseLink(
   if (!client) return false;
   if (!(await verifyReleaseOwnership(artistId, [releaseId]))) return false;
 
+  // `external_id` is deliberately absent, not null. PostgREST's upsert updates only the columns
+  // present in the payload, so leaving it out keeps whatever id ingest already stored for this
+  // platform — writing an explicit null would erase the one thing that makes a re-crawl
+  // idempotent, and the next crawl would mint a duplicate source rather than update this row.
   const { error } = await client.from('release_sources').upsert(
     {
       release_id: releaseId,
       platform,
       url,
-      external_id: null,
       source: 'claimed',
       last_seen_at: new Date().toISOString(),
     },

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -820,7 +820,13 @@ export async function persistReleases(
 interface DetailToPersist {
   releaseDate: string | null;
   datePrecision: string;
-  status: string;
+  /**
+   * Null when this source has nothing to say about the release row itself — Faircamp publishes
+   * prices but no date anywhere in its markup, so it can't derive a status either. Writing its
+   * default 'released' would overwrite an 'announced' that Bandcamp got right from a real
+   * pre-order, so the row is left alone entirely and only the offers are written.
+   */
+  status: string | null;
   offers: Array<{
     format: string;
     price: number | null;
@@ -857,7 +863,7 @@ export async function persistReleaseDetail(
   try {
     // A date the artist authored outranks anything upstream says, and status is derived from
     // the date, so a curated date takes both columns out of ingest's hands.
-    if (!release.curatedFields.includes('release_date')) {
+    if (detail.status !== null && !release.curatedFields.includes('release_date')) {
       const patch: Record<string, unknown> = { status: detail.status };
       if (detail.releaseDate) {
         patch.release_date = detail.releaseDate;

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -5,6 +5,7 @@
 // search-sources, and for the same reason: this is the part with decisions in it, so it
 // should be testable without a network or a database.
 
+import { parse, type HTMLElement } from 'node-html-parser';
 import {
   parseBandcampGridReleases,
   parseBandcampReleaseDetail,
@@ -597,9 +598,19 @@ export interface FaircampReleaseCandidate {
 /**
  * Find candidate release links on a Faircamp artist homepage.
  *
- * Deliberately permissive rather than exhaustive: any bare relative path (`slug/`, no query, no
- * subpath) is a candidate. Some will be wrong — a theme page using an unrecognized slug, say —
- * accepted per the "even a high failure rate beats nothing" call on this source specifically.
+ * Faircamp's generator wraps each release in `<div class="release">`, and on a site hosting more
+ * than one artist it puts that release's credited artists in a nested `<div class="release_artists">`
+ * — as links of exactly the same shape as the release's own (`kl/`, `blg/`). Reading every bare
+ * relative link, as this used to, therefore catalogs a multi-artist site's *artists* as records:
+ * on music.kidlightbulbs.com that produced release rows called "Kid Lightbulbs" and "Brandon
+ * Lucas Green". Nothing in a release page's own markup distinguishes them afterwards — both
+ * render `og:title` and neither sets a useful `og:type` — so the discrimination has to happen
+ * here, where the structure still says which link is which.
+ *
+ * Still permissive within a release block: two links point at the same release (its cover and
+ * its title) and both are accepted, deduped by slug. The fallback for a page with no release
+ * blocks at all keeps the old scan, minus artist credits — a markup change should cost coverage,
+ * not correctness.
  */
 export function ingestFaircampHomeLinks(html: string, pageUrl: string): FaircampReleaseCandidate[] {
   const out: FaircampReleaseCandidate[] = [];
@@ -612,8 +623,13 @@ export function ingestFaircampHomeLinks(html: string, pageUrl: string): Faircamp
     return out;
   }
 
-  for (const match of html.matchAll(/href="([^"]+)"/g)) {
-    const raw = match[1];
+  const root = parse(html);
+  const blocks = root.querySelectorAll('div.release');
+  const anchors = (blocks.length > 0 ? blocks.flatMap(b => b.querySelectorAll('a[href]')) : root.querySelectorAll('a[href]'))
+    .filter(a => !isArtistCredit(a));
+
+  for (const anchor of anchors) {
+    const raw = anchor.getAttribute('href') ?? '';
     if (!/^[a-z0-9][a-z0-9-]*\/$/i.test(raw)) continue;
 
     const slug = raw.slice(0, -1).toLowerCase();
@@ -634,9 +650,20 @@ export function ingestFaircampHomeLinks(html: string, pageUrl: string): Faircamp
   return out;
 }
 
+/** Is this link one of a release's credited artists rather than the release itself? */
+function isArtistCredit(anchor: HTMLElement): boolean {
+  for (let node: HTMLElement | null = anchor; node; node = node.parentNode) {
+    if (node.classList?.contains('release_artists')) return true;
+  }
+  return false;
+}
+
 export interface FaircampReleasePage {
   title: string;
   artworkUrl: string | null;
+  /** Relative href of this release's purchase page, where the price lives. Null when there
+   *  isn't one — a free, unlisted or code-unlocked release has no purchase page at all. */
+  purchaseHref: string | null;
 }
 
 function decodeHtmlEntities(s: string): string {
@@ -664,7 +691,63 @@ export function ingestFaircampReleasePage(html: string): FaircampReleasePage | n
   const imageMatch = html.match(/<meta\s+property="og:image"\s+content="([^"]*)"/i);
   const artworkUrl = imageMatch ? decodeHtmlEntities(imageMatch[1]).trim() || null : null;
 
-  return { title, artworkUrl };
+  const purchaseMatch = html.match(/href="(purchase\/[A-Za-z0-9_-]+\/)"/);
+
+  return { title, artworkUrl, purchaseHref: purchaseMatch ? purchaseMatch[1] : null };
+}
+
+/**
+ * Read a Faircamp purchase page's price.
+ *
+ * Faircamp's release pages carry no price at all — no JSON-LD, no microdata, nothing — which is
+ * why the catalog showed "Still gathering formats and prices" on every Faircamp release
+ * indefinitely. The price lives one level down, on `{release}/purchase/{token}/`, and this
+ * reads it there.
+ *
+ * Matched against Faircamp's own generator (`renderer/src/pages/multitrack_purchase.rs`), which
+ * emits one of two shapes:
+ *
+ * - **A price input** for anything with a range — name-your-price ("$0 or more"), "up to $10",
+ *   or "$5–20". `data-min` is the floor, and the floor is the honest figure to publish: it is
+ *   what a fan can actually pay. `0` means name-your-price, which the display layer already
+ *   renders as such rather than as "free".
+ * - **No input at all** for a single fixed price, rendered as text. The surrounding words are
+ *   localized, but the generator always writes the amount immediately before the ISO currency
+ *   code, so that adjacency is what's matched rather than any English string.
+ *
+ * Everything Faircamp sells here is a download, so the offer is always `digital` — the page's
+ * own "available formats" line lists codecs (MP3, FLAC, WAV), not physical formats.
+ *
+ * Returns null when no price can be read, which callers must not turn into a price of zero:
+ * "we couldn't read it" and "you may pay nothing" are different claims about someone's income.
+ */
+export function ingestFaircampPurchasePage(html: string): IngestedOffer | null {
+  const input = html.match(/<input\b[^>]*\bid="price"[^>]*>/);
+  if (input) {
+    const min = input[0].match(/data-min="([0-9]+(?:\.[0-9]+)?)"/);
+    if (!min) return null;
+    // The currency code is written immediately after the input, inside the same wrapper.
+    const currency = html.slice(input.index! + input[0].length).match(/^\s*([A-Z]{3})\b/);
+    return { format: 'digital', price: Number(min[1]), currency: currency ? currency[1] : null, availability: 'available' };
+  }
+
+  const fixed = stripTags(html).match(/([0-9]+(?:[.,][0-9]+)?)\s+([A-Z]{3})\b/);
+  if (!fixed) return null;
+
+  return {
+    format: 'digital',
+    price: Number(fixed[1].replace(',', '.')),
+    currency: fixed[2],
+    availability: 'available',
+  };
+}
+
+/** Text content only, so a localized price line can be matched without markup in the way. */
+function stripTags(html: string): string {
+  return html
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ');
 }
 
 export interface FaircampReleaseToPersist {

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -498,6 +498,7 @@ export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail 
 
   for (const entry of releases) {
     if (!isRecord(entry)) continue;
+    if (!isThisReleasesItem(entry)) continue;
     for (const offer of asArray(entry.offers)) {
       if (!isRecord(offer)) continue;
       offers.push({
@@ -511,6 +512,32 @@ export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail 
   }
 
   return { datePublished, offers };
+}
+
+/** `item_type` values that are something other than this release: see `isThisReleasesItem`. */
+const CROSS_CATALOG_ITEM_TYPES = new Set(['i', 'b']);
+
+/**
+ * Is this `albumRelease` entry something you can buy *of this release*?
+ *
+ * An album page's `albumRelease` list is not only that album's packages. Bandcamp also parks
+ * two whole-catalog products in it, both typed `DigitalFormat` and indistinguishable from the
+ * album's own download except by `item_type`:
+ *
+ * - `i` — the artist's **monthly subscription**. Priced per month, not per record.
+ * - `b` — the **full digital discography** bundle. Priced for every release at once.
+ *
+ * Left in, they become digital offers on this release, and `aggregateOffers` keeps the cheapest
+ * digital price — so a $5 album next to a $3.33/month subscription is published as "$5 → $3.33".
+ * That is a wrong price on a page whose entire job is being accurate about what an artist is
+ * paid, and it happened: Kid Lightbulbs' albums were all quoting the subscription fee.
+ *
+ * A missing `item_type` is kept rather than dropped — the known intruders both carry one, and
+ * refusing everything unlabelled would silently empty the offers on any page whose markup drifts.
+ */
+function isThisReleasesItem(entry: Record<string, unknown>): boolean {
+  const itemType = additionalProperty(entry.additionalProperty, 'item_type');
+  return !itemType || !CROSS_CATALOG_ITEM_TYPES.has(itemType.toLowerCase().trim());
 }
 
 /** First JSON-LD object in the page that satisfies `predicate`. Malformed blocks are skipped. */

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -1,3 +1,4 @@
+import { useState, type ReactNode } from 'react';
 import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate } from '../../../../api/shared/release-display';
 import { PLATFORMS } from '../../../../api/shared/platform-registry';
 import { PlatformIcon } from './PlatformIcon';
@@ -5,6 +6,9 @@ import type { ArtistPagePayload } from '../types/artist-page';
 import type { SourceId } from '../types';
 
 type Release = NonNullable<ArtistPagePayload['releases']>[number];
+
+/** Releases per page. Two columns of five. */
+const PAGE_SIZE = 10;
 
 /**
  * An artist's releases, each linking to its buying guide at `/a/{artist}/{release}`.
@@ -26,6 +30,9 @@ type Release = NonNullable<ArtistPagePayload['releases']>[number];
  * nothing and renders a blank page. It also strands history: the URL changes, React renders
  * nothing, and Back has nowhere sensible to go. A real navigation reaches the one renderer that
  * exists, which is also what makes an in-app click and a pasted link produce the same page.
+ *
+ * Paginated ten at a time in two columns, so a long discography stays one glance rather than a
+ * scroll past the platform links this page exists to show.
  */
 export function ReleasesSection({
   releases,
@@ -36,20 +43,66 @@ export function ReleasesSection({
   total: number;
   artistSlug: string;
 }) {
+  const [page, setPage] = useState(0);
+
   if (releases.length === 0) return null;
+
+  // Paged over what the payload already carries rather than fetched a page at a time: the whole
+  // list arrives with the page, so turning a page is instant and costs no request. `total` can
+  // still exceed it for an unusually large catalogue, which the note below reports honestly
+  // instead of pretending the last page is the end of the discography.
+  const pageCount = Math.ceil(releases.length / PAGE_SIZE);
+  const current = Math.min(page, pageCount - 1);
+  const shown = releases.slice(current * PAGE_SIZE, current * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <div className="mt-6">
       <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3">Releases</h2>
-      <div className="grid gap-2">
-        {releases.map(release => (
+      <div className="grid gap-2 sm:grid-cols-2">
+        {shown.map(release => (
           <ReleaseRow key={release.slug} release={release} artistSlug={artistSlug} />
         ))}
       </div>
+
+      {pageCount > 1 && (
+        <nav className="mt-3 flex items-center justify-center gap-3" aria-label="Releases pages">
+          <PageButton onClick={() => setPage(current - 1)} disabled={current === 0}>
+            ← Previous
+          </PageButton>
+          <span className="text-xs text-text-muted" aria-live="polite">
+            Page {current + 1} of {pageCount}
+          </span>
+          <PageButton onClick={() => setPage(current + 1)} disabled={current === pageCount - 1}>
+            Next →
+          </PageButton>
+        </nav>
+      )}
+
       {total > releases.length && (
-        <p className="mt-2.5 text-xs text-text-muted">and {total - releases.length} more</p>
+        <p className="mt-2.5 text-center text-xs text-text-muted">and {total - releases.length} more</p>
       )}
     </div>
+  );
+}
+
+function PageButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="px-3 py-1.5 rounded-lg border border-border text-xs text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-40 disabled:cursor-default disabled:hover:bg-transparent"
+    >
+      {children}
+    </button>
   );
 }
 

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -18,6 +18,27 @@ const PLATFORM_OPTIONS = (Object.values(sources) as { id: SourceId; name: string
 
 const RELEASE_TYPES = ['album', 'ep', 'single', 'compilation', 'live', 'remix', 'other'] as const;
 
+/**
+ * What the artist typed, as a URL the server will accept — or null if it can't be one.
+ *
+ * The server requires an http(s) URL, and pasting `subvert.fm/artist/record` (no scheme) is the
+ * ordinary way to get that wrong. Assuming https rather than rejecting is safe here: the value
+ * is stored and linked, never fetched, and every platform this page lists serves https.
+ */
+function normalizeLinkUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    // A bare word is a valid URL to the parser but not an address anyone meant to paste.
+    return parsed.hostname.includes('.') ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 interface OwnerRelease {
   id: string;
   title: string;
@@ -160,6 +181,17 @@ export function ArtistReleasesPage() {
             </PageSkeleton>
           ) : (
             <>
+              {/* Above the list, not below it: scanning is where an artist starts, and on a real
+                  catalogue the bottom of the page is a long scroll away. */}
+              {catalog?.canTrigger && (
+                <CatalogNowPanel
+                  slug={slug}
+                  token={session?.access_token}
+                  catalog={catalog}
+                  onFinished={fetchReleases}
+                />
+              )}
+
               <button
                 onClick={() => setShowAddForm(v => !v)}
                 className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-sm font-medium hover:bg-bg-hover transition-colors"
@@ -210,15 +242,6 @@ export function ArtistReleasesPage() {
                     />
                   ))}
                 </div>
-              )}
-
-              {catalog?.canTrigger && (
-                <CatalogNowPanel
-                  slug={slug}
-                  token={session?.access_token}
-                  catalog={catalog}
-                  onFinished={fetchReleases}
-                />
               )}
             </>
           )}
@@ -365,14 +388,14 @@ function CatalogNowPanel({
   }, [slug, token, poll]);
 
   return (
-    <div className="mt-8 p-4 rounded-xl border border-dashed border-border space-y-2">
+    <div className="p-4 rounded-xl border border-dashed border-border space-y-2">
       <h2 className="font-display text-base font-semibold text-text-primary">
         Look for releases on your links
       </h2>
       <p className="text-xs text-text-muted">
         Checks the platforms on your profile — Bandcamp, Discogs, Faircamp — and adds anything it
         finds. Some platforms can't be read automatically, so this won't always find everything;
-        whatever it misses you can add by hand above.
+        whatever it misses you can add by hand below.
       </p>
       <div className="flex flex-wrap items-center gap-3 pt-1">
         <button
@@ -434,7 +457,7 @@ function ReleaseCard({
   onDismiss: () => void;
   onMerge: (keepId: string, dropId: string) => void;
   onUpdate: (patch: { title?: string; releaseDate?: string | null; artworkUrl?: string | null }) => void;
-  onAddLink: (platform: string, url: string) => void;
+  onAddLink: (platform: string, url: string) => Promise<boolean>;
 }) {
   const busy = (key: string) => actionLoading === key;
   const date = formatReleaseDate(release.releaseDate, release.datePrecision);
@@ -537,13 +560,33 @@ function EditReleaseForm({
   busy: boolean;
   linkBusy: boolean;
   onSave: (patch: { title?: string; releaseDate?: string | null; artworkUrl?: string | null }) => void;
-  onAddLink: (platform: string, url: string) => void;
+  onAddLink: (platform: string, url: string) => Promise<boolean>;
 }) {
   const [title, setTitle] = useState(release.title);
   const [releaseDate, setReleaseDate] = useState(release.releaseDate ?? '');
   const [artworkUrl, setArtworkUrl] = useState(release.artworkUrl ?? '');
   const [linkPlatform, setLinkPlatform] = useState<string>(PLATFORM_OPTIONS[0]?.id ?? '');
   const [linkUrl, setLinkUrl] = useState('');
+  const [linkStatus, setLinkStatus] = useState<{ ok: boolean; message: string } | null>(null);
+
+  async function handleAddLink() {
+    const url = normalizeLinkUrl(linkUrl);
+    if (!url) {
+      setLinkStatus({ ok: false, message: "That doesn't look like a web address." });
+      return;
+    }
+
+    setLinkStatus(null);
+    const added = await onAddLink(linkPlatform, url);
+    // The typed URL is kept on failure. Clearing it optimistically threw away what the artist
+    // wrote whenever the save was rejected, so the only way to retry was to type it again.
+    if (added) {
+      setLinkUrl('');
+      setLinkStatus({ ok: true, message: 'Link added.' });
+    } else {
+      setLinkStatus({ ok: false, message: "Couldn't add that link — see the error above." });
+    }
+  }
 
   return (
     <div className="pt-3 border-t border-border space-y-4">
@@ -607,17 +650,19 @@ function EditReleaseForm({
             className="flex-1 min-w-[160px] px-3 py-2 rounded-lg bg-bg-secondary border border-border/50 text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-accent-primary/50"
           />
           <button
-            onClick={() => {
-              if (!linkUrl.trim()) return;
-              onAddLink(linkPlatform, linkUrl.trim());
-              setLinkUrl('');
-            }}
+            onClick={handleAddLink}
             disabled={linkBusy || !linkUrl.trim()}
             className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors disabled:opacity-50"
           >
             {linkBusy ? 'Adding...' : 'Add link'}
           </button>
         </div>
+        {/* Beside the field that caused it. The page-level error banner sits above the whole
+            release list, which on a real catalogue is far off-screen from the form being used —
+            so a rejected link looked exactly like a button that did nothing. */}
+        {linkStatus && (
+          <p className={`text-xs ${linkStatus.ok ? 'text-green-500' : 'text-red-400'}`}>{linkStatus.message}</p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -313,6 +313,14 @@ export function DashboardPage() {
                           >
                             View
                           </Link>
+                          {/* Reachable from the profile editor too, but releases are the thing an
+                              artist comes back to correct — worth one click from here. */}
+                          <Link
+                            to={`/artist-edit/${profile.slug}/releases`}
+                            className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
+                          >
+                            Releases
+                          </Link>
                           <button
                             onClick={() => handleRemoveClaimedProfile(profile.id, profile.artistId, profile.slug)}
                             className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-red-400 hover:border-red-500/30 transition-colors"

--- a/apps/web/tests/unit/ArtistReleasesPage.test.tsx
+++ b/apps/web/tests/unit/ArtistReleasesPage.test.tsx
@@ -157,6 +157,54 @@ describe('ArtistReleasesPage', () => {
     });
   });
 
+  // Adding a link is the action most likely to be typed slightly wrong, and it used to fail
+  // invisibly: the server rejects a scheme-less URL, and the only report of that was a banner
+  // above the whole release list, off-screen from the form.
+  it('adds a link, sending a scheme-less address as https', async () => {
+    setupFetchMock([releaseItem()]);
+    renderPage();
+
+    await waitFor(() => screen.getByText('Edit / add link'));
+    fireEvent.click(screen.getByText('Edit / add link'));
+
+    const urlInputs = screen.getAllByPlaceholderText('https://...');
+    fireEvent.change(urlInputs[urlInputs.length - 1], {
+      target: { value: 'subvert.fm/kid-lightbulbs/infinite-normal' },
+    });
+    fireEvent.click(screen.getByText('Add link'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body.action).toBe('addLink');
+      expect(body.url).toBe('https://subvert.fm/kid-lightbulbs/infinite-normal');
+    });
+    await waitFor(() => expect(screen.getByText('Link added.')).toBeTruthy());
+  });
+
+  it('reports a rejected link beside the field and keeps what was typed', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined) {
+        return Promise.resolve({ ok: true, json: async () => ({ releases: [releaseItem()] }) });
+      }
+      return Promise.resolve({ ok: false, status: 400, json: async () => ({ error: 'Unknown platform' }) });
+    });
+    renderPage();
+
+    await waitFor(() => screen.getByText('Edit / add link'));
+    fireEvent.click(screen.getByText('Edit / add link'));
+
+    const urlInputs = screen.getAllByPlaceholderText('https://...') as HTMLInputElement[];
+    const urlInput = urlInputs[urlInputs.length - 1];
+    fireEvent.change(urlInput, { target: { value: 'https://subvert.fm/a/b' } });
+    fireEvent.click(screen.getByText('Add link'));
+
+    await waitFor(() => expect(screen.getByText(/Couldn't add that link/)).toBeTruthy());
+    expect(urlInput.value).toBe('https://subvert.fm/a/b');
+  });
+
   it('shows an empty state when there is nothing catalogued', async () => {
     setupFetchMock([]);
     renderPage();


### PR DESCRIPTION
Four bugs found on a real catalog run against Kid Lightbulbs.

## Bandcamp quoted the subscription fee as the album price

An album page's JSON-LD `albumRelease` list isn't only that album's packages — Bandcamp parks two whole-catalog products in it, both typed `DigitalFormat`/`Digital` and indistinguishable from the album's own download except by `item_type`:

| item_type | what it is | price on INFINITE NORMAL |
|---|---|---|
| `a` | the album | $0 (name your price) |
| `i` | **monthly subscription** | $3.33/month |
| `b` | **full digital discography** | $23.20 |

Offers collapse to the cheapest per format, so on any album priced above $3.33 the subscription won. Both cross-catalog products are now dropped. A package with no `item_type` is kept — the known intruders both carry one, and refusing everything unlabelled would silently empty the offers on any page whose markup drifts.

## Faircamp catalogued artists as releases

On a multi-artist Faircamp site, each release block carries its credited artists as relative links of exactly the same shape as the release links beside them:

```html
<div class="release">
  <a href="infinite-normal/">INFINITE NORMAL</a>
  <div class="release_artists"><a href="kl/">Kid Lightbulbs</a></div>
</div>
```

The ingest read every bare relative link, so `kl/` and `blg/` became releases. Now restricted to links inside a release block, excluding the artist-credit div; a page with no release blocks still falls back to the old scan, minus credits. Verified against the live homepage: 23 releases, no artists.

Nothing on the linked page distinguishes them afterwards — an artist page and a release page both publish an `og:title`, and neither sets a useful `og:type` — so it has to be caught at the homepage.

## Faircamp releases never got a price

Faircamp publishes no price on a release page at all: no JSON-LD, no microdata, nothing. It lives one level down on `{release}/purchase/{token}/`. That page is now fetched and read for a digital offer, budgeted and refreshed on the same 30-day rule as Bandcamp's detail pass.

Matched against Faircamp's own generator (`renderer/src/pages/multitrack_purchase.rs`) rather than guessed, so both shapes parse: a price input with `data-min` (name-your-price, "up to X", "$5–20") and a fixed price rendered as localized text. Unreadable means no offer, never a price of zero.

The empty state's copy changes from "Still gathering formats and prices." to "Price information not available." — for a release whose purchase page can't be read, nothing is coming, and the old wording was a promise we don't keep.

## Artist pages paginate releases two-up

Ten per page in two columns, collapsing to one column under 640px, paged over the payload already fetched so turning a page costs no request. The payload cap rises 24 → 60 (six pages) since it now bounds the payload rather than what a fan can reach.

## Subvert: investigated, not fixable here

`subvert.fm` sits behind a Vercel bot wall that 429s everything, including `robots.txt`, so Unstream never fetches it. Subvert links enter the catalog only when they appear in markup fetched for another reason, and `kidlightbulbs.com` links exactly one release URL. The other three albums aren't linked from any page we fetch, so there is nothing to find. No code change.

## Existing bad rows

The parser fix stops new ones; it doesn't delete the artist-as-release rows already written. Those can be hidden from the artist's own release curation UI.

## Testing

- `npm run build` green (lint, `test:api` 518, `test:unit` 523).
- 7 new tests in `release-ingest.test.ts`. The subscription test was verified to fail with the filter neutralized.
- Both Faircamp parsers run against the live pages: the homepage yields 23 releases and no artists; INFINITE NORMAL's purchase page yields `{digital, price 0, USD, available}`.
- Pagination verified in the browser at 1280px (two columns) and 375px (one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)