### PR TITLE
Backfill artist rows for the 736 published pages that 404'd

### DIFF
--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -34,8 +34,9 @@ export function artistSlug(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
-// Determine if a platform URL is a direct link (not a search URL)
-function isDirectLink(url: string): boolean {
+// Determine if a platform URL is a direct link (not a search URL).
+// Exported so scripts/backfill-published-artist-rows.ts stores exactly what a search would store.
+export function isDirectLink(url: string): boolean {
   const lower = url.toLowerCase();
   return (
     !lower.includes('duckduckgo.com') &&
@@ -45,8 +46,9 @@ function isDirectLink(url: string): boolean {
   );
 }
 
-// Platforms that are manual search links, not real artist presences
-const EXCLUDED_PLATFORMS = new Set(['buymeacoffee', 'kofi', 'ampwall']);
+// Platforms that are manual search links, not real artist presences.
+// Exported alongside isDirectLink for the same reason — see above.
+export const EXCLUDED_PLATFORMS = new Set(['buymeacoffee', 'kofi', 'ampwall']);
 
 // How long before artist data is considered stale (24 hours)
 const FRESHNESS_TTL_MS = 24 * 60 * 60 * 1000;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:data": "tsx scripts/generate-artist-data.ts",
     "generate:social": "tsx scripts/generate-social-posts.ts",
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
+    "backfill:artist-rows": "npx tsx scripts/backfill-published-artist-rows.ts",
     "ingest:try": "npx tsx scripts/ingest-releases.ts",
     "preview:release": "npx tsx scripts/preview-release-page.ts",
     "catalog:artist": "npx tsx scripts/catalog-artist.ts",

--- a/scripts/backfill-published-artist-rows.ts
+++ b/scripts/backfill-published-artist-rows.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill `artists` + `artist_links` rows for the artist pages we publish but never stored.
+ *
+ * Why this exists: `data/artists-manifest.json` (791 artists) feeds the sitemap and the generated
+ * social posts, but /artist/:slug renders from Supabase — and rows only appear there when someone
+ * *searches* an artist (`persistSearchResults`). Nothing ever seeded the published set, so at the
+ * time of writing only 55 of the 791 had a row and the other 736 returned 404 to fans and to
+ * Google. The static data under `data/artists/` has been orphaned since #274 moved the page onto
+ * /api/artist-page; this script pours it into the database the page actually reads.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-published-artist-rows.ts              # dry run (default)
+ *   npx tsx scripts/backfill-published-artist-rows.ts --write      # actually insert
+ *   npx tsx scripts/backfill-published-artist-rows.ts --limit=10   # try a small slice first
+ *
+ * Safety properties, in order of how much they matter:
+ *
+ *  - **Insert-only.** Any slug that already has a row is skipped untouched, whatever its state.
+ *    Nothing here updates or deletes an existing artist or link. Claimed profiles therefore can't
+ *    be affected even in principle — which is the point, given the artist_links wipe of 2026-07-29.
+ *  - **The slug comes from the manifest, never derived from the name.** `artistSlug()` in db.ts
+ *    strips accents to hyphens (`Jónsi` → `j-nsi`), and 34 of the 791 manifest slugs disagree with
+ *    it. Deriving would file those artists under URLs the sitemap doesn't advertise, leaving the
+ *    404 unfixed while looking successful.
+ *  - **No cataloguing is triggered.** `persistSearchResults` requests a release catalogue for every
+ *    artist with a Bandcamp link; doing that for 736 artists at once would dump hundreds of crawls
+ *    on Bandcamp. Releases can be catalogued later, deliberately and in batches.
+ *  - Link filtering reuses `isDirectLink` / `EXCLUDED_PLATFORMS` imported from db.ts, so a
+ *    backfilled artist stores exactly what a searched artist would.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createClient } from '@supabase/supabase-js';
+import { isDirectLink, EXCLUDED_PLATFORMS } from '../api/functions/db';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface ManifestEntry {
+  slug: string;
+  name: string;
+  imageUrl?: string | null;
+}
+
+interface StaticPlatform {
+  sourceId: string;
+  url: string;
+  latestRelease?: unknown;
+}
+
+interface StaticArtist {
+  id?: string;
+  name: string;
+  type?: string;
+  imageUrl?: string | null;
+  platforms?: StaticPlatform[];
+  matchConfidence?: string;
+}
+
+const args = process.argv.slice(2);
+const write = args.includes('--write');
+const limitArg = args.find(a => a.startsWith('--limit='));
+const limit = limitArg ? Number(limitArg.split('=')[1]) : Infinity;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing ${name}. Source your .env before running this.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const supabase = createClient(requireEnv('SUPABASE_URL'), requireEnv('SUPABASE_SERVICE_KEY'));
+
+/** Slugs that already have an artists row, looked up in chunks to stay under URL length limits. */
+async function findExistingSlugs(slugs: string[]): Promise<Set<string>> {
+  const existing = new Set<string>();
+  for (let i = 0; i < slugs.length; i += 200) {
+    const chunk = slugs.slice(i, i + 200);
+    const { data, error } = await supabase.from('artists').select('slug').in('slug', chunk);
+    if (error) {
+      console.error('Failed to read existing artists:', error.message);
+      process.exit(1);
+    }
+    for (const row of data) existing.add(row.slug);
+  }
+  return existing;
+}
+
+interface Candidate {
+  slug: string;
+  name: string;
+  imageUrl: string | null;
+  matchConfidence: 'verified' | 'unverified';
+  links: Array<{ platform: string; url: string; latestRelease: unknown }>;
+}
+
+/** Read a published slug's static file and reduce it to what we'd store. Null if unusable. */
+function buildCandidate(entry: ManifestEntry): Candidate | { skip: string } {
+  const path = resolve(repoRoot, 'data/artists', `${entry.slug}.json`);
+  if (!existsSync(path)) return { skip: 'no static file' };
+
+  let parsed: StaticArtist[];
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8')) as StaticArtist[];
+  } catch {
+    return { skip: 'unparseable static file' };
+  }
+
+  const artist = Array.isArray(parsed) ? parsed[0] : (parsed as unknown as StaticArtist);
+  if (!artist?.name) return { skip: 'no artist in static file' };
+
+  const links = (artist.platforms ?? [])
+    .filter(p => !EXCLUDED_PLATFORMS.has(p.sourceId) && isDirectLink(p.url))
+    .map(p => ({ platform: p.sourceId, url: p.url, latestRelease: p.latestRelease ?? null }));
+
+  // Same rule persistSearchResults applies: an artist with no real link has no page worth serving.
+  if (links.length === 0) return { skip: 'no direct links after filtering' };
+
+  return {
+    slug: entry.slug,
+    name: artist.name,
+    imageUrl: artist.imageUrl || entry.imageUrl || null,
+    matchConfidence: artist.matchConfidence === 'verified' ? 'verified' : 'unverified',
+    links,
+  };
+}
+
+async function insertCandidate(c: Candidate): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('artists')
+    .insert({
+      slug: c.slug,
+      name: c.name,
+      image_url: c.imageUrl,
+      match_confidence: c.matchConfidence,
+      source: 'auto',
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) return `artist insert failed: ${error?.message ?? 'no row returned'}`;
+
+  // Deduped by platform: Postgres rejects a bulk insert touching the same conflict key twice, and
+  // a couple of static files list a platform more than once.
+  const byPlatform = new Map(c.links.map((l, index) => [l.platform, {
+    artist_id: data.id,
+    platform: l.platform,
+    url: l.url,
+    source: 'search',
+    is_direct: true,
+    latest_release: l.latestRelease,
+    display_order: index,
+  }]));
+
+  const { error: linkError } = await supabase.from('artist_links').insert([...byPlatform.values()]);
+  if (linkError) return `links insert failed: ${linkError.message}`;
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  const manifest = JSON.parse(
+    readFileSync(resolve(repoRoot, 'data/artists-manifest.json'), 'utf8')
+  ) as ManifestEntry[];
+
+  console.log(`Manifest: ${manifest.length} published artists`);
+
+  const existing = await findExistingSlugs(manifest.map(e => e.slug));
+  console.log(`Already have a row: ${existing.size}`);
+
+  const missing = manifest.filter(e => !existing.has(e.slug));
+  console.log(`Missing a row: ${missing.length}\n`);
+
+  const candidates: Candidate[] = [];
+  const skips = new Map<string, string[]>();
+
+  for (const entry of missing) {
+    const result = buildCandidate(entry);
+    if ('skip' in result) {
+      const list = skips.get(result.skip) ?? [];
+      list.push(entry.slug);
+      skips.set(result.skip, list);
+    } else {
+      candidates.push(result);
+    }
+  }
+
+  for (const [reason, slugs] of skips) {
+    console.log(`Skipped — ${reason}: ${slugs.length}`);
+    console.log(`  ${slugs.slice(0, 8).join(', ')}${slugs.length > 8 ? ' …' : ''}`);
+  }
+
+  const planned = candidates.slice(0, limit === Infinity ? candidates.length : limit);
+  const totalLinks = planned.reduce((sum, c) => sum + c.links.length, 0);
+  console.log(`\nWould insert ${planned.length} artists and ${totalLinks} links.`);
+  console.log('Sample:');
+  for (const c of planned.slice(0, 5)) {
+    console.log(`  ${c.slug.padEnd(24)} ${c.matchConfidence.padEnd(10)} ${c.links.length} links  ${c.links.map(l => l.platform).join(', ')}`);
+  }
+
+  if (!write) {
+    console.log('\nDry run — nothing written. Re-run with --write to insert.');
+    return;
+  }
+
+  console.log('\nWriting…');
+  let inserted = 0;
+  const failures: string[] = [];
+
+  for (const c of planned) {
+    const error = await insertCandidate(c);
+    if (error) {
+      failures.push(`${c.slug}: ${error}`);
+    } else {
+      inserted++;
+      if (inserted % 50 === 0) console.log(`  ${inserted}/${planned.length}`);
+    }
+  }
+
+  console.log(`\nInserted ${inserted} artists.`);
+  if (failures.length) {
+    console.log(`${failures.length} failed:`);
+    for (const f of failures.slice(0, 20)) console.log(`  ${f}`);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
**Already run against production — all 791 published artist slugs now return 200.** This PR is the script that did it, kept so the work is reviewable and repeatable.

## The problem

`data/artists-manifest.json` (791 artists) feeds the sitemap and the generated social posts, but `/artist/:slug` renders from Supabase — and rows only land there when someone **searches** an artist, via `persistSearchResults`. Nothing ever seeded the published set.

| | before | after |
|---|---|---|
| published slugs with an `artists` row | 55 | **791** |
| returning 404 | **736** | 0 |

Found while building the 404 signal in #382 — checking the alert would actually fire is what surfaced it. This is a *different* bug from #380: that one fixed artists who have a row but were refused by the claimed filter. These had no row at all. `git log -S` dates it to **#274 (2026-06-16)**, when `ArtistPage` moved onto `/api/artist-page` and orphaned `data/artists/`.

## Three decisions worth reviewing

**The slug comes from the manifest, never derived from the name.** `artistSlug()` in db.ts turns accents into hyphens — `Jónsi` → `j-nsi`, `Hüsker Dü` → `h-sker-d` — and disagrees with the manifest on **34 of 791**. Deriving would have filed those under URLs the sitemap doesn't advertise: 404 unfixed, run looking successful. All 34 verified live afterwards.

**Insert-only.** Existing rows are skipped untouched whatever their state, so claimed profiles can't be affected even in principle — the published set and the claimed set turn out to be disjoint anyway. `source='claimed'` was 124 before and after. `artists.slug` is UNIQUE (`artists_slug_key`, confirmed by probing a duplicate insert), so a re-run fails safely rather than duplicating.

**No cataloguing is triggered.** `persistSearchResults` requests a release catalogue for every artist with a Bandcamp link, and *all* 791 have one — reusing it wholesale would have dumped hundreds of crawls on Bandcamp at once. Releases can be catalogued later, deliberately and in batches.

Link filtering imports `isDirectLink` / `EXCLUDED_PLATFORMS` from db.ts rather than restating them, so a backfilled artist stores exactly what a searched artist would. That's the only change to existing code: two symbols made `export`.

## Verification

- Dry run first (the default), then `--limit=3 --write`, checked those three live, then the rest.
- 736 artists, 4,786 links, zero failures, zero skips.
- All 791 slugs return 200, sampled across the alphabet and across every accent case.
- `808-state` rendered in the browser: pills, payout percentages, AI-policy badges, socials, claim CTA.
- Spot-checked stored Bandcamp URLs — the 303s are legitimate artist→album redirects, not dead links.
- 523 API tests pass; lint unchanged from baseline; `tsc` clean on both touched files.

`match_confidence` is `verified` for all 736. That's earned, not assumed: `generate-artist-data.ts` only ever saved artists with a real, non-empty presence on a qualifying platform. It does roughly triple the `verified` population, which feeds typeahead ranking — worth an eye on suggestions over the next few days.

**Rollback**, if ever needed: these rows are identifiable as `source='auto'` with `created_at` on 2026-08-01 and a slug in the manifest; `artist_links` cascade on delete.

## Follow-on

With this merged, #382's published-slug 404 signal starts life quiet instead of reporting 736 known-broken URLs — which was the reason to do this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)