### PR TITLE
Serve unclaimed artists from /api/artist-page instead of a 404

### DIFF
--- a/api/functions/__tests__/artist-page.test.ts
+++ b/api/functions/__tests__/artist-page.test.ts
@@ -1,0 +1,123 @@
+// GET /api/artist-page — the JSON the React artist page renders from.
+//
+// The thing worth locking: an *unclaimed* artist gets a 200 with their links. This endpoint
+// shipped for claimed profiles only, and once #369 made real browsers render /artist/:slug from
+// the SPA instead of the static edge HTML, that filter turned into a 404 on every one of the ~790
+// unclaimed artist pages — while crawlers, which the edge function still serves, saw a fine page.
+// Restore the `match_confidence === 'claimed'` gate anywhere in this path and the first test here
+// fails.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getArtistProfileBySlug: vi.fn(),
+  getArtistReleases: vi.fn(),
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getArtistProfileBySlug: mocks.getArtistProfileBySlug,
+  getArtistReleases: mocks.getArtistReleases,
+}));
+
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getClientIp: () => '203.0.113.1',
+}));
+
+import { handler } from '../artist-page';
+
+const artistRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'artist-1',
+  slug: 'funkadelic',
+  name: 'Funkadelic',
+  image_url: 'https://f4.bcbits.com/img/0026457743_23.jpg',
+  match_confidence: 'verified',
+  country: null,
+  country_code: null,
+  city: null,
+  ...overrides,
+});
+
+const links = [
+  { platform: 'bandcamp', url: 'https://funkadelic.bandcamp.com', display_name: null },
+  { platform: 'discogs', url: 'https://www.discogs.com/artist/29923', display_name: null },
+  // Search-engine junk the page filters out.
+  { platform: 'kofi', url: 'https://duckduckgo.com/?q=site:ko-fi.com+Funkadelic', display_name: null },
+];
+
+const call = (slug: string) => handler({ httpMethod: 'GET', queryStringParameters: { slug }, headers: {} });
+
+describe('GET /api/artist-page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkRateLimit.mockResolvedValue({ limited: false });
+    mocks.getArtistReleases.mockResolvedValue({ releases: [], total: 0 });
+  });
+
+  it('returns 200 with links for an unclaimed artist', async () => {
+    mocks.getArtistProfileBySlug.mockResolvedValue({ artist: artistRow(), profile: null, links });
+
+    const res = await call('funkadelic');
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(res.body);
+    expect(body.artist.name).toBe('Funkadelic');
+    expect(body.links.map((l: { url: string }) => l.url)).toEqual([
+      'https://funkadelic.bandcamp.com',
+      'https://www.discogs.com/artist/29923',
+    ]);
+    // No verifiedAt means the SPA renders UnclaimedQuietCard rather than the rich profile.
+    expect(body.profile).toBeNull();
+  });
+
+  it('reports a verified claimed artist as claimed', async () => {
+    mocks.getArtistProfileBySlug.mockResolvedValue({
+      artist: artistRow({ match_confidence: 'claimed' }),
+      profile: {
+        bio: 'Free your mind.',
+        custom_image_url: 'https://example.com/custom.jpg',
+        featured_embed: null,
+        verified_at: '2026-06-01T00:00:00.000Z',
+        link_dividers: null,
+      },
+      links,
+    });
+
+    const body = JSON.parse((await call('funkadelic')).body);
+    expect(body.profile.verifiedAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(body.artist.imageUrl).toBe('https://example.com/custom.jpg');
+  });
+
+  it('does not treat a profile row on an unclaimed artist as claimed', async () => {
+    // Mid-claim state: the profile row exists but the artist was never marked claimed. The edge
+    // function shows crawlers the quiet card here, so the SPA has to as well.
+    mocks.getArtistProfileBySlug.mockResolvedValue({
+      artist: artistRow({ match_confidence: 'verified' }),
+      profile: {
+        bio: null,
+        custom_image_url: 'https://example.com/custom.jpg',
+        featured_embed: null,
+        verified_at: '2026-06-01T00:00:00.000Z',
+        link_dividers: null,
+      },
+      links,
+    });
+
+    const body = JSON.parse((await call('funkadelic')).body);
+    expect(body.profile.verifiedAt).toBeNull();
+    expect(body.artist.imageUrl).toBe('https://f4.bcbits.com/img/0026457743_23.jpg');
+  });
+
+  it('404s when there is no artist row for the slug', async () => {
+    mocks.getArtistProfileBySlug.mockResolvedValue(null);
+
+    const res = await call('not-a-real-artist');
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('400s without a slug', async () => {
+    const res = await handler({ httpMethod: 'GET', queryStringParameters: {}, headers: {} });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -1,5 +1,6 @@
 // API endpoint: GET /api/artist-page?slug=...
-// Returns the full rich-profile payload for a claimed artist as JSON.
+// Returns an artist's page payload as JSON — the rich profile for a claimed artist, the links
+// and releases for an unclaimed one.
 // This is the data source for the React SPA artist page (UNS-102).
 
 import { getArtistProfileBySlug, getArtistReleases } from './db';
@@ -38,7 +39,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   try {
     const bundle = await getArtistProfileBySlug(slug);
 
-    // getArtistProfileBySlug returns null if artist not found or not claimed
+    // getArtistProfileBySlug returns null only if there's no artist row for this slug
     if (!bundle) {
       return {
         statusCode: 404,
@@ -98,11 +99,16 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       };
     });
 
+    // Same claimed test the artist-page-static edge function applies, so the two renderers of
+    // this URL agree on which card a fan sees: a profile row alone isn't enough, the artist row
+    // has to be claimed too.
+    const isClaimed = artistRow.match_confidence === 'claimed' && !!profile?.verified_at;
+
     // Sanitize the featured embed
     const featuredEmbed = sanitizeEmbed(profile?.featured_embed ?? null);
 
     // Build the image URL: custom > artist row > null
-    const imageUrl = profile?.custom_image_url || artistRow.image_url || null;
+    const imageUrl = (isClaimed && profile?.custom_image_url) || artistRow.image_url || null;
 
     // Releases. The page paginates these ten at a time rather than listing them all, so the cap
     // here bounds the payload, not what a fan can reach: six pages, which covers every catalogue
@@ -125,7 +131,8 @@ export async function handler(event: { queryStringParameters?: Record<string, st
         bio: profile.bio,
         customImageUrl: profile.custom_image_url,
         featuredEmbed,
-        verifiedAt: profile.verified_at,
+        // The SPA picks RichArtistProfile vs UnclaimedQuietCard off this field.
+        verifiedAt: isClaimed ? profile.verified_at : null,
       } : null,
       links,
       // Indexes into `links` above which a horizontal divider is drawn.

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -150,8 +150,11 @@ export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfil
       .single();
 
     if (artistError || !artist) return null;
-    if (artist.match_confidence !== 'claimed') return null;
 
+    // Deliberately no `match_confidence === 'claimed'` filter. Unclaimed artists have a real row
+    // and real links, and /artist/:slug renders them as the quiet card — the same page the
+    // artist-page-static edge function serves crawlers, which has never had this filter either.
+    // Gating here 404'd every unclaimed artist page for anyone running JS (see #369).
     const artistRow = artist as ArtistRow;
     const artistId = artistRow.id;
 


### PR DESCRIPTION
## The bug

`https://unstream.stream/artist/funkadelic` showed **"We couldn't find that artist"** — a URL we'd just put in a social post. Searching "funkadelic" returned the same artist fine, so the data was never missing.

It isn't Funkadelic. It's **~790 of the 791 generated artist pages** — every artist who hasn't claimed their profile. Measured before the fix:

| slug | `/api/artist-page` |
|---|---|
| funkadelic, air, al-green, agalloch, aiko, sufjan-stevens | 404 |
| kid-lightbulbs (claimed) | 200 |

## Why it happened

The page fetches `/api/artist-page?slug=…`, which returned 404. `getArtistProfileBySlug` refused anything whose `match_confidence` wasn't `'claimed'` — correct when the endpoint shipped in #272 for the claimed-profile page, and harmless while the `artist-page-static` edge function rendered these URLs for everyone.

#369 then correctly stopped serving real browsers static HTML and handed them the SPA, which reads this endpoint. The claimed-only filter became a 404 for every fan running JavaScript.

**Crawlers never saw it.** The edge function has never had that filter, so social previews, Google's index and any `curl` check all kept returning a full page. Only the click broke. The SPA even shipped an `UnclaimedQuietCard` branch its own endpoint could never feed — dead since June 16.

## The change

- Drop the `match_confidence === 'claimed'` filter in `db.ts`. `artist-page.ts` is its only caller, so nothing else shifts.
- Mirror the edge function's claimed test — artist row claimed **and** profile verified — for the custom image and for the `verifiedAt` the SPA branches on. Without this, an artist mid-claim could get the rich profile in the SPA and the quiet card from the edge function: the same two-renderers-disagree class as #369.
- New `api/functions/__tests__/artist-page.test.ts`: unclaimed, claimed, mid-claim, missing slug, no slug.

## Reviewer notes

- **The test has teeth.** I reinstated the gate and confirmed 2 of the 5 tests fail, rather than trusting that they would.
- **Verified against real data, not mocks.** Ran the real handler against production Supabase (read-only): Funkadelic returns 6 links and 13 releases, Kid Lightbulbs' profile is byte-for-byte unchanged, an unknown slug still 404s. Then rendered both branches in a browser — no console errors.
- **`semantic-revert-check` may flag this.** The diff deletes a line that reads like a deliberate access check. It isn't a revert: the check was never a security boundary — the same rows are already public through the edge function, and `artist_links` for unclaimed artists are served to crawlers today.
- Rebased onto `main` after #379 landed. No conflicts — that PR touched web components, this touches `api/`. 527 web + 523 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)