### PR TITLE
Make Sentry actually deliver, and report 404s on URLs we publish

### DIFF
--- a/api/functions/__tests__/artist-page.test.ts
+++ b/api/functions/__tests__/artist-page.test.ts
@@ -13,6 +13,9 @@ const mocks = vi.hoisted(() => ({
   getArtistProfileBySlug: vi.fn(),
   getArtistReleases: vi.fn(),
   checkRateLimit: vi.fn(),
+  checkSentryDedup: vi.fn(),
+  captureMessage: vi.fn(),
+  isPublishedArtistSlug: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -22,7 +25,20 @@ vi.mock('../db', () => ({
 
 vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.checkRateLimit,
+  checkSentryDedup: mocks.checkSentryDedup,
   getClientIp: () => '203.0.113.1',
+}));
+
+// Mocked so these tests assert on what the endpoint *decides to report*, independent of whether a
+// DSN is configured. Whether the events then leave the process is the deployment's problem —
+// which is exactly how 77 call sites managed to report nothing for weeks without a test noticing.
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureMessage: mocks.captureMessage },
+}));
+
+// The real module reads data/artists-manifest.json; published-artist-slugs.test.ts covers that.
+vi.mock('../../shared/published-artist-slugs', () => ({
+  isPublishedArtistSlug: mocks.isPublishedArtistSlug,
 }));
 
 import { handler } from '../artist-page';
@@ -53,10 +69,12 @@ describe('GET /api/artist-page', () => {
     vi.clearAllMocks();
     mocks.checkRateLimit.mockResolvedValue({ limited: false });
     mocks.getArtistReleases.mockResolvedValue({ releases: [], total: 0 });
+    mocks.checkSentryDedup.mockResolvedValue(true);
+    mocks.isPublishedArtistSlug.mockReturnValue(false);
   });
 
   it('returns 200 with links for an unclaimed artist', async () => {
-    mocks.getArtistProfileBySlug.mockResolvedValue({ artist: artistRow(), profile: null, links });
+    mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: { artist: artistRow(), profile: null, links }, failed: false });
 
     const res = await call('funkadelic');
     expect(res.statusCode).toBe(200);
@@ -72,7 +90,7 @@ describe('GET /api/artist-page', () => {
   });
 
   it('reports a verified claimed artist as claimed', async () => {
-    mocks.getArtistProfileBySlug.mockResolvedValue({
+    mocks.getArtistProfileBySlug.mockResolvedValue({ failed: false, bundle: {
       artist: artistRow({ match_confidence: 'claimed' }),
       profile: {
         bio: 'Free your mind.',
@@ -82,7 +100,7 @@ describe('GET /api/artist-page', () => {
         link_dividers: null,
       },
       links,
-    });
+    } });
 
     const body = JSON.parse((await call('funkadelic')).body);
     expect(body.profile.verifiedAt).toBe('2026-06-01T00:00:00.000Z');
@@ -92,7 +110,7 @@ describe('GET /api/artist-page', () => {
   it('does not treat a profile row on an unclaimed artist as claimed', async () => {
     // Mid-claim state: the profile row exists but the artist was never marked claimed. The edge
     // function shows crawlers the quiet card here, so the SPA has to as well.
-    mocks.getArtistProfileBySlug.mockResolvedValue({
+    mocks.getArtistProfileBySlug.mockResolvedValue({ failed: false, bundle: {
       artist: artistRow({ match_confidence: 'verified' }),
       profile: {
         bio: null,
@@ -102,7 +120,7 @@ describe('GET /api/artist-page', () => {
         link_dividers: null,
       },
       links,
-    });
+    } });
 
     const body = JSON.parse((await call('funkadelic')).body);
     expect(body.profile.verifiedAt).toBeNull();
@@ -110,7 +128,7 @@ describe('GET /api/artist-page', () => {
   });
 
   it('404s when there is no artist row for the slug', async () => {
-    mocks.getArtistProfileBySlug.mockResolvedValue(null);
+    mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: false });
 
     const res = await call('not-a-real-artist');
     expect(res.statusCode).toBe(404);
@@ -119,5 +137,60 @@ describe('GET /api/artist-page', () => {
   it('400s without a slug', async () => {
     const res = await handler({ httpMethod: 'GET', queryStringParameters: {}, headers: {} });
     expect(res.statusCode).toBe(400);
+  });
+
+  // --- the 404 signal (UNS: Funkadelic follow-up) ---
+
+  describe('reporting', () => {
+    it('reports a 404 on a slug we publish', async () => {
+      mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: false });
+      mocks.isPublishedArtistSlug.mockReturnValue(true);
+
+      expect((await call('funkadelic')).statusCode).toBe(404);
+      expect(mocks.captureMessage).toHaveBeenCalledTimes(1);
+      const [message, opts] = mocks.captureMessage.mock.calls[0];
+      expect(message).toContain('published artist slug');
+      expect(opts.tags.slug).toBe('funkadelic');
+    });
+
+    it('stays quiet on a 404 for a slug we never published', async () => {
+      // The whole point of gating on the manifest: crawlers and typos must not drown the signal.
+      mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: false });
+      mocks.isPublishedArtistSlug.mockReturnValue(false);
+
+      expect((await call('asdfasdf')).statusCode).toBe(404);
+      expect(mocks.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('reports a published-slug 404 only once per dedup window', async () => {
+      mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: false });
+      mocks.isPublishedArtistSlug.mockReturnValue(true);
+      mocks.checkSentryDedup.mockResolvedValue(false); // already reported this hour
+
+      expect((await call('funkadelic')).statusCode).toBe(404);
+      expect(mocks.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('503s and reports when the lookup itself fails, rather than 404ing', async () => {
+      // The distinction that matters: a database outage must not render as "artist not found" on
+      // every page. A 404 here would be a monitoring signal that actively lies.
+      mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: true });
+
+      const res = await call('funkadelic');
+      expect(res.statusCode).toBe(503);
+      expect(res.headers['Cache-Control']).toBe('no-store');
+      expect(mocks.captureMessage).toHaveBeenCalledTimes(1);
+      expect(mocks.captureMessage.mock.calls[0][1].level).toBe('error');
+    });
+
+    it('does not fire the published-slug 404 signal when the lookup failed', async () => {
+      // failed=true must take the 503 branch even for a published slug, so an outage reports as an
+      // outage rather than as ~790 "we publish a broken URL" warnings.
+      mocks.getArtistProfileBySlug.mockResolvedValue({ bundle: null, failed: true });
+      mocks.isPublishedArtistSlug.mockReturnValue(true);
+
+      expect((await call('funkadelic')).statusCode).toBe(503);
+      expect(mocks.captureMessage.mock.calls[0][0]).toContain('lookup failed');
+    });
   });
 });

--- a/api/functions/__tests__/published-artist-slugs.test.ts
+++ b/api/functions/__tests__/published-artist-slugs.test.ts
@@ -1,0 +1,31 @@
+// The manifest-backed "do we publish this slug?" check behind the artist-page 404 signal.
+//
+// Deliberately NOT mocked: the failure mode worth guarding is the real
+// data/artists-manifest.json import silently resolving to nothing, which would make the 404 signal
+// permanently quiet while every unit test that mocks it kept passing.
+
+import { describe, it, expect } from 'vitest';
+import { isPublishedArtistSlug, publishedArtistSlugCount } from '../../shared/published-artist-slugs';
+
+describe('published artist slugs', () => {
+  it('loads the real manifest', () => {
+    // Exact count will drift as artists are generated; the point is that it's populated, not 0 or 1.
+    expect(publishedArtistSlugCount()).toBeGreaterThan(500);
+  });
+
+  it('recognises a slug we publish', () => {
+    expect(isPublishedArtistSlug('funkadelic')).toBe(true);
+  });
+
+  it('rejects a slug we do not publish', () => {
+    expect(isPublishedArtistSlug('definitely-not-an-artist-we-generated')).toBe(false);
+  });
+
+  it('is case-insensitive, since URLs arrive however they were typed', () => {
+    expect(isPublishedArtistSlug('Funkadelic')).toBe(true);
+  });
+
+  it('does not treat the empty slug as published', () => {
+    expect(isPublishedArtistSlug('')).toBe(false);
+  });
+});

--- a/api/functions/artist-page.ts
+++ b/api/functions/artist-page.ts
@@ -4,7 +4,9 @@
 // This is the data source for the React SPA artist page (UNS-102).
 
 import { getArtistProfileBySlug, getArtistReleases } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
+import { Sentry } from '../lib/sentry';
+import { isPublishedArtistSlug } from '../shared/published-artist-slugs';
 import { PLATFORMS } from '../shared/platform-registry';
 import { isBandcampFriday } from '../shared/bandcamp-friday';
 import { mainLinkDividerIndexes } from '../shared/link-dividers';
@@ -37,10 +39,39 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   }
 
   try {
-    const bundle = await getArtistProfileBySlug(slug);
+    const { bundle, failed } = await getArtistProfileBySlug(slug);
 
-    // getArtistProfileBySlug returns null only if there's no artist row for this slug
+    // The lookup itself broke. Say so with a 503 instead of claiming the artist doesn't exist —
+    // a Supabase outage would otherwise render as every artist page 404ing convincingly.
+    if (failed) {
+      Sentry.captureMessage('[artist-page] artist lookup failed', {
+        level: 'error',
+        tags: { slug },
+        extra: { context: 'artist-page.lookupFailed' },
+      });
+      return {
+        statusCode: 503,
+        headers: { ...CORS_HEADERS, 'Cache-Control': 'no-store' },
+        body: JSON.stringify({ error: 'Artist lookup temporarily unavailable' }),
+      };
+    }
+
     if (!bundle) {
+      // A 404 for a slug we publish in data/artists-manifest.json is our bug: that manifest feeds
+      // the sitemap and the social posts, so the URL is one we've handed out. A 404 for anything
+      // else is just a fan or a crawler guessing, and reporting those would bury the real signal.
+      //
+      // Deduped per slug for 24h. That bound matters right now: at the time of writing only 55 of
+      // the 791 published slugs have an `artists` row, so this fires for the rest until that gap is
+      // closed (populate the rows, or stop publishing slugs with no data). One event per slug per
+      // day keeps that backlog readable instead of one per request.
+      if (isPublishedArtistSlug(slug) && await checkSentryDedup(`artist-page-404:${slug}`, 86400)) {
+        Sentry.captureMessage('[artist-page] 404 for a published artist slug', {
+          level: 'warning',
+          tags: { slug },
+          extra: { context: 'artist-page.publishedSlug404' },
+        });
+      }
       return {
         statusCode: 404,
         headers: CORS_HEADERS,

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -134,22 +134,35 @@ export interface ArtistProfileBundle {
 }
 
 /**
- * Fetch the artist row + profile row + links for a claimed artist.
- * Returns null if the artist doesn't exist or isn't claimed.
+ * Fetch the artist row + profile row + links for an artist.
+ *
+ * Three outcomes, deliberately distinguishable — a caller that can't tell "no such artist" from
+ * "the database didn't answer" turns an outage into a page full of 404s that look like the truth:
+ *   { bundle }            — found
+ *   { bundle: null }      — no artist row with this slug
+ *   { failed: true }      — the lookup itself failed (no client, query error, exception)
  */
-export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfileBundle | null> {
+export interface ArtistProfileLookup {
+  bundle: ArtistProfileBundle | null;
+  failed: boolean;
+}
+
+export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfileLookup> {
   const client = getClient();
-  if (!client) return null;
+  // No service-role client means the credentials are missing, not that the artist is missing.
+  if (!client) return { bundle: null, failed: true };
 
   try {
-    // Find the artist row first
+    // Find the artist row first. maybeSingle() rather than single(): single() reports "0 rows" as
+    // an error, which is what made a genuine absence indistinguishable from a real failure.
     const { data: artist, error: artistError } = await client
       .from('artists')
       .select('*')
       .eq('slug', slug)
-      .single();
+      .maybeSingle();
 
-    if (artistError || !artist) return null;
+    if (artistError) return { bundle: null, failed: true };
+    if (!artist) return { bundle: null, failed: false };
 
     // Deliberately no `match_confidence === 'claimed'` filter. Unclaimed artists have a real row
     // and real links, and /artist/:slug renders them as the quiet card — the same page the
@@ -173,13 +186,16 @@ export async function getArtistProfileBySlug(slug: string): Promise<ArtistProfil
     ]);
 
     return {
-      artist: artistRow,
-      profile: (profileResult.data as ArtistProfileRow | null) ?? null,
-      links: (linksResult.data as LinkRow[]) || [],
+      bundle: {
+        artist: artistRow,
+        profile: (profileResult.data as ArtistProfileRow | null) ?? null,
+        links: (linksResult.data as LinkRow[]) || [],
+      },
+      failed: false,
     };
   } catch (error) {
     console.error('[DB] getArtistProfileBySlug error:', error);
-    return null;
+    return { bundle: null, failed: true };
   }
 }
 

--- a/api/shared/published-artist-slugs.ts
+++ b/api/shared/published-artist-slugs.ts
@@ -1,0 +1,28 @@
+// The artist slugs Unstream itself publishes.
+//
+// `data/artists-manifest.json` is what feeds the sitemap and the generated social posts
+// (scripts/generate-sitemap.ts, scripts/generate-social-posts.ts), so it is exactly the set of
+// /artist/:slug URLs we hand to Google and put in posts. A 404 on one of these is never a fan
+// typing a name wrong — it's us advertising a URL that doesn't work, which is how the Funkadelic
+// bug (#380) reached a social post before anyone noticed.
+//
+// Imported as JSON rather than read from disk: Netlify bundles a function's imports, but files
+// merely present in the repo aren't included at runtime.
+
+import manifest from '../../data/artists-manifest.json';
+
+const publishedSlugs = new Set<string>(
+  (manifest as Array<{ slug?: string }>)
+    .map(entry => entry.slug)
+    .filter((slug): slug is string => typeof slug === 'string' && slug.length > 0)
+);
+
+/** True if we publish /artist/{slug} — i.e. a 404 for it is our bug, not a bad guess by a fan. */
+export function isPublishedArtistSlug(slug: string): boolean {
+  return publishedSlugs.has(slug.toLowerCase());
+}
+
+/** Count of published slugs. Exposed so a test can catch the manifest failing to load at all. */
+export function publishedArtistSlugCount(): number {
+  return publishedSlugs.size;
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,8 +6,13 @@
 
 [[headers]]
   for = "/*"
+  # connect-src note: Sentry's ingest host is region-scoped — ours is
+  # o…ingest.us.sentry.io. `*.ingest.sentry.io` does NOT cover it: CSP host wildcards are a
+  # suffix match, and `.ingest.sentry.io` is not a suffix of `.ingest.us.sentry.io`. That
+  # one missing `us.` silently dropped every browser error event between setup and 2026-08-01.
+  # If the Sentry org ever moves region, this host has to move with it.
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' gc.zgo.at letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://unstream.goatcounter.com https://letterbird.co https://*.ingest.sentry.io; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' gc.zgo.at letterbird.co; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://unstream.goatcounter.com https://letterbird.co https://*.ingest.us.sentry.io; img-src 'self' https: data:; frame-src https:; object-src 'none'; base-uri 'self'"
 
 [[edge_functions]]
   path = "/"


### PR DESCRIPTION
Brandon: *"I get \*zero\* error reports out of Sentry, despite us having set it up."* He's right, and there were two independent reasons — neither of which would have caught the Funkadelic bug anyway. So this fixes the delivery faults *and* adds the signal that would actually have caught it.

## 1. Client events were blocked by our own CSP

`connect-src` allowed `https://*.ingest.sentry.io`. The DSN host is `o4510896048242688.ingest.**us**.sentry.io`. CSP host wildcards are a suffix match, and `.ingest.sentry.io` is not a suffix of `.ingest.us.sentry.io`.

Verified on production rather than inferred from the spec — same fetch, two hosts:

| host | result |
|---|---|
| `…ingest.us.sentry.io` (real) | **BLOCKED: Failed to fetch** |
| `…ingest.sentry.io` (allowed by CSP) | ALLOWED |

**58 client-side capture calls** have never delivered. No CSP violation showed in the console, which is why it went unseen. This is the second time a telemetry tool has silently died on a CSP hostname here — Umami, 2026-04, same shape — so the reasoning is now a comment in `netlify.toml`.

## 2. `SENTRY_DSN` was never set — ⚠️ needs you

`netlify env:list` has `VITE_SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`, but **no `SENTRY_DSN`**. `api/lib/sentry.ts` reads only that, returns early, and leaves `Sentry` a no-op stub — so all **19 server-side capture calls** do nothing, including the new ones in this PR.

I could not set it: env writes are blocked in my sandbox. **This PR is inert server-side until you run:**

```
npx netlify env:set SENTRY_DSN "<same value as VITE_SENTRY_DSN>" --context production
```

## 3. The 404 signal

The honest part first: **the Funkadelic 404 would not have alerted even with Sentry fully working.** `ArtistPage.tsx` treats 404 as an expected outcome and `artist-page.ts` returned it as a normal response. Generic error reporting can't catch a deliberate 404. So this reports the two cases that are genuinely ours:

- **A 404 on a slug we publish.** `data/artists-manifest.json` feeds the sitemap and the social posts, so those URLs are ones we hand out — a 404 there is our bug. A 404 on anything else is a fan or crawler guessing and stays quiet, or it buries the signal. Deduped per slug for 24h.
- **A failed lookup now 503s instead of 404ing.** `getArtistProfileBySlug` was collapsing "no such artist", "query errored" and "no service-role client" into one `null`, so a Supabase outage would have rendered as every artist page convincingly reporting the artist doesn't exist. It returns `{ bundle, failed }` now.

## 🚩 What this surfaced — bigger than the bug we just fixed

Building the signal meant checking it would actually fire, so I audited the manifest against the database:

**Only 55 of the 791 published artist slugs have an `artists` row. The other 736 404 right now, in production, after #380.**

All 791 are in `sitemap.xml`. I confirmed live: `funkadelic` returns 200 (it has a row), while `air`, `agalloch`, `al-green`, `aiko` all still 404.

This is a *different* bug from #380 — that one fixed artists who have a row. These have no row at all. `git log -S` dates it to **#274 (2026-06-16)**, when `ArtistPage.tsx` stopped reading `data/artists/{slug}.json` and moved to `/api/artist-page`: the 791 generated static files were orphaned, and nothing reads them at runtime now.

**So my earlier "#380 fixes ~790 pages" was wrong** — it fixed 55. Worth deciding before merge, because the new signal will report those 736 on day one (bounded to one event per slug per day). Options: populate the rows, or stop publishing slugs with no data. Happy to take either as the next PR.

## Verification

- New tests: 10 on the endpoint, 5 on the manifest module. **Teeth proven** — neutralised the manifest gate (the "stays quiet" test fails) and the `failed` branch (both 503 tests fail).
- The manifest-module test deliberately does *not* mock the JSON import, since it silently resolving to nothing is the failure worth guarding.
- Confirmed Netlify's bundler inlines the manifest: esbuilt the module and executed it from the bundle — 791 slugs, correct answers. Adds ~127KB to that function's bundle.
- 533 API + 528 web tests pass. Lint unchanged from baseline (77 pre-existing). `tsc` clean on all three touched source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)