### PR TITLE
Make platform pills chunkier and lay them out for phones

### DIFF
--- a/apps/web/src/components/ResultCardPlatforms.tsx
+++ b/apps/web/src/components/ResultCardPlatforms.tsx
@@ -58,7 +58,7 @@ export function ResultCardPlatforms({ platforms, category, compact = false, onRe
           {category}
         </h4>
       )}
-      <div className="flex flex-wrap gap-2">
+      <div className="platform-pill-row">
         {visiblePlatforms.map(platform => (
           <PlatformBadge key={platform.sourceId} platform={platform} onRemoveLink={onRemoveLink} />
         ))}
@@ -72,7 +72,7 @@ export function ResultCardPlatforms({ platforms, category, compact = false, onRe
         </button>
       )}
       {showAll && hasMore && (
-        <div className="flex flex-wrap gap-2">
+        <div className="platform-pill-row">
           {platforms.slice(4).map(platform => (
             <PlatformBadge key={platform.sourceId} platform={platform} onRemoveLink={onRemoveLink} />
           ))}

--- a/apps/web/src/components/RichArtistProfile.tsx
+++ b/apps/web/src/components/RichArtistProfile.tsx
@@ -183,9 +183,9 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
               {linkGroups.map((group, groupIndex) => (
                 <Fragment key={groupIndex}>
                   {groupIndex > 0 && <hr className="border-0 border-t border-border" />}
-                  <div className="flex flex-wrap items-center gap-2">
-                    {group.map(link => (
-                      <Fragment key={link.platform + link.url}>
+                  <div className="platform-pill-row">
+                    {group.map(link => {
+                      const badge = (
                         <SourceBadge
                           source={getSource(link.platform as SourceId)}
                           url={link.url}
@@ -193,11 +193,19 @@ export function RichArtistProfile({ payload, slug, justClaimed, onSave, onUnsave
                           displayName={link.displayName ?? undefined}
                           onClick={() => handleLinkClick(link.platform)}
                         />
-                        {link.bandcampFriday && (
+                      );
+                      const key = link.platform + link.url;
+
+                      // The Bandcamp Friday label rides along in the same cell, so the
+                      // pill row stays one grid cell per platform on a phone.
+                      if (!link.bandcampFriday) return <Fragment key={key}>{badge}</Fragment>;
+                      return (
+                        <span key={key} className="flex items-center gap-2">
+                          {badge}
                           <span className="bandcamp-friday-label">Bandcamp Friday!</span>
-                        )}
-                      </Fragment>
-                    ))}
+                        </span>
+                      );
+                    })}
                   </div>
                 </Fragment>
               ))}

--- a/apps/web/src/components/SourceBadge.tsx
+++ b/apps/web/src/components/SourceBadge.tsx
@@ -25,7 +25,7 @@ export function SourceBadge({ source, url, isDirectLink, displayName, onClick }:
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 px-2 py-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        className="inline-flex items-center gap-1.5 min-h-11 px-2 py-2.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
         title={`Search for this artist on ${label}`}
         onClick={() => { analytics.trackPlatformClick(label); onClick?.(); }}
       >
@@ -68,7 +68,8 @@ export function SourceBadge({ source, url, isDirectLink, displayName, onClick }:
       onClick={() => { analytics.trackPlatformClick(label); onClick?.(); }}
     >
       <PlatformIcon sourceId={source.id} color={textColor} emoji={source.icon} />
-      <span className="flex items-center gap-1">
+      {/* Wraps rather than overflowing when the pill is a narrow grid cell on a phone. */}
+      <span className="flex flex-wrap items-center gap-1">
         {label}
         {hasPayoutPercent ? (
           <span

--- a/apps/web/src/components/UnclaimedQuietCard.tsx
+++ b/apps/web/src/components/UnclaimedQuietCard.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { ArtistPagePayload } from '../types/artist-page';
 import { sources } from '../services/sources';
 import { analytics } from '../services/analytics';
-import { PlatformIcon } from './PlatformIcon';
 import { ReleasesSection } from './ReleasesSection';
 import { SocialIcon } from './SocialIcon';
+import { SourceBadge } from './SourceBadge';
+import { getSource } from './ResultCardUtils';
 import type { SourceId } from '../types';
 
 interface UnclaimedQuietCardProps {
@@ -107,39 +108,28 @@ export function UnclaimedQuietCard({ payload, slug, justClaimed, onSave, onUnsav
           <h2 className="text-[11px] uppercase tracking-wider text-text-muted mb-3">
             Support directly
           </h2>
-          <div className="grid gap-2">
+          {/* Same platform pills as the search results and claimed artist pages. */}
+          <div className="platform-pill-row">
             {links.map((link) => {
-              const source = sources[link.platform as SourceId];
-              const isOther = link.platform === 'other' || link.platform.startsWith('other_');
-              const linkName = link.displayName || (isOther ? 'Link' : (source?.name || link.platform));
-              const linkColor = source?.color || '#71717a';
-              const isBCFriday = link.bandcampFriday;
-
-              return (
-                <a
-                  key={link.platform + link.url}
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-track-platform={link.platform}
-                  className={`flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors ${
-                    isBCFriday
-                      ? 'border-[#1da0c3]/25 bg-[#1da0c3]/[0.06] hover:bg-[#1da0c3]/10'
-                      : 'border-border hover:bg-bg-hover'
-                  }`}
-                  style={!isBCFriday ? { backgroundColor: `${linkColor}08` } : undefined}
+              const badge = (
+                <SourceBadge
+                  source={getSource(link.platform as SourceId)}
+                  url={link.url}
+                  isDirectLink
+                  displayName={link.displayName ?? undefined}
                   onClick={() => handleLinkClick(link.platform)}
-                >
-                  <span className="text-xl inline-flex items-center justify-center w-5">
-                    <PlatformIcon sourceId={link.platform as SourceId} color={linkColor} emoji={source?.icon || '🔗'} className="w-5 h-5" />
-                  </span>
-                  <span className="flex-1 font-medium text-text-primary">{linkName}</span>
-                  {isBCFriday && (
-                    <span className="text-[11px] font-bold text-[#1da0c3] animate-pulse">
-                      Bandcamp Friday!
-                    </span>
-                  )}
-                </a>
+                />
+              );
+              const key = link.platform + link.url;
+
+              // The Bandcamp Friday label rides along in the same cell, so the
+              // pill row stays one grid cell per platform on a phone.
+              if (!link.bandcampFriday) return <Fragment key={key}>{badge}</Fragment>;
+              return (
+                <span key={key} className="flex items-center gap-2">
+                  {badge}
+                  <span className="bandcamp-friday-label">Bandcamp Friday!</span>
+                </span>
               );
             })}
           </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -185,7 +185,18 @@
   }
 
   .source-badge {
-    @apply inline-flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium transition-colors;
+    /* min-height keeps every pill a 44px tap target and stops a row of pills with
+       and without a payout badge from looking ragged. */
+    @apply inline-flex items-center gap-2 min-h-11 px-3.5 py-2.5 rounded-lg text-sm font-medium transition-colors;
+  }
+
+  /* Rows of platform pills (search results and the artist page).
+     Phones get one full-width pill per row, or two on a wide phone — a wrapped
+     flex row leaves a ragged staircase of odd widths at that size. From `sm` up
+     there's room for the pills to hug their own content again. */
+  .platform-pill-row {
+    @apply grid gap-2 sm:flex sm:flex-wrap;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   }
 
   .result-card {
@@ -253,6 +264,16 @@
     opacity: 1;
     visibility: visible;
     transition-delay: 0.25s;
+  }
+
+  /* The tooltip only opens on hover, so on a touch device it is unreachable —
+     but `visibility: hidden` still takes up layout, and a 180px tooltip on a
+     right-hand pill hung past the viewport and made the page scroll sideways.
+     Keep it out of the box model where it can never be shown. */
+  @media (hover: none) {
+    .payout-tooltip {
+      display: none;
+    }
   }
 
   /* Custom tooltip for AI policy badges */

--- a/apps/web/tests/unit/RichArtistProfile.test.tsx
+++ b/apps/web/tests/unit/RichArtistProfile.test.tsx
@@ -125,6 +125,8 @@ describe('RichArtistProfile', () => {
 
     const patreonLink = document.querySelector('a.source-badge[href="https://patreon.com/kidlightbulbs"]');
     expect(patreonLink).toBeTruthy();
+    // The row is a grid on phones and a wrapped flex row from `sm` up.
+    expect(bandcampLink!.closest('.platform-pill-row')).toBeTruthy();
   });
 
   it('renders the payout percent on each pill', () => {

--- a/apps/web/tests/unit/UnclaimedQuietCard.test.tsx
+++ b/apps/web/tests/unit/UnclaimedQuietCard.test.tsx
@@ -76,6 +76,13 @@ describe('UnclaimedQuietCard', () => {
     expect(screen.getByText('Bandcamp')).toBeTruthy();
   });
 
+  it('renders platform links as pills in a responsive row', () => {
+    render(<UnclaimedQuietCard payload={unclaimedPayload} slug="some-artist" />);
+    const pill = document.querySelector('a.source-badge[href="https://some-artist.bandcamp.com"]');
+    expect(pill).toBeTruthy();
+    expect(pill!.closest('.platform-pill-row')).toBeTruthy();
+  });
+
   it('renders social links', () => {
     render(<UnclaimedQuietCard payload={unclaimedPayload} slug="some-artist" />);
     expect(screen.getByText('Follow')).toBeTruthy();


### PR DESCRIPTION
Follow-up to #379. The pills were tight to read and small to tap, and on a phone the wrapped flex row left a ragged staircase of odd widths with only one pill per line anyway.

## What changed

**Chunkier pills.** `.source-badge` goes from `px-3 py-1.5` to `px-3.5 py-2.5` with a 44px `min-height` — so every pill is a full tap target, and a row mixing pills with and without a payout badge no longer looks ragged (they were 40px vs 44px).

**A layout built for phones.** The new `.platform-pill-row` is a grid below `sm` and a wrapped flex row above it:

| Width | Result |
|---|---|
| 375px (iPhone SE / 13 mini) | 1 column, 343px full-width pills |
| 430px (Pro Max) | 2 columns, 195px pills |
| 900px (desktop) | unchanged — pills hug their own content |

`repeat(auto-fill, minmax(180px, 1fr))` picks the column count from the space available, so it's the device that decides 100% vs 50%, not a hardcoded breakpoint. In a 2-column cell the longest labels wrap their payout/AI chips onto a second line; grid keeps both cells in a row the same height.

**Applied everywhere the pills appear:** search results (`ResultCardPlatforms`), claimed artist pages (`RichArtistProfile`), and the unclaimed artist pages behind `/artist/*` (`UnclaimedQuietCard`) — those were still on the old full-width link rows.

## A bug this surfaced

At 430px the page scrolled sideways: `scrollWidth` 443 vs `clientWidth` 430. The culprit is the payout tooltip, which is hidden with `visibility: hidden` — still in the layout — so the 180px tooltip on a right-hand pill hangs past the viewport edge. It only opens on hover, so on touch it is unreachable dead weight. Now `display: none` under `@media (hover: none)`; removing it from layout takes `scrollWidth` back to exactly 430. Desktop hover behaviour is untouched.

## Verification

Measured in the browser at 375 / 430 / 900 via iframes (real viewport widths, so the media queries actually apply): all pills 44px tall, no horizontal overflow at any width, on both the artist page and search results. 528 unit tests pass. Lint output is byte-identical with these changes stashed.

## Not changed

The `artist-page-static` edge render still emits the old rows. It only serves crawlers ([artist-page-static.ts:207](https://github.com/brandonlucasgreen/unstream/blob/main/api/edge/artist-page-static.ts#L207)) — every human on `/artist/*` gets the React page this PR updates. Happy to bring the SSR template along if you want the markup consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)