### PR TITLE
Make a requested re-catalogue actually re-read prices

### DIFF
--- a/api/functions/__tests__/admin-catalog-artist.test.ts
+++ b/api/functions/__tests__/admin-catalog-artist.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getCatalogState: vi.fn(),
   clearCatalogCooldown: vi.fn(),
+  clearReleaseDetailCooldown: vi.fn(),
   authenticateAdmin: vi.fn(),
   fetch: vi.fn(() => Promise.resolve({ status: 202, ok: false } as Response)),
 }));
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../db', () => ({
   getCatalogState: mocks.getCatalogState,
   clearCatalogCooldown: mocks.clearCatalogCooldown,
+  clearReleaseDetailCooldown: mocks.clearReleaseDetailCooldown,
 }));
 
 vi.mock('../middleware', () => ({
@@ -44,6 +46,7 @@ beforeEach(() => {
   mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
   mocks.getCatalogState.mockResolvedValue({ ok: true, state: null });
   mocks.clearCatalogCooldown.mockResolvedValue(undefined);
+  mocks.clearReleaseDetailCooldown.mockResolvedValue(undefined);
   vi.stubGlobal('fetch', mocks.fetch);
   process.env.RELEASE_CATALOG_ENABLED = 'true';
   process.env.INTERNAL_FUNCTION_SECRET = 'secret';
@@ -103,6 +106,11 @@ describe('POST — starting a crawl', () => {
     expect(response.statusCode).toBe(202);
     // Without this the button appears to work and silently does nothing for a week.
     expect(mocks.clearCatalogCooldown).toHaveBeenCalledWith(ARTIST);
+    // And the detail reset, or the crawl re-reads only the release list: prices live on
+    // individual release pages, which both detail passes skip once a source has been read.
+    // A parser fix for a wrong price would ship, the button would report success, and the
+    // wrong price would stay on the page for another 30 days.
+    expect(mocks.clearReleaseDetailCooldown).toHaveBeenCalledWith(ARTIST);
     expect(mocks.fetch).toHaveBeenCalledOnce();
   });
 

--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   mergeReleases: vi.fn(),
   getCatalogState: vi.fn(),
   clearCatalogCooldown: vi.fn(),
+  clearReleaseDetailCooldown: vi.fn(),
   cacheDeleteByArtist: vi.fn(),
   triggerCatalogNow: vi.fn(),
 }));
@@ -38,6 +39,7 @@ vi.mock('../db', () => ({
   mergeReleases: mocks.mergeReleases,
   getCatalogState: mocks.getCatalogState,
   clearCatalogCooldown: mocks.clearCatalogCooldown,
+  clearReleaseDetailCooldown: mocks.clearReleaseDetailCooldown,
 }));
 
 // buildCorsHeaders is NOT stubbed to a constant — this endpoint performs writes, and one thing
@@ -99,6 +101,7 @@ beforeEach(() => {
   mocks.mergeReleases.mockResolvedValue({ ok: true });
   mocks.getCatalogState.mockResolvedValue({ ok: true, state: null });
   mocks.clearCatalogCooldown.mockResolvedValue(undefined);
+  mocks.clearReleaseDetailCooldown.mockResolvedValue(undefined);
   mocks.triggerCatalogNow.mockResolvedValue({ ok: true });
 });
 
@@ -250,6 +253,9 @@ describe('POST — catalog (self-serve scan)', () => {
     const r = await post({ action: 'catalog', slug: SLUG });
     expect(r.statusCode).toBe(202);
     expect(mocks.clearCatalogCooldown).toHaveBeenCalledWith('artist-1');
+    // Prices only refresh if the sources are reset too — otherwise "Scan my links" re-confirms
+    // the release list and leaves every stored price exactly as it was.
+    expect(mocks.clearReleaseDetailCooldown).toHaveBeenCalledWith('artist-1');
     expect(mocks.triggerCatalogNow).toHaveBeenCalledWith('artist-1');
   });
 

--- a/api/functions/admin-catalog-artist.ts
+++ b/api/functions/admin-catalog-artist.ts
@@ -18,7 +18,7 @@
 // The GET is what the button uses to decide whether to show itself: visibility follows the
 // server's real admin rule rather than a copy of it in page markup.
 
-import { clearCatalogCooldown, getCatalogState } from './db';
+import { clearCatalogCooldown, clearReleaseDetailCooldown, getCatalogState } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
 import { triggerCatalogNow } from './request-catalog';
 
@@ -78,7 +78,10 @@ export async function handler(event: {
     return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
+  // Both, always: the cooldown lets the crawl run, and the detail reset is what makes it
+  // re-read prices rather than only re-confirming the release list. See db.ts.
   await clearCatalogCooldown(artistId);
+  await clearReleaseDetailCooldown(artistId);
   const queued = await triggerCatalogNow(artistId);
 
   if (!queued.ok) {

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -23,6 +23,7 @@ import {
   mergeReleases,
   getCatalogState,
   clearCatalogCooldown,
+  clearReleaseDetailCooldown,
 } from './db';
 import { authenticateAdmin, authenticateBearer, buildCorsHeaders } from './middleware';
 import { cacheDeleteByArtist } from './cache';
@@ -219,7 +220,10 @@ export async function handler(event: {
       };
     }
 
-    await clearCatalogCooldown(artistId);
+    // Both, always: the cooldown lets the crawl run, and the detail reset is what makes it
+  // re-read prices rather than only re-confirming the release list. See db.ts.
+  await clearCatalogCooldown(artistId);
+  await clearReleaseDetailCooldown(artistId);
     const queued = await triggerCatalogNow(artistId);
     if (!queued.ok) {
       return { statusCode: queued.status, headers: CORS_HEADERS, body: JSON.stringify({ error: queued.error }) };

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -59,8 +59,17 @@ const DELAY_BETWEEN_ARTISTS_MS = 1_000;
 // — but a blanket sweep of ~800 artists × ~20 releases would be 16,000 requests, which is a
 // crawl programme, not a parser change. Four limits keep it a trickle:
 
-/** Newest-first, so a large discography gets its recent releases priced on the first run. */
-const MAX_DETAIL_FETCHES_PER_ARTIST = 20;
+/**
+ * Newest-first, so a large discography gets its recent releases priced on the first run.
+ *
+ * Raised from 20 once an explicit re-catalogue started resetting every source to unpriced
+ * (`clearReleaseDetailCooldown`): at 20, an artist with more releases than that could never get
+ * their whole catalogue priced, because each press re-read the same newest 20 and left the tail
+ * permanently unread. 40 covers every catalogue measured so far — 22 for Kid Lightbulbs, 16 for
+ * Sufjan Stevens, 33 for the largest live Mirlo artist — and costs 40 paced seconds for one
+ * artist. The invocation-wide cap below still bounds a whole batch.
+ */
+const MAX_DETAIL_FETCHES_PER_ARTIST = 40;
 
 /** Invocation-wide, so a 25-artist batch can't multiply into hundreds of requests. */
 const MAX_DETAIL_FETCHES_PER_RUN = 100;

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -578,6 +578,43 @@ export async function clearCatalogCooldown(artistId: string): Promise<void> {
   if (error) console.error('[DB] clearCatalogCooldown failed:', error.message);
 }
 
+/**
+ * Mark every one of an artist's sources as never priced, so a deliberately-requested crawl
+ * re-reads the release pages instead of only the grid.
+ *
+ * **Clearing the artist's cooldown alone is not enough**, and the gap is invisible: the crawl
+ * runs, reports success, and changes nothing an artist can see. Dates, formats and prices live
+ * only on individual release pages, and both detail passes skip a source that was already read —
+ * Bandcamp's within `DETAIL_REFRESH_DAYS`, Discogs' ever. That refresh rule is right for the
+ * demand-driven crawl it was written for, where re-reading every page weekly would triple the
+ * request count for data that rarely moves. It is wrong for someone standing in front of the
+ * button having just been told their prices are wrong: found once, in exactly that situation,
+ * when a parser fix for a bad Bandcamp price shipped and re-cataloguing didn't apply it.
+ *
+ * Null, not backdated: "never read" is the honest state for a source whose stored price we've
+ * decided not to trust, and it's what both passes already test for.
+ */
+export async function clearReleaseDetailCooldown(artistId: string): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+
+  const { data, error: readError } = await client.from('releases').select('id').eq('artist_id', artistId);
+  if (readError) {
+    console.error('[DB] clearReleaseDetailCooldown read failed:', readError.message);
+    return;
+  }
+
+  const releaseIds = ((data as { id: string }[] | null) || []).map(r => r.id);
+  if (releaseIds.length === 0) return;
+
+  const { error } = await client
+    .from('release_sources')
+    .update({ detail_checked_at: null })
+    .in('release_id', releaseIds);
+
+  if (error) console.error('[DB] clearReleaseDetailCooldown failed:', error.message);
+}
+
 interface ReleaseToPersist {
   title: string;
   slug: string;


### PR DESCRIPTION
Re-cataloguing Kid Lightbulbs after #377 changed nothing visible, and the crawl reported success.

## Why

Clearing the artist's cooldown lets the run happen. But dates, formats and prices come **only** from individual release pages, and both detail passes skip a source that has already been read:

```js
// catalog-artist-background.ts
function needsDetail(release) {
  if (!release.detailCheckedAt) return true;
  return Date.now() - new Date(release.detailCheckedAt).getTime() > 30 * 24 * 3600_000;
}
```

Discogs is stricter still — `if (release.detailCheckedAt) continue;`, never re-priced.

The earlier catalogue stamped every Bandcamp source, so the re-run re-read the release *list*, skipped every release page, and left every wrong price in place. The `item_type` fix from #377 was deployed and correct; it was simply never asked to parse anything.

That refresh rule is right for the demand-driven crawl it was written for — re-reading every page weekly would triple the request count for data that rarely moves. It's wrong for someone who has just been told their prices are wrong and pressed the button.

## The fix

Both explicit triggers — the admin button and the artist's own "Scan my links" — now also reset that artist's sources to unpriced (`clearReleaseDetailCooldown`). Null, not backdated: "never read" is the honest state for a price we've decided not to trust, and it's what both passes already test for.

**Per-artist detail budget 20 → 40**, as a direct consequence. With every source reset, an artist with more than 20 releases could never get their whole catalogue priced — each press re-read the same newest 20 and left the tail permanently unread. 40 covers every catalogue measured (22 Kid Lightbulbs, 16 Sufjan Stevens, 33 for the largest live Mirlo artist) and costs 40 paced seconds for one artist. The invocation-wide cap of 100 still bounds a whole batch.

## Testing

`npm run build` green (518 API, 525 web). Both trigger tests assert the reset and **both fail without it** — verified by neutralizing the call.

## What this does not fix

The Faircamp rows that were catalogued as releases (`Kid Lightbulbs`, `Brandon Lucas Green`) are still in the database. #377 stops new ones; it doesn't delete existing rows. Hide them from Manage Releases, or say the word for a one-off cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)