### PR TITLE
Base sitemap lastmod on the database, and stop listing URLs that 404

### DIFF
--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -17,4747 +17,4747 @@
   </url>
   <url>
     <loc>https://unstream.stream/artist/12-stones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/808-state</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/aaron-carter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/abbey-lincoln</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/above-beyond</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/absurd</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ace-frehley</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/achille-lauro</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/adam-jones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/adrian-belew</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/afroman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/against-me</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/agalloch</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/agnes-obel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/aiko</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/air</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/airbourne</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/al-green</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alan-jackson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/albert-hammond-jr</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alcazar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alcest</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alestorm</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alex-chilton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alex-skolnick</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alex-warren</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alexa</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alexandra-burke</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ali-zafar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alice-faye</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alice-merton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alice-phoebe-lou</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alicia-witt</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alien-ant-farm</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alison-krauss</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alison-mosshart</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/all-that-remains</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/all-time-low</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/allie-x</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alma</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/alter-bridge</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/amadou-mariam</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/amaral</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/amber-rose</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/amber</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/amy-irving</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anathema</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/andrew-latimer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/andrew-wood</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/andrius-pojavis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/andy-bell</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ane-brun</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/angie-stone</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ani-difranco</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/animal-collective</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/animals-as-leaders</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anitta</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anna-von-hausswolff</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anne-marie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anneke-van-giersbergen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anoushka-shankar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/antestor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/anti-flag</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/aphex-twin</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/architects</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/arrested-development</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/artie-shaw</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/as-i-lay-dying</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/asher-roth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ashok-kumar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/asking-alexandria</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/at-the-gates</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/aurora</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/avishai-cohen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/axel-rudi-pell</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/azam-ali</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/azis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/aziza-mustafa-zadeh</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/baaba-maal</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/babyface</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/band-of-horses</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/basement-jaxx</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bbno</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/beach-house</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bear-mccreary</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bebe</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/behemoth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/belinda-carlisle</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/belinda</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/belle-and-sebastian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/belphegor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/benny-golson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bert-jansch</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/beth-hart</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/beth-orton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/betty-davis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/big-mama-thornton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bijelo-dugme</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bikini-kill</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/billy-preston</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/birdy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/black-uhuru</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/blaze-bayley</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/blind-guardian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/blonde-redhead</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/blood-red-shoes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/blutengel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bobby-darin</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bobby-kimball</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/boggie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bombay-bicycle-club</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bon-iver</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/booker-t-jones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/boombox</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/boy-george</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/boys-like-girls</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/boz-scaggs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bradley-joseph</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brainstorm</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brendan-murray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brendan-perry</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brian-hyland</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brian-tyler</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bright-eyes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bronski-beat</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brook-benton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brooke-candy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bruce-hornsby</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/brunette</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bryan-greenberg</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bt</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/burl-ives</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/bush</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/buzzcocks</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/c-ur-de-pirate</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cake</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/caleb-landry-jones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/calogero</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/can</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/candlemass</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/caravan-palace</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/caravan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/carcass</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/carl-perkins</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/carmine-appice</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/caro-emerald</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/caroline-polachek</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/carpathian-forest</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cassandra-wilson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cattle-decapitation</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cavalera-conspiracy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/celldweller</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/charles-trenet</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/charlie-clouser</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/charlie-mcgettigan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/chic</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/chickenfoot</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/chip-taylor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/chris-barnes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/christopher-cross</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/christy-moore</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/chuck-mangione</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cigarettes-after-sex</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cinderella</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/circus-mircus</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/clairo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/claude</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/clint-mansell</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/clutch</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cocorosie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/coldrain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/common</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/converge</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/conway-twitty</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/corrosion-of-conformity</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cosmic-gate</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/courtney-barnett</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/crass</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/creed</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cristina-branco</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cryptopsy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/culture-beat</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/cutting-crew</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dale-crover</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/daler-mehndi</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dan-balan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dan-hartman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/daniel-johnston</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/daniel-lanois</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/danny-saucedo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/daron-malakian-and-scars-on-broadway</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/daughter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/david-byrne</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/david-cross</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/david-ellefson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/david-sylvian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/de-la-soul</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/deafheaven</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dean-edwards</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/death-cab-for-cutie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/deathstars</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/decapitated</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dee-dee-bridgewater</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dee-snider</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/deicide</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/del-shannon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/delain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dennis-brown</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/denzel-curry</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/descendents</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/destruction</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/devendra-banhart</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/devildriver</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/devin-townsend</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/devourment</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/diamanda-galas</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/die-krupps</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dinah-jane</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dinosaur-jr</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/diplo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dixie-d-amelio</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/doc-watson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/donna-lewis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/down</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/draconian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dubioza-kolektiv</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dusty-hill</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/dying-fetus</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eddie-clarke</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eddie-floyd</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/editors</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eimear-quinn</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/einsturzende-neubauten</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eisbrecher</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elbow</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eliane-elias</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elizabeth-cotten</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elliot-goldenthal</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elliott-smith</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elvin-bishop</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/elza-soares</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/emmy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/emperor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/enslaved</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/entombed</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/escape-the-fate</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/esperanza-spalding</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ethel-cain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/eugene-levy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/evergrey</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/everlast</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/exodus</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/explosions-in-the-sky</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/faith-no-more</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/faithless</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fecal-matter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/femi-kuti</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fine-young-cannibals</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/five-finger-death-punch</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fka-twigs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fleet-foxes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/flogging-molly</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/floor-jansen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/flora-purim</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/focus</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/foreigner</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fountains-of-wayne</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/frank-iero</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/frankie-avalon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/fun</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/funkadelic</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gala</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/galena</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gamma-ray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gang-of-four</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/garmarna</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/garou</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gary-numan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gary</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gate</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gazebo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gentle-giant</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/george-jones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/george-thorogood</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gilda</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/girl-in-red</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gisela</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gladys-knight</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/glass-animals</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/glen-matlock</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/go-a</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/godspeed-you-black-emperor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gogol-bordello</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/golden-child</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gotye</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/graham-greene</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/grandmaster-flash</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/green-river</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gregg-allman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gregorian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gregory-isaacs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/grimes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/grizzly-bear</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/groove-armada</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gunna</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gunther</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/guru</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gustavo-cerati</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gustavo-santaolalla</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/gwar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/haggard</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/haim</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hammerfall</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/happy-mondays</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hatebreed</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hector-lavoe</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/helmet</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/herman-s-hermits</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hide</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/highlight</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hildegard-knef</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hot-chip</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/hubert-sumlin</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/husker-du</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/huun-huur-tu</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/i-dle</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ian-hunter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ian-mcdonald</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ian-stewart</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/iannis-xenakis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ice-t</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/iced-earth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/idan-raichel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ike-turner</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ill-nino</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/immortal</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/imogen-heap</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/interpol</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/iq</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/irma-thomas</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/iron-wine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jack-dejohnette</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jack-teagarden</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jack-white</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jackie-deshannon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jackson-wang</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jacob-collier</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/james-cotton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/james-labrie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/james-newton-howard</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/james-taylor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jan-akkerman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/janis-ian</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jason-white</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jax-jones</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jello-biafra</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jeremih</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jessica-jung</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jill-johnson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jimmy-reed</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jinjer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jls</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/joanna-newsom</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/joe-elliott</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/joe-henderson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/joe-jackson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-cooper</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-fogerty</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-kay</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-prine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-taylor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/john-williams</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/johnny-nash</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jonathan-richman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jonny-greenwood</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jonsi</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jose-gonzalez</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/josipa-lisac</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/judy-collins</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/juli</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/julie-bergan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/julien-baker</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/june-carter-cash</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/justice</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/jyj</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/k-d-lang</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kard</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/karen-o</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/karl-bartos</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/katarsis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/katatonia</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kate-nash</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/keb-mo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/keith-david</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/keith-emerson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/keke-palmer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kelis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kendji-girac</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kenshi-yonezu</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kent</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/keri-hilson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kiesza</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/killswitch-engage</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kim-deal</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kim-gordon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kim-wilde</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/king-diamond</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kirka</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/klaus-schulze</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kneecap</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/knife-party</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/koko-taylor</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kool-g-rap</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/korpiklaani</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/koza-mostra</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kristin-chenoweth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/krs-one</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kula-shaker</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/kvelertak</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/l-a-guns</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lacrimosa</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ladytron</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/laibach</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/latto</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/laura-marling</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/laurie-anderson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lcd-soundsystem</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/le-tigre</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/leaves-eyes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lee-ranaldo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lena-raine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/les-rita-mitsouko</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lesley-gore</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/levina</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lex-barker</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lhasa-de-sela</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lil-peep</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lil-tecca</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/linda-perry</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/link-wray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/liquid-tension-experiment</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lisa-miskovsky</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lissie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/little-walter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/liv-kristine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lord-of-the-lost</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lovebugs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lucero</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lucinda-williams</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/lucy-dacus</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/luke-black</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/luna</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/m83</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mac-demarco</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/macy-gray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/madeleine-peyroux</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/madison-beer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/magazine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/magma</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/maksim</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/malcolm-young</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/malice-mizer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/malu</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/manu-chao</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/manu-dibango</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/marc-almond</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/maria-mena</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/marina-satti</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mario-lanza</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mark-owen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mark-sheppard</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/martha-wainwright</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/martin-barre</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/martin-gore</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/maruv</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mary-hopkin</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mase</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mashina-vremeni</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/massiel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/masta-killa</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/matthew-morrison</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/max-romeo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/meat-puppets</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mecano</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/megara</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/melvins</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/merle-haggard</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mf-doom</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mgmt</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/michael-kiwanuka</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/michael-rice</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/michelle-creber</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mike-bloomfield</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mike-love</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/milton-nascimento</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mindless-self-indulgence</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/minor-threat</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/minus-one</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mira-awad</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/miranda-july</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mitski</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/modest-mouse</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mogwai</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/molchat-doma</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/montaigne</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/morcheeba</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/moya-brennan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mr-bungle</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mr-president</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mudhoney</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mulatu-astatke</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/mum</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/my-dying-bride</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/myles-kennedy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/naviband</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/neil-murray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/neko-case</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nemo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/neneh-cherry</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/neu</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/neutral-milk-hotel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nick-carter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nicola-piovani</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nicolas-jaar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nightmare</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nile</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nina-kraviz</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nina-nesbitt</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nino-rota</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/no-use-for-a-name</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/noel-gallagher-s-high-flying-birds</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/nofx</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/o-torvald</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/obituary</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/okean-elzy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/olafur-arnalds</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/omar-souleyman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/omega</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/onewe</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/onyx</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/oomph</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/orchestral-manoeuvres-in-the-dark</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/os-mutantes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/otep</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/owl-city</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/p-o-d</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pain-of-salvation</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/panik</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/papa-roach</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/parker-posey</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pat-carroll</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pat-o-brien</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/patti-page</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/paul-di-anno</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/paul-oakenfold</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/paul-weller</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pavement</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/peter-brotzmann</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/peter-hook</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/peter-nalitch</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/philip-selway</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/phoebe-bridgers</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pierce-the-veil</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pierre-schaeffer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pink-martini</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/piqued-jacks</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/plain-white-t-s</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pomme</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/porcupine-tree</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/portugal-the-man</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/powerwolf</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pulp</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/pusha-t</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/puuluup</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/queens-of-the-stone-age</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/quicksilver-messenger-service</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/quiet-riot</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/r-l-burnside</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rachael-yamagata</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rainbow</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/randy-newman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/raphael</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ratt</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rbd</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rebecca-sugar</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/redone</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/regina</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/regine-velasquez</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ricchi-e-poveri</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/richard-carpenter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/richie-hawtin</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rick-wakeman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rita</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/riz-ahmed</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rob-halford</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/robert-miles</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/robert-wilson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roberto-alagna</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/robyn</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/rodrigo-y-gabriela</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roisin-murphy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roy-ayers</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roy-buchanan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roy-haynes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/roy-rogers</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/royksopp</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ruben-blades</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/running-wild</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ry-cooder</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/s-h-e</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/saba</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/salif-keita</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sandra</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sara-tavares</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sarah-mclachlan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sash</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/satoshi</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/satyricon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sebastian-bach</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/secret-garden</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/selah-sue</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sentenced</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shaggy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shagrath</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shakespears-sister</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shane-west</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sharon-corr</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sheila-e</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shel-silverstein</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shkodra-elektronike</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/shpongle</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/six-feet-under</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sixpence-none-the-richer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sjon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/skillet</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/skinny-puppy</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/skip-james</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/skunk-anansie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sleater-kinney</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/slint</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/slot</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/slowdive</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sly-stone</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/snow</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sofi-marinova</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/soft-machine</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sohee</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sona-jobarteh</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sonia</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sonny-chiba</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sopor-aeternus-the-ensemble-of-shadows</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sparklehorse</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/splean</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/squarepusher</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steel-panther</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/stefania</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/stephen-foster</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/stereo-mike</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/stereolab</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steve-lukather</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steve-miller</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steve-perry</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steve-reich</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/steve-vai</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/stray-cats</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/suffocation</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/sugababes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/suicide</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/surie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/susanne-sundf-r</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/suzanne-vega</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/swans</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/t-o-p</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/taking-back-sunday</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tanya-tucker</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tautumeitas</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/telex</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tenacious-d</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/teresa-brewer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-13th-floor-elevators</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-1975</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-agonist</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-all-american-rejects</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-ark</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-birthday-massacre</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-breeders</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-byrds</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-coasters</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-cult</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-damned</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-darkness</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-decemberists</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-dodos</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-fratellis</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-fray</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-futureheads</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-game</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-hardkiss</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-jesus-and-mary-chain</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-kills</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-knife</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-lemonheads</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-magnetic-fields</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-mamas</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-national</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-orb</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-piano-guys</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-postal-service</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-pretty-reckless</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-psychedelic-furs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-raconteurs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-residents</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-roop</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-searchers</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-seekers</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-shaggs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-shins</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-sugarcubes</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-sweet</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-swinging-blue-jeans</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-the</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-used</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-wanted</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-waterboys</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-wombats</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/the-xx</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/theodor-andrei</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/they-might-be-giants</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/throbbing-gristle</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tico-torres</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tigran-hamasyan</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tim-staffell</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/timo-tolkki</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tina-karol</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tinariwen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tindersticks</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tiny-tim</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tlc</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tom-hamilton</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tom-lehrer</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tom-morello</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tommy-emmanuel</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tony-allen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tony-joe-white</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/toshi</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/transatlantic</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/trentem-ller</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tristania</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/turbonegro</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tv-on-the-radio</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tyagaraja</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tyler-bates</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/tyr</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ufo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ultravox</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/underoath</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/van-canto</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/vanessa-amorosi</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/venom</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/vesna</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/vince-clarke</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/vnv-nation</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/w-a-s-p</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/walk-off-the-earth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wallows</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wanda-jackson</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wang-leehom</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wayv</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/white-zombie</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wilco</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wild-youth</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/will-champion</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/william-duvall</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/willie-colon</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/windir</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/winter</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wolf-alice</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/wolfmother</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/woody-herman</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/x</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/xandria</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/yann-tiersen</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/yeah-yeah-yeahs</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/yo-la-tengo</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/yolanda-be-cool</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/youngboy-never-broke-again</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/zakk-wylde</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/ziferblat</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://unstream.stream/artist/zoe</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -4,11 +4,26 @@
  *
  * Output: public/sitemap.xml
  * Usage: npx tsx scripts/generate-sitemap.ts
+ *
+ * Artist entries are reconciled against Supabase, because the manifest alone describes the
+ * *static* files under data/artists/ — which nothing has rendered since #274 moved the page onto
+ * /api/artist-page. Two things went wrong as a result, both fixed here:
+ *
+ *   - `lastmod` was every artist's `lastUpdated` from the manifest, i.e. the day the static file
+ *     was generated (2026-03-24 for all 791). It said nothing about the page a visitor gets, and
+ *     told Google nothing had changed on the day 736 of those pages came back to life.
+ *   - Every manifest slug was listed whether or not it resolved, so the sitemap advertised 736
+ *     404s for six weeks (see PR #384).
+ *
+ * So: `lastmod` comes from `artists.updated_at`, and a slug with no artist row is left out rather
+ * than advertised. If Supabase can't be reached the build must not fail or silently ship an empty
+ * sitemap, so it falls back to the old manifest-only behaviour and says so loudly.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { createClient } from '@supabase/supabase-js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = join(__dirname, '..', 'data', 'artists-manifest.json');
@@ -42,7 +57,42 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function main() {
+/**
+ * `updated_at` per published slug, or null if Supabase is unreachable/unconfigured.
+ *
+ * Null is the "couldn't ask" signal and is handled differently from an artist simply being absent
+ * — the distinction that stops a credentials problem from silently emptying the sitemap.
+ */
+async function fetchArtistUpdatedAt(slugs: string[]): Promise<Map<string, string> | null> {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) {
+    console.warn('⚠️  SUPABASE_URL/SUPABASE_SERVICE_KEY not set — falling back to manifest dates.');
+    return null;
+  }
+
+  const client = createClient(url, key);
+  const updatedAt = new Map<string, string>();
+
+  for (let i = 0; i < slugs.length; i += 200) {
+    const { data, error } = await client
+      .from('artists')
+      .select('slug, updated_at')
+      .in('slug', slugs.slice(i, i + 200));
+
+    if (error) {
+      console.warn(`⚠️  Supabase lookup failed (${error.message}) — falling back to manifest dates.`);
+      return null;
+    }
+    for (const row of data) {
+      if (row.updated_at) updatedAt.set(row.slug, row.updated_at);
+    }
+  }
+
+  return updatedAt;
+}
+
+async function main() {
   // Static pages
   const staticPages = [
     { url: '/', changefreq: 'weekly', priority: '1.0' },
@@ -56,12 +106,22 @@ function main() {
     <priority>${page.priority}</priority>
   </url>`);
 
-  // Artist pages from manifest
+  // Artist pages from manifest, reconciled against the database that actually renders them
   if (existsSync(MANIFEST_PATH)) {
     const manifest: ManifestEntry[] = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'));
+    const updatedAt = await fetchArtistUpdatedAt(manifest.map(a => a.slug));
+
+    let omitted = 0;
 
     for (const artist of manifest) {
-      const lastmod = artist.lastUpdated.split('T')[0]; // YYYY-MM-DD
+      // Only skip when we actually know the artist is absent. A null map means the lookup failed,
+      // in which case listing everything (the old behaviour) beats shipping a gutted sitemap.
+      if (updatedAt && !updatedAt.has(artist.slug)) {
+        omitted++;
+        continue;
+      }
+
+      const lastmod = (updatedAt?.get(artist.slug) ?? artist.lastUpdated).split('T')[0]; // YYYY-MM-DD
       urls.push(`  <url>
     <loc>${escapeXml(`${BASE_URL}/artist/${artist.slug}`)}</loc>
     <lastmod>${lastmod}</lastmod>
@@ -70,7 +130,11 @@ function main() {
   </url>`);
     }
 
-    console.log(`Added ${manifest.length} artist URLs to sitemap`);
+    console.log(`Added ${manifest.length - omitted} artist URLs to sitemap`);
+    if (omitted > 0) {
+      console.log(`Omitted ${omitted} manifest slug${omitted === 1 ? '' : 's'} with no artist row — ${omitted === 1 ? 'that URL 404s' : 'those URLs 404'}.`);
+      console.log('  Run `npm run backfill:artist-rows` to give them pages instead of dropping them.');
+    }
   } else {
     console.log('No artists manifest found, generating sitemap with static pages only');
   }
@@ -101,4 +165,9 @@ ${urls.join('\n')}
   console.log(`Wrote sitemap to ${OUTPUT_PATH} (${urls.length} URLs)`);
 }
 
-main();
+// Fail the build rather than deploy whatever sitemap happened to be on disk. Supabase being
+// unreachable is already handled inside as a fallback, so reaching here means a real fault.
+main().catch(error => {
+  console.error('Sitemap generation failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Follow-on to #384. Those 736 pages came back to life today, but the sitemap still tells Google nothing has changed since March.

## The problem

Every artist URL carried the same date:

```
791 artist URLs, all <lastmod>2026-03-24</lastmod>
```

That's `lastUpdated` from the manifest — the day the **static file** under `data/artists/` was generated. Nothing has rendered those files since #274 moved the page onto `/api/artist-page`, so the date describes an artifact no visitor ever sees. It's not merely stale, it's measuring the wrong thing.

`lastmod` is only a hint, and Google weighs it by how accurate it's historically been — but right now it points actively the wrong way on 736 URLs that just changed.

## The change

**`lastmod` comes from `artists.updated_at`.** The resulting spread:

```
737  2026-08-01   ← the backfill
  6  2026-03-28
  5  2026-06-25
  4  2026-06-13
  …  genuine per-artist dates
```

A real distribution, not a blanket "everything changed today" — which is what keeps the field worth trusting. Future builds keep tracking real per-artist changes.

**A manifest slug with no artist row is omitted rather than advertised.** This is the standing fix for what #384 cleaned up by hand: the sitemap can no longer promise Google a URL that 404s. When it drops one it says so, and points at `npm run backfill:artist-rows`.

## Failure handling

Supabase being unreachable is treated as its own case, not folded into "artist missing" — otherwise one expired key would silently ship a sitemap containing zero artists. On missing credentials or a query error it warns and falls back to the old manifest-date behaviour, listing everything. A genuine fault still fails the build rather than deploying whatever was on disk.

## Verification

All four paths exercised:

| path | result |
|---|---|
| real credentials | 791 URLs, real dates |
| no credentials | ⚠️ warns, 791 URLs, manifest dates |
| rejected API key | ⚠️ warns, 791 URLs, manifest dates |
| manifest slug with no row | omitted + actionable message |

Also ran the exact build invocation (`cd apps/web && npx tsx ../../scripts/generate-sitemap.ts` — the build runs it from `apps/web`, so the relative path and module resolution matter) and `npx tsc -b`. Lint unchanged from baseline.

**One thing to confirm on the deploy preview:** whether `SUPABASE_URL` / `SUPABASE_SERVICE_KEY` are scoped to *builds* and not just functions. If they aren't, this degrades to today's behaviour and the fix is a scope change in Netlify, not code. I'll check the preview's `sitemap.xml` once it's built.

## After merging

Worth hitting **"Validate fix"** on the 404 report in Search Console — that asks Google to re-check in bulk rather than waiting for its own crawl schedule, which is the stronger lever of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)