### PR TITLE
Show artist page support links as platform pills

### DIFF
--- a/apps/web/src/components/RichArtistProfile.tsx
+++ b/apps/web/src/components/RichArtistProfile.tsx
@@ -2,9 +2,10 @@ import { Fragment, useState, useCallback } from 'react';
 import type { ArtistPagePayload } from '../types/artist-page';
 import { sources } from '../services/sources';
 import { analytics } from '../services/analytics';
-import { PlatformIcon } from './PlatformIcon';
 import { ReleasesSection } from './ReleasesSection';
 import { SocialIcon } from './SocialIcon';
+import { SourceBadge } from './SourceBadge';
+import { getSource } from './ResultCardUtils';
 import type { SourceId } from '../types';
 
 interface RichArtistProfileProps {
@@ -17,6 +18,28 @@ interface RichArtistProfileProps {
   disabledSave?: boolean;
 }
 
+type ArtistLink = ArtistPagePayload['links'][number];
+
+/**
+ * Split the artist's links at the divider positions they chose, so each group can
+ * render as its own wrapped row of pills with a rule between rows.
+ */
+function groupLinksByDivider(links: ArtistLink[], dividerIndexes: Set<number>): ArtistLink[][] {
+  const groups: ArtistLink[][] = [];
+  let current: ArtistLink[] = [];
+
+  links.forEach((link, index) => {
+    if (dividerIndexes.has(index) && current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+    current.push(link);
+  });
+
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
 function getLocationText(artist: ArtistPagePayload['artist']): string {
   const region = artist.country || artist.countryCode;
   if (artist.city && region) return `${artist.city}, ${region}`;
@@ -27,7 +50,7 @@ function getLocationText(artist: ArtistPagePayload['artist']): string {
 
 export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave, isSaved = false, disabledSave = false }: RichArtistProfileProps) {
   const { artist, profile, links, socialLinks } = payload;
-  const dividerIndexes = new Set(payload.linkDividers ?? []);
+  const linkGroups = groupLinksByDivider(links, new Set(payload.linkDividers ?? []));
   const imageUrl = profile?.customImageUrl || artist.imageUrl;
   const locationText = getLocationText(artist);
 
@@ -149,59 +172,35 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
           </div>
         )}
 
-        {/* Main Platform Links */}
-        {links.length > 0 && (
+        {/* Main Platform Links — the same platform pills the search results use, in the
+            artist's own order. Dividers the artist placed split the pills into rows. */}
+        {linkGroups.length > 0 && (
           <div className={profile?.featuredEmbed ? 'mt-6' : ''}>
             <h2 className="text-[11px] uppercase tracking-wider text-text-muted mb-3">
               Support directly
             </h2>
-            <div className="grid gap-2">
-              {links.map((link, index) => {
-                const source = sources[link.platform as SourceId];
-                const isOther = link.platform === 'other' || link.platform.startsWith('other_');
-                const linkName = link.displayName || (isOther ? 'Link' : (source?.name || link.platform));
-                const linkColor = source?.color || '#71717a';
-                const isBCFriday = link.bandcampFriday;
-
-                return (
-                  <Fragment key={link.platform + link.url}>
-                    {/* Group divider placed by the artist */}
-                    {dividerIndexes.has(index) && (
-                      <hr className="border-0 border-t border-border my-1" />
-                    )}
-                    <a
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      data-track-platform={link.platform}
-                      className={`flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors ${
-                        isBCFriday
-                          ? 'border-[#1da0c3]/25 bg-[#1da0c3]/[0.06] hover:bg-[#1da0c3]/10'
-                          : 'border-border hover:bg-bg-hover'
-                      }`}
-                      style={!isBCFriday ? { backgroundColor: `${linkColor}08` } : undefined}
-                      onClick={() => handleLinkClick(link.platform)}
-                    >
-                      <span className="text-xl inline-flex items-center justify-center w-5">
-                        {source && !isOther && source.icon !== '🔗' && typeof source.icon === 'string' && source.icon.length <= 2 ? (
-                          <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source.icon} className="w-5 h-5" />
-                        ) : (
-                          <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source?.icon || '🔗'} className="w-5 h-5" />
+            <div className="space-y-3">
+              {linkGroups.map((group, groupIndex) => (
+                <Fragment key={groupIndex}>
+                  {groupIndex > 0 && <hr className="border-0 border-t border-border" />}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {group.map(link => (
+                      <Fragment key={link.platform + link.url}>
+                        <SourceBadge
+                          source={getSource(link.platform as SourceId)}
+                          url={link.url}
+                          isDirectLink
+                          displayName={link.displayName ?? undefined}
+                          onClick={() => handleLinkClick(link.platform)}
+                        />
+                        {link.bandcampFriday && (
+                          <span className="bandcamp-friday-label">Bandcamp Friday!</span>
                         )}
-                      </span>
-                      <span className="flex-1 font-medium text-text-primary">{linkName}</span>
-                      {link.payoutPercent && (
-                        <span className="text-xs text-text-muted">{link.payoutPercent} to artist</span>
-                      )}
-                      {isBCFriday && (
-                        <span className="text-[11px] font-bold text-[#1da0c3] animate-pulse">
-                          Bandcamp Friday!
-                        </span>
-                      )}
-                    </a>
-                  </Fragment>
-                );
-              })}
+                      </Fragment>
+                    ))}
+                  </div>
+                </Fragment>
+              ))}
             </div>
           </div>
         )}

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -9,9 +9,11 @@ interface SourceBadgeProps {
   url: string;
   isDirectLink?: boolean;
   displayName?: string;
+  /** Extra tracking for callers that know more than the platform name (e.g. the artist page). */
+  onClick?: () => void;
 }
 
-export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBadgeProps) {
+export function SourceBadge({ source, url, isDirectLink, displayName, onClick }: SourceBadgeProps) {
   const label = displayName ?? source.name;
   // If we have a direct link, show as verified even if source is normally searchOnly
   const isSearchOnly = isDirectLink ? false : (source.searchOnly ?? false);
@@ -25,7 +27,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1.5 px-2 py-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
         title={`Search for this artist on ${label}`}
-        onClick={() => analytics.trackPlatformClick(label)}
+        onClick={() => { analytics.trackPlatformClick(label); onClick?.(); }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -63,7 +65,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName }: SourceBa
         backgroundColor: bgColor,
         color: textColor,
       }}
-      onClick={() => analytics.trackPlatformClick(label)}
+      onClick={() => { analytics.trackPlatformClick(label); onClick?.(); }}
     >
       <PlatformIcon sourceId={source.id} color={textColor} emoji={source.icon} />
       <span className="flex items-center gap-1">

--- a/apps/web/tests/unit/RichArtistProfile.test.tsx
+++ b/apps/web/tests/unit/RichArtistProfile.test.tsx
@@ -116,21 +116,32 @@ describe('RichArtistProfile', () => {
     expect(screen.queryByText('Featured Release')).toBeNull();
   });
 
-  it('renders each main link with data-track-platform, target, and rel', () => {
+  it('renders each main link as a platform pill with target and rel', () => {
     render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
-    const bandcampLink = document.querySelector('a[data-track-platform="bandcamp"]');
+    const bandcampLink = document.querySelector('a.source-badge[href="https://kidlightbulbs.bandcamp.com"]');
     expect(bandcampLink).toBeTruthy();
     expect(bandcampLink!.getAttribute('target')).toBe('_blank');
     expect(bandcampLink!.getAttribute('rel')).toBe('noopener noreferrer');
 
-    const patreonLink = document.querySelector('a[data-track-platform="patreon"]');
+    const patreonLink = document.querySelector('a.source-badge[href="https://patreon.com/kidlightbulbs"]');
     expect(patreonLink).toBeTruthy();
   });
 
-  it('renders the payout percent when link.payoutPercent is set', () => {
+  it('renders the payout percent on each pill', () => {
     render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
-    expect(screen.getByText('80-85% to artist')).toBeTruthy();
-    expect(screen.getByText('86-90% to artist')).toBeTruthy();
+    expect(screen.getByText('80-85%')).toBeTruthy();
+    expect(screen.getByText('86-90%')).toBeTruthy();
+  });
+
+  it('falls back to the "Link" pill for custom links with no display name', () => {
+    const payload = {
+      ...basePayload,
+      links: [{ platform: 'other_1', url: 'https://example.com', displayName: null, payoutPercent: null, bandcampFriday: false }],
+    };
+    render(<RichArtistProfile payload={payload} slug="kid-lightbulbs" />);
+    const link = document.querySelector('a.source-badge[href="https://example.com"]');
+    expect(link).toBeTruthy();
+    expect(link!.textContent).toContain('Link');
   });
 
   it('renders the Bandcamp Friday badge when link.bandcampFriday is true', () => {
@@ -153,7 +164,14 @@ describe('RichArtistProfile', () => {
     render(<RichArtistProfile payload={{ ...basePayload, linkDividers: [1] }} slug="kid-lightbulbs" />);
     const divider = document.querySelector('hr');
     expect(divider).toBeTruthy();
-    expect(divider!.nextElementSibling?.getAttribute('data-track-platform')).toBe('patreon');
+    // The divider starts a new row of pills; the link it points at leads that row.
+    const nextRowLink = divider!.nextElementSibling?.querySelector('a.source-badge');
+    expect(nextRowLink?.getAttribute('href')).toBe('https://patreon.com/kidlightbulbs');
+  });
+
+  it('does not render a divider before the first link', () => {
+    render(<RichArtistProfile payload={{ ...basePayload, linkDividers: [0] }} slug="kid-lightbulbs" />);
+    expect(document.querySelectorAll('hr').length).toBe(0);
   });
 
   it('renders the social links section only when socialLinks.length > 0', () => {


### PR DESCRIPTION
The releases section made the "Support directly" list feel oversized: eight platforms meant eight full-width rows before a fan reached anything else.

This renders them as the same `SourceBadge` pills the search results use — in the artist's own order, **not** grouped by category.

## Measured

Same 8-link fixture, `getBoundingClientRect()` on the section:

| | Height | Rows |
|---|---|---|
| Before | 542px | 8 |
| After | 210px | 4 |

Widest pill is 257px, so it fits a 375px phone column without horizontal overflow.

## Changes

- **`RichArtistProfile.tsx`** — stacked rows → `SourceBadge` in a wrapped flex. New pure helper `groupLinksByDivider` splits links at the divider positions the artist chose, so each group is its own wrapped row with a rule between rows. Dividers still mean what they meant.
- **`SourceBadge.tsx`** — optional `onClick`, fired alongside its own `trackPlatformClick`, so the artist page keeps `trackArtistLinkClick`. Same both-events pairing `ResultCardRelease` and `ResultCardSocial` already use.
- Tests updated, plus new coverage for the custom-link ("Link") fallback and for a leading divider not drawing a stray rule.

## Worth knowing

- Pills carry the payout badge and AI-policy chip from the platform registry, so the section shows *more* signal than the old rows did — those only showed a payout when the stored link row happened to have one.
- Bandcamp Friday: the pill's built-in `~97%` treatment covers it, and the pulsing "Bandcamp Friday!" label stays beside the pill. It now uses the `.bandcamp-friday-label` class that was already in `index.css` but unused.
- `data-track-platform` is gone from these links. Nothing outside the component tests read it.

## Deliberately unchanged

- `UnclaimedQuietCard` keeps the old rows — unclaimed pages are intentionally quieter.
- The `artist-page-static` edge function still emits the old rows. That render is crawler-only, so no human sees the mismatch.

Verified in the browser with a throwaway Vite harness (the dev API has no `/api/artist-page` mock). 527 unit tests pass; lint clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)