### PR TITLE
Releases steps 10, 5 and 6: Jam.coop, catalog-backed alerts, per-fan feeds

### DIFF
--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -55,17 +55,25 @@ const CSS = `
   .site-header { padding: 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 16px; }
   .site-header .brand { display: flex; align-items: center; gap: 8px; font-size: 20px; font-weight: 700; color: var(--text); text-decoration: none; flex-shrink: 0; }
   .site-header .brand:hover { opacity: 0.8; }
-  .site-header .header-search { display: flex; gap: 8px; flex: 1; max-width: 420px; margin: 0 auto; }
-  .site-header .header-search input { flex: 1; min-width: 0; background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px; font-size: 14px; color: var(--text); font-family: inherit; }
+  /* Matches the React HeaderSearch this page can't render: a magnifying glass inside the
+     field and no submit button. Enter submits the form, which is what the icon implies and
+     what every other page in the app does — a separate "Search" button only appeared here
+     because plain SSR made it the obvious way to submit. */
+  .site-header .header-search { position: relative; flex: 1; max-width: 420px; margin: 0 auto; }
+  .site-header .header-search-icon { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: var(--muted); pointer-events: none; }
+  .site-header .header-search input { width: 100%; min-width: 0; background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px 8px 36px; font-size: 14px; color: var(--text); font-family: inherit; }
+  .site-header .header-search input::placeholder { color: var(--muted); }
   .site-header .header-search input:focus { outline: none; border-color: var(--accent); }
-  .site-header .header-search button { border: 0; border-radius: 8px; padding: 8px 14px; background: var(--accent); color: #fff; font-size: 14px; font-weight: 500; cursor: pointer; font-family: inherit; }
   @media (max-width: 640px) { .site-header .header-search { display: none; } }
   /* Unlike artist-page-static, this page has no SPA counterpart to hand real browsers off to
      (see the note at the top of this file) — every visitor sees this exact header, so it's the
      only place a signed-out fan following a release alert can reach the login page. */
   .site-header .nav-right { display: flex; align-items: center; flex-shrink: 0; }
-  .site-header .nav-link { color: var(--muted); text-decoration: none; font-size: 14px; }
-  .site-header .nav-link:hover { color: var(--text); }
+  /* A filled accent button, matching the React header's Login. It was a muted text link here,
+     which read as secondary navigation rather than the primary action for a signed-out fan
+     arriving from a release alert. */
+  .site-header .nav-button { padding: 8px 16px; border-radius: 8px; background: var(--accent); color: #fff; text-decoration: none; font-size: 14px; font-weight: 600; box-shadow: 0 1px 2px rgba(0,0,0,0.2); }
+  .site-header .nav-button:hover { opacity: 0.9; }
 
   .release-head { display: flex; gap: 20px; align-items: flex-start; }
   .release-art { width: 160px; height: 160px; flex-shrink: 0; border-radius: 12px; border: 1px solid var(--border); background: var(--bg2); object-fit: cover; }
@@ -318,11 +326,11 @@ export default async function handler(request: Request, context: Context) {
          HeaderSearch. Submitting lands on /?q=… where the SPA renders results. Never point
          this at /search — that URL belongs to the noscript-search edge function. -->
     <form class="header-search" action="/" method="get" role="search">
+      <svg class="header-search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
       <input type="text" name="q" placeholder="Search artists..." aria-label="Search artists" enterkeyhint="search">
-      <button type="submit">Search</button>
     </form>
     <div class="nav-right">
-      <a href="/login" class="nav-link">Login</a>
+      <a href="/login" class="nav-button">Login</a>
     </div>
   </header>
 

--- a/api/functions/__tests__/check-releases-ssrf.test.ts
+++ b/api/functions/__tests__/check-releases-ssrf.test.ts
@@ -14,6 +14,9 @@ const mocks = vi.hoisted(() => ({
   checkRateLimit: vi.fn(),
   getClientIp: vi.fn(() => '1.2.3.4'),
   isStoredArtistLink: vi.fn(),
+  // Null by default: "this artist has never been catalogued", which is what sends every test
+  // in this file down the live-scrape path the SSRF rules govern.
+  getReleasesForAlerts: vi.fn(async () => null),
   fetch: vi.fn(),
   lookup: vi.fn(),
 }));
@@ -32,6 +35,7 @@ vi.mock('../ratelimit', () => ({
 
 vi.mock('../db', () => ({
   isStoredArtistLink: mocks.isStoredArtistLink,
+  getReleasesForAlerts: mocks.getReleasesForAlerts,
 }));
 
 import { handler } from '../check-releases';
@@ -63,6 +67,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.checkRateLimit.mockResolvedValue({ limited: false });
   mocks.isStoredArtistLink.mockResolvedValue(false);
+  // No catalog for this artist, so every test here exercises the live-scrape path whose SSRF
+  // behaviour this file exists to pin. Set explicitly rather than relying on clearAllMocks
+  // leaving the hoisted default in place.
+  mocks.getReleasesForAlerts.mockResolvedValue(null);
   // Default: everything resolves to an ordinary public address.
   mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
   vi.stubGlobal('fetch', mocks.fetch);
@@ -485,7 +493,13 @@ describe('rate limiting', () => {
 
 describe('backward compatibility with shipped clients', () => {
   // The Mac app (3.3.x) and extension (2.5.x) are already released against this contract.
-  it('keeps the response shape', async () => {
+  //
+  // This used to assert the exact key set, which would forbid ever adding a field. That is
+  // stricter than the actual constraint: the Mac client decodes into a Swift `Codable` struct
+  // and the extension reads named properties off the parsed object, so both ignore keys they
+  // don't know. What they cannot survive is a *removed* or *retyped* field — so that is what
+  // is pinned here, on both response paths.
+  it('keeps the legacy fields a shipped client decodes', async () => {
     mocks.fetch.mockResolvedValue(res(200, { body: '<html></html>' }));
 
     const r = await post({
@@ -494,8 +508,49 @@ describe('backward compatibility with shipped clients', () => {
     });
 
     const parsed = JSON.parse(r.body);
-    expect(Object.keys(parsed).sort()).toEqual(['artistName', 'release']);
-    expect(parsed.artistName).toBe('Someone');
+    expect(parsed).toHaveProperty('artistName', 'Someone');
+    expect(parsed).toHaveProperty('release');
+    expect(parsed.release === null || typeof parsed.release === 'object').toBe(true);
+  });
+
+  it('keeps the legacy release fields when the catalog answers', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [
+        {
+          slug: 'a-record',
+          title: 'A Record',
+          releaseDate: '2026-07-20',
+          datePrecision: 'day',
+          status: 'released',
+          artworkUrl: null,
+          sources: [
+            {
+              platform: 'bandcamp',
+              url: 'https://someone.bandcamp.com/album/a-record',
+              offers: [{ price: 8, currency: 'USD', availability: 'available' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const parsed = JSON.parse((await post({
+      artistName: 'Someone',
+      platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    })).body);
+
+    // Exactly the four keys ReleaseCheckAPI.swift's APIRelease declares, all non-optional there.
+    expect(parsed.release).toMatchObject({
+      releaseName: 'A Record',
+      releaseDate: '2026-07-20',
+      platform: 'bandcamp',
+    });
+    expect(typeof parsed.release.releaseUrl).toBe('string');
+    // The Swift client parses this with a yyyy-MM-dd formatter and throws otherwise.
+    expect(parsed.release.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Not fetched at all: the catalog answered.
+    expect(mocks.fetch).not.toHaveBeenCalled();
   });
 
   it('still rejects a request with no platform URLs', async () => {

--- a/api/functions/__tests__/feed-format.test.ts
+++ b/api/functions/__tests__/feed-format.test.ts
@@ -1,0 +1,270 @@
+// iCalendar and Atom generation.
+//
+// Worth testing carefully because the failure mode is *silent*: a malformed .ics doesn't error
+// in Apple Calendar, it just shows an empty subscription, and an unescaped comma truncates a
+// release title at the comma without anything looking wrong. None of that is visible from
+// reading the output — only from asserting the rules RFC 5545 actually imposes.
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildAtom,
+  buildIcs,
+  escapeIcsText,
+  escapeXml,
+  foldIcsLine,
+  releasePageUrl,
+  type FeedRelease,
+} from '../../shared/feed-format';
+
+const NOW = new Date('2026-08-01T12:00:00Z');
+
+function release(over: Partial<FeedRelease> = {}): FeedRelease {
+  return {
+    artistName: 'Kid Lightbulbs',
+    artistSlug: 'kid-lightbulbs',
+    title: 'Infinite Normal',
+    releaseSlug: 'infinite-normal',
+    releaseDate: '2026-09-01',
+    offerSummary: 'from $8 · ≈$6.80 to artist',
+    platforms: ['Bandcamp', 'Mirlo'],
+    ...over,
+  };
+}
+
+/** Unfold a document back into logical lines, the way a real parser does. */
+function logicalLines(ics: string): string[] {
+  return ics.split('\r\n').reduce<string[]>((out, line) => {
+    if (line.startsWith(' ') && out.length > 0) out[out.length - 1] += line.slice(1);
+    else if (line) out.push(line);
+    return out;
+  }, []);
+}
+
+describe('escapeIcsText', () => {
+  // A raw comma is a value separator in RFC 5545, so an unescaped one silently truncates the
+  // title in the subscriber's calendar. Album titles have commas in them constantly.
+  it('escapes the four characters that change meaning', () => {
+    expect(escapeIcsText('Hello, World')).toBe('Hello\\, World');
+    expect(escapeIcsText('A; B')).toBe('A\\; B');
+    expect(escapeIcsText('back\\slash')).toBe('back\\\\slash');
+    expect(escapeIcsText('one\ntwo')).toBe('one\\ntwo');
+  });
+
+  // Backslashes must be escaped before the escapes this function adds, or those get re-escaped.
+  it('does not double-escape its own output', () => {
+    expect(escapeIcsText('a\\,b')).toBe('a\\\\\\,b');
+  });
+
+  it('handles CRLF and bare CR as one newline each', () => {
+    expect(escapeIcsText('a\r\nb')).toBe('a\\nb');
+    expect(escapeIcsText('a\rb')).toBe('a\\nb');
+  });
+});
+
+describe('foldIcsLine', () => {
+  it('leaves a short line alone', () => {
+    expect(foldIcsLine('SUMMARY:Short')).toBe('SUMMARY:Short');
+  });
+
+  it('folds a long line into 75-octet pieces with a leading space', () => {
+    const folded = foldIcsLine('SUMMARY:' + 'a'.repeat(200));
+    const lines = folded.split('\r\n');
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).toHaveLength(75);
+    for (const line of lines.slice(1)) expect(line.startsWith(' ')).toBe(true);
+    // Unfolding must reproduce the original exactly.
+    expect(lines.map((l, i) => (i === 0 ? l : l.slice(1))).join('')).toBe('SUMMARY:' + 'a'.repeat(200));
+  });
+
+  // The reason folding counts octets rather than characters: splitting mid-sequence produces
+  // mojibake or a parse error for a title like "Ágætis byrjun".
+  it('never splits a multi-byte character across the boundary', () => {
+    const folded = foldIcsLine('SUMMARY:' + 'é'.repeat(80)); // é is 2 bytes in UTF-8
+
+    for (const line of folded.split('\r\n')) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+      // A broken split would leave a replacement character behind.
+      expect(line).not.toContain('�');
+    }
+    expect(folded.split('\r\n').map((l, i) => (i === 0 ? l : l.slice(1))).join(''))
+      .toBe('SUMMARY:' + 'é'.repeat(80));
+  });
+
+  it('keeps every emitted line within 75 octets', () => {
+    const folded = foldIcsLine('DESCRIPTION:' + 'ünstream '.repeat(40));
+    for (const line of folded.split('\r\n')) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+    }
+  });
+});
+
+describe('buildIcs', () => {
+  it('produces a well-formed calendar with one event per release', () => {
+    const ics = buildIcs([release()], 'Unstream — Upcoming releases', NOW);
+    const lines = logicalLines(ics);
+
+    expect(lines[0]).toBe('BEGIN:VCALENDAR');
+    expect(lines[lines.length - 1]).toBe('END:VCALENDAR');
+    expect(lines).toContain('VERSION:2.0');
+    expect(lines.filter(l => l === 'BEGIN:VEVENT')).toHaveLength(1);
+    expect(lines.filter(l => l === 'END:VEVENT')).toHaveLength(1);
+  });
+
+  // Bare LF is rejected outright by some clients.
+  it('uses CRLF line endings throughout and ends with one', () => {
+    const ics = buildIcs([release()], 'Cal', NOW);
+    expect(ics.endsWith('\r\n')).toBe(true);
+    expect(ics.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  // A release date is a day, not a moment. An event at 00:00 UTC lands on the previous day for
+  // every subscriber west of Greenwich.
+  it('writes all-day events with an exclusive end date', () => {
+    const lines = logicalLines(buildIcs([release({ releaseDate: '2026-09-01' })], 'Cal', NOW));
+
+    expect(lines).toContain('DTSTART;VALUE=DATE:20260901');
+    expect(lines).toContain('DTEND;VALUE=DATE:20260902');
+    // No time component on the event bounds — a DATE-TIME value would look like
+    // `...:20260901T000000Z`. (Checked against the value after the colon, since the property
+    // name `VALUE=DATE` legitimately contains a T.)
+    for (const prop of ['DTSTART', 'DTEND']) {
+      const line = lines.find(l => l.startsWith(prop))!;
+      expect(line.split(':')[1]).toMatch(/^\d{8}$/);
+    }
+  });
+
+  it('rolls the end date over a month boundary correctly', () => {
+    const lines = logicalLines(buildIcs([release({ releaseDate: '2026-09-30' })], 'Cal', NOW));
+    expect(lines).toContain('DTEND;VALUE=DATE:20261001');
+  });
+
+  it('rolls over a leap day correctly', () => {
+    const lines = logicalLines(buildIcs([release({ releaseDate: '2028-02-29' })], 'Cal', NOW));
+    expect(lines).toContain('DTEND;VALUE=DATE:20280301');
+  });
+
+  // A subscribed calendar re-fetches forever. An unstable UID piles up a fresh copy of every
+  // release on every refresh.
+  it('gives each release a stable UID across rebuilds', () => {
+    const first = logicalLines(buildIcs([release()], 'Cal', new Date('2026-08-01T00:00:00Z')));
+    const second = logicalLines(buildIcs([release()], 'Cal', new Date('2026-12-25T00:00:00Z')));
+
+    const uidOf = (lines: string[]) => lines.find(l => l.startsWith('UID:'));
+    expect(uidOf(first)).toBe('UID:kid-lightbulbs-infinite-normal@unstream.stream');
+    expect(uidOf(second)).toBe(uidOf(first));
+  });
+
+  it('gives two releases distinct UIDs', () => {
+    const lines = logicalLines(
+      buildIcs([release(), release({ releaseSlug: 'other', title: 'Other' })], 'Cal', NOW)
+    );
+    const uids = lines.filter(l => l.startsWith('UID:'));
+    expect(new Set(uids).size).toBe(2);
+  });
+
+  it('escapes a comma in a release title rather than truncating it', () => {
+    const lines = logicalLines(buildIcs([release({ title: 'Hello, Goodbye' })], 'Cal', NOW));
+    const summary = lines.find(l => l.startsWith('SUMMARY:'));
+
+    expect(summary).toContain('Hello\\, Goodbye');
+  });
+
+  // Pillar 3: a calendar entry deep-linking to one shop hides the payout comparison.
+  it('links to the Unstream release page and shows the price', () => {
+    const lines = logicalLines(buildIcs([release()], 'Cal', NOW));
+
+    expect(lines).toContain('URL:https://unstream.stream/a/kid-lightbulbs/infinite-normal');
+    const description = lines.find(l => l.startsWith('DESCRIPTION:')) ?? '';
+    expect(description).toContain('Bandcamp\\, Mirlo');
+    expect(description).toContain('to artist');
+  });
+
+  it('omits the price line rather than inventing one when no offer is known', () => {
+    const lines = logicalLines(buildIcs([release({ offerSummary: '' })], 'Cal', NOW));
+    const description = lines.find(l => l.startsWith('DESCRIPTION:')) ?? '';
+
+    expect(description).not.toContain('undefined');
+    expect(description).toContain('https://unstream.stream/a/');
+  });
+
+  it('produces a valid empty calendar when there is nothing coming', () => {
+    const lines = logicalLines(buildIcs([], 'Cal', NOW));
+
+    expect(lines[0]).toBe('BEGIN:VCALENDAR');
+    expect(lines[lines.length - 1]).toBe('END:VCALENDAR');
+    expect(lines.filter(l => l === 'BEGIN:VEVENT')).toHaveLength(0);
+  });
+
+  it('folds a very long title so no physical line breaks the 75-octet rule', () => {
+    const ics = buildIcs([release({ title: 'A'.repeat(300) })], 'Cal', NOW);
+
+    for (const line of ics.split('\r\n')) {
+      expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+    }
+  });
+});
+
+describe('buildAtom', () => {
+  const opts = { title: 'Unstream', selfUrl: 'https://unstream.stream/feed/f/x.xml', feedId: 'tag:x' };
+
+  it('produces a feed with one entry per release', () => {
+    const xml = buildAtom([release()], opts, NOW);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml.match(/<entry>/g)).toHaveLength(1);
+    expect(xml.trimEnd().endsWith('</feed>')).toBe(true);
+  });
+
+  it('escapes XML metacharacters in a title', () => {
+    const xml = buildAtom([release({ title: 'Rock & Roll <b>' })], opts, NOW);
+
+    expect(xml).toContain('Rock &amp; Roll &lt;b&gt;');
+    expect(xml).not.toContain('<b>');
+  });
+
+  // A feed whose timestamp changes on every fetch tells every reader it changed.
+  it('dates the feed from the newest release, not from now', () => {
+    const xml = buildAtom(
+      [release({ releaseDate: '2026-09-01' }), release({ releaseSlug: 'b', releaseDate: '2026-10-15' })],
+      opts,
+      NOW
+    );
+
+    expect(xml).toContain('<updated>2026-10-15T00:00:00Z</updated>');
+  });
+
+  it('falls back to now for an empty feed, since <updated> is required', () => {
+    const xml = buildAtom([], opts, NOW);
+    expect(xml).toContain('<updated>2026-08-01T12:00:00Z</updated>');
+    expect(xml).not.toContain('<entry>');
+  });
+
+  it('gives each entry a stable, distinct id', () => {
+    const xml = buildAtom([release(), release({ releaseSlug: 'other' })], opts, NOW);
+    const ids = [...xml.matchAll(/<id>([^<]+)<\/id>/g)].map(m => m[1]);
+
+    // One feed id plus two entry ids, all distinct.
+    expect(new Set(ids).size).toBe(3);
+    expect(ids).toContain('tag:unstream.stream,2026:release/kid-lightbulbs/infinite-normal');
+  });
+});
+
+describe('escapeXml', () => {
+  it('escapes all five XML metacharacters', () => {
+    expect(escapeXml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&apos;');
+  });
+
+  it('escapes the ampersand first so entities are not mangled', () => {
+    expect(escapeXml('&lt;')).toBe('&amp;lt;');
+  });
+});
+
+describe('releasePageUrl', () => {
+  it('percent-encodes slugs', () => {
+    expect(releasePageUrl('sigur rós', 'ágætis byrjun')).toBe(
+      'https://unstream.stream/a/sigur%20r%C3%B3s/%C3%A1g%C3%A6tis%20byrjun'
+    );
+  });
+});

--- a/api/functions/__tests__/feed-format.test.ts
+++ b/api/functions/__tests__/feed-format.test.ts
@@ -26,7 +26,11 @@ function release(over: Partial<FeedRelease> = {}): FeedRelease {
     releaseSlug: 'infinite-normal',
     releaseDate: '2026-09-01',
     offerSummary: 'from $8 · ≈$6.80 to artist',
-    platforms: ['Bandcamp', 'Mirlo'],
+    artworkUrl: 'https://f4.bcbits.com/img/a1234.jpg',
+    sources: [
+      { name: 'Bandcamp', url: 'https://kidlightbulbs.bandcamp.com/album/infinite-normal' },
+      { name: 'Mirlo', url: 'https://mirlo.space/kid-lightbulbs/release/infinite-normal' },
+    ],
     ...over,
   };
 }
@@ -176,8 +180,46 @@ describe('buildIcs', () => {
 
     expect(lines).toContain('URL:https://unstream.stream/a/kid-lightbulbs/infinite-normal');
     const description = lines.find(l => l.startsWith('DESCRIPTION:')) ?? '';
-    expect(description).toContain('Bandcamp\\, Mirlo');
     expect(description).toContain('to artist');
+  });
+
+  // The gap this closes: entries named "Bandcamp, Faircamp" and gave the reader no way to reach
+  // either. DESCRIPTION is plain text, so bare URLs on their own lines — every client linkifies
+  // those, and there is no anchor markup available.
+  it('lists a reachable URL per platform in the description', () => {
+    const lines = logicalLines(buildIcs([release()], 'Cal', NOW));
+    const description = lines.find(l => l.startsWith('DESCRIPTION:')) ?? '';
+
+    expect(description).toContain('Bandcamp: https://kidlightbulbs.bandcamp.com/album/infinite-normal');
+    expect(description).toContain('Mirlo: https://mirlo.space/kid-lightbulbs/release/infinite-normal');
+  });
+
+  it('attaches the cover art with a declared type', () => {
+    const lines = logicalLines(buildIcs([release()], 'Cal', NOW));
+    expect(lines).toContain('ATTACH;FMTTYPE=image/jpeg:https://f4.bcbits.com/img/a1234.jpg');
+  });
+
+  it('declares the right type for a png, and none for an unknown extension', () => {
+    const png = logicalLines(buildIcs([release({ artworkUrl: 'https://x.test/a.png' })], 'Cal', NOW));
+    expect(png).toContain('ATTACH;FMTTYPE=image/png:https://x.test/a.png');
+
+    // Asserting image/jpeg over something unidentified can make a client reject the attachment;
+    // FMTTYPE is optional, so omitting it beats guessing.
+    const odd = logicalLines(buildIcs([release({ artworkUrl: 'https://x.test/image' })], 'Cal', NOW));
+    expect(odd).toContain('ATTACH:https://x.test/image');
+  });
+
+  it('omits ATTACH entirely when there is no artwork', () => {
+    const lines = logicalLines(buildIcs([release({ artworkUrl: null })], 'Cal', NOW));
+    expect(lines.some(l => l.startsWith('ATTACH'))).toBe(false);
+  });
+
+  // A URI value is not TEXT: escaping its commas to `\,` would corrupt the address.
+  it('does not text-escape URLs in ATTACH or URL', () => {
+    const lines = logicalLines(
+      buildIcs([release({ artworkUrl: 'https://x.test/a,b.jpg' })], 'Cal', NOW)
+    );
+    expect(lines).toContain('ATTACH;FMTTYPE=image/jpeg:https://x.test/a,b.jpg');
   });
 
   it('omits the price line rather than inventing one when no offer is known', () => {
@@ -215,6 +257,31 @@ describe('buildAtom', () => {
     expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
     expect(xml.match(/<entry>/g)).toHaveLength(1);
     expect(xml.trimEnd().endsWith('</feed>')).toBe(true);
+  });
+
+  it('links every platform and embeds the artwork in the entry content', () => {
+    const xml = buildAtom([release()], opts, NOW);
+
+    // <content type="html"> is entity-encoded, so the markup appears escaped in the raw feed and
+    // the reader decodes it once before rendering.
+    expect(xml).toContain('&lt;img src=&quot;https://f4.bcbits.com/img/a1234.jpg&quot;');
+    expect(xml).toContain('&lt;a href=&quot;https://kidlightbulbs.bandcamp.com/album/infinite-normal&quot;&gt;Bandcamp');
+    expect(xml).toContain('&lt;a href=&quot;https://mirlo.space/kid-lightbulbs/release/infinite-normal&quot;&gt;Mirlo');
+  });
+
+  // For readers that only walk <link> elements rather than rendering content.
+  it('emits a related link per platform and an enclosure for the artwork', () => {
+    const xml = buildAtom([release()], opts, NOW);
+
+    expect(xml).toContain('<link rel="related" type="text/html" href="https://kidlightbulbs.bandcamp.com/album/infinite-normal" title="Bandcamp"/>');
+    expect(xml).toContain('<link rel="enclosure" type="image/jpeg" href="https://f4.bcbits.com/img/a1234.jpg"/>');
+  });
+
+  it('omits the enclosure and the img when there is no artwork', () => {
+    const xml = buildAtom([release({ artworkUrl: null })], opts, NOW);
+
+    expect(xml).not.toContain('rel="enclosure"');
+    expect(xml).not.toContain('&lt;img');
   });
 
   it('escapes XML metacharacters in a title', () => {

--- a/api/functions/__tests__/feed-releases.test.ts
+++ b/api/functions/__tests__/feed-releases.test.ts
@@ -1,0 +1,278 @@
+// The feed endpoint: routing, and the privacy properties of the token path.
+//
+// The security-relevant assertions here are the ones about what the response *doesn't* do —
+// a token must never be cacheable by a shared cache, an unknown token must be indistinguishable
+// from a malformed one, and a handle that hasn't opted into sharing must 404 exactly like a
+// handle that doesn't exist (otherwise the feed enumerates who has an account).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => '1.2.3.4'),
+  getFeedTokenOwner: vi.fn(),
+  getFeedReleasesForUser: vi.fn(),
+  getFeedReleasesForArtist: vi.fn(),
+  getFeedReleasesForHandle: vi.fn(),
+}));
+
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getClientIp: mocks.getClientIp,
+}));
+vi.mock('../db', () => ({
+  getFeedTokenOwner: mocks.getFeedTokenOwner,
+  getFeedReleasesForUser: mocks.getFeedReleasesForUser,
+  getFeedReleasesForArtist: mocks.getFeedReleasesForArtist,
+  getFeedReleasesForHandle: mocks.getFeedReleasesForHandle,
+}));
+
+import { handler, parsePath, requestPath } from '../feed-releases';
+
+const TOKEN = 'kZ8vQ2mN4pR7sT1wY6bE3hJ9lX0cA5dF8gK2nP4qS7u';
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    artistName: 'Kid Lightbulbs',
+    artistSlug: 'kid-lightbulbs',
+    title: 'Infinite Normal',
+    releaseSlug: 'infinite-normal',
+    releaseDate: '2026-09-01',
+    offerSummary: '',
+    platforms: [],
+    sources: [{ platform: 'bandcamp', offers: [{ price: 8, currency: 'USD', availability: 'available' }] }],
+    ...over,
+  };
+}
+
+function get(path: string) {
+  return handler({
+    httpMethod: 'GET',
+    rawUrl: `https://unstream.stream${path}`,
+    headers: { 'x-nf-client-connection-ip': '1.2.3.4' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.checkRateLimit.mockResolvedValue({ limited: false });
+  mocks.getFeedTokenOwner.mockResolvedValue(null);
+  mocks.getFeedReleasesForUser.mockResolvedValue([]);
+  mocks.getFeedReleasesForArtist.mockResolvedValue(null);
+  mocks.getFeedReleasesForHandle.mockResolvedValue(null);
+});
+
+describe('requestPath', () => {
+  // Every route reaches this function through a status-200 rewrite, and on a rewrite
+  // `event.path` can be the rewrite target, which carries no routing information at all.
+  it('prefers rawUrl over path, because a rewrite overwrites path', () => {
+    expect(
+      requestPath({ path: '/.netlify/functions/feed-releases', rawUrl: 'https://unstream.stream/feed/f/abc.ics' })
+    ).toBe('/feed/f/abc.ics');
+  });
+
+  it('falls back to path when rawUrl is absent or unparseable', () => {
+    expect(requestPath({ path: '/feed/f/abc.ics' })).toBe('/feed/f/abc.ics');
+    expect(requestPath({ path: '/feed/f/abc.ics', rawUrl: 'not a url' })).toBe('/feed/f/abc.ics');
+  });
+
+  it('drops the query string', () => {
+    expect(requestPath({ rawUrl: 'https://unstream.stream/feed/f/abc.ics?x=1' })).toBe('/feed/f/abc.ics');
+  });
+});
+
+describe('parsePath', () => {
+  it('recognises all three shapes in both formats', () => {
+    expect(parsePath('/feed/f/abc.ics')).toEqual({ kind: 'token', token: 'abc', format: 'ics' });
+    expect(parsePath('/feed/f/abc.xml')).toEqual({ kind: 'token', token: 'abc', format: 'xml' });
+    expect(parsePath('/u/brandon/releases.ics')).toEqual({ kind: 'handle', handle: 'brandon', format: 'ics' });
+    expect(parsePath('/a/kid-lightbulbs/releases.xml')).toEqual({
+      kind: 'artist',
+      slug: 'kid-lightbulbs',
+      format: 'xml',
+    });
+  });
+
+  it('rejects anything else', () => {
+    expect(parsePath('/feed/f/abc.json')).toBeNull();
+    expect(parsePath('/feed/f/a/b.ics')).toBeNull();
+    expect(parsePath('/u/brandon')).toBeNull();
+    expect(parsePath('/a/kid-lightbulbs/some-release')).toBeNull();
+    expect(parsePath('/')).toBeNull();
+  });
+});
+
+describe('the private token feed', () => {
+  it('serves a calendar for a known token', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([row()]);
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r.statusCode).toBe(200);
+    expect(r.headers['Content-Type']).toBe('text/calendar; charset=utf-8');
+    expect(r.body).toContain('BEGIN:VCALENDAR');
+    expect(r.body).toContain('Infinite Normal');
+  });
+
+  it('serves Atom for the same token', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([row()]);
+
+    const r = await get(`/feed/f/${TOKEN}.xml`);
+
+    expect(r.statusCode).toBe(200);
+    expect(r.headers['Content-Type']).toBe('application/atom+xml; charset=utf-8');
+    expect(r.body).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+  });
+
+  // A fan's subscription list must not sit in a CDN or any shared cache.
+  it('marks the private feed no-store and noindex', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r.headers['Cache-Control']).toBe('private, no-store');
+    expect(r.headers['X-Robots-Tag']).toBe('noindex, nofollow');
+  });
+
+  // 404 rather than 401: a 401 invites retrying, and confirming "well-formed but unknown"
+  // tells an anonymous caller more than they need.
+  it('404s an unknown token, identically to a malformed one', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue(null);
+
+    const unknown = await get(`/feed/f/${TOKEN}.ics`);
+    const malformed = await get('/feed/f/short.ics');
+
+    expect(unknown.statusCode).toBe(404);
+    expect(malformed.statusCode).toBe(404);
+    expect(unknown.body).toBe(malformed.body);
+  });
+
+  // Shape-check first so a scan of junk paths costs no database work.
+  it('does not query the database for a token that cannot be one', async () => {
+    await get('/feed/f/../../etc/passwd.ics');
+    await get('/feed/f/short.ics');
+
+    expect(mocks.getFeedTokenOwner).not.toHaveBeenCalled();
+  });
+
+  it('serves an empty but valid calendar when nothing is coming up', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([]);
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r.statusCode).toBe(200);
+    expect(r.body).toContain('BEGIN:VCALENDAR');
+    expect(r.body).toContain('END:VCALENDAR');
+    expect(r.body).not.toContain('BEGIN:VEVENT');
+  });
+});
+
+describe('the public handle feed', () => {
+  it('serves a shared list', async () => {
+    mocks.getFeedReleasesForHandle.mockResolvedValue({ displayName: 'brandon', releases: [row()] });
+
+    const r = await get('/u/brandon/releases.ics');
+
+    expect(r.statusCode).toBe(200);
+    expect(r.body).toContain("brandon's upcoming releases");
+  });
+
+  // Null covers both "no such handle" and "hasn't opted into sharing" — the same 404 either
+  // way, so the feed can't enumerate which handles exist.
+  it('404s a handle that has not opted into sharing', async () => {
+    mocks.getFeedReleasesForHandle.mockResolvedValue(null);
+
+    const r = await get('/u/private-person/releases.ics');
+
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('lets a public feed be cached, unlike the private one', async () => {
+    mocks.getFeedReleasesForHandle.mockResolvedValue({ displayName: 'brandon', releases: [] });
+
+    const r = await get('/u/brandon/releases.xml');
+
+    expect(r.headers['Cache-Control']).toBe('public, max-age=1800');
+  });
+});
+
+describe('the public artist feed', () => {
+  it('serves one artist’s upcoming releases', async () => {
+    mocks.getFeedReleasesForArtist.mockResolvedValue({ artistName: 'Kid Lightbulbs', releases: [row()] });
+
+    const r = await get('/a/kid-lightbulbs/releases.xml');
+
+    expect(r.statusCode).toBe(200);
+    expect(r.body).toContain('Kid Lightbulbs — upcoming releases');
+  });
+
+  it('404s an unknown artist', async () => {
+    const r = await get('/a/nobody/releases.xml');
+    expect(r.statusCode).toBe(404);
+  });
+});
+
+describe('platform naming and ordering', () => {
+  // Registry names, not raw ids: "Jam.coop", never "jamcoop".
+  it('uses proper platform names in the event description', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([
+      row({ sources: [{ platform: 'jamcoop', offers: [] }] }),
+    ]);
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r.body).toContain('Jam.coop');
+    expect(r.body).not.toContain('jamcoop');
+  });
+
+  // The same artist-paying-first guardrail as the release page and the alerts: a secondhand
+  // Discogs listing must never be named ahead of a direct Bandcamp purchase.
+  it('names the artist-paying platform first', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([
+      row({
+        sources: [
+          { platform: 'discogs', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
+          { platform: 'bandcamp', offers: [{ price: 8, currency: 'USD', availability: 'available' }] },
+        ],
+      }),
+    ]);
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r.body).toMatch(/Bandcamp\\?, ?Discogs/);
+  });
+});
+
+describe('method and rate limiting', () => {
+  it('allows HEAD, which some calendar clients probe with', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+
+    const r = await handler({
+      httpMethod: 'HEAD',
+      rawUrl: `https://unstream.stream/feed/f/${TOKEN}.ics`,
+      headers: {},
+    });
+
+    expect(r.statusCode).toBe(200);
+  });
+
+  it('rejects a write method', async () => {
+    const r = await handler({ httpMethod: 'POST', rawUrl: `https://unstream.stream/feed/f/${TOKEN}.ics`, headers: {} });
+    expect(r.statusCode).toBe(405);
+  });
+
+  it('returns the limiter response when limited', async () => {
+    const limited = { statusCode: 429, headers: {}, body: 'slow down' };
+    mocks.checkRateLimit.mockResolvedValue({ limited: true, response: limited });
+
+    const r = await get(`/feed/f/${TOKEN}.ics`);
+
+    expect(r).toBe(limited);
+    expect(mocks.getFeedTokenOwner).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/feed-releases.test.ts
+++ b/api/functions/__tests__/feed-releases.test.ts
@@ -40,9 +40,19 @@ function row(over: Record<string, unknown> = {}) {
     releaseDate: '2026-09-01',
     offerSummary: '',
     platforms: [],
-    sources: [{ platform: 'bandcamp', offers: [{ price: 8, currency: 'USD', availability: 'available' }] }],
+    artworkUrl: null,
+    sources: [{ platform: 'bandcamp', url: 'https://x.bandcamp.com/album/a-record', offers: [{ price: 8, currency: 'USD', availability: 'available' }] }],
     ...over,
   };
+}
+
+/**
+ * ICS content lines are folded at 75 octets, so a raw `toContain` against the body fails
+ * whenever the string it's looking for straddles a fold. Unfold first, the way a real parser
+ * does, and assert against the logical content.
+ */
+function unfoldIcs(body: string): string {
+  return body.replace(/\r\n /g, '');
 }
 
 function get(path: string) {
@@ -234,13 +244,13 @@ describe('platform naming and ordering', () => {
   it('uses proper platform names in the event description', async () => {
     mocks.getFeedTokenOwner.mockResolvedValue('user-1');
     mocks.getFeedReleasesForUser.mockResolvedValue([
-      row({ sources: [{ platform: 'jamcoop', offers: [] }] }),
+      row({ sources: [{ platform: 'jamcoop', url: 'https://jam.coop/artists/x/albums/a', offers: [] }] }),
     ]);
 
     const r = await get(`/feed/f/${TOKEN}.ics`);
 
-    expect(r.body).toContain('Jam.coop');
-    expect(r.body).not.toContain('jamcoop');
+    expect(unfoldIcs(r.body)).toContain('Jam.coop');
+    expect(unfoldIcs(r.body)).not.toContain('jamcoop:');
   });
 
   // The same artist-paying-first guardrail as the release page and the alerts: a secondhand
@@ -250,15 +260,30 @@ describe('platform naming and ordering', () => {
     mocks.getFeedReleasesForUser.mockResolvedValue([
       row({
         sources: [
-          { platform: 'discogs', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
-          { platform: 'bandcamp', offers: [{ price: 8, currency: 'USD', availability: 'available' }] },
+          { platform: 'discogs', url: 'https://discogs.com/release/1', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
+          { platform: 'bandcamp', url: 'https://x.bandcamp.com/album/a-record', offers: [{ price: 8, currency: 'USD', availability: 'available' }] },
         ],
       }),
     ]);
 
     const r = await get(`/feed/f/${TOKEN}.ics`);
 
-    expect(r.body).toMatch(/Bandcamp\\?, ?Discogs/);
+    // One line per platform now, so "first" means the earlier line — Bandcamp (80-85%) ahead of
+    // Discogs (no published payout), never the other way round.
+    const body = unfoldIcs(r.body);
+    expect(body.indexOf('Bandcamp:')).toBeGreaterThan(-1);
+    expect(body.indexOf('Bandcamp:')).toBeLessThan(body.indexOf('Discogs:'));
+  });
+
+  it('gives every platform a reachable link, not just a name', async () => {
+    mocks.getFeedTokenOwner.mockResolvedValue('user-1');
+    mocks.getFeedReleasesForUser.mockResolvedValue([row()]);
+
+    const ics = await get(`/feed/f/${TOKEN}.ics`);
+    const atom = await get(`/feed/f/${TOKEN}.xml`);
+
+    expect(unfoldIcs(ics.body)).toContain('Bandcamp: https://x.bandcamp.com/album/a-record');
+    expect(atom.body).toContain('href="https://x.bandcamp.com/album/a-record"');
   });
 });
 

--- a/api/functions/__tests__/feed-releases.test.ts
+++ b/api/functions/__tests__/feed-releases.test.ts
@@ -200,13 +200,27 @@ describe('the public handle feed', () => {
 });
 
 describe('the public artist feed', () => {
-  it('serves one artist’s upcoming releases', async () => {
+  it('serves one artist’s releases', async () => {
     mocks.getFeedReleasesForArtist.mockResolvedValue({ artistName: 'Kid Lightbulbs', releases: [row()] });
 
     const r = await get('/a/kid-lightbulbs/releases.xml');
 
     expect(r.statusCode).toBe(200);
-    expect(r.body).toContain('Kid Lightbulbs — upcoming releases');
+    expect(r.body).toContain('Kid Lightbulbs — releases');
+  });
+
+  // An artist feed is a discography, not a calendar of what's imminent — the window belongs to
+  // the per-fan feeds. Saying "upcoming" here would misdescribe a feed full of back catalogue.
+  it('does not describe an artist feed as upcoming, in either format', async () => {
+    mocks.getFeedReleasesForArtist.mockResolvedValue({ artistName: 'Kid Lightbulbs', releases: [row()] });
+
+    const atom = await get('/a/kid-lightbulbs/releases.xml');
+    const ics = await get('/a/kid-lightbulbs/releases.ics');
+
+    expect(atom.body.toLowerCase()).not.toContain('upcoming');
+    expect(ics.body.toLowerCase()).not.toContain('upcoming');
+    // …and the calendar description names the artist rather than "the artists you support".
+    expect(ics.body).toContain('Releases by Kid Lightbulbs');
   });
 
   it('404s an unknown artist', async () => {

--- a/api/functions/__tests__/release-alerts.test.ts
+++ b/api/functions/__tests__/release-alerts.test.ts
@@ -1,0 +1,321 @@
+// The catalog-backed alert path, and the four spec §5 defects it exists to fix.
+//
+// Each defect below is a real, shipped bug described in
+// docs/specs/unstream-releases-v1-scope.md §5 — these lock the fix rather than the plumbing:
+//
+//   2. an upcoming release could never be alerted on (`daysDiff >= 0` filtered the future out)
+//   3. only the latest release per platform was ever seen
+//   4. a multi-platform release was collapsed to one platform by a hardcoded priority list
+//   7. the notification body named one platform and no price
+//
+// Defect 1 is client-side (Swift) and lives in apps/mac/UnstreamTests.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => '1.2.3.4'),
+  isStoredArtistLink: vi.fn(),
+  getReleasesForAlerts: vi.fn(),
+  fetch: vi.fn(),
+  lookup: vi.fn(),
+}));
+
+vi.mock('dns/promises', () => ({ lookup: mocks.lookup }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getClientIp: mocks.getClientIp,
+}));
+vi.mock('../db', () => ({
+  isStoredArtistLink: mocks.isStoredArtistLink,
+  getReleasesForAlerts: mocks.getReleasesForAlerts,
+}));
+
+import { handler } from '../check-releases';
+
+function post(body: unknown) {
+  return handler({
+    httpMethod: 'POST',
+    headers: { 'x-nf-client-connection-ip': '1.2.3.4' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function check(body: Record<string, unknown> = {}) {
+  const r = await post({
+    artistName: 'Someone',
+    platforms: { bandcamp: 'https://someone.bandcamp.com' },
+    ...body,
+  });
+  return JSON.parse(r.body);
+}
+
+function source(platform: string, offers: { price: number | null; currency: string | null; availability: string }[] = []) {
+  return { platform, url: `https://${platform}.example/a-record`, offers };
+}
+
+function release(over: Record<string, unknown> = {}) {
+  return {
+    slug: 'a-record',
+    title: 'A Record',
+    releaseDate: '2026-07-20',
+    datePrecision: 'day',
+    status: 'released',
+    artworkUrl: null,
+    sources: [source('bandcamp', [{ price: 8, currency: 'USD', availability: 'available' }])],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.checkRateLimit.mockResolvedValue({ limited: false });
+  mocks.isStoredArtistLink.mockResolvedValue(false);
+  mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+  mocks.fetch.mockResolvedValue({ ok: true, status: 200, url: 'https://x', text: async () => '<html></html>' });
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+describe('catalog vs live scrape', () => {
+  // The distinction this whole endpoint turns on. Getting it backwards either stops alerting
+  // for every uncatalogued artist, or re-scrapes Bandcamp for everyone forever.
+  it('answers from the catalog without fetching anything', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [release()] });
+
+    const parsed = await check();
+
+    expect(parsed.source).toBe('catalog');
+    expect(parsed.releases).toHaveLength(1);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('reports a genuine empty catalog as no releases, still without fetching', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [] });
+
+    const parsed = await check();
+
+    expect(parsed.source).toBe('catalog');
+    expect(parsed.release).toBeNull();
+    expect(parsed.releases).toEqual([]);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  // Null means "never catalogued", which is not evidence about releases — so it must scrape.
+  it('falls back to a live scrape when the artist has no catalog at all', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue(null);
+    mocks.isStoredArtistLink.mockResolvedValue(true);
+
+    const parsed = await check();
+
+    expect(parsed.source).toBe('live');
+    expect(mocks.fetch).toHaveBeenCalled();
+  });
+
+  // A database failure is also not evidence about releases.
+  it('falls back to a live scrape when the catalog read throws', async () => {
+    mocks.getReleasesForAlerts.mockRejectedValue(new Error('supabase down'));
+    mocks.isStoredArtistLink.mockResolvedValue(true);
+
+    const parsed = await check();
+
+    expect(parsed.source).toBe('live');
+    expect(mocks.fetch).toHaveBeenCalled();
+  });
+});
+
+describe('defect 2 — upcoming releases can be alerted on', () => {
+  it('returns a future-dated release and marks it announced', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ releaseDate: '2099-09-01', status: 'announced', title: 'Next Year' })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0]).toMatchObject({ releaseName: 'Next Year', status: 'announced' });
+    expect(parsed.release.releaseName).toBe('Next Year');
+  });
+});
+
+describe('defect 3 — more than one release survives', () => {
+  it('returns every release in the window, not just the newest', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [
+        release({ slug: 'newer', title: 'Newer', releaseDate: '2026-07-25' }),
+        release({ slug: 'older', title: 'Older', releaseDate: '2026-07-02' }),
+      ],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases.map((r: { releaseName: string }) => r.releaseName)).toEqual(['Newer', 'Older']);
+    // The single-release field a shipped client reads still gets the newest.
+    expect(parsed.release.releaseName).toBe('Newer');
+  });
+});
+
+describe('defect 4 — multi-platform releases are not collapsed', () => {
+  it('reports every platform a release is on', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [
+        release({
+          sources: [
+            source('discogs', [{ price: 2.64, currency: 'USD', availability: 'available' }]),
+            source('bandcamp', [{ price: 8, currency: 'USD', availability: 'available' }]),
+          ],
+        }),
+      ],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0].platforms).toHaveLength(2);
+    expect(parsed.releases[0].platforms).toContain('discogs');
+    expect(parsed.releases[0].platforms).toContain('bandcamp');
+  });
+
+  // Ordering is the guardrail the sourcing spec insists on: a used Discogs copy at $2.64 must
+  // never lead over a direct Bandcamp purchase at $8, even though it is cheaper, because
+  // Discogs pays the artist nothing.
+  it('leads with the artist-paying platform, not the cheapest', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [
+        release({
+          sources: [
+            source('discogs', [{ price: 2.64, currency: 'USD', availability: 'available' }]),
+            source('bandcamp', [{ price: 8, currency: 'USD', availability: 'available' }]),
+          ],
+        }),
+      ],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0].platform).toBe('bandcamp');
+    expect(parsed.releases[0].platforms[0]).toBe('bandcamp');
+  });
+});
+
+describe('defect 7 — the alert body has something to say', () => {
+  it('carries a price and a payout estimate', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ sources: [source('bandcamp', [{ price: 8, currency: 'USD', availability: 'available' }])] })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0].offerSummary).toContain('$8');
+    expect(parsed.releases[0].offerSummary).toContain('to artist');
+  });
+
+  // Zero means name-your-price, never free. Every Kid Lightbulbs release is name-your-price,
+  // so this is the common case, not an edge one.
+  it('says name-your-price rather than $0', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ sources: [source('bandcamp', [{ price: 0, currency: 'USD', availability: 'available' }])] })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0].offerSummary).toBe('Name your price');
+  });
+
+  it('leaves the summary empty rather than inventing one when there are no offers', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ sources: [source('bandcamp')] })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases[0].offerSummary).toBe('');
+  });
+});
+
+describe('alerts point at the release page', () => {
+  // Pillar 3 of the spec: today an alert hands a fan straight to one shop, which hides the
+  // payout comparison at the exact moment they are deciding where to buy.
+  it('links to the Unstream release page, keeping the platform URL alongside', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [release()] });
+
+    const parsed = await check();
+
+    expect(parsed.release.releaseUrl).toBe('https://unstream.stream/a/someone/a-record');
+    expect(parsed.releases[0].platformUrl).toBe('https://bandcamp.example/a-record');
+  });
+
+  it('encodes slugs into the release page URL', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'sigur rós',
+      releases: [release({ slug: 'ágætis byrjun' })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.release.releaseUrl).toBe(
+      'https://unstream.stream/a/sigur%20r%C3%B3s/%C3%A1g%C3%A6tis%20byrjun'
+    );
+  });
+});
+
+describe('releases that cannot be acted on are dropped', () => {
+  it('skips a release with no source to buy from', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ sources: [] })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases).toEqual([]);
+    expect(parsed.release).toBeNull();
+  });
+
+  // An undated release says nothing about being new, and grid ingest produces plenty of them.
+  it('skips an undated release', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({
+      artistSlug: 'someone',
+      releases: [release({ releaseDate: null })],
+    });
+
+    const parsed = await check();
+
+    expect(parsed.releases).toEqual([]);
+  });
+});
+
+describe('the lookback window', () => {
+  it('defaults to 31 days, matching what shipped clients assume', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [] });
+    await check();
+    expect(mocks.getReleasesForAlerts).toHaveBeenCalledWith('Someone', 31);
+  });
+
+  it('honours a wider window a newer client asks for', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [] });
+    await check({ sinceDays: 90 });
+    expect(mocks.getReleasesForAlerts).toHaveBeenCalledWith('Someone', 90);
+  });
+
+  // Not a way to pull a whole discography out of an alerts endpoint.
+  it('caps an absurd window at a year', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [] });
+    await check({ sinceDays: 100_000 });
+    expect(mocks.getReleasesForAlerts).toHaveBeenCalledWith('Someone', 365);
+  });
+
+  it('ignores a nonsense window rather than failing the request', async () => {
+    mocks.getReleasesForAlerts.mockResolvedValue({ artistSlug: 'someone', releases: [] });
+    await check({ sinceDays: -5 });
+    expect(mocks.getReleasesForAlerts).toHaveBeenCalledWith('Someone', 31);
+
+    mocks.getReleasesForAlerts.mockClear();
+    await check({ sinceDays: 'lots' });
+    expect(mocks.getReleasesForAlerts).toHaveBeenCalledWith('Someone', 31);
+  });
+});

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -225,6 +225,127 @@ function detailPage(opts: {
   </head><body></body></html>`;
 }
 
+/**
+ * A standalone-track page's JSON-LD, as the live pages publish it: `@type: MusicRecording`, no
+ * top-level `albumRelease`, and the purchasable items hanging off `inAlbum` — the track's own
+ * download *plus* every physical package of the album it belongs to.
+ */
+function trackPage(opts: {
+  trackId?: string | null;
+  datePublished?: string;
+  /** The track's own download. */
+  own?: { price: number; currency?: string } | null;
+  /** The surrounding album's packages, which are NOT buyable as this track. */
+  albumPackages?: Array<{ format: string; price: number; packageId: string }>;
+  host?: string;
+  slug?: string;
+}): string {
+  const host = opts.host ?? 'https://artist.bandcamp.com';
+  const slug = opts.slug ?? 'a-single';
+  const trackId = opts.trackId === undefined ? '748933878' : opts.trackId;
+
+  const albumRelease: unknown[] = [];
+  if (opts.own !== null) {
+    albumRelease.push({
+      '@type': ['MusicRelease', 'Product'],
+      musicReleaseFormat: 'DigitalFormat',
+      name: 'A Single',
+      additionalProperty: [{ '@type': 'PropertyValue', name: 'type_name', value: 'Digital' }],
+      offers: {
+        '@type': 'Offer',
+        url: `${host}/track/${slug}#t${trackId}-buy`,
+        price: opts.own?.price ?? 1.5,
+        priceCurrency: opts.own?.currency ?? 'USD',
+        availability: 'OnlineOnly',
+      },
+    });
+  }
+  for (const pkg of opts.albumPackages ?? []) {
+    albumRelease.push({
+      '@type': ['MusicRelease', 'Product'],
+      musicReleaseFormat: pkg.format,
+      name: `THE ALBUM ${pkg.format}`,
+      offers: {
+        '@type': 'Offer',
+        url: `${host}/track/${slug}#p${pkg.packageId}-buy`,
+        price: pkg.price,
+        priceCurrency: 'USD',
+        availability: 'InStock',
+      },
+    });
+  }
+
+  const graph: Record<string, unknown> = {
+    '@type': 'MusicRecording',
+    name: 'A Single',
+    datePublished: opts.datePublished ?? '30 May 2025 00:00:00 GMT',
+    ...(trackId ? { additionalProperty: [{ '@type': 'PropertyValue', name: 'track_id', value: trackId }] } : {}),
+    inAlbum: { '@type': 'MusicAlbum', name: 'THE ALBUM', albumRelease },
+  };
+  return `<html><head><script type="application/ld+json">${JSON.stringify(graph)}</script></head><body></body></html>`;
+}
+
+// Standalone `/track/` pages were reported as having no formats at all — 183 of 777 Bandcamp
+// sources, every one a track URL. The old parser only read a top-level `albumRelease`, and a
+// comment asserted track pages "carry a date but no offers at all". That was wrong: the track's
+// own purchase is published under `inAlbum.albumRelease`, with a real price and currency.
+describe('ingestBandcampDetail — standalone track pages', () => {
+  it('reads the track\'s own digital price from inAlbum', () => {
+    const out = ingestBandcampDetail(trackPage({ own: { price: 1, currency: 'GBP' } }));
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([
+      { format: 'digital', price: 1, currency: 'GBP', availability: 'available' },
+    ]);
+    expect(out.detail.releaseDate).toBe('2025-05-30');
+  });
+
+  // The one that matters. A track page also lists the *album's* vinyl/CD/cassette, and buying
+  // those gets you the album, not this track — so publishing "this single is available on vinyl
+  // for $30" would be a wrong claim about what someone's money buys.
+  it('does not attribute the album\'s physical packages to the track', () => {
+    const out = ingestBandcampDetail(
+      trackPage({
+        own: { price: 1.5 },
+        albumPackages: [
+          { format: 'VinylFormat', price: 30, packageId: '3409308344' },
+          { format: 'CDFormat', price: 15, packageId: '3713717029' },
+          { format: 'CassetteFormat', price: 15, packageId: '7013211' },
+        ],
+      })
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers.map(o => o.format)).toEqual(['digital']);
+    expect(out.detail.offers[0].price).toBe(1.5);
+  });
+
+  // Without a track id there is nothing to tell the track's download apart from the album's
+  // packages, so no price at all beats a possibly-wrong one.
+  it('emits no offers when the track id is missing', () => {
+    const out = ingestBandcampDetail(
+      trackPage({ trackId: null, albumPackages: [{ format: 'VinylFormat', price: 30, packageId: '1' }] })
+    );
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([]);
+    // The date still parses — a missing price is not a missing page.
+    expect(out.detail.releaseDate).toBe('2025-05-30');
+  });
+
+  it('still reads the date when the track has no purchase offer at all', () => {
+    const out = ingestBandcampDetail(trackPage({ own: null }));
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.detail.offers).toEqual([]);
+    expect(out.detail.releaseDate).toBe('2025-05-30');
+  });
+});
+
 describe('ingestBandcampDetail', () => {
   it('reads the date and every purchasable format', () => {
     const out = ingestBandcampDetail(

--- a/api/functions/__tests__/release-ingest.test.ts
+++ b/api/functions/__tests__/release-ingest.test.ts
@@ -21,6 +21,10 @@ import {
   ingestFaircampReleasePage,
   buildFaircampRelease,
   findDiscoveredReleaseLinks,
+  ingestJamcoopArtistPage,
+  ingestJamcoopAlbumPage,
+  buildJamcoopRelease,
+  jamcoopArtistUrl,
   type DiscogsArtistReleaseEntry,
 } from '../release-ingest';
 
@@ -884,5 +888,238 @@ describe('findDiscoveredReleaseLinks', () => {
   it('skips a slug with no letters or numbers to match on', () => {
     const out = findDiscoveredReleaseLinks('<a href="https://subvert.fm/artist/---">A</a>', 'https://example.com/');
     expect(out).toEqual([]);
+  });
+});
+
+// --- Jam.coop -----------------------------------------------------------------
+//
+// Markup shapes below are copied from live jam.coop pages (fetched 2026-08-01), trimmed to the
+// parts the parsers read. The price line and the "Released:" label are reproduced verbatim,
+// since those two strings are the whole contract.
+
+const JAMCOOP_ARTIST_URL = 'https://jam.coop/artists/carya-amara';
+
+function jamcoopAlbumHtml(opts: {
+  title?: string;
+  released?: string;
+  priceLine?: string;
+  description?: string;
+} = {}): string {
+  const { title = 'Carrion Carya Amara', released = 'October 4, 2024' } = opts;
+  const priceLine = opts.priceLine ?? '£3.00 or more. Digital download. MP3 and FLAC';
+  // The description is emitted *before* the price line on purpose. "First price-shaped string on
+  // the page" would be a plausible-looking parser, and putting the description after the price
+  // would let it pass — so the fixture is ordered to make the "Digital download" anchor the only
+  // thing that can produce the right answer.
+  return `<html><body>
+    <img class="w-full" src="https://cdn.jam.coop/art.jpg" />
+    <h1 class="text-lg font-medium leading-tight">${title}</h1>
+    <h2 class="text-sm"><a href="/artists/carya-amara">Carya Amara</a></h2>
+    ${opts.description ? `<section><p>${opts.description}</p></section>` : ''}
+    <div>
+      <form class="button_to" method="get" action="/artists/carya-amara/albums/x/purchases/new"><button>Buy</button></form>
+      <p class="text-xs text-slate-600">${priceLine}</p>
+    </div>
+    <section class="mt-6"><p><strong>Released:</strong> ${released}</p></section>
+  </body></html>`;
+}
+
+describe('ingestJamcoopArtistPage', () => {
+  it('finds the artist’s albums and their grid artwork', () => {
+    const html = `<html><body>
+      <a href="/artists/carya-amara/albums/carrion-carya-amara">
+        <div><img class="object-cover" src="https://cdn.jam.coop/a.jpg" /></div>
+        <p>Carrion Carya Amara</p>
+      </a>
+      <a href="/artists/carya-amara/albums/second-record">
+        <div><img src="https://cdn.jam.coop/b.jpg" /></div>
+      </a>
+    </body></html>`;
+
+    expect(ingestJamcoopArtistPage(html, JAMCOOP_ARTIST_URL)).toEqual([
+      {
+        slug: 'carrion-carya-amara',
+        url: 'https://jam.coop/artists/carya-amara/albums/carrion-carya-amara',
+        artworkUrl: 'https://cdn.jam.coop/a.jpg',
+      },
+      {
+        slug: 'second-record',
+        url: 'https://jam.coop/artists/carya-amara/albums/second-record',
+        artworkUrl: 'https://cdn.jam.coop/b.jpg',
+      },
+    ]);
+  });
+
+  // The page links to other artists too (nav, credits, a "more from jam.coop" rail). Cataloguing
+  // those under this artist would attribute someone else's record to them.
+  it('refuses albums belonging to a different artist on the same page', () => {
+    const html = `
+      <a href="/artists/carya-amara/albums/mine">Mine</a>
+      <a href="/artists/someone-else/albums/theirs">Theirs</a>
+    `;
+    const out = ingestJamcoopArtistPage(html, JAMCOOP_ARTIST_URL);
+    expect(out.map(c => c.slug)).toEqual(['mine']);
+  });
+
+  it('refuses an album link that leaves the host', () => {
+    const html = '<a href="https://evil.example/artists/carya-amara/albums/x">X</a>';
+    expect(ingestJamcoopArtistPage(html, JAMCOOP_ARTIST_URL)).toEqual([]);
+  });
+
+  it('ignores links that are not album routes', () => {
+    const html = `
+      <a href="/artists">Artists</a>
+      <a href="/artists/carya-amara">The artist</a>
+      <a href="/tags/electronic">electronic</a>
+    `;
+    expect(ingestJamcoopArtistPage(html, JAMCOOP_ARTIST_URL)).toEqual([]);
+  });
+
+  it('deduplicates an album linked twice (cover and title both link to it)', () => {
+    const html = `
+      <a href="/artists/carya-amara/albums/one"><img src="https://cdn.jam.coop/a.jpg" /></a>
+      <a href="/artists/carya-amara/albums/one">One</a>
+    `;
+    expect(ingestJamcoopArtistPage(html, JAMCOOP_ARTIST_URL)).toHaveLength(1);
+  });
+});
+
+describe('ingestJamcoopAlbumPage', () => {
+  it('reads title, artwork, date and the digital offer', () => {
+    const page = ingestJamcoopAlbumPage(jamcoopAlbumHtml(), new Date('2026-08-01T00:00:00Z'));
+    expect(page).toEqual({
+      title: 'Carrion Carya Amara',
+      artworkUrl: 'https://cdn.jam.coop/art.jpg',
+      releaseDate: '2024-10-04',
+      datePrecision: 'day',
+      status: 'released',
+      offers: [{ format: 'digital', price: 3, currency: 'GBP', availability: 'available' }],
+    });
+  });
+
+  // "£7.00 or more" is name-your-price with a floor. The floor is what a fan can actually pay,
+  // so it is the honest figure to publish — the same call the Faircamp purchase parser makes.
+  it('publishes the floor of a "or more" price, not zero', () => {
+    const page = ingestJamcoopAlbumPage(
+      jamcoopAlbumHtml({ priceLine: '£7.00 or more. Digital download. MP3 and FLAC' })
+    );
+    expect(page?.offers[0]).toMatchObject({ price: 7, currency: 'GBP' });
+  });
+
+  // A genuine zero floor is real name-your-price, which the display layer renders as such.
+  it('keeps a zero floor as zero', () => {
+    const page = ingestJamcoopAlbumPage(
+      jamcoopAlbumHtml({ priceLine: '£0.00 or more. Digital download. MP3 and FLAC' })
+    );
+    expect(page?.offers[0]).toMatchObject({ price: 0, currency: 'GBP' });
+  });
+
+  // A symbol outside the mapped set fails the price pattern outright, so no offer is stored.
+  // That is the intended outcome: formatMoney defaults a null currency to USD, so a price kept
+  // without an identified currency would render "¥800" as "$800".
+  it('emits no offer at all rather than a price in an unidentifiable currency', () => {
+    const page = ingestJamcoopAlbumPage(
+      jamcoopAlbumHtml({ priceLine: '¥800 or more. Digital download. MP3 and FLAC' })
+    );
+    expect(page?.offers).toEqual([]);
+    expect(page?.title).toBe('Carrion Carya Amara'); // the rest of the page still parses
+  });
+
+  // The price is anchored on "Digital download" precisely so a figure quoted in an album
+  // description can't be mistaken for the asking price.
+  it('does not take a price out of the release description', () => {
+    const page = ingestJamcoopAlbumPage(
+      jamcoopAlbumHtml({
+        description: 'Recorded on a £50 cassette deck.',
+        priceLine: '£4.00 or more. Digital download. MP3 and FLAC',
+      })
+    );
+    expect(page?.offers[0]).toMatchObject({ price: 4 });
+  });
+
+  it('marks a future-dated release announced', () => {
+    const page = ingestJamcoopAlbumPage(
+      jamcoopAlbumHtml({ released: 'December 1, 2026' }),
+      new Date('2026-08-01T00:00:00Z')
+    );
+    expect(page?.releaseDate).toBe('2026-12-01');
+    expect(page?.status).toBe('announced');
+  });
+
+  // A missing date is "we don't know", never a guessed one.
+  it('leaves the date null when the page has no Released label', () => {
+    const html = '<html><body><h1>Untitled</h1><p class="text-xs">£2.00 or more. Digital download.</p></body></html>';
+    const page = ingestJamcoopAlbumPage(html);
+    expect(page?.releaseDate).toBeNull();
+    expect(page?.datePrecision).toBe('unknown');
+  });
+
+  it('returns null when there is no title to read', () => {
+    expect(ingestJamcoopAlbumPage('<html><body><p>Not an album page</p></body></html>')).toBeNull();
+  });
+
+  it('still returns the release when there is no price at all', () => {
+    const html = '<html><body><h1>Free Thing</h1><p><strong>Released:</strong> March 2, 2024</p></body></html>';
+    const page = ingestJamcoopAlbumPage(html);
+    expect(page?.offers).toEqual([]);
+    expect(page?.releaseDate).toBe('2024-03-02');
+  });
+});
+
+describe('buildJamcoopRelease', () => {
+  const candidate = {
+    slug: 'carrion-carya-amara',
+    url: 'https://jam.coop/artists/carya-amara/albums/carrion-carya-amara',
+    artworkUrl: 'https://cdn.jam.coop/grid.jpg',
+  };
+
+  it('carries the album page’s date and offers through to the persist shape', () => {
+    const page = ingestJamcoopAlbumPage(jamcoopAlbumHtml())!;
+    const built = buildJamcoopRelease(page, candidate, new Set());
+    expect(built).toMatchObject({
+      title: 'Carrion Carya Amara',
+      slug: 'carrion-carya-amara',
+      matchKey: 'carrioncaryaamara',
+      releaseDate: '2024-10-04',
+      externalUrl: candidate.url,
+      offers: [{ format: 'digital', price: 3, currency: 'GBP', availability: 'available' }],
+    });
+  });
+
+  it('falls back to the grid artwork when the album page has none', () => {
+    const page = { ...ingestJamcoopAlbumPage(jamcoopAlbumHtml())!, artworkUrl: null };
+    expect(buildJamcoopRelease(page, candidate, new Set())?.artworkUrl).toBe('https://cdn.jam.coop/grid.jpg');
+  });
+
+  it('avoids a slug already taken in this run', () => {
+    const page = ingestJamcoopAlbumPage(jamcoopAlbumHtml())!;
+    const built = buildJamcoopRelease(page, candidate, new Set(['carrion-carya-amara']));
+    expect(built?.slug).not.toBe('carrion-carya-amara');
+  });
+
+  it('refuses a title with nothing to match on', () => {
+    const page = { ...ingestJamcoopAlbumPage(jamcoopAlbumHtml())!, title: '!!!' };
+    expect(buildJamcoopRelease(page, candidate, new Set())).toBeNull();
+  });
+});
+
+describe('jamcoopArtistUrl', () => {
+  it('normalizes an album link back to the artist page', () => {
+    expect(jamcoopArtistUrl('https://jam.coop/artists/carya-amara/albums/carrion-carya-amara')).toBe(
+      'https://jam.coop/artists/carya-amara'
+    );
+  });
+
+  it('passes an artist page through unchanged', () => {
+    expect(jamcoopArtistUrl('https://jam.coop/artists/carya-amara')).toBe('https://jam.coop/artists/carya-amara');
+  });
+
+  it('refuses a URL with no artist in it', () => {
+    expect(jamcoopArtistUrl('https://jam.coop/')).toBeNull();
+    expect(jamcoopArtistUrl('https://jam.coop/newsletters')).toBeNull();
+  });
+
+  it('refuses a non-http scheme', () => {
+    expect(jamcoopArtistUrl('javascript:alert(1)//artists/x')).toBeNull();
   });
 });

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -16,6 +16,7 @@ import {
   getArtistForCatalog,
   persistDiscogsReleases,
   persistFaircampReleases,
+  persistJamcoopReleases,
   persistMusicBrainzEnrichment,
   persistReleaseDetail,
   persistReleases,
@@ -29,6 +30,7 @@ import { safeFetch, safeHostname } from './safe-fetch';
 import {
   bandcampMusicUrl,
   buildFaircampRelease,
+  buildJamcoopRelease,
   findDiscoveredReleaseLinks,
   ingestBandcampDetail,
   ingestBandcampGrid,
@@ -37,9 +39,13 @@ import {
   ingestFaircampHomeLinks,
   ingestFaircampPurchasePage,
   ingestFaircampReleasePage,
+  ingestJamcoopAlbumPage,
+  ingestJamcoopArtistPage,
   ingestMusicBrainzReleaseGroups,
+  jamcoopArtistUrl,
   type DiscogsArtistReleaseEntry,
   type DiscogsReleaseDetailRaw,
+  type IngestedOffer,
   type MusicBrainzReleaseGroupRaw,
 } from './release-ingest';
 import { isCatalogEnabled } from './request-catalog';
@@ -157,6 +163,30 @@ interface FaircampBudget {
   deadline: number;
 }
 
+// --- Jam.coop budgets ----------------------------------------------------------
+//
+// One small co-op's own servers, so the pacing is deliberately gentler than the ~1/sec used
+// against Bandcamp. Jam.coop's robots.txt sets no crawl-delay at all — this is courtesy, not
+// compliance, and it costs nothing because the catalogues are small (one album is typical;
+// the largest seen was a handful).
+//
+// Cheaper per release than any other source: title, artwork, date, price, currency and format
+// all arrive in the single album-page fetch, so a release costs one request rather than
+// Faircamp's two or Bandcamp's grid-plus-detail.
+
+const DELAY_BETWEEN_JAMCOOP_FETCHES_MS = 1_500;
+
+/** Bounds one artist with an unusually large Jam.coop catalogue. */
+const MAX_JAMCOOP_RELEASES_PER_ARTIST = 20;
+
+/** Invocation-wide, artist pages and album pages combined. */
+const MAX_JAMCOOP_FETCHES_PER_RUN = 60;
+
+interface JamcoopBudget {
+  fetchesLeft: number;
+  deadline: number;
+}
+
 function isAuthorized(header: string | undefined): boolean {
   // Reuses the secret this repo already has for internal function-to-function calls
   // (resolve-url, search-sources, and both v1 wrappers). A second near-identically-named
@@ -227,6 +257,10 @@ export async function handler(event: {
     fetchesLeft: MAX_FAIRCAMP_FETCHES_PER_RUN,
     deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
   };
+  const jamcoopBudget: JamcoopBudget = {
+    fetchesLeft: MAX_JAMCOOP_FETCHES_PER_RUN,
+    deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
+  };
   const enrichmentDeadline = Date.now() + ENRICHMENT_CUTOFF_MS;
 
   for (const [index, artistId] of artistIds.entries()) {
@@ -240,7 +274,14 @@ export async function handler(event: {
     if (index > 0) await sleep(DELAY_BETWEEN_ARTISTS_MS);
 
     try {
-      const found = await catalogArtist(artistId, budget, discogsBudget, faircampBudget, enrichmentDeadline);
+      const found = await catalogArtist(
+        artistId,
+        budget,
+        discogsBudget,
+        faircampBudget,
+        jamcoopBudget,
+        enrichmentDeadline
+      );
       if (found === null) {
         skipped++;
       } else {
@@ -272,6 +313,7 @@ async function catalogArtist(
   budget: DetailBudget,
   discogsBudget: DiscogsBudget,
   faircampBudget: FaircampBudget,
+  jamcoopBudget: JamcoopBudget,
   enrichmentDeadline: number
 ): Promise<number | null> {
   const artist = await getArtistForCatalog(artistId);
@@ -279,8 +321,8 @@ async function catalogArtist(
     await recordCatalogOutcome(artistId, { error: 'artist not found' });
     return null;
   }
-  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl) {
-    await recordCatalogOutcome(artistId, { error: 'no bandcamp, discogs, or faircamp link stored' });
+  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl && !artist.jamcoopUrl) {
+    await recordCatalogOutcome(artistId, { error: 'no bandcamp, discogs, faircamp, or jam.coop link stored' });
     return null;
   }
 
@@ -309,6 +351,11 @@ async function catalogArtist(
     await catalogMusicBrainz(artistId, artist.name);
     if (artist.faircampUrl) {
       totalFound += await catalogFaircamp(artistId, artist.faircampUrl, faircampBudget);
+    }
+    if (artist.jamcoopUrl) {
+      const { found, detailed } = await catalogJamcoop(artistId, artist.jamcoopUrl, jamcoopBudget);
+      totalFound += found;
+      totalDetailed += detailed;
     }
     if (artist.officialSiteUrl) {
       await catalogOfficialSite(artistId, artist.officialSiteUrl);
@@ -636,6 +683,127 @@ async function catalogFaircampPrices(
         error instanceof Error ? error.message : String(error)
       );
     }
+  }
+}
+
+/**
+ * The Jam.coop pass: fetch the artist page for its album list, then one page per album for
+ * everything else.
+ *
+ * Unlike Faircamp there is no second "prices live somewhere else" round trip — Jam.coop's album
+ * page carries the date and the price alongside the title and artwork, so one fetch produces a
+ * complete release.
+ *
+ * That single fetch is also why this pass has no 30-day `detail_checked_at` skip like Bandcamp's
+ * and Faircamp's detail passes do: the album page *is* how a release is identified at all, so
+ * there is nothing to skip to. Every run re-reads every album page. That's affordable here and
+ * nowhere else — Jam.coop catalogues are tiny (one album is typical across the platform's 231
+ * artists), the per-artist cooldown is 7 days, and the per-artist ceiling is 20 — so the worst
+ * case for one artist is 21 requests a week, against Bandcamp's grid-plus-40.
+ *
+ * Returns found/detailed separately so `releases_detailed` stays meaningful — the two fail
+ * independently here just as they do for Bandcamp (an artist page can parse perfectly while
+ * every album page is unreachable).
+ *
+ * Never throws: a Jam.coop hiccup is worth logging, not worth failing an artist whose Bandcamp
+ * pass may have already succeeded this run.
+ */
+async function catalogJamcoop(
+  artistId: string,
+  storedUrl: string,
+  budget: JamcoopBudget
+): Promise<{ found: number; detailed: number }> {
+  try {
+    // Two different questions, same as the Bandcamp pass: the allowlist answers "is this really
+    // Jam.coop" (a claimed artist can store any URL against the platform), safeFetch answers
+    // "is this safe to fetch".
+    if (!isUrlHostnameAllowed(storedUrl)) {
+      console.warn(`[catalog] stored jam.coop url not allowlisted: ${safeHostname(storedUrl)}`);
+      return { found: 0, detailed: 0 };
+    }
+
+    const artistUrl = jamcoopArtistUrl(storedUrl);
+    if (!artistUrl) {
+      console.warn(`[catalog] could not derive jam.coop artist url for artist ${artistId}`);
+      return { found: 0, detailed: 0 };
+    }
+
+    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) return { found: 0, detailed: 0 };
+    budget.fetchesLeft--;
+
+    const response = await safeFetch(artistUrl, 10_000);
+    if (!response?.ok) return { found: 0, detailed: 0 };
+
+    const landedUrl = response.url || artistUrl;
+    const candidates = ingestJamcoopArtistPage(await response.text(), landedUrl).slice(
+      0,
+      MAX_JAMCOOP_RELEASES_PER_ARTIST
+    );
+    if (candidates.length === 0) return { found: 0, detailed: 0 };
+
+    const takenSlugs = new Set<string>();
+    const toPersist: Parameters<typeof persistJamcoopReleases>[1] = [];
+    // Offers are read now but written after the release rows exist, since an offer hangs off a
+    // `release_sources.id` that only comes into being at persist time.
+    const offersByUrl = new Map<string, IngestedOffer[]>();
+
+    for (const candidate of candidates) {
+      if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+        console.log(`[catalog] jam.coop budget spent for artist ${artistId}`);
+        break;
+      }
+      if (toPersist.length > 0) await sleep(DELAY_BETWEEN_JAMCOOP_FETCHES_MS);
+      budget.fetchesLeft--;
+
+      try {
+        const albumResponse = await safeFetch(candidate.url, 10_000);
+        if (!albumResponse?.ok) continue;
+
+        const page = ingestJamcoopAlbumPage(await albumResponse.text());
+        if (!page) {
+          console.warn(`[catalog] unreadable jam.coop album page: ${candidate.url}`);
+          continue;
+        }
+
+        const release = buildJamcoopRelease(page, candidate, takenSlugs);
+        if (!release) continue;
+
+        takenSlugs.add(release.slug);
+        toPersist.push(release);
+        if (release.offers.length > 0) offersByUrl.set(release.externalUrl, release.offers);
+      } catch (error) {
+        console.warn(
+          `[catalog] jam.coop album fetch failed for ${safeHostname(candidate.url)}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    if (toPersist.length === 0) return { found: 0, detailed: 0 };
+
+    const written = await persistJamcoopReleases(artistId, toPersist);
+
+    let detailed = 0;
+    for (const release of written) {
+      const offers = offersByUrl.get(release.url);
+      if (!offers) continue;
+
+      // status null: the release row's date and status were already written by
+      // persistJamcoopReleases from this same page, so restating them here would be a second
+      // write of the same fact — and would overwrite a date another source got more precisely.
+      const ok = await persistReleaseDetail(release, {
+        releaseDate: null,
+        datePrecision: 'unknown',
+        status: null,
+        offers,
+      });
+      if (ok) detailed++;
+    }
+
+    return { found: written.length, detailed };
+  } catch (error) {
+    console.warn('[catalog] jam.coop ingest failed:', error instanceof Error ? error.message : String(error));
+    return { found: 0, detailed: 0 };
   }
 }
 

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -1,8 +1,28 @@
+// Release alerts.
+//
+// Two paths, and which one runs is the whole point of this file:
+//
+// 1. **The catalog** (`getReleasesForAlerts`). Preferred. Every release in the window, with
+//    every platform it's on and what each costs — built once on the server by the cataloging
+//    pipeline rather than re-derived per fan. This is what fixes spec §5 defects 2, 3 and 4:
+//    upcoming releases can be alerted on, more than one release per artist survives, and a
+//    record on both Bandcamp and Mirlo says so instead of silently picking one.
+// 2. **A live scrape**, exactly as before, for an artist the catalog has never seen. Falling
+//    back rather than returning nothing matters: coverage is demand-driven, so an artist nobody
+//    has saved or searched yet has no catalog, and treating that as "no new releases" would
+//    silently switch alerts off for them.
+//
+// The response stays backwards-compatible on purpose. `release` (singular) is still populated
+// for the shipped Mac app and browser extension, which decode exactly that field; `releases`
+// (plural) is additive and carries what a newer client can use. Both shipped clients decode
+// `platform` as a plain string and ignore unknown keys, so neither breaks on the new fields.
+
 import { parse } from 'node-html-parser';
 import { isSafePublicHostname, isUrlHostnameAllowed } from './middleware';
 import { checkRateLimit, getClientIp } from './ratelimit';
-import { isStoredArtistLink } from './db';
+import { getReleasesForAlerts, isStoredArtistLink, type AlertRelease } from './db';
 import { safeFetch, safeHostname } from './safe-fetch';
+import { leadingOfferSummary, orderedSourcePlatforms } from '../shared/release-display';
 
 interface PlatformUrls {
   bandcamp?: string;
@@ -14,17 +34,39 @@ interface ReleaseResult {
   releaseName: string;
   releaseDate: string; // ISO format
   releaseUrl: string;
-  platform: 'bandcamp' | 'faircamp' | 'mirlo';
+  /**
+   * The platform an alert leads with. Not a closed set any more: with the catalog behind this,
+   * a release can lead with any platform in the registry (jam.coop, Discogs, …), and both
+   * shipped clients decode this as a plain string.
+   */
+  platform: string;
+}
+
+/** What a catalog-backed alert carries beyond the legacy single-release shape. */
+interface CatalogReleaseResult extends ReleaseResult {
+  /** Every platform this release is on, artist-paying first. Defect 4: never collapsed to one. */
+  platforms: string[];
+  /** 'announced' for a release dated in the future — defect 2, which could not fire before. */
+  status: string;
+  /** "from £3 · ≈£2.55 to artist", or 'Name your price'. Defect 7: a body worth reading. */
+  offerSummary: string;
+  /** The platform's own page, for a client that would rather link straight to the shop. */
+  platformUrl: string;
 }
 
 interface CheckReleasesRequest {
   artistName: string;
   platforms: PlatformUrls;
+  /** How far back to look. Optional; shipped clients don't send it. */
+  sinceDays?: number;
 }
 
 interface CheckReleasesResponse {
   artistName: string;
   release: ReleaseResult | null;
+  releases?: CatalogReleaseResult[];
+  /** Which path answered — so a client (and a human debugging one) can tell. */
+  source?: 'catalog' | 'live';
   error?: string;
 }
 
@@ -72,12 +114,34 @@ function parseDateToISO(dateStr: string): string | null {
   return null;
 }
 
-// Check if release is within the last 30 days (slightly lenient for timezone/timing differences)
-function isWithinLastMonth(dateStr: string): boolean {
+/** Default lookback. Matches the window shipped clients already assume. */
+const DEFAULT_WINDOW_DAYS = 31;
+
+/**
+ * Ceiling on a caller-supplied window. A year is far more than a client catching up after a
+ * long sleep needs, and it stops the parameter being a way to ask for an artist's whole
+ * discography through an alerts endpoint.
+ */
+const MAX_WINDOW_DAYS = 365;
+
+function resolveWindowDays(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return DEFAULT_WINDOW_DAYS;
+  return Math.min(Math.floor(raw), MAX_WINDOW_DAYS);
+}
+
+/**
+ * Is this release recent enough to alert on — **or still to come**?
+ *
+ * The old version of this required `daysDiff >= 0`, which discarded every future-dated release
+ * (spec §5 defect 2). A pre-announced record was filtered out for being in the future, and by
+ * the time it came out it had usually aged past the window, so it was never alerted on at all.
+ * A future date is now the *best* reason to alert, not a disqualification.
+ */
+function isWithinWindow(dateStr: string, windowDays: number, now: Date = new Date()): boolean {
   const releaseDate = new Date(dateStr);
-  const now = new Date();
+  if (Number.isNaN(releaseDate.getTime())) return false;
   const daysDiff = (now.getTime() - releaseDate.getTime()) / (1000 * 60 * 60 * 24);
-  return daysDiff >= 0 && daysDiff <= 31;
+  return daysDiff <= windowDays;
 }
 
 // Check Bandcamp for latest release
@@ -281,7 +345,7 @@ async function checkMirlo(mirloUrl: string): Promise<ReleaseResult | null> {
 }
 
 // Main check function - checks all platforms and returns the best result
-async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult | null> {
+async function checkAllPlatforms(platforms: PlatformUrls, windowDays: number): Promise<ReleaseResult | null> {
   const results: ReleaseResult[] = [];
 
   // Check all platforms in parallel
@@ -291,10 +355,9 @@ async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult
     platforms.mirlo ? checkMirlo(platforms.mirlo) : Promise.resolve(null),
   ]);
 
-  // Collect successful results that are within the last 30 days
   for (const check of checks) {
     if (check.status === 'fulfilled' && check.value) {
-      if (isWithinLastMonth(check.value.releaseDate)) {
+      if (isWithinWindow(check.value.releaseDate, windowDays)) {
         results.push(check.value);
       }
     }
@@ -302,17 +365,71 @@ async function checkAllPlatforms(platforms: PlatformUrls): Promise<ReleaseResult
 
   if (results.length === 0) return null;
 
-  // Priority order: Mirlo > Faircamp > Bandcamp
-  const priorityOrder: ReleaseResult['platform'][] = ['mirlo', 'faircamp', 'bandcamp'];
+  // Priority order: Mirlo > Faircamp > Bandcamp.
+  //
+  // Still a hardcoded list, and still wrong in the way spec §5 defect 4 describes — a release on
+  // both Bandcamp and Mirlo is reported as one platform and the fan never learns about the
+  // other. It is left alone deliberately: this path only runs for an artist with no catalog, it
+  // has one scraped result per platform and no offer data to rank them by, and the real fix is
+  // the catalog path above, which reports every platform. Changing the order here would move
+  // the arbitrariness around rather than remove it.
+  const priorityOrder = ['mirlo', 'faircamp', 'bandcamp'];
 
-  // Find the highest priority platform with a release
   for (const platform of priorityOrder) {
     const result = results.find(r => r.platform === platform);
     if (result) return result;
   }
 
-  // Fallback to first result
   return results[0];
+}
+
+// ---------------------------------------------------------------------------
+// The catalog path
+// ---------------------------------------------------------------------------
+
+/** The Unstream release page an alert should lead to, rather than one platform's shop. */
+function releasePageUrl(artistSlug: string, releaseSlug: string): string {
+  return `https://unstream.stream/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(releaseSlug)}`;
+}
+
+/**
+ * Turn catalogued releases into alert results.
+ *
+ * Two things here are the product decision, not plumbing:
+ *
+ * - **`releaseUrl` is the Unstream release page, not the platform's.** That is pillar 3 of the
+ *   spec: today an alert hands a fan straight to one shop, which hides the payout comparison at
+ *   the exact moment they are deciding where to buy. The platform's own URL is still returned
+ *   alongside, as `platformUrl`.
+ * - **The leading platform is the artist-paying one**, via `orderedSourcePlatforms` — the same
+ *   ordering the release page and the artist page already use, rather than this file's old
+ *   hardcoded `mirlo > faircamp > bandcamp`.
+ *
+ * Releases with no source at all are dropped: an alert a fan cannot act on is noise.
+ */
+function toCatalogResults(artistSlug: string, releases: AlertRelease[]): CatalogReleaseResult[] {
+  const out: CatalogReleaseResult[] = [];
+
+  for (const release of releases) {
+    if (!release.releaseDate || release.sources.length === 0) continue;
+
+    const platforms = orderedSourcePlatforms(release.sources);
+    const leading = platforms[0];
+    const leadingSource = release.sources.find(s => s.platform === leading);
+
+    out.push({
+      releaseName: release.title,
+      releaseDate: release.releaseDate,
+      releaseUrl: releasePageUrl(artistSlug, release.slug),
+      platform: leading,
+      platforms,
+      status: release.status,
+      offerSummary: leadingOfferSummary(release.sources),
+      platformUrl: leadingSource?.url ?? '',
+    });
+  }
+
+  return out;
 }
 
 const CORS_HEADERS = {
@@ -370,6 +487,33 @@ export async function handler(event: {
     return jsonResponse(400, { error: 'artistName and platforms are required' });
   }
 
+  const windowDays = resolveWindowDays(request.sinceDays);
+
+  // The catalog first. Answering from it costs one database read instead of two to four
+  // outbound scrapes, and it is the only path that can report an upcoming release, a second
+  // release in the same window, or more than one platform.
+  //
+  // A null here means this artist has never been catalogued — not that they have nothing new —
+  // so it falls through to the live scrape rather than reporting a negative we didn't establish.
+  try {
+    const catalogued = await getReleasesForAlerts(request.artistName, windowDays);
+    if (catalogued) {
+      const releases = toCatalogResults(catalogued.artistSlug, catalogued.releases);
+      const response: CheckReleasesResponse = {
+        artistName: request.artistName,
+        // Newest first out of the query, so the head is the one a single-release client should
+        // show. Still populated for the shipped Mac app and extension, which read only this.
+        release: releases[0] ?? null,
+        releases,
+        source: 'catalog',
+      };
+      return jsonResponse(200, response, { 'Cache-Control': 'no-cache' });
+    }
+  } catch (error) {
+    // A catalog read failing is not evidence about releases either — fall through and scrape.
+    console.error('[check-releases] catalog read failed, falling back to live check:', error);
+  }
+
   const requested = PLATFORM_KEYS.filter(
     p => typeof request.platforms[p] === 'string' && (request.platforms[p] as string).length > 0
   );
@@ -404,11 +548,30 @@ export async function handler(event: {
   }
 
   try {
-    const release = await checkAllPlatforms(platforms);
+    const release = await checkAllPlatforms(platforms, windowDays);
 
     const response: CheckReleasesResponse = {
       artistName: request.artistName,
       release,
+      // One scraped release at most, so the plural field says the same thing rather than
+      // being absent — a client reading `releases` shouldn't have to special-case this path.
+      //
+      // `offerSummary` is empty and `platforms` has one entry because that is genuinely all a
+      // scrape of one platform's latest release establishes. Status is derived rather than
+      // assumed 'released': now that a future date is no longer filtered out, a scraped
+      // pre-announcement can reach here.
+      releases: release
+        ? [
+            {
+              ...release,
+              platforms: [release.platform],
+              status: release.releaseDate > new Date().toISOString().slice(0, 10) ? 'announced' : 'released',
+              offerSummary: '',
+              platformUrl: release.releaseUrl,
+            },
+          ]
+        : [],
+      source: 'live',
     };
 
     // Don't cache release checks

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3326,7 +3326,14 @@ export interface FeedReleaseRow {
   releaseDate: string;
   offerSummary: string;
   platforms: string[];
-  sources: { platform: string; offers: { price: number | null; currency: string | null; availability: string }[] }[];
+  /** Cover art, so a feed entry can show the record rather than just name it. */
+  artworkUrl: string | null;
+  sources: {
+    platform: string;
+    /** The platform's own page. Feed entries link each platform rather than listing dead names. */
+    url: string;
+    offers: { price: number | null; currency: string | null; availability: string }[];
+  }[];
 }
 
 /**
@@ -3345,9 +3352,11 @@ type FeedQueryRow = {
   slug: string;
   title: string;
   release_date: string | null;
+  artwork_url: string | null;
   artists: { name: string; slug: string } | null;
   release_sources: {
     platform: string;
+    url: string;
     release_offers: { price: number | null; currency: string | null; availability: string }[] | null;
   }[] | null;
 };
@@ -3363,16 +3372,18 @@ function toFeedRows(rows: FeedQueryRow[]): FeedReleaseRow[] {
       releaseDate: r.release_date!,
       offerSummary: '',
       platforms: [],
+      artworkUrl: r.artwork_url,
       sources: (r.release_sources || []).map(s => ({
         platform: s.platform,
+        url: s.url,
         offers: s.release_offers || [],
       })),
     }));
 }
 
 const FEED_SELECT =
-  'slug, title, release_date, artists!inner ( name, slug ),' +
-  ' release_sources ( platform, release_offers ( price, currency, availability ) )';
+  'slug, title, release_date, artwork_url, artists!inner ( name, slug ),' +
+  ' release_sources ( platform, url, release_offers ( price, currency, availability ) )';
 
 /** Soonest first — a calendar and a reader both want the next thing at the top. */
 function feedSince(now: Date): string {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3427,10 +3427,23 @@ export async function getFeedReleasesForUser(userId: string, now: Date = new Dat
   }
 }
 
-/** The same feed for one artist, for the public /a/{slug}/releases.xml. */
+/**
+ * One artist's feed, for the public `/a/{slug}/releases.{xml,ics}`.
+ *
+ * **Deliberately unwindowed, unlike the per-fan and per-handle feeds above.** Those are a
+ * calendar of what's coming across everything you follow, where a trailing window keeps the
+ * thing usable. An artist feed is a different object: it is that artist's *discography*, and
+ * someone subscribing to it wants the back catalogue, not just whatever happens to be imminent.
+ * Brandon, on his own artist feed: *"It really should include everything - not just upcoming
+ * ones."*
+ *
+ * Ordered newest-first rather than soonest-first, which is both the RSS convention and the safe
+ * pairing with `FEED_MAX_RELEASES`: an ascending order plus a cap would silently drop an artist's
+ * *recent* work in favour of their oldest.
+ */
 export async function getFeedReleasesForArtist(
   artistSlugValue: string,
-  now: Date = new Date()
+  _now: Date = new Date()
 ): Promise<{ artistName: string; releases: FeedReleaseRow[] } | null> {
   const client = getClient();
   if (!client) return null;
@@ -3451,8 +3464,11 @@ export async function getFeedReleasesForArtist(
       .eq('artist_id', id)
       .eq('is_hidden', false)
       .eq('needs_review', false)
-      .gte('release_date', feedSince(now))
-      .order('release_date', { ascending: true })
+      // No date floor: the whole catalogue, past and upcoming. `not.is.null` because an undated
+      // release has no event to place in a calendar and no meaningful position in a feed —
+      // `toFeedRows` drops those anyway, so excluding them here stops them eating the cap.
+      .not('release_date', 'is', null)
+      .order('release_date', { ascending: false })
       .limit(FEED_MAX_RELEASES);
 
     if (error) {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -993,6 +993,7 @@ export interface ArtistForCatalog {
   bandcampUrl: string | null;
   discogsUrl: string | null;
   faircampUrl: string | null;
+  jamcoopUrl: string | null;
   officialSiteUrl: string | null;
 }
 
@@ -1014,7 +1015,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
         .from('artist_links')
         .select('platform, url')
         .eq('artist_id', artistId)
-        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'officialsite']),
+        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'officialsite']),
     ]);
 
     if (artistError || !artistRow) {
@@ -1029,6 +1030,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
       bandcampUrl: links.find(l => l.platform === 'bandcamp')?.url ?? null,
       discogsUrl: links.find(l => l.platform === 'discogs')?.url ?? null,
       faircampUrl: links.find(l => l.platform === 'faircamp')?.url ?? null,
+      jamcoopUrl: links.find(l => l.platform === 'jamcoop')?.url ?? null,
       officialSiteUrl: links.find(l => l.platform === 'officialsite')?.url ?? null,
     };
   } catch (error) {
@@ -1483,6 +1485,178 @@ export async function persistFaircampReleases(
     return written;
   } catch (error) {
     console.error('[DB] persistFaircampReleases error:', error);
+    return [];
+  }
+}
+
+/**
+ * Write a Jam.coop catalog pass.
+ *
+ * Matches on `match_key` alone for the same reason `persistFaircampReleases` does: Jam.coop
+ * files every release under `/albums/` and exposes no type field, so its inferred release type
+ * is too weak to partition identity by, and partitioning by it would produce a duplicate row
+ * every time Bandcamp had already typed the same record correctly.
+ *
+ * Where it differs from Faircamp is the date. Jam.coop publishes one on the album page, so this
+ * fills `release_date`/`date_precision` on an existing row that lacks them — under the same
+ * never-overwrite rules as everywhere else: a stored date wins over a new one, and a date the
+ * artist curated is never touched at all.
+ */
+interface JamcoopReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+export async function persistJamcoopReleases(
+  artistId: string,
+  releases: JamcoopReleaseToPersist[]
+): Promise<PersistedRelease[]> {
+  const client = getClient();
+  if (!client || releases.length === 0) return [];
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, release_date, artwork_url, curated_fields')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistJamcoopReleases read failed:', readError.message);
+      return [];
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      artwork_url: string | null;
+      curated_fields: string[] | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
+    const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+
+    const written: PersistedRelease[] = [];
+
+    for (const release of releases) {
+      const prior = byMatchKey.get(release.matchKey);
+
+      let releaseId: string;
+      let curatedFields: string[];
+
+      if (prior) {
+        const curated = new Set(prior.curated_fields ?? []);
+        curatedFields = [...curated];
+        const patch: Record<string, unknown> = {};
+
+        if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
+          patch.artwork_url = release.artworkUrl;
+        }
+        if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
+          patch.release_date = release.releaseDate;
+          patch.date_precision = release.datePrecision;
+          // Status is derived from the date, so the two move together — but only when this pass
+          // is the one supplying the date. An existing dated row keeps whatever status its own
+          // source derived, including an 'announced' from a real pre-order flag.
+          patch.status = release.status;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistJamcoopReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        const fuzzy = existing.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
+
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            release_date: release.releaseDate,
+            date_precision: release.datePrecision,
+            status: release.status,
+            artwork_url: release.artworkUrl,
+            source: 'auto',
+            ...(fuzzy && { needs_review: true, flagged_against_release_id: fuzzy.id }),
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistJamcoopReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        curatedFields = [];
+
+        const createdRow: ExistingRow = {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          release_date: release.releaseDate,
+          artwork_url: release.artworkUrl,
+          curated_fields: [],
+        };
+        byMatchKey.set(release.matchKey, createdRow);
+        existing.push(createdRow);
+
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true, flagged_against_release_id: releaseId })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistJamcoopReleases fuzzy-flag failed:', flagError.message);
+        }
+      }
+
+      const source = await upsertReleaseSource(
+        client,
+        releaseId,
+        'jamcoop',
+        release.externalUrl,
+        release.externalUrl,
+        claimedKeys
+      );
+      if (!source) {
+        console.error('[DB] persistJamcoopReleases source write failed for release', releaseId);
+        continue;
+      }
+
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields,
+      });
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistJamcoopReleases error:', error);
     return [];
   }
 }
@@ -2897,5 +3071,434 @@ export async function getArtistReleases(
   } catch (error) {
     console.error('[DB] getArtistReleases error:', error);
     return { releases: [], total: 0 };
+  }
+}
+
+// --- Releases for alerts ---
+
+export interface AlertRelease {
+  /** Release slug, for building the /a/{artist}/{release} link an alert points at. */
+  slug: string;
+  title: string;
+  releaseDate: string | null;
+  datePrecision: string | null;
+  status: string;
+  artworkUrl: string | null;
+  sources: {
+    platform: string;
+    /** The platform's own page for this release — the fallback link when a fan wants the source. */
+    url: string;
+    offers: { price: number | null; currency: string | null; availability: string }[];
+  }[];
+}
+
+export interface AlertReleases {
+  /** The catalogued artist's slug, which may differ from the caller's derived one. */
+  artistSlug: string;
+  releases: AlertRelease[];
+}
+
+/**
+ * Everything an alert needs for one artist, straight out of the catalog.
+ *
+ * **Returns null when this artist has no catalog at all, and `[]` when they have one with
+ * nothing new in it.** Those are different facts and the caller depends on the difference: the
+ * first means "we haven't looked yet, go and scrape" and the second means "we looked and there
+ * is genuinely nothing". Collapsing them into an empty array is the single most repeated bug
+ * class in this codebase, and here it would either silently stop alerting for every artist
+ * without a catalog, or re-scrape Bandcamp for every artist forever.
+ *
+ * The window is a floor, not a range. Anything dated on or after `today - windowDays` qualifies,
+ * **including releases dated in the future** — which is the whole point of the fix. The old
+ * client-side check required `daysDiff >= 0`, so a pre-announced record was filtered out for
+ * being in the future and then aged past the window before it ever became "recent"; the most
+ * delightful possible alert ("your artist just announced an album for September") could not fire
+ * at all. Undated releases are excluded: with no date there is nothing to say is new, and grid
+ * ingest produces plenty of them.
+ */
+export async function getReleasesForAlerts(
+  artistName: string,
+  windowDays: number,
+  now: Date = new Date()
+): Promise<AlertReleases | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data: artist, error: artistError } = await client
+      .from('artists')
+      .select('id, slug')
+      .eq('slug', artistSlug(artistName))
+      .maybeSingle();
+
+    if (artistError) {
+      console.error('[DB] getReleasesForAlerts artist lookup failed:', artistError.message);
+      return null;
+    }
+    if (!artist) return null;
+
+    const { id, slug } = artist as { id: string; slug: string };
+
+    // Has this artist ever been catalogued? Asked separately from the windowed read because a
+    // catalogued artist with a quiet month and an artist nobody has ever crawled produce the
+    // same empty result set, and only the second one should trigger a live scrape.
+    const { count: catalogued, error: countError } = await client
+      .from('releases')
+      .select('id', { count: 'exact', head: true })
+      .eq('artist_id', id);
+
+    if (countError) {
+      console.error('[DB] getReleasesForAlerts count failed:', countError.message);
+      return null;
+    }
+    if (!catalogued) return null;
+
+    const since = new Date(now.getTime() - windowDays * 86_400_000).toISOString().slice(0, 10);
+
+    const { data, error } = await client
+      .from('releases')
+      .select(
+        'slug, title, release_date, date_precision, status, artwork_url,' +
+        ' release_sources ( platform, url, release_offers ( price, currency, availability ) )'
+      )
+      .eq('artist_id', id)
+      .eq('is_hidden', false)
+      // A tier-3 fuzzy flag means we are not sure this is a distinct record. Sending a push
+      // notification about it would publish that uncertainty to a fan's lock screen, so flagged
+      // rows wait for the review queue rather than alerting.
+      .eq('needs_review', false)
+      .gte('release_date', since)
+      .order('release_date', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      console.error('[DB] getReleasesForAlerts read failed:', error.message);
+      return null;
+    }
+
+    type Row = {
+      slug: string;
+      title: string;
+      release_date: string | null;
+      date_precision: string | null;
+      status: string;
+      artwork_url: string | null;
+      release_sources: {
+        platform: string;
+        url: string;
+        release_offers: { price: number | null; currency: string | null; availability: string }[] | null;
+      }[] | null;
+    };
+
+    const releases = ((data as unknown as Row[]) || []).map(r => ({
+      slug: r.slug,
+      title: r.title,
+      releaseDate: r.release_date,
+      datePrecision: r.date_precision,
+      status: r.status,
+      artworkUrl: r.artwork_url,
+      sources: (r.release_sources || []).map(s => ({
+        platform: s.platform,
+        url: s.url,
+        offers: s.release_offers || [],
+      })),
+    }));
+
+    return { artistSlug: slug, releases };
+  } catch (error) {
+    console.error('[DB] getReleasesForAlerts error:', error);
+    return null;
+  }
+}
+
+// --- Release feeds (/feed/f/{token}.ics) ---
+
+/**
+ * Look up whose feed this token is.
+ *
+ * The token *is* the authorization — a calendar client sends no session — so this is the whole
+ * auth check for the feed path. Returns null for an unknown token, which the caller must turn
+ * into a 404 rather than a 401: a 401 invites retrying with a different token, and confirming
+ * "this token shape exists but is wrong" is more than an anonymous caller needs to know.
+ *
+ * Never log the token. It's a credential in a URL, and path tokens end up in access logs and
+ * referrers by default (spec §8).
+ */
+export async function getFeedTokenOwner(token: string): Promise<string | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data, error } = await client
+      .from('release_feed_tokens')
+      .select('user_id')
+      .eq('token', token)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[DB] getFeedTokenOwner failed:', error.message);
+      return null;
+    }
+    return data ? (data as { user_id: string }).user_id : null;
+  } catch (error) {
+    console.error('[DB] getFeedTokenOwner error:', error);
+    return null;
+  }
+}
+
+/** The user's existing feed token, or null if they've never made one. */
+export async function getFeedToken(userId: string): Promise<string | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data, error } = await client
+      .from('release_feed_tokens')
+      .select('token')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[DB] getFeedToken failed:', error.message);
+      return null;
+    }
+    return data ? (data as { token: string }).token : null;
+  } catch (error) {
+    console.error('[DB] getFeedToken error:', error);
+    return null;
+  }
+}
+
+/**
+ * Issue a feed token, replacing any existing one.
+ *
+ * Upsert on `user_id` rather than insert-then-delete, so rotation is a single statement and
+ * there is never a window where the user has no token at all. The caller generates the value —
+ * `crypto.randomBytes` lives at the endpoint, keeping this module free of the "how much entropy"
+ * decision.
+ */
+export async function setFeedToken(userId: string, token: string): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    const { error } = await client
+      .from('release_feed_tokens')
+      .upsert(
+        { user_id: userId, token, rotated_at: new Date().toISOString() },
+        { onConflict: 'user_id' }
+      );
+
+    if (error) {
+      console.error('[DB] setFeedToken failed:', error.message);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[DB] setFeedToken error:', error);
+    return false;
+  }
+}
+
+/** Revoke the user's feed token entirely, breaking every existing subscription. */
+export async function deleteFeedToken(userId: string): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  try {
+    const { error } = await client.from('release_feed_tokens').delete().eq('user_id', userId);
+    if (error) {
+      console.error('[DB] deleteFeedToken failed:', error.message);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[DB] deleteFeedToken error:', error);
+    return false;
+  }
+}
+
+export interface FeedReleaseRow {
+  artistName: string;
+  artistSlug: string;
+  title: string;
+  releaseSlug: string;
+  releaseDate: string;
+  offerSummary: string;
+  platforms: string[];
+  sources: { platform: string; offers: { price: number | null; currency: string | null; availability: string }[] }[];
+}
+
+/**
+ * How far back a feed reaches. Spec §3 argues for upcoming releases only ("a calendar of past
+ * releases is a changelog"), and that argument is right about the *back catalogue* — but a
+ * record that came out last week is still something a subscriber may not have bought yet, which
+ * is the same purchase-intent moment the alerts serve. A short trailing window keeps that case
+ * and stops the feed reading as broken while catalog coverage is still thin.
+ */
+export const FEED_TRAILING_DAYS = 30;
+
+/** Cap on events in one feed, so a fan with hundreds of saved artists still gets a usable file. */
+const FEED_MAX_RELEASES = 200;
+
+type FeedQueryRow = {
+  slug: string;
+  title: string;
+  release_date: string | null;
+  artists: { name: string; slug: string } | null;
+  release_sources: {
+    platform: string;
+    release_offers: { price: number | null; currency: string | null; availability: string }[] | null;
+  }[] | null;
+};
+
+function toFeedRows(rows: FeedQueryRow[]): FeedReleaseRow[] {
+  return rows
+    .filter(r => r.release_date && r.artists)
+    .map(r => ({
+      artistName: r.artists!.name,
+      artistSlug: r.artists!.slug,
+      title: r.title,
+      releaseSlug: r.slug,
+      releaseDate: r.release_date!,
+      offerSummary: '',
+      platforms: [],
+      sources: (r.release_sources || []).map(s => ({
+        platform: s.platform,
+        offers: s.release_offers || [],
+      })),
+    }));
+}
+
+const FEED_SELECT =
+  'slug, title, release_date, artists!inner ( name, slug ),' +
+  ' release_sources ( platform, release_offers ( price, currency, availability ) )';
+
+/** Soonest first — a calendar and a reader both want the next thing at the top. */
+function feedSince(now: Date): string {
+  return new Date(now.getTime() - FEED_TRAILING_DAYS * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Every release worth putting in one fan's feed: across all their saved artists, dated within
+ * the trailing window or still to come.
+ *
+ * Two exclusions match the alert path for the same reasons — hidden releases are suppressed by
+ * an artist and must stay invisible, and a `needs_review` tier-3 fuzzy flag means we aren't sure
+ * the release is distinct, which is not something to publish into someone's calendar.
+ */
+export async function getFeedReleasesForUser(userId: string, now: Date = new Date()): Promise<FeedReleaseRow[]> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const { data: saved, error: savedError } = await client
+      .from('saved_artists')
+      .select('artist_id')
+      .eq('user_id', userId);
+
+    if (savedError) {
+      console.error('[DB] getFeedReleasesForUser saved read failed:', savedError.message);
+      return [];
+    }
+
+    const artistIds = ((saved as { artist_id: string }[]) || []).map(r => r.artist_id);
+    if (artistIds.length === 0) return [];
+
+    const { data, error } = await client
+      .from('releases')
+      .select(FEED_SELECT)
+      .in('artist_id', artistIds)
+      .eq('is_hidden', false)
+      .eq('needs_review', false)
+      .gte('release_date', feedSince(now))
+      .order('release_date', { ascending: true })
+      .limit(FEED_MAX_RELEASES);
+
+    if (error) {
+      console.error('[DB] getFeedReleasesForUser read failed:', error.message);
+      return [];
+    }
+
+    return toFeedRows((data as unknown as FeedQueryRow[]) || []);
+  } catch (error) {
+    console.error('[DB] getFeedReleasesForUser error:', error);
+    return [];
+  }
+}
+
+/** The same feed for one artist, for the public /a/{slug}/releases.xml. */
+export async function getFeedReleasesForArtist(
+  artistSlugValue: string,
+  now: Date = new Date()
+): Promise<{ artistName: string; releases: FeedReleaseRow[] } | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data: artist, error: artistError } = await client
+      .from('artists')
+      .select('id, name')
+      .eq('slug', artistSlugValue)
+      .maybeSingle();
+
+    if (artistError || !artist) return null;
+    const { id, name } = artist as { id: string; name: string };
+
+    const { data, error } = await client
+      .from('releases')
+      .select(FEED_SELECT)
+      .eq('artist_id', id)
+      .eq('is_hidden', false)
+      .eq('needs_review', false)
+      .gte('release_date', feedSince(now))
+      .order('release_date', { ascending: true })
+      .limit(FEED_MAX_RELEASES);
+
+    if (error) {
+      console.error('[DB] getFeedReleasesForArtist read failed:', error.message);
+      return null;
+    }
+
+    return { artistName: name, releases: toFeedRows((data as unknown as FeedQueryRow[]) || []) };
+  } catch (error) {
+    console.error('[DB] getFeedReleasesForArtist error:', error);
+    return null;
+  }
+}
+
+/**
+ * The public feed for a shared list at /u/{handle}.
+ *
+ * Gated on the same opt-in the HTML page uses (`usernames.saved_artists_public`) — a handle
+ * existing is not consent to publish that person's subscriptions as a calendar. Returns null
+ * when the handle is unknown *or* not shared, so the caller 404s either way and the feed can't
+ * be used to probe which handles exist.
+ */
+export async function getFeedReleasesForHandle(
+  handle: string,
+  now: Date = new Date()
+): Promise<{ displayName: string; releases: FeedReleaseRow[] } | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  try {
+    const { data: row, error } = await client
+      .from('usernames')
+      .select('user_id, username, saved_artists_public')
+      .eq('username', handle.toLowerCase())
+      .maybeSingle();
+
+    if (error || !row) return null;
+    const username = row as { user_id: string; username: string; saved_artists_public: boolean };
+    if (!username.saved_artists_public) return null;
+
+    return {
+      displayName: username.username,
+      releases: await getFeedReleasesForUser(username.user_id, now),
+    };
+  } catch (error) {
+    console.error('[DB] getFeedReleasesForHandle error:', error);
+    return null;
   }
 }

--- a/api/functions/feed-releases.ts
+++ b/api/functions/feed-releases.ts
@@ -83,7 +83,15 @@ function toFeedReleases(rows: FeedReleaseRow[]): FeedRelease[] {
     releaseSlug: row.releaseSlug,
     releaseDate: row.releaseDate,
     offerSummary: leadingOfferSummary(row.sources),
-    platforms: orderedSourcePlatforms(row.sources).map(p => PLATFORMS[p]?.name ?? p),
+    artworkUrl: row.artworkUrl,
+    // Ordered artist-paying-first, then paired with the platform's own page so a feed entry can
+    // actually link "Bandcamp" rather than just print it. `orderedSourcePlatforms` returns ids,
+    // so the URL is looked up back on the row it came from.
+    sources: orderedSourcePlatforms(row.sources).flatMap(id => {
+      const source = row.sources.find(s => s.platform === id);
+      if (!source?.url) return [];
+      return [{ name: PLATFORMS[id]?.name ?? id, url: source.url }];
+    }),
   }));
 }
 

--- a/api/functions/feed-releases.ts
+++ b/api/functions/feed-releases.ts
@@ -1,0 +1,225 @@
+// Release feeds: private per-fan, public per-handle, public per-artist.
+//
+//   /feed/f/{token}.ics   private, primary  — the fan's own subscription
+//   /feed/f/{token}.xml   private Atom, same token
+//   /u/{handle}/releases.ics|.xml   public, only for lists already opted into sharing
+//   /a/{artist}/releases.xml        public per-artist
+//
+// A Netlify function rather than an edge function because it needs `db.ts` and `crypto`, and
+// because a feed is not an SEO surface — there is no crawler-versus-browser split to make, so
+// none of the SSR/edge machinery buys anything here.
+//
+// SECURITY POSTURE FOR THE PRIVATE FEED. Calendar clients cannot authenticate: Apple Calendar
+// and Google Calendar fetch a URL on a schedule with no OAuth, no bearer header and no cookies.
+// The path token is therefore the entire credential, and it is handled as one:
+//
+//   - **Never logged.** Not on success, not on failure, not in an error message. Path tokens
+//     leak through access logs and Referer headers by default (spec §8), so nothing here ever
+//     puts the raw token into a string that goes anywhere but the database query.
+//   - **`Cache-Control: private, no-store`** so no shared cache or CDN retains a fan's
+//     subscription list.
+//   - **`X-Robots-Tag: noindex, nofollow`** in case a token URL is ever pasted somewhere public.
+//   - **404, never 401, for a bad token.** A 401 invites retrying, and distinguishing
+//     "well-formed but unknown" from "malformed" tells an anonymous caller more than they need.
+
+import { getClientIp, checkRateLimit } from './ratelimit';
+import {
+  getFeedReleasesForArtist,
+  getFeedReleasesForHandle,
+  getFeedReleasesForUser,
+  getFeedTokenOwner,
+  type FeedReleaseRow,
+} from './db';
+import { buildAtom, buildIcs, type FeedRelease } from '../shared/feed-format';
+import { leadingOfferSummary, orderedSourcePlatforms } from '../shared/release-display';
+import { PLATFORMS } from '../shared/platform-registry';
+
+const SITE = 'https://unstream.stream';
+
+/** Tokens are 32 bytes of base64url. Anything not that shape can't be one — refuse before querying. */
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{20,64}$/;
+
+type Format = 'ics' | 'xml';
+
+/** One response shape for every path, so callers (and tests) don't have to narrow a union. */
+interface FeedResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function feedHeaders(format: Format, isPrivate: boolean): Record<string, string> {
+  return {
+    'Content-Type':
+      format === 'ics' ? 'text/calendar; charset=utf-8' : 'application/atom+xml; charset=utf-8',
+    'X-Robots-Tag': 'noindex, nofollow',
+    'Cache-Control': isPrivate ? 'private, no-store' : 'public, max-age=1800',
+    // A calendar client fetching cross-origin (some web clients do) needs this; the body is
+    // already public-by-token, so there is nothing further to protect with an origin check.
+    'Access-Control-Allow-Origin': '*',
+  };
+}
+
+function notFound(): FeedResponse {
+  return {
+    statusCode: 404,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Robots-Tag': 'noindex, nofollow' },
+    body: 'Not found',
+  };
+}
+
+/**
+ * Turn stored rows into feed entries, adding the two derived display fields.
+ *
+ * Platform names are the registry's, not raw ids — "Jam.coop", not "jamcoop". Ordering is
+ * `orderedSourcePlatforms`, artist-paying first, the same rule the release page and the alerts
+ * use, so a secondhand Discogs listing never leads over a direct purchase.
+ */
+function toFeedReleases(rows: FeedReleaseRow[]): FeedRelease[] {
+  return rows.map(row => ({
+    artistName: row.artistName,
+    artistSlug: row.artistSlug,
+    title: row.title,
+    releaseSlug: row.releaseSlug,
+    releaseDate: row.releaseDate,
+    offerSummary: leadingOfferSummary(row.sources),
+    platforms: orderedSourcePlatforms(row.sources).map(p => PLATFORMS[p]?.name ?? p),
+  }));
+}
+
+function render(
+  releases: FeedReleaseRow[],
+  format: Format,
+  opts: { title: string; selfUrl: string; feedId: string },
+  isPrivate: boolean
+): FeedResponse {
+  const entries = toFeedReleases(releases);
+  const body =
+    format === 'ics'
+      ? buildIcs(entries, opts.title)
+      : buildAtom(entries, { title: opts.title, selfUrl: opts.selfUrl, feedId: opts.feedId });
+
+  return { statusCode: 200, headers: feedHeaders(format, isPrivate), body };
+}
+
+/**
+ * The path the client actually asked for.
+ *
+ * All five routes reach this function through a `status = 200` rewrite, and on a rewrite
+ * `event.path` is not dependable — it can be the rewrite *target*
+ * (`/.netlify/functions/feed-releases`), which carries none of the routing information. Netlify
+ * always sets `rawUrl` to the full original request URL, so that is the source of truth here,
+ * with `path` kept only as a fallback for the direct-invocation and test cases.
+ */
+export function requestPath(event: { path?: string; rawUrl?: string }): string {
+  if (event.rawUrl) {
+    try {
+      return new URL(event.rawUrl).pathname;
+    } catch {
+      // fall through to `path`
+    }
+  }
+  return event.path || '';
+}
+
+/**
+ * Pull the route out of the path.
+ *
+ * Read from the path rather than a query parameter deliberately: `?token=` would put the
+ * credential somewhere even more prone to logging, and calendar clients handle a plain path URL
+ * (with a file extension they recognize) far more reliably.
+ */
+export function parsePath(path: string):
+  | { kind: 'token'; token: string; format: Format }
+  | { kind: 'handle'; handle: string; format: Format }
+  | { kind: 'artist'; slug: string; format: Format }
+  | null {
+  const priv = path.match(/^\/feed\/f\/([^/]+)\.(ics|xml)$/);
+  if (priv) return { kind: 'token', token: priv[1], format: priv[2] as Format };
+
+  const handle = path.match(/^\/u\/([^/]+)\/releases\.(ics|xml)$/);
+  if (handle) return { kind: 'handle', handle: decodeURIComponent(handle[1]), format: handle[2] as Format };
+
+  const artist = path.match(/^\/a\/([^/]+)\/releases\.(ics|xml)$/);
+  if (artist) return { kind: 'artist', slug: decodeURIComponent(artist[1]), format: artist[2] as Format };
+
+  return null;
+}
+
+export async function handler(event: {
+  httpMethod?: string;
+  path?: string;
+  rawUrl?: string;
+  headers?: Record<string, string | undefined>;
+}): Promise<FeedResponse> {
+  // Calendar clients issue GET, and some probe with HEAD first.
+  if (event.httpMethod !== 'GET' && event.httpMethod !== 'HEAD') {
+    return { statusCode: 405, headers: { 'Content-Type': 'text/plain' }, body: 'Method not allowed' };
+  }
+
+  const route = parsePath(requestPath(event));
+  if (!route) return notFound();
+
+  // 'lenient' rather than 'strict': a household behind one IP with several subscribed clients
+  // polling on their own schedules is normal traffic, not abuse.
+  const rl = await checkRateLimit(getClientIp(event.headers || {}), 'lenient', {
+    'Content-Type': 'text/plain',
+  });
+  if (rl.limited) return rl.response as FeedResponse;
+
+  if (route.kind === 'token') {
+    // Shape-check before touching the database, so a scan of junk paths costs nothing.
+    if (!TOKEN_PATTERN.test(route.token)) return notFound();
+
+    const userId = await getFeedTokenOwner(route.token);
+    // Deliberately indistinguishable from a malformed token, and deliberately not logged with
+    // the token value attached.
+    if (!userId) return notFound();
+
+    const releases = await getFeedReleasesForUser(userId);
+    return render(
+      releases,
+      route.format,
+      {
+        title: 'Unstream — Upcoming releases',
+        // Self-link uses the real URL, which necessarily contains the token; that is the one
+        // place it legitimately appears, inside a body only its owner can fetch.
+        selfUrl: `${SITE}/feed/f/${route.token}.${route.format}`,
+        feedId: `tag:unstream.stream,2026:feed/private`,
+      },
+      true
+    );
+  }
+
+  if (route.kind === 'handle') {
+    const result = await getFeedReleasesForHandle(route.handle);
+    // Null covers both "no such handle" and "not opted into sharing" — same 404 either way, so
+    // the feed can't be used to enumerate which handles exist.
+    if (!result) return notFound();
+
+    return render(
+      result.releases,
+      route.format,
+      {
+        title: `Unstream — ${result.displayName}'s upcoming releases`,
+        selfUrl: `${SITE}/u/${encodeURIComponent(result.displayName)}/releases.${route.format}`,
+        feedId: `tag:unstream.stream,2026:feed/u/${result.displayName}`,
+      },
+      false
+    );
+  }
+
+  const artist = await getFeedReleasesForArtist(route.slug);
+  if (!artist) return notFound();
+
+  return render(
+    artist.releases,
+    route.format,
+    {
+      title: `${artist.artistName} — upcoming releases`,
+      selfUrl: `${SITE}/a/${encodeURIComponent(route.slug)}/releases.${route.format}`,
+      feedId: `tag:unstream.stream,2026:feed/a/${route.slug}`,
+    },
+    false
+  );
+}

--- a/api/functions/feed-releases.ts
+++ b/api/functions/feed-releases.ts
@@ -90,13 +90,13 @@ function toFeedReleases(rows: FeedReleaseRow[]): FeedRelease[] {
 function render(
   releases: FeedReleaseRow[],
   format: Format,
-  opts: { title: string; selfUrl: string; feedId: string },
+  opts: { title: string; selfUrl: string; feedId: string; description?: string },
   isPrivate: boolean
 ): FeedResponse {
   const entries = toFeedReleases(releases);
   const body =
     format === 'ics'
-      ? buildIcs(entries, opts.title)
+      ? buildIcs(entries, opts.title, new Date(), opts.description)
       : buildAtom(entries, { title: opts.title, selfUrl: opts.selfUrl, feedId: opts.feedId });
 
   return { statusCode: 200, headers: feedHeaders(format, isPrivate), body };
@@ -216,7 +216,8 @@ export async function handler(event: {
     artist.releases,
     route.format,
     {
-      title: `${artist.artistName} — upcoming releases`,
+      title: `${artist.artistName} — releases`,
+      description: `Releases by ${artist.artistName}, from Unstream`,
       selfUrl: `${SITE}/a/${encodeURIComponent(route.slug)}/releases.${route.format}`,
       feedId: `tag:unstream.stream,2026:feed/a/${route.slug}`,
     },

--- a/api/functions/me-feed-token.ts
+++ b/api/functions/me-feed-token.ts
@@ -1,0 +1,115 @@
+// API endpoint: /api/me/feed-token
+//
+// GET    — the user's feed URLs, creating a token on first ask.
+// POST   — rotate: issue a new token, instantly breaking every existing subscription.
+// DELETE — revoke entirely.
+//
+// Follows the same conventions as the other me-* endpoints (bearer auth against the anon
+// client, hand-rolled permissive CORS, service-role client for the write). These are the only
+// files in api/tsconfig.json's typecheck include — keep this one in it.
+
+import { randomBytes } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import { deleteFeedToken, getFeedToken, setFeedToken } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+};
+
+const SITE = 'https://unstream.stream';
+
+/**
+ * 32 bytes, base64url — 256 bits of entropy in a 43-character path segment.
+ *
+ * This is the whole credential for the private feed, and unlike a password it is never rate-
+ * limited behind a login form: anyone may request any `/feed/f/{x}.ics`. So it has to be
+ * unguessable by brute force outright, not merely hard to guess. base64url because the value
+ * goes in a URL path and must survive being copied between a browser, a calendar client's text
+ * field, and back.
+ *
+ * `randomBytes` from node:crypto, not `crypto.subtle`, which isn't available in Netlify
+ * Functions.
+ */
+function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+async function authenticateRequest(authHeader: string | undefined): Promise<string | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return data.user.id;
+}
+
+function feedUrls(token: string) {
+  return {
+    ics: `${SITE}/feed/f/${token}.ics`,
+    atom: `${SITE}/feed/f/${token}.xml`,
+  };
+}
+
+function json(statusCode: number, body: unknown) {
+  return {
+    statusCode,
+    // The response contains the token, so it must not be cached anywhere shared.
+    headers: { ...CORS_HEADERS, 'Cache-Control': 'private, no-store' },
+    body: JSON.stringify(body),
+  };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const userId = await authenticateRequest(event.headers.authorization);
+  if (!userId) return json(401, { error: 'Not signed in' });
+
+  if (event.httpMethod === 'GET') {
+    // Created on first read rather than at signup: most fans will never subscribe, and a token
+    // that exists is a credential that can leak, so it shouldn't be minted speculatively.
+    const existing = await getFeedToken(userId);
+    if (existing) return json(200, { ...feedUrls(existing), created: false });
+
+    const token = generateToken();
+    if (!(await setFeedToken(userId, token))) {
+      return json(500, { error: 'Could not create a feed link' });
+    }
+    return json(200, { ...feedUrls(token), created: true });
+  }
+
+  if (event.httpMethod === 'POST') {
+    const token = generateToken();
+    if (!(await setFeedToken(userId, token))) {
+      return json(500, { error: 'Could not rotate the feed link' });
+    }
+    // Said plainly so the UI can warn before the user does it: rotation is not additive.
+    return json(200, { ...feedUrls(token), rotated: true });
+  }
+
+  if (event.httpMethod === 'DELETE') {
+    if (!(await deleteFeedToken(userId))) {
+      return json(500, { error: 'Could not revoke the feed link' });
+    }
+    return json(200, { revoked: true });
+  }
+
+  return json(405, { error: 'Method not allowed' });
+}

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -792,6 +792,255 @@ export function buildFaircampRelease(
 }
 
 // ---------------------------------------------------------------------------
+// Jam.coop — a co-op marketplace, server-rendered, and the cheapest good source after Bandcamp
+// ---------------------------------------------------------------------------
+//
+// Jam.coop is small (231 artists in its own directory) but it is the best-shaped source this
+// feature has added since Bandcamp, for three reasons worth writing down:
+//
+// - **robots.txt permits everything.** Fetched and checked before a line of this was written:
+//   the file contains a single comment and no `Disallow` at all — unlike Mirlo, whose genuinely
+//   better API is `Disallow: /v1/` and therefore stays unbuilt (spec §10).
+// - **It is entirely server-rendered.** No client-side hydration to defeat, unlike Bandwagon's
+//   `/albums` listing, which returned nothing.
+// - **One request per release gets everything.** Title, artwork, date, price, currency and
+//   format all live on the album page — so unlike Faircamp (which needs a second purchase-page
+//   request for a price, and has no date at *any* depth) a release costs exactly one fetch.
+//
+// Two-tier like every other source: `/artists/{slug}` lists the albums, `/artists/{slug}/albums/{album}`
+// has the detail.
+
+/** Ceiling on albums read off one artist page, before the per-run budget applies. */
+const JAMCOOP_MAX_CANDIDATES = 40;
+
+export interface JamcoopReleaseCandidate {
+  /** The album's own slug, used only for dedup within a page. */
+  slug: string;
+  url: string;
+  /** Grid artwork, kept as a fallback for an album page that somehow has no image. */
+  artworkUrl: string | null;
+}
+
+/**
+ * Find an artist's albums on their Jam.coop artist page.
+ *
+ * Matched on the **href shape** (`/artists/{artist}/albums/{album}`) rather than on the
+ * surrounding markup's classes. Jam.coop is a Tailwind app, so its class strings
+ * (`font-medium text-slate-600 break-words`) are presentational and would change on any
+ * redesign, whereas the route shape is the app's own URL contract. The same reasoning is why
+ * the album parser below reads `<h1>` and the `Released:` label instead of class selectors.
+ *
+ * Only albums belonging to the artist whose page this is are accepted — the page also links to
+ * other artists (a "more from Jam.coop" rail, compilation credits), and cataloguing those under
+ * this artist would attribute someone else's record to them.
+ */
+export function ingestJamcoopArtistPage(html: string, pageUrl: string): JamcoopReleaseCandidate[] {
+  const out: JamcoopReleaseCandidate[] = [];
+  const seen = new Set<string>();
+
+  let base: URL;
+  let artistSlug: string;
+  try {
+    base = new URL(pageUrl);
+    const match = base.pathname.match(/^\/artists\/([^/]+)/);
+    if (!match) return out;
+    artistSlug = match[1].toLowerCase();
+  } catch {
+    return out;
+  }
+
+  const root = parse(html);
+
+  for (const anchor of root.querySelectorAll('a[href]')) {
+    const href = anchor.getAttribute('href') ?? '';
+
+    let url: URL;
+    try {
+      url = new URL(href, base);
+    } catch {
+      continue;
+    }
+    // An href out of fetched markup is untrusted — same rule as `resolveReleaseUrl`.
+    if (url.host !== base.host) continue;
+
+    const match = url.pathname.match(/^\/artists\/([^/]+)\/albums\/([^/]+)\/?$/);
+    if (!match) continue;
+    if (match[1].toLowerCase() !== artistSlug) continue;
+
+    const slug = match[2].toLowerCase();
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+
+    const img = anchor.querySelector('img');
+    out.push({
+      slug,
+      url: url.toString(),
+      artworkUrl: img?.getAttribute('src')?.trim() || null,
+    });
+
+    if (out.length >= JAMCOOP_MAX_CANDIDATES) break;
+  }
+
+  return out;
+}
+
+export interface JamcoopAlbumPage {
+  title: string;
+  artworkUrl: string | null;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  /** Empty when no price could be read — never a zero standing in for "unknown". */
+  offers: IngestedOffer[];
+}
+
+/**
+ * Symbols Jam.coop's price line can carry, onto ISO codes.
+ *
+ * Deliberately only these three. A symbol that isn't here fails to match the price pattern at
+ * all, so the release is stored with **no offer** rather than with a price in a guessed
+ * currency: `formatMoney` defaults a null currency to USD, so publishing "¥800" as
+ * `currency: null` would render it "$800" — a wrong number about someone's money on the page
+ * whose whole job is being right about that. Every release sampled across the platform quoted
+ * GBP (Jam.coop is a UK co-op); the other two are forward-looking, not observed.
+ */
+const JAMCOOP_CURRENCY_SYMBOLS: Record<string, string> = {
+  '£': 'GBP',
+  '€': 'EUR',
+  $: 'USD',
+};
+
+/**
+ * Read one Jam.coop album page: title, artwork, release date, and its single digital offer.
+ *
+ * Returns null when there's no `<h1>` to take a title from, which means the fetch didn't land
+ * on an album page (a redirect to a listing, an error page) rather than that the album has no
+ * title.
+ *
+ * **"£7.00 or more" is published as 7.00, not as name-your-price.** The floor is what a fan can
+ * actually pay, which is the honest figure — the same call `ingestFaircampPurchasePage` makes
+ * about Faircamp's `data-min`, and for the same reason. A genuine "£0.00 or more" still lands
+ * as `price: 0`, which the display layer already renders as "Name your price" rather than
+ * "free".
+ *
+ * Everything Jam.coop sells is a download ("Digital download. MP3 and FLAC"), so the offer is
+ * always `digital`; there is no physical stock and therefore nothing that can be sold out.
+ */
+export function ingestJamcoopAlbumPage(html: string, now: Date = new Date()): JamcoopAlbumPage | null {
+  const root = parse(html);
+
+  const title = root.querySelector('h1')?.textContent?.trim();
+  if (!title) return null;
+
+  const artworkUrl = root.querySelector('img')?.getAttribute('src')?.trim() || null;
+
+  // Jam.coop writes "<strong>Released:</strong> October 4, 2024". The label is matched rather
+  // than a position, and the value handed to the shared date parser rather than parsed here.
+  const dateMatch = stripTags(html).match(/Released:\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})/);
+  const { date, precision } = parseReleaseDate(dateMatch ? dateMatch[1] : null, now);
+
+  return {
+    title,
+    artworkUrl,
+    releaseDate: date,
+    datePrecision: precision,
+    // No pre-order flag exists in Jam.coop's markup, so a future date is the only signal —
+    // which is exactly what deriveStatus falls back to.
+    status: deriveStatus(date, false, now),
+    offers: parseJamcoopOffer(html),
+  };
+}
+
+/**
+ * The price line, e.g. "£3.00 or more. Digital download. MP3 and FLAC".
+ *
+ * Anchored on "Digital download" rather than on the amount alone: an album page also carries
+ * track durations, track numbers and a description that may quote prices, and matching the
+ * first currency-shaped string on the page would eventually pick one of those up.
+ */
+function parseJamcoopOffer(html: string): IngestedOffer[] {
+  const line = stripTags(html).match(
+    /([£€$])\s*([0-9]+(?:\.[0-9]{1,2})?)[^.]*\.\s*Digital download/
+  );
+  if (!line) return [];
+
+  const price = Number(line[2]);
+  if (!Number.isFinite(price)) return [];
+
+  return [
+    { format: 'digital', price, currency: JAMCOOP_CURRENCY_SYMBOLS[line[1]], availability: 'available' },
+  ];
+}
+
+export interface JamcoopReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  artworkUrl: string | null;
+  externalUrl: string;
+  offers: IngestedOffer[];
+}
+
+/**
+ * Combine an album page with its candidate link into something ready to persist.
+ *
+ * Release type comes from the title alone, via the same fallback Faircamp uses — Jam.coop files
+ * everything under `/albums/` regardless of length, so the route says nothing about type. A
+ * track count was considered and rejected: a one-track release is as likely to be a long-form
+ * ambient album as a single, and 'other' is an honest "we don't know" where a guess would be a
+ * claim.
+ *
+ * `takenSlugs` is read, not written — the caller adds each returned slug before the next call,
+ * since albums are fetched one at a time rather than as one batch.
+ */
+export function buildJamcoopRelease(
+  page: JamcoopAlbumPage,
+  candidate: JamcoopReleaseCandidate,
+  takenSlugs: ReadonlySet<string>
+): JamcoopReleaseToPersist | null {
+  const matchKey = releaseMatchKey(page.title);
+  if (!matchKey) return null;
+
+  return {
+    title: page.title,
+    slug: uniqueReleaseSlug(page.title, takenSlugs),
+    matchKey,
+    releaseType: mapDiscogsFormatToReleaseType(null, page.title),
+    releaseDate: page.releaseDate,
+    datePrecision: page.datePrecision,
+    status: page.status,
+    artworkUrl: page.artworkUrl ?? candidate.artworkUrl,
+    externalUrl: candidate.url,
+    offers: page.offers,
+  };
+}
+
+/**
+ * The `/artists/{slug}` URL for a stored Jam.coop link.
+ *
+ * Stored links come from the directory scrape in `search-sources.ts`, which already produces
+ * this shape — but a claimed artist can save any URL to their profile, so a link pointing at an
+ * album or at the bare host is normalized back to the artist page rather than fetched as-is.
+ */
+export function jamcoopArtistUrl(storedUrl: string): string | null {
+  try {
+    const u = new URL(storedUrl);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+
+    const match = u.pathname.match(/^\/artists\/([^/]+)/);
+    if (!match) return null;
+
+    return `${u.origin}/artists/${match[1]}`;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Discovered links — a specific release, spotted on a page we fetched for another reason
 // ---------------------------------------------------------------------------
 //

--- a/api/functions/search-parsers.ts
+++ b/api/functions/search-parsers.ts
@@ -488,12 +488,25 @@ export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail 
 
   const datePublished = typeof graph.datePublished === 'string' ? graph.datePublished : null;
 
-  // Albums list every package (digital, vinyl, CD, cassette, merch) as an `albumRelease`
-  // entry, each with its own `offers`. Standalone track pages are `MusicRecording` and carry
-  // a date but no offers at all — their price lives only in the tralbum blob, and without a
-  // currency beside it. A price with a guessed currency is worse than no price, so a single
-  // ingests its date and no offer.
-  const releases = Array.isArray(graph.albumRelease) ? graph.albumRelease : [];
+  // Albums (`MusicAlbum`) list every package — digital, vinyl, CD, cassette, merch — as a
+  // top-level `albumRelease` entry with its own `offers`.
+  //
+  // Standalone track pages (`MusicRecording`) have no top-level `albumRelease`; theirs lives at
+  // `inAlbum.albumRelease`. This used to be documented here as "track pages carry a date but no
+  // offers at all", which was simply **wrong** — verified against live pages, a track's own
+  // purchase is published in the JSON-LD with a real price *and* currency. Believing the old
+  // note cost the catalogue a price on 183 of 777 Bandcamp sources (24%), every one of them a
+  // `/track/` URL, which surfaced as "No formats listed on this page".
+  const trackId = additionalProperty(graph.additionalProperty, 'track_id');
+  const isTrackPage = !Array.isArray(graph.albumRelease);
+  const inAlbum = isRecord(graph.inAlbum) ? graph.inAlbum : null;
+
+  const releases = Array.isArray(graph.albumRelease)
+    ? graph.albumRelease
+    : Array.isArray(inAlbum?.albumRelease)
+      ? inAlbum.albumRelease
+      : [];
+
   const offers: BandcampDetailOffer[] = [];
 
   for (const entry of releases) {
@@ -501,6 +514,14 @@ export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail 
     if (!isThisReleasesItem(entry)) continue;
     for (const offer of asArray(entry.offers)) {
       if (!isRecord(offer)) continue;
+      // On a track page the surrounding album's *physical* packages are listed too, and they
+      // are not things you can buy of this track: a single would otherwise be published as
+      // available on vinyl for $30, when that $30 buys the whole album. Bandcamp distinguishes
+      // them in the offer URL — the track's own download is `#t{track_id}-buy`, every album
+      // package is `#p{package_id}-buy` — so that is what's matched. Same class of problem as
+      // `isThisReleasesItem` below, one level further in.
+      if (isTrackPage && !isThisTracksOffer(offer, trackId)) continue;
+
       offers.push({
         format: stripSchemaPrefix(entry.musicReleaseFormat),
         typeName: additionalProperty(entry.additionalProperty, 'type_name'),
@@ -512,6 +533,21 @@ export function parseBandcampReleaseDetail(html: string): BandcampReleaseDetail 
   }
 
   return { datePublished, offers };
+}
+
+/**
+ * On a `MusicRecording` page, is this offer for the track itself rather than for the album it
+ * belongs to?
+ *
+ * Matched on the offer URL's `#t{track_id}-buy` fragment. Refuses when the track id is unknown,
+ * because without it there is nothing to tell the track's own download apart from the album's —
+ * and publishing an album's vinyl price against a single track is a wrong number about what
+ * someone is buying, which is worse than showing no price at all.
+ */
+function isThisTracksOffer(offer: Record<string, unknown>, trackId: string | null): boolean {
+  if (!trackId) return false;
+  const url = typeof offer.url === 'string' ? offer.url : '';
+  return url.includes(`#t${trackId}-buy`);
 }
 
 /** `item_type` values that are something other than this release: see `isThisReleasesItem`. */

--- a/api/shared/feed-format.ts
+++ b/api/shared/feed-format.ts
@@ -113,7 +113,7 @@ function eventDescription(release: FeedRelease): string {
 }
 
 /**
- * A whole calendar of upcoming releases.
+ * A whole calendar of releases.
  *
  * All-day events, because a release date is a day and not a moment — an event at "00:00 UTC"
  * lands on the wrong day for anyone west of Greenwich, which for a US subscriber means every
@@ -123,7 +123,15 @@ function eventDescription(release: FeedRelease): string {
  * existing entry instead of duplicating it — a subscribed calendar re-fetches indefinitely, and
  * an unstable UID would pile up a new copy of every release on every refresh.
  */
-export function buildIcs(releases: FeedRelease[], calendarName: string, now: Date = new Date()): string {
+export function buildIcs(
+  releases: FeedRelease[],
+  calendarName: string,
+  now: Date = new Date(),
+  /** One line describing the calendar. Defaults to the per-fan feed's wording, since that is
+   *  the primary feed; an artist feed passes its own, because "from the artists you support"
+   *  is plainly untrue of a single artist's discography. */
+  description = 'Upcoming releases from the artists you support on Unstream'
+): string {
   const lines: string[] = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
@@ -131,7 +139,7 @@ export function buildIcs(releases: FeedRelease[], calendarName: string, now: Dat
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
     `X-WR-CALNAME:${escapeIcsText(calendarName)}`,
-    'X-WR-CALDESC:Upcoming releases from the artists you support on Unstream',
+    `X-WR-CALDESC:${escapeIcsText(description)}`,
     // Clients that honour it back off to daily; a release calendar changes slowly.
     'REFRESH-INTERVAL;VALUE=DURATION:P1D',
     'X-PUBLISHED-TTL:P1D',

--- a/api/shared/feed-format.ts
+++ b/api/shared/feed-format.ts
@@ -20,8 +20,16 @@ export interface FeedRelease {
   releaseDate: string;
   /** "from $8 · ≈$6.80 to artist", or ''. Shown in the event description when present. */
   offerSummary: string;
-  /** Platforms this release is on, artist-paying first. */
-  platforms: string[];
+  /**
+   * Where you can buy it, artist-paying first — display name plus the platform's own page.
+   *
+   * Named `sources` rather than the old `platforms: string[]` because a bare list of names was
+   * exactly the problem: a feed entry said "Bandcamp, Faircamp" and gave the reader no way to
+   * reach either.
+   */
+  sources: { name: string; url: string }[];
+  /** Cover art. Null when the release has none — never rendered as a broken image. */
+  artworkUrl: string | null;
 }
 
 const SITE = 'https://unstream.stream';
@@ -98,18 +106,54 @@ function icsTimestamp(now: Date): string {
 }
 
 /**
- * What an event says beyond its title: where to buy, for how much, and the link back.
+ * What an event says beyond its title: where to buy, for how much, and the links.
  *
- * The link is to the Unstream release page, never to one platform — the same pillar-3 rule the
- * alerts follow. A calendar entry that deep-links to one shop hides the payout comparison at
- * exactly the moment it matters.
+ * The event's own `URL` property stays the Unstream release page — the same pillar-3 rule the
+ * alerts follow, since a calendar entry that deep-links to one shop hides the payout comparison
+ * at exactly the moment it matters. But `URL` is single-valued in RFC 5545, so the per-platform
+ * links go in the description, one per line: naming "Bandcamp, Faircamp" without giving the
+ * reader a way to reach either was the gap this closes.
+ *
+ * Written as bare URLs on their own lines because iCalendar DESCRIPTION is **plain text** — there
+ * is no anchor markup to use, and every calendar client linkifies a bare URL. Anything cleverer
+ * would show up as literal angle brackets in Apple Calendar.
  */
 function eventDescription(release: FeedRelease): string {
   const parts: string[] = [];
-  if (release.platforms.length > 0) parts.push(`On ${release.platforms.join(', ')}`);
   if (release.offerSummary) parts.push(release.offerSummary);
   parts.push(releasePageUrl(release.artistSlug, release.releaseSlug));
+
+  for (const source of release.sources) {
+    parts.push(`${source.name}: ${source.url}`);
+  }
+
   return parts.join('\n');
+}
+
+/** Extensions Bandcamp and the other sources actually serve, onto iCalendar FMTTYPE values. */
+const IMAGE_MIME: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+/**
+ * `ATTACH` line for the cover art, or null.
+ *
+ * `FMTTYPE` is only declared when the extension actually says what the image is. Asserting
+ * `image/jpeg` over a PNG is the kind of small lie that makes a client refuse the attachment
+ * outright, and the parameter is optional — omitting it is better than guessing.
+ *
+ * The URI is **not** run through `escapeIcsText`: this is a URI value, not TEXT, and escaping
+ * its commas to `\,` would corrupt the address. Same reason `URL:` below is unescaped.
+ */
+function artworkAttachLine(artworkUrl: string | null): string | null {
+  if (!artworkUrl) return null;
+  const ext = artworkUrl.split('?')[0].split('.').pop()?.toLowerCase() ?? '';
+  const mime = IMAGE_MIME[ext];
+  return mime ? `ATTACH;FMTTYPE=${mime}:${artworkUrl}` : `ATTACH:${artworkUrl}`;
 }
 
 /**
@@ -148,6 +192,7 @@ export function buildIcs(
   const stamp = icsTimestamp(now);
 
   for (const release of releases) {
+    const attach = artworkAttachLine(release.artworkUrl);
     lines.push(
       'BEGIN:VEVENT',
       `UID:${release.artistSlug}-${release.releaseSlug}@unstream.stream`,
@@ -157,6 +202,7 @@ export function buildIcs(
       `SUMMARY:${escapeIcsText(`${release.artistName} — ${release.title}`)}`,
       `DESCRIPTION:${escapeIcsText(eventDescription(release))}`,
       `URL:${releasePageUrl(release.artistSlug, release.releaseSlug)}`,
+      ...(attach ? [attach] : []),
       'TRANSP:TRANSPARENT',
       'END:VEVENT'
     );
@@ -181,6 +227,45 @@ export function escapeXml(value: string): string {
     .replace(/'/g, '&apos;');
 }
 
+/** The image's MIME type from its extension, defaulting to JPEG — what Bandcamp serves. */
+function imageMimeType(url: string): string {
+  const ext = url.split('?')[0].split('.').pop()?.toLowerCase() ?? '';
+  return IMAGE_MIME[ext] ?? 'image/jpeg';
+}
+
+/**
+ * The rich body of an entry: cover art, the price line, and a link per platform.
+ *
+ * Escaped **twice**, deliberately, and it is correct: values are escaped as they go into the
+ * HTML, then `<content type="html">` requires the whole HTML string to be entity-encoded again
+ * so it survives as XML character data. The reader decodes once to recover the HTML and renders
+ * it. Getting this wrong in either direction either breaks the XML or shows visible tags.
+ *
+ * The artwork is hotlinked from wherever the platform serves it, same as the artist page already
+ * does. Rehosting at feed scale raises rights questions this feature has not answered.
+ */
+function entryHtml(release: FeedRelease, pageUrl: string): string {
+  const parts: string[] = [];
+
+  if (release.artworkUrl) {
+    parts.push(
+      `<p><a href="${escapeXml(pageUrl)}"><img src="${escapeXml(release.artworkUrl)}" alt="${escapeXml(release.title)}" width="300"/></a></p>`
+    );
+  }
+
+  if (release.offerSummary) parts.push(`<p>${escapeXml(release.offerSummary)}</p>`);
+
+  if (release.sources.length > 0) {
+    const links = release.sources
+      .map(source => `<a href="${escapeXml(source.url)}">${escapeXml(source.name)}</a>`)
+      .join(' &middot; ');
+    parts.push(`<p>Buy on: ${links}</p>`);
+  }
+
+  parts.push(`<p><a href="${escapeXml(pageUrl)}">Compare where to buy on Unstream</a></p>`);
+  return parts.join('');
+}
+
 /**
  * The same releases as an Atom feed, for RSS readers.
  *
@@ -202,7 +287,7 @@ export function buildAtom(
   const entries = releases.map(release => {
     const url = releasePageUrl(release.artistSlug, release.releaseSlug);
     const summaryParts = [
-      release.platforms.length > 0 ? `On ${release.platforms.join(', ')}` : '',
+      release.sources.length > 0 ? `On ${release.sources.map(x => x.name).join(', ')}` : '',
       release.offerSummary,
     ].filter(Boolean);
 
@@ -211,9 +296,22 @@ export function buildAtom(
       `    <title>${escapeXml(`${release.artistName} — ${release.title}`)}</title>`,
       `    <id>tag:unstream.stream,2026:release/${escapeXml(release.artistSlug)}/${escapeXml(release.releaseSlug)}</id>`,
       `    <link rel="alternate" type="text/html" href="${escapeXml(url)}"/>`,
+      // One `rel="related"` per platform. A reader that renders the HTML content below gets the
+      // links anyway; this is for the ones that only walk <link> elements.
+      ...release.sources.map(
+        source => `    <link rel="related" type="text/html" href="${escapeXml(source.url)}" title="${escapeXml(source.name)}"/>`
+      ),
+      // Podcast-style enclosure, which is how most readers find a per-entry image.
+      ...(release.artworkUrl
+        ? [`    <link rel="enclosure" type="${escapeXml(imageMimeType(release.artworkUrl))}" href="${escapeXml(release.artworkUrl)}"/>`]
+        : []),
       `    <updated>${release.releaseDate}T00:00:00Z</updated>`,
       `    <author><name>${escapeXml(release.artistName)}</name></author>`,
-      `    <summary>${escapeXml(summaryParts.join(' · ') || 'Upcoming release')}</summary>`,
+      // `summary` stays plain text for readers that show only that; `content` carries the
+      // artwork and the real links. Both are populated on purpose — a reader shows one or the
+      // other and there is no way to know which.
+      `    <summary>${escapeXml(summaryParts.join(' · ') || 'New release')}</summary>`,
+      `    <content type="html">${escapeXml(entryHtml(release, url))}</content>`,
       '  </entry>',
     ].join('\n');
   });

--- a/api/shared/feed-format.ts
+++ b/api/shared/feed-format.ts
@@ -1,0 +1,225 @@
+/**
+ * Building iCalendar and Atom documents for release feeds.
+ *
+ * Pure string work, split out from the serving function for the same reason
+ * `release-display.ts` was: it is fiddly, spec-governed, and a subscriber's calendar client
+ * either parses it or silently shows nothing. A malformed feed fails *quietly* in Apple
+ * Calendar — no error, just an empty subscription — so this is exactly the code that needs
+ * tests rather than a look.
+ *
+ * Imported with an explicit `.ts` extension by any edge function (Deno requires it) and without
+ * one by node, the same arrangement `release-display.ts` and `bandcamp-friday.ts` already use.
+ */
+
+export interface FeedRelease {
+  artistName: string;
+  artistSlug: string;
+  title: string;
+  releaseSlug: string;
+  /** `YYYY-MM-DD`. Releases without one never reach here — there is no event to place. */
+  releaseDate: string;
+  /** "from $8 · ≈$6.80 to artist", or ''. Shown in the event description when present. */
+  offerSummary: string;
+  /** Platforms this release is on, artist-paying first. */
+  platforms: string[];
+}
+
+const SITE = 'https://unstream.stream';
+
+export function releasePageUrl(artistSlug: string, releaseSlug: string): string {
+  return `${SITE}/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(releaseSlug)}`;
+}
+
+// ---------------------------------------------------------------------------
+// iCalendar (RFC 5545)
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a value for an iCalendar TEXT property.
+ *
+ * Order matters: backslashes first, or the escapes added below get re-escaped. Real release
+ * titles hit every one of these — commas and semicolons are common in album names, and a raw
+ * comma in a SUMMARY is a *value separator* in RFC 5545, so an unescaped one silently truncates
+ * the title at the comma in the subscriber's calendar.
+ */
+export function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\r|\n/g, '\\n');
+}
+
+/**
+ * Fold a content line to 75 octets, per RFC 5545 §3.1.
+ *
+ * Counted in **UTF-8 bytes, not characters** — folding by `.length` would split a multi-byte
+ * character across the boundary and produce mojibake or a parse failure in a title like
+ * "Ágætis byrjun". Continuation lines start with a single space, which the parser strips.
+ */
+export function foldIcsLine(line: string): string {
+  const bytes = new TextEncoder().encode(line);
+  if (bytes.length <= 75) return line;
+
+  const out: string[] = [];
+  let start = 0;
+  // First line takes 75 octets; continuations take 74 plus the leading space.
+  let limit = 75;
+
+  while (start < bytes.length) {
+    let end = Math.min(start + limit, bytes.length);
+    // Never cut inside a UTF-8 sequence: continuation bytes match 0b10xxxxxx.
+    while (end > start && end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+
+    const chunk = new TextDecoder().decode(bytes.slice(start, end));
+    out.push(out.length === 0 ? chunk : ` ${chunk}`);
+    start = end;
+    limit = 74;
+  }
+
+  return out.join('\r\n');
+}
+
+/** `YYYY-MM-DD` → `YYYYMMDD`, the DATE form an all-day event uses. */
+function icsDate(iso: string): string {
+  return iso.replace(/-/g, '');
+}
+
+/** The day after `iso`, since DTEND on an all-day VEVENT is exclusive. */
+function nextDay(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d + 1));
+  return icsDate(date.toISOString().slice(0, 10));
+}
+
+/** UTC timestamp form for DTSTAMP. */
+function icsTimestamp(now: Date): string {
+  return `${now.toISOString().slice(0, 19).replace(/[-:]/g, '')}Z`;
+}
+
+/**
+ * What an event says beyond its title: where to buy, for how much, and the link back.
+ *
+ * The link is to the Unstream release page, never to one platform — the same pillar-3 rule the
+ * alerts follow. A calendar entry that deep-links to one shop hides the payout comparison at
+ * exactly the moment it matters.
+ */
+function eventDescription(release: FeedRelease): string {
+  const parts: string[] = [];
+  if (release.platforms.length > 0) parts.push(`On ${release.platforms.join(', ')}`);
+  if (release.offerSummary) parts.push(release.offerSummary);
+  parts.push(releasePageUrl(release.artistSlug, release.releaseSlug));
+  return parts.join('\n');
+}
+
+/**
+ * A whole calendar of upcoming releases.
+ *
+ * All-day events, because a release date is a day and not a moment — an event at "00:00 UTC"
+ * lands on the wrong day for anyone west of Greenwich, which for a US subscriber means every
+ * release shows up a day early.
+ *
+ * `uid` is derived from the artist and release slug, so re-fetching the feed updates the
+ * existing entry instead of duplicating it — a subscribed calendar re-fetches indefinitely, and
+ * an unstable UID would pile up a new copy of every release on every refresh.
+ */
+export function buildIcs(releases: FeedRelease[], calendarName: string, now: Date = new Date()): string {
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Unstream//Release Feed//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `X-WR-CALNAME:${escapeIcsText(calendarName)}`,
+    'X-WR-CALDESC:Upcoming releases from the artists you support on Unstream',
+    // Clients that honour it back off to daily; a release calendar changes slowly.
+    'REFRESH-INTERVAL;VALUE=DURATION:P1D',
+    'X-PUBLISHED-TTL:P1D',
+  ];
+
+  const stamp = icsTimestamp(now);
+
+  for (const release of releases) {
+    lines.push(
+      'BEGIN:VEVENT',
+      `UID:${release.artistSlug}-${release.releaseSlug}@unstream.stream`,
+      `DTSTAMP:${stamp}`,
+      `DTSTART;VALUE=DATE:${icsDate(release.releaseDate)}`,
+      `DTEND;VALUE=DATE:${nextDay(release.releaseDate)}`,
+      `SUMMARY:${escapeIcsText(`${release.artistName} — ${release.title}`)}`,
+      `DESCRIPTION:${escapeIcsText(eventDescription(release))}`,
+      `URL:${releasePageUrl(release.artistSlug, release.releaseSlug)}`,
+      'TRANSP:TRANSPARENT',
+      'END:VEVENT'
+    );
+  }
+
+  lines.push('END:VCALENDAR');
+
+  // CRLF throughout, per RFC 5545 — bare LF is rejected outright by some clients.
+  return lines.map(foldIcsLine).join('\r\n') + '\r\n';
+}
+
+// ---------------------------------------------------------------------------
+// Atom
+// ---------------------------------------------------------------------------
+
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * The same releases as an Atom feed, for RSS readers.
+ *
+ * `<updated>` on the feed is the newest release date rather than "now": a feed whose timestamp
+ * changes on every fetch tells every reader it changed, which is how a quiet feed turns into a
+ * noisy one. With no entries at all it falls back to `now`, since the element is required.
+ */
+export function buildAtom(
+  releases: FeedRelease[],
+  opts: { title: string; selfUrl: string; feedId: string },
+  now: Date = new Date()
+): string {
+  const newest = releases.reduce<string | null>(
+    (max, r) => (max === null || r.releaseDate > max ? r.releaseDate : max),
+    null
+  );
+  const updated = newest ? `${newest}T00:00:00Z` : now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+  const entries = releases.map(release => {
+    const url = releasePageUrl(release.artistSlug, release.releaseSlug);
+    const summaryParts = [
+      release.platforms.length > 0 ? `On ${release.platforms.join(', ')}` : '',
+      release.offerSummary,
+    ].filter(Boolean);
+
+    return [
+      '  <entry>',
+      `    <title>${escapeXml(`${release.artistName} — ${release.title}`)}</title>`,
+      `    <id>tag:unstream.stream,2026:release/${escapeXml(release.artistSlug)}/${escapeXml(release.releaseSlug)}</id>`,
+      `    <link rel="alternate" type="text/html" href="${escapeXml(url)}"/>`,
+      `    <updated>${release.releaseDate}T00:00:00Z</updated>`,
+      `    <author><name>${escapeXml(release.artistName)}</name></author>`,
+      `    <summary>${escapeXml(summaryParts.join(' · ') || 'Upcoming release')}</summary>`,
+      '  </entry>',
+    ].join('\n');
+  });
+
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <title>${escapeXml(opts.title)}</title>`,
+    `  <id>${escapeXml(opts.feedId)}</id>`,
+    `  <updated>${updated}</updated>`,
+    `  <link rel="self" href="${escapeXml(opts.selfUrl)}"/>`,
+    '  <generator uri="https://unstream.stream">Unstream</generator>',
+    ...entries,
+    '</feed>',
+    '',
+  ].join('\n');
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -33,11 +33,16 @@
     "functions/me-settings.ts",
     "functions/me-username.ts",
     "functions/me-password.ts",
+    "functions/me-feed-token.ts",
+    "functions/feed-releases.ts",
     "functions/redis.ts",
     "functions/cache.ts",
+    "shared/feed-format.ts",
     "functions/__tests__/me-settings.test.ts",
     "functions/__tests__/me-username.test.ts",
     "functions/__tests__/me-password.test.ts",
+    "functions/__tests__/feed-format.test.ts",
+    "functions/__tests__/feed-releases.test.ts",
     "functions/__tests__/redis-resilience.test.ts"
   ]
 }

--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		5AF682136B14D6BDCBF42E4A /* UnstreamShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B86644D0E7917D893B1E7A3 /* UnstreamShortcuts.swift */; };
 		5B170D71E9A7E9A471424F16 /* iOSSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359150E4043D5233395827D3 /* iOSSettingsTab.swift */; platformFilters = (ios, ); };
 		5FFFE71A1135656E81B34BDB /* DeviceIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFF951B15732D3AD206D247 /* DeviceIDManager.swift */; };
+		63E898D2663789CC76EF14C1 /* ReleaseAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C32A6DB203A3FC0A26D719 /* ReleaseAlertTests.swift */; };
 		640AB7A350949FAA23C72A53 /* iOSContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5033CFF636FB4C7C07D315A6 /* iOSContentView.swift */; platformFilters = (ios, ); };
 		64514560D09214DE420ED24D /* NowPlayingNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93B97CDB100943ECCA942E6 /* NowPlayingNotificationManager.swift */; platformFilters = (macos, ); };
 		7182754E06D41AE6FB47653A /* SupportListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F5BF0BE3FBF25D3C4102A6 /* SupportListManager.swift */; };
@@ -131,6 +132,7 @@
 		529125F63F2294A642A38108 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		590FD31A0B703B21FFCCBEA7 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		607E17AC019A1B8698E64ACC /* Unstream.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Unstream.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		66C32A6DB203A3FC0A26D719 /* ReleaseAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseAlertTests.swift; sourceTree = "<group>"; };
 		673FC4B1F41A233725896DB8 /* ReleaseCheckAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseCheckAPI.swift; sourceTree = "<group>"; };
 		6B52C116B5CC91BC40D028AF /* GlobalHotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalHotkeyManager.swift; sourceTree = "<group>"; };
 		752695EB82D70EEE00B921FA /* TipJarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipJarView.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				99D11E8AD4C3856F744DAA65 /* Info.plist */,
+				66C32A6DB203A3FC0A26D719 /* ReleaseAlertTests.swift */,
 				16504D9BC91FD976CD10D549 /* SavedArtistsSyncTests.swift */,
 			);
 			path = UnstreamTests;
@@ -510,6 +513,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63E898D2663789CC76EF14C1 /* ReleaseAlertTests.swift in Sources */,
 				93956240B6028E760C791028 /* SavedArtistsSyncTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/mac/Unstream/Models/ReleaseAlert.swift
+++ b/apps/mac/Unstream/Models/ReleaseAlert.swift
@@ -6,8 +6,16 @@ struct NewRelease: Codable, Identifiable {
     let artistName: String
     let releaseName: String
     let releaseDate: Date
+    /// The Unstream release page, so a fan lands on the payout comparison rather than one shop.
     let releaseUrl: String
-    let platform: String  // "bandcamp", "faircamp", or "mirlo"
+    /// The platform an alert leads with — now any platform in the registry, not a fixed three.
+    let platform: String
+    /// Every platform this release is on. Empty means the server didn't say (an older deploy).
+    let platforms: [String]
+    /// "released" or "announced". An announced release is dated in the future.
+    let status: String
+    /// "from $8 · ≈$6.80 to artist", or "Name your price". Empty when no price is known.
+    let offerSummary: String
     let detectedAt: Date
 
     /// Returns true if this release should still be displayed (within 30 days of detection)
@@ -15,14 +23,50 @@ struct NewRelease: Codable, Identifiable {
         Date().timeIntervalSince(detectedAt) < 30 * 24 * 60 * 60
     }
 
-    init(artistName: String, releaseName: String, releaseDate: Date, releaseUrl: String, platform: String) {
+    var isUpcoming: Bool { status == "announced" }
+
+    /// The leading platform's proper name. `.capitalized` on the raw id renders "Jamcoop" and
+    /// "Kofi", which is why every display site should use this instead.
+    var displayPlatform: String {
+        platformCatalog[platform]?.name ?? platform.capitalized
+    }
+
+    init(
+        artistName: String,
+        releaseName: String,
+        releaseDate: Date,
+        releaseUrl: String,
+        platform: String,
+        platforms: [String] = [],
+        status: String = "released",
+        offerSummary: String = ""
+    ) {
         self.id = UUID()
         self.artistName = artistName
         self.releaseName = releaseName
         self.releaseDate = releaseDate
         self.releaseUrl = releaseUrl
         self.platform = platform
+        self.platforms = platforms.isEmpty ? [platform] : platforms
+        self.status = status
+        self.offerSummary = offerSummary
         self.detectedAt = Date()
+    }
+
+    // Decoded with defaults so alerts persisted by an earlier build — which had none of the
+    // three new fields — still load instead of throwing the whole stored list away.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        artistName = try c.decode(String.self, forKey: .artistName)
+        releaseName = try c.decode(String.self, forKey: .releaseName)
+        releaseDate = try c.decode(Date.self, forKey: .releaseDate)
+        releaseUrl = try c.decode(String.self, forKey: .releaseUrl)
+        platform = try c.decode(String.self, forKey: .platform)
+        detectedAt = try c.decode(Date.self, forKey: .detectedAt)
+        platforms = try c.decodeIfPresent([String].self, forKey: .platforms) ?? [platform]
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? "released"
+        offerSummary = try c.decodeIfPresent(String.self, forKey: .offerSummary) ?? ""
     }
 }
 
@@ -95,4 +139,25 @@ struct ReleaseCheckResult {
     let releaseDate: Date
     let releaseUrl: String
     let platform: String
+    let platforms: [String]
+    let status: String
+    let offerSummary: String
+
+    init(
+        releaseName: String,
+        releaseDate: Date,
+        releaseUrl: String,
+        platform: String,
+        platforms: [String] = [],
+        status: String = "released",
+        offerSummary: String = ""
+    ) {
+        self.releaseName = releaseName
+        self.releaseDate = releaseDate
+        self.releaseUrl = releaseUrl
+        self.platform = platform
+        self.platforms = platforms.isEmpty ? [platform] : platforms
+        self.status = status
+        self.offerSummary = offerSummary
+    }
 }

--- a/apps/mac/Unstream/ReleaseAlertManager.swift
+++ b/apps/mac/Unstream/ReleaseAlertManager.swift
@@ -216,23 +216,22 @@ class ReleaseAlertManager: ObservableObject {
             // Skip if no supported platforms
             guard !platforms.isEmpty else { continue }
 
-            // Call API to check for releases (API handles priority internally)
-            if let release = await checkViaAPI(artistName: entry.artistName, platforms: platforms) {
-                foundNewReleases.append(release)
-            }
+            // The server returns every release in the window, not just the newest, so an artist
+            // who put out two records since the last check produces two alerts.
+            foundNewReleases.append(contentsOf: await checkViaAPI(artistName: entry.artistName, platforms: platforms))
         }
 
-        // Update state with new releases
+        // Update state with new releases.
+        //
+        // There is deliberately no second dedup here. There used to be one — it asked whether
+        // the display list already held *any* release by this artist, and skipped the release if
+        // so. That was wrong in a way that lost data permanently: checkViaAPI has already done
+        // the correct per-release dedup and has already recorded the release as known, so an
+        // artist's genuinely-new second record was dropped from both the list and the
+        // notification while being marked as seen — making it undetectable forever after.
         if !foundNewReleases.isEmpty {
-            var releasesToNotify: [NewRelease] = []
-            for release in foundNewReleases {
-                let alreadyKnown = newReleases.contains(where: { $0.artistName.lowercased() == release.artistName.lowercased() })
-                if !alreadyKnown {
-                    newReleases.append(release)
-                    checkState.newReleases.append(release)
-                    releasesToNotify.append(release)
-                }
-            }
+            newReleases.append(contentsOf: foundNewReleases)
+            checkState.newReleases.append(contentsOf: foundNewReleases)
 
             // Save state and wait for UI to update before sending notifications
             saveState()
@@ -240,44 +239,112 @@ class ReleaseAlertManager: ObservableObject {
             // Small delay to ensure SwiftUI has time to update the UI
             try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
 
-            // Send individual notifications for each new release
-            if !releasesToNotify.isEmpty {
-                await sendNotifications(for: releasesToNotify)
-            }
+            await sendNotifications(for: foundNewReleases)
         }
     }
 
-    private func checkViaAPI(artistName: String, platforms: [String: String]) async -> NewRelease? {
+    /// Ask the server what's new for one artist, and keep only what we haven't seen before.
+    private func checkViaAPI(artistName: String, platforms: [String: String]) async -> [NewRelease] {
         do {
-            guard let result = try await releaseAPI.checkReleases(artistName: artistName, platforms: platforms) else {
-                return nil
-            }
+            let results = try await releaseAPI.checkReleases(artistName: artistName, platforms: platforms)
+            return Self.selectUnseen(results, artistName: artistName, state: &checkState)
+        } catch {
+            print("API check failed for \(artistName): \(error)")
+            return []
+        }
+    }
 
-            // Check if we already know about this release (on ANY platform)
-            if checkState.isKnownReleaseByName(result.releaseName, for: artistName) {
-                return nil
-            }
+    /// Which of these results haven't we alerted on before? Marks each one it returns as known.
+    ///
+    /// **This is the only dedup point, and that is the fix.** Identity is the release name,
+    /// compared across platforms so one record on both Bandcamp and Mirlo is one alert rather
+    /// than two — but *within* an artist, so a second, different record is always new.
+    ///
+    /// There used to be a second layer on top of this in `checkAllArtists`, asking whether the
+    /// display list already held any release by the same artist. Because this function has
+    /// already recorded the release as known by the time that check ran, a genuinely-new second
+    /// record was dropped from the list and the notification while being marked as seen — so it
+    /// could never be detected again. Extracted here, `inout` over the state, so the rule can be
+    /// tested directly rather than only through a network call.
+    nonisolated static func selectUnseen(
+        _ results: [ReleaseCheckResult],
+        artistName: String,
+        state: inout ReleaseCheckState
+    ) -> [NewRelease] {
+        var fresh: [NewRelease] = []
 
-            // Mark as known
-            checkState.addKnownRelease(
+        for result in results {
+            if state.isKnownReleaseByName(result.releaseName, for: artistName) { continue }
+
+            state.addKnownRelease(
                 KnownRelease(releaseName: result.releaseName, releaseDate: result.releaseDate, platform: result.platform),
                 for: artistName
             )
 
-            return NewRelease(
+            fresh.append(NewRelease(
                 artistName: artistName,
                 releaseName: result.releaseName,
                 releaseDate: result.releaseDate,
                 releaseUrl: result.releaseUrl,
-                platform: result.platform
-            )
-        } catch {
-            print("API check failed for \(artistName): \(error)")
-            return nil
+                platform: result.platform,
+                platforms: result.platforms,
+                status: result.status,
+                offerSummary: result.offerSummary
+            ))
         }
+
+        return fresh
     }
 
     // MARK: - Notifications
+
+    /// What a release notification actually says.
+    ///
+    /// The old body was `"X" is out now on Bandcamp!` — one platform, no formats, no price, at
+    /// the exact moment someone is deciding whether and where to buy. With the catalog behind
+    /// the API there is real information to offer instead, so this builds up from whatever the
+    /// server actually knew rather than asserting a fixed shape:
+    ///
+    ///   "Infinite Normal" — out now on Bandcamp and Mirlo · from $8 · ≈$6.80 to artist
+    ///   "Next Year" — announced, 1 September
+    ///
+    /// Nothing is invented: an empty `offerSummary` (no price read yet) simply omits that
+    /// clause rather than printing a placeholder.
+    /// `nonisolated` because it is a pure function of its argument — it touches no manager
+    /// state, so there is no reason to make callers (including tests) hop to the main actor.
+    nonisolated static func notificationBody(for release: NewRelease) -> String {
+        var parts: [String] = []
+
+        let where_ = formatPlatformList(release.platforms)
+        if release.isUpcoming {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "d MMMM"
+            let date = formatter.string(from: release.releaseDate)
+            parts.append(where_.isEmpty ? "announced for \(date)" : "announced for \(date) on \(where_)")
+        } else {
+            parts.append(where_.isEmpty ? "out now" : "out now on \(where_)")
+        }
+
+        if !release.offerSummary.isEmpty {
+            parts.append(release.offerSummary)
+        }
+
+        return "\"\(release.releaseName)\" — " + parts.joined(separator: " · ")
+    }
+
+    /// "Bandcamp", "Bandcamp and Mirlo", "Bandcamp, Mirlo and 2 more" — a notification body has
+    /// very little room, so a long list is summarized rather than truncated mid-name.
+    nonisolated private static func formatPlatformList(_ platforms: [String]) -> String {
+        // platformCatalog carries the proper display name ("Jam.coop", "Ko-fi"), which
+        // `.capitalized` would mangle. An unknown id falls back rather than being dropped.
+        let names = platforms.map { platformCatalog[$0]?.name ?? $0.capitalized }
+        switch names.count {
+        case 0: return ""
+        case 1: return names[0]
+        case 2: return "\(names[0]) and \(names[1])"
+        default: return "\(names[0]), \(names[1]) and \(names.count - 2) more"
+        }
+    }
 
     private func sendNotifications(for releases: [NewRelease]) async {
         // Check authorization status first
@@ -288,8 +355,10 @@ class ReleaseAlertManager: ObservableObject {
         for release in releases {
 
             let content = UNMutableNotificationContent()
-            content.title = "New Release from \(release.artistName)"
-            content.body = "\"\(release.releaseName)\" is out now on \(release.platform.capitalized)!"
+            content.title = release.isUpcoming
+                ? "\(release.artistName) — coming soon"
+                : "New Release from \(release.artistName)"
+            content.body = Self.notificationBody(for: release)
             content.sound = .default
             content.userInfo = ["releaseUrl": release.releaseUrl]
 

--- a/apps/mac/Unstream/Services/ReleaseCheckAPI.swift
+++ b/apps/mac/Unstream/Services/ReleaseCheckAPI.swift
@@ -11,21 +11,35 @@ actor ReleaseCheckAPI {
         self.session = URLSession(configuration: config)
     }
 
-    /// Check for new releases for an artist
+    /// Check for new releases for an artist.
+    ///
+    /// Returns **every** release the server reports in the window, not just the newest one.
+    /// The server now answers from Unstream's own release catalog where it has one, so a single
+    /// call can legitimately describe two new records, an upcoming announcement, and every
+    /// platform each is available on — none of which the old single-release shape could carry.
+    ///
     /// - Parameters:
     ///   - artistName: The artist's name
     ///   - platforms: Dictionary of platform URLs (bandcamp, faircamp, mirlo)
-    /// - Returns: The release check result, or nil if no recent release found
-    func checkReleases(artistName: String, platforms: [String: String]) async throws -> ReleaseCheckResult? {
+    ///   - sinceDays: How far back to look. The server defaults to 31 when this is nil.
+    /// - Returns: The releases found, newest first. Empty when there are none.
+    func checkReleases(
+        artistName: String,
+        platforms: [String: String],
+        sinceDays: Int? = nil
+    ) async throws -> [ReleaseCheckResult] {
         guard let url = URL(string: baseURL) else {
             throw ReleaseCheckAPIError.invalidURL
         }
 
         // Build request body
-        let requestBody: [String: Any] = [
+        var requestBody: [String: Any] = [
             "artistName": artistName,
             "platforms": platforms
         ]
+        if let sinceDays {
+            requestBody["sinceDays"] = sinceDays
+        }
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: requestBody) else {
             throw ReleaseCheckAPIError.encodingError
@@ -50,38 +64,38 @@ actor ReleaseCheckAPI {
         let decoder = JSONDecoder()
         let apiResponse = try decoder.decode(CheckReleasesResponse.self, from: data)
 
-        guard let release = apiResponse.release else {
-            return nil
-        }
+        // Prefer the plural field. `release` is the same data narrowed to one entry, kept by the
+        // server for clients older than this one — reading both would double-count.
+        let apiReleases = apiResponse.releases ?? apiResponse.release.map { [$0] } ?? []
 
-        // Parse the ISO date string to Date
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withFullDate]
-
-        guard let releaseDate = dateFormatter.date(from: release.releaseDate) else {
-            // Try alternative date format (just YYYY-MM-DD)
-            let simpleFormatter = DateFormatter()
-            simpleFormatter.dateFormat = "yyyy-MM-dd"
-            simpleFormatter.locale = Locale(identifier: "en_US_POSIX")
-
-            guard let date = simpleFormatter.date(from: release.releaseDate) else {
-                throw ReleaseCheckAPIError.dateParseError
-            }
-
+        // A release whose date won't parse is skipped rather than failing the whole artist:
+        // one malformed date should not cost a fan every other alert in the same response.
+        return apiReleases.compactMap { release in
+            guard let date = Self.parseDate(release.releaseDate) else { return nil }
             return ReleaseCheckResult(
                 releaseName: release.releaseName,
                 releaseDate: date,
                 releaseUrl: release.releaseUrl,
-                platform: release.platform
+                platform: release.platform,
+                platforms: release.platforms ?? [release.platform],
+                status: release.status ?? "released",
+                offerSummary: release.offerSummary ?? ""
             )
         }
+    }
 
-        return ReleaseCheckResult(
-            releaseName: release.releaseName,
-            releaseDate: releaseDate,
-            releaseUrl: release.releaseUrl,
-            platform: release.platform
-        )
+    /// The server sends plain `yyyy-MM-dd`. Both formatters are kept because the field is
+    /// declared only as "ISO format" in the API contract.
+    private static func parseDate(_ raw: String) -> Date? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withFullDate]
+        if let date = iso.date(from: raw) { return date }
+
+        let simple = DateFormatter()
+        simple.dateFormat = "yyyy-MM-dd"
+        simple.locale = Locale(identifier: "en_US_POSIX")
+        simple.timeZone = TimeZone(identifier: "UTC")
+        return simple.date(from: raw)
     }
 }
 
@@ -90,6 +104,7 @@ actor ReleaseCheckAPI {
 private struct CheckReleasesResponse: Codable {
     let artistName: String
     let release: APIRelease?
+    let releases: [APIRelease]?
     let error: String?
 }
 
@@ -98,6 +113,10 @@ private struct APIRelease: Codable {
     let releaseDate: String
     let releaseUrl: String
     let platform: String
+    // Optional: absent on the legacy `release` field and on older server deploys.
+    let platforms: [String]?
+    let status: String?
+    let offerSummary: String?
 }
 
 // MARK: - Errors

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -416,13 +416,13 @@ struct NewReleaseBadge: View {
             .cornerRadius(6)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("New release: \(release.releaseName) on \(release.platform.capitalized)")
+        .accessibilityLabel("New release: \(release.releaseName) on \(release.displayPlatform)")
         #if os(macOS)
-        .help("Open \(release.releaseName) on \(release.platform.capitalized)")
+        .help("Open \(release.releaseName) on \(release.displayPlatform)")
         #endif
         .linkActions(
             url: URL(string: release.releaseUrl),
-            openTitle: "Open on \(release.platform.capitalized)",
+            openTitle: "Open on \(release.displayPlatform)",
             onOpen: openRelease
         )
         #if os(iOS)

--- a/apps/mac/Unstream/Views/iOS/ReleasesTab.swift
+++ b/apps/mac/Unstream/Views/iOS/ReleasesTab.swift
@@ -99,7 +99,7 @@ private struct ReleaseRow: View {
                     Text(release.releaseName)
                         .font(.subheadline)
                         .foregroundColor(.primary)
-                    Text("on \(release.platform.capitalized)")
+                    Text("on \(release.displayPlatform)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/apps/mac/UnstreamTests/ReleaseAlertTests.swift
+++ b/apps/mac/UnstreamTests/ReleaseAlertTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import Unstream
+
+/// Release alerts: the dedup rule, and the notification body.
+///
+/// The dedup tests exist because of a bug that lost data permanently rather than merely
+/// displaying it wrong (spec §5 defect 1). `ReleaseAlertManager` had two layers of dedup:
+/// the inner one, in `checkViaAPI`, correctly matched on release name and recorded the release
+/// as known; the outer one then asked whether the display list already held *any* release by
+/// that artist and dropped the release if it did. So an artist with an unread alert who put out
+/// a second record had that second record dropped from the list and the notification while
+/// already being marked known — making it undetectable on every future check.
+///
+/// `ReleaseCheckState` is the piece that decides "have we seen this before", so that is what
+/// these exercise directly.
+final class ReleaseAlertTests: XCTestCase {
+
+    private func known(_ name: String, platform: String = "bandcamp") -> KnownRelease {
+        KnownRelease(releaseName: name, releaseDate: Date(timeIntervalSince1970: 0), platform: platform)
+    }
+
+    // MARK: - Dedup identity
+
+    func testSecondReleaseFromSameArtistIsNotAlreadyKnown() {
+        var state = ReleaseCheckState()
+        state.addKnownRelease(known("First Record"), for: "Someone")
+
+        // The exact case the old outer dedup got wrong: same artist, different record.
+        XCTAssertTrue(state.isKnownReleaseByName("First Record", for: "Someone"))
+        XCTAssertFalse(
+            state.isKnownReleaseByName("Second Record", for: "Someone"),
+            "A different release by a known artist must not count as already seen"
+        )
+    }
+
+    func testSameReleaseOnAnotherPlatformIsAlreadyKnown() {
+        var state = ReleaseCheckState()
+        state.addKnownRelease(known("Infinite Normal", platform: "bandcamp"), for: "Kid Lightbulbs")
+
+        // One record on two platforms is one alert, not two.
+        XCTAssertTrue(state.isKnownReleaseByName("Infinite Normal", for: "Kid Lightbulbs"))
+    }
+
+    func testKnownReleasesAreScopedToTheArtist() {
+        var state = ReleaseCheckState()
+        state.addKnownRelease(known("Greatest Hits"), for: "Artist A")
+
+        XCTAssertFalse(
+            state.isKnownReleaseByName("Greatest Hits", for: "Artist B"),
+            "Two artists can release records with the same title"
+        )
+    }
+
+    func testArtistMatchingIsCaseInsensitive() {
+        var state = ReleaseCheckState()
+        state.addKnownRelease(known("A Record"), for: "Sigur Rós")
+
+        XCTAssertTrue(state.isKnownReleaseByName("a record", for: "sigur rós"))
+    }
+
+    func testAddingTheSameReleaseTwiceDoesNotDuplicateIt() {
+        var state = ReleaseCheckState()
+        state.addKnownRelease(known("A Record"), for: "Someone")
+        state.addKnownRelease(known("A Record"), for: "Someone")
+
+        XCTAssertEqual(state.releases(for: "Someone").count, 1)
+    }
+
+    // MARK: - The defect itself, across two checks
+
+    private func result(_ name: String, platform: String = "bandcamp") -> ReleaseCheckResult {
+        ReleaseCheckResult(
+            releaseName: name,
+            releaseDate: Date(timeIntervalSince1970: 1_756_684_800),
+            releaseUrl: "https://unstream.stream/a/someone/\(name.lowercased().replacingOccurrences(of: " ", with: "-"))",
+            platform: platform
+        )
+    }
+
+    /// The regression test for spec §5 defect 1, replayed as it actually happened: a first check
+    /// finds one record and the fan never opens the alert, then a second check finds a second
+    /// record while the first is still unread.
+    ///
+    /// Under the old code the second record was dropped — the outer dedup saw "this artist
+    /// already has an unread alert" — *after* `checkViaAPI` had already written it to
+    /// `knownReleases`. So it never appeared and could never be found again.
+    func testSecondReleaseSurvivesWhileTheFirstIsStillUnread() {
+        var state = ReleaseCheckState()
+
+        let firstCheck = ReleaseAlertManager.selectUnseen(
+            [result("First Record")], artistName: "Someone", state: &state
+        )
+        XCTAssertEqual(firstCheck.map(\.releaseName), ["First Record"])
+
+        // The fan hasn't dismissed it; it's still sitting in the display list.
+        let secondCheck = ReleaseAlertManager.selectUnseen(
+            [result("Second Record"), result("First Record")], artistName: "Someone", state: &state
+        )
+
+        XCTAssertEqual(
+            secondCheck.map(\.releaseName),
+            ["Second Record"],
+            "The new record must come through, and the already-seen one must not repeat"
+        )
+    }
+
+    func testTwoNewReleasesInOneCheckBothComeThrough() {
+        var state = ReleaseCheckState()
+
+        let found = ReleaseAlertManager.selectUnseen(
+            [result("A"), result("B")], artistName: "Someone", state: &state
+        )
+
+        XCTAssertEqual(found.map(\.releaseName), ["A", "B"])
+    }
+
+    func testTheSameRecordOnTwoPlatformsIsOneAlert() {
+        var state = ReleaseCheckState()
+
+        let found = ReleaseAlertManager.selectUnseen(
+            [result("Infinite Normal", platform: "bandcamp"), result("Infinite Normal", platform: "mirlo")],
+            artistName: "Kid Lightbulbs",
+            state: &state
+        )
+
+        XCTAssertEqual(found.count, 1)
+    }
+
+    func testRecheckingWithNothingNewReturnsNothing() {
+        var state = ReleaseCheckState()
+        _ = ReleaseAlertManager.selectUnseen([result("A")], artistName: "Someone", state: &state)
+
+        let again = ReleaseAlertManager.selectUnseen([result("A")], artistName: "Someone", state: &state)
+
+        XCTAssertTrue(again.isEmpty)
+    }
+
+    func testCarriesTheCatalogFieldsOntoTheAlert() {
+        var state = ReleaseCheckState()
+        let rich = ReleaseCheckResult(
+            releaseName: "Infinite Normal",
+            releaseDate: Date(timeIntervalSince1970: 1_756_684_800),
+            releaseUrl: "https://unstream.stream/a/kid-lightbulbs/infinite-normal",
+            platform: "bandcamp",
+            platforms: ["bandcamp", "mirlo"],
+            status: "announced",
+            offerSummary: "from $8 · ≈$6.80 to artist"
+        )
+
+        let found = ReleaseAlertManager.selectUnseen([rich], artistName: "Kid Lightbulbs", state: &state)
+
+        XCTAssertEqual(found.first?.platforms, ["bandcamp", "mirlo"])
+        XCTAssertEqual(found.first?.offerSummary, "from $8 · ≈$6.80 to artist")
+        XCTAssertTrue(found.first?.isUpcoming ?? false)
+    }
+
+    // MARK: - Notification body (defect 7)
+
+    private func release(
+        name: String = "Infinite Normal",
+        platform: String = "bandcamp",
+        platforms: [String] = [],
+        status: String = "released",
+        offerSummary: String = "",
+        date: Date = Date(timeIntervalSince1970: 1_756_684_800) // 2025-09-01
+    ) -> NewRelease {
+        NewRelease(
+            artistName: "Kid Lightbulbs",
+            releaseName: name,
+            releaseDate: date,
+            releaseUrl: "https://unstream.stream/a/kid-lightbulbs/infinite-normal",
+            platform: platform,
+            platforms: platforms,
+            status: status,
+            offerSummary: offerSummary
+        )
+    }
+
+    func testBodyNamesEveryPlatformAndThePrice() {
+        let body = ReleaseAlertManager.notificationBody(
+            for: release(platforms: ["bandcamp", "mirlo"], offerSummary: "from $8 · ≈$6.80 to artist")
+        )
+
+        XCTAssertTrue(body.contains("Bandcamp and Mirlo"), body)
+        XCTAssertTrue(body.contains("from $8"), body)
+        XCTAssertTrue(body.contains("to artist"), body)
+    }
+
+    func testBodyOmitsThePriceClauseRatherThanInventingOne() {
+        let body = ReleaseAlertManager.notificationBody(for: release(offerSummary: ""))
+
+        XCTAssertEqual(body, "\"Infinite Normal\" — out now on Bandcamp")
+        XCTAssertFalse(body.contains("·"), "No trailing separator when there is no price")
+    }
+
+    func testUpcomingReleaseReadsAsAnnouncedNotOutNow() {
+        let body = ReleaseAlertManager.notificationBody(for: release(status: "announced"))
+
+        XCTAssertTrue(body.contains("announced"), body)
+        XCTAssertFalse(body.contains("out now"), body)
+    }
+
+    func testPlatformNamesUseTheCatalogNotCapitalization() {
+        // `.capitalized` renders these "Jamcoop" and "Kofi".
+        let body = ReleaseAlertManager.notificationBody(for: release(platform: "jamcoop", platforms: ["jamcoop"]))
+
+        XCTAssertTrue(body.contains("Jam.coop"), body)
+        XCTAssertFalse(body.contains("Jamcoop"), body)
+    }
+
+    func testLongPlatformListIsSummarized() {
+        let body = ReleaseAlertManager.notificationBody(
+            for: release(platforms: ["bandcamp", "mirlo", "jamcoop", "discogs"])
+        )
+
+        XCTAssertTrue(body.contains("Bandcamp, Mirlo and 2 more"), body)
+    }
+
+    // MARK: - Persistence compatibility
+
+    /// Alerts stored by an earlier build have none of the three fields added alongside the
+    /// catalog rewiring. Decoding must fill them in rather than throwing, which would discard a
+    /// fan's whole stored alert list on upgrade.
+    func testDecodesAnAlertPersistedByAnOlderBuild() throws {
+        let legacy = """
+        {
+          "id": "\(UUID().uuidString)",
+          "artistName": "Kid Lightbulbs",
+          "releaseName": "Infinite Normal",
+          "releaseDate": 750000000,
+          "releaseUrl": "https://kidlightbulbs.bandcamp.com/album/infinite-normal",
+          "platform": "bandcamp",
+          "detectedAt": 750000000
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(NewRelease.self, from: legacy)
+
+        XCTAssertEqual(decoded.releaseName, "Infinite Normal")
+        XCTAssertEqual(decoded.platforms, ["bandcamp"])
+        XCTAssertEqual(decoded.status, "released")
+        XCTAssertEqual(decoded.offerSummary, "")
+        XCTAssertFalse(decoded.isUpcoming)
+    }
+}

--- a/apps/web/src/components/ReleaseFeedControls.tsx
+++ b/apps/web/src/components/ReleaseFeedControls.tsx
@@ -1,0 +1,163 @@
+import { useState, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface FeedUrls {
+  ics: string;
+  atom: string;
+}
+
+/**
+ * Subscribe to a private calendar of upcoming releases from your saved artists.
+ *
+ * The link is **not fetched on mount.** A feed token is a credential, and one is created the
+ * first time it's asked for — so loading /settings shouldn't mint one for every visitor who
+ * never wanted a calendar. The user presses a button; that press is the request.
+ *
+ * The URL is deliberately shown in full rather than hidden behind a copy button alone: calendar
+ * clients are subscribed to by pasting a URL, and a user needs to be able to get at it on a
+ * second device. It's treated as a secret in the copy ("anyone with this link…") rather than in
+ * the markup, which matches how Google and Apple present their own private calendar addresses.
+ */
+export function ReleaseFeedControls() {
+  const { session } = useAuth();
+  const [urls, setUrls] = useState<FeedUrls | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<'ics' | 'atom' | null>(null);
+  const [confirmingRotate, setConfirmingRotate] = useState(false);
+
+  const call = useCallback(
+    async (method: 'GET' | 'POST' | 'DELETE') => {
+      if (!session) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/me/feed-token', {
+          method,
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!res.ok) throw new Error(`feed-token ${method} failed: ${res.status}`);
+
+        const data = await res.json();
+        setUrls(data.revoked ? null : { ics: data.ics, atom: data.atom });
+      } catch (e) {
+        Sentry.captureException(e, { extra: { context: 'ReleaseFeedControls.call', method } });
+        setError('Something went wrong. Please try again.');
+      } finally {
+        setBusy(false);
+        setConfirmingRotate(false);
+      }
+    },
+    [session]
+  );
+
+  const copy = async (which: 'ics' | 'atom', value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(which);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      // Clipboard can be blocked by permissions; the URL is on screen to copy by hand.
+    }
+  };
+
+  if (!urls) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-text-muted">
+          Subscribe once in Apple Calendar, Google Calendar, or an RSS reader and see everything
+          your saved artists have coming — not one subscription per artist.
+        </p>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <button
+          onClick={() => call('GET')}
+          disabled={busy || !session}
+          className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? 'Creating…' : 'Create my feed link'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-muted">
+        Anyone with these links can see what your saved artists have coming, so treat them like a
+        password. Rotating issues new links and stops the old ones working everywhere.
+      </p>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {/*
+        The extension is in the label as well as the URL. The two links differ *only* in their
+        last four characters, which is exactly the part an input this width truncates — so on
+        screen they look identical and it's easy to paste the wrong one into a calendar client
+        and get nothing. Naming the extension is cheaper than fighting the input's scroll
+        position.
+      */}
+      {([
+        { key: 'ics', label: 'Calendar (Apple, Google)', ext: '.ics', value: urls.ics },
+        { key: 'atom', label: 'RSS reader', ext: '.xml', value: urls.atom },
+      ] as const).map(({ key, label, ext, value }) => (
+        <div key={key} className="space-y-1">
+          <label className="text-xs uppercase tracking-wide text-text-muted">
+            {label} <span className="font-mono normal-case text-text-primary">{ext}</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              readOnly
+              value={value}
+              onFocus={e => e.currentTarget.select()}
+              className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-bg-primary border border-border text-sm font-mono text-text-primary"
+            />
+            <button
+              onClick={() => copy(key, value)}
+              className="px-3 py-2 rounded-lg border border-border text-sm hover:bg-bg-primary shrink-0"
+            >
+              {copied === key ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      ))}
+
+      <div className="flex flex-wrap gap-2 pt-2">
+        {confirmingRotate ? (
+          <>
+            <button
+              onClick={() => call('POST')}
+              disabled={busy}
+              className="px-3 py-2 rounded-lg bg-red-500/90 text-white text-sm font-medium hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? 'Rotating…' : 'Yes, break existing subscriptions'}
+            </button>
+            <button
+              onClick={() => setConfirmingRotate(false)}
+              className="px-3 py-2 rounded-lg border border-border text-sm hover:bg-bg-primary"
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => setConfirmingRotate(true)}
+              disabled={busy}
+              className="px-3 py-2 rounded-lg border border-border text-sm hover:bg-bg-primary disabled:opacity-50"
+            >
+              Rotate links
+            </button>
+            <button
+              onClick={() => call('DELETE')}
+              disabled={busy}
+              className="px-3 py-2 rounded-lg border border-border text-sm text-text-muted hover:bg-bg-primary disabled:opacity-50"
+            >
+              Turn off
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -57,7 +57,36 @@ export function ReleasesSection({
 
   return (
     <div className="mt-6">
-      <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3">Releases</h2>
+      {/*
+        The feed links live in the heading rather than under the list. They were a separate line
+        at the foot of the section first, which put them furthest from the thing they subscribe
+        to and read as a stray footnote. Sitting in the heading they're findable without taking
+        any vertical space of their own.
+
+        Plain <a>, not react-router <Link>: these are served by a Netlify function, so a
+        client-side navigation would try to render them in-app and fail.
+      */}
+      <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3">
+        Releases
+        <span aria-hidden="true"> · </span>
+        <span className="sr-only">— </span>
+        Subscribe via{' '}
+        <a
+          href={`/a/${encodeURIComponent(artistSlug)}/releases.xml`}
+          className="hover:text-accent-primary hover:underline"
+          title="Subscribe in an RSS reader"
+        >
+          RSS
+        </a>
+        {' or '}
+        <a
+          href={`/a/${encodeURIComponent(artistSlug)}/releases.ics`}
+          className="hover:text-accent-primary hover:underline"
+          title="Subscribe in Apple Calendar, Google Calendar or another calendar app"
+        >
+          ICS
+        </a>
+      </h2>
       <div className="grid gap-2 sm:grid-cols-2">
         {shown.map(release => (
           <ReleaseRow key={release.slug} release={release} artistSlug={artistSlug} />
@@ -82,32 +111,6 @@ export function ReleasesSection({
         <p className="mt-2.5 text-center text-xs text-text-muted">and {total - releases.length} more</p>
       )}
 
-      {/*
-        The per-artist feeds had no entry point anywhere in the app — they worked, but the only
-        way to find one was to already know the URL. This is the natural place: it sits with the
-        releases it describes, and only renders when there are releases to follow.
-
-        Plain <a> rather than react-router <Link>: these are not SPA routes. They are served by
-        a Netlify function, so a client-side navigation would try to render them in-app and fail.
-      */}
-      <p className="mt-3 text-center text-xs text-text-muted">
-        Follow for new releases:{' '}
-        <a
-          href={`/a/${encodeURIComponent(artistSlug)}/releases.ics`}
-          className="text-accent-primary hover:underline"
-          title="Subscribe in Apple Calendar, Google Calendar or another calendar app"
-        >
-          ICS
-        </a>
-        {' · '}
-        <a
-          href={`/a/${encodeURIComponent(artistSlug)}/releases.xml`}
-          className="text-accent-primary hover:underline"
-          title="Subscribe in an RSS reader"
-        >
-          XML
-        </a>
-      </p>
     </div>
   );
 }

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -58,33 +58,35 @@ export function ReleasesSection({
   return (
     <div className="mt-6">
       {/*
-        The feed links live in the heading rather than under the list. They were a separate line
-        at the foot of the section first, which put them furthest from the thing they subscribe
-        to and read as a stray footnote. Sitting in the heading they're findable without taking
-        any vertical space of their own.
+        The feed links live in the heading rather than under the list — as icons, since the
+        calendar and RSS marks are both conventional enough to carry the meaning without the
+        words. They were a full sentence at the foot of the section first, which put them
+        furthest from the thing they subscribe to and read as a stray footnote.
+
+        Icon-only, so each anchor carries an `aria-label`: a screen reader would otherwise
+        announce nothing but the link. `title` gives the same text as a hover tooltip for
+        sighted users, who get no other explanation of what the marks do.
 
         Plain <a>, not react-router <Link>: these are served by a Netlify function, so a
         client-side navigation would try to render them in-app and fail.
       */}
-      <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3">
+      <h2 className="text-xs uppercase tracking-wider text-text-muted mb-3 flex items-center gap-2">
         Releases
-        <span aria-hidden="true"> · </span>
-        <span className="sr-only">— </span>
-        Subscribe via{' '}
-        <a
-          href={`/a/${encodeURIComponent(artistSlug)}/releases.xml`}
-          className="hover:text-accent-primary hover:underline"
-          title="Subscribe in an RSS reader"
-        >
-          RSS
-        </a>
-        {' or '}
         <a
           href={`/a/${encodeURIComponent(artistSlug)}/releases.ics`}
-          className="hover:text-accent-primary hover:underline"
+          className="text-text-muted hover:text-accent-primary transition-colors"
+          aria-label="Subscribe to this artist's releases in a calendar app"
           title="Subscribe in Apple Calendar, Google Calendar or another calendar app"
         >
-          ICS
+          <CalendarIcon />
+        </a>
+        <a
+          href={`/a/${encodeURIComponent(artistSlug)}/releases.xml`}
+          className="text-text-muted hover:text-accent-primary transition-colors"
+          aria-label="Subscribe to this artist's releases in an RSS reader"
+          title="Subscribe in an RSS reader"
+        >
+          <RssIcon />
         </a>
       </h2>
       <div className="grid gap-2 sm:grid-cols-2">
@@ -208,5 +210,49 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
         </span>
       )}
     </a>
+  );
+}
+
+/**
+ * Both marks are drawn as strokes at the same weight so they read as a pair. The RSS icon is
+ * conventionally solid, but a filled mark beside an outlined calendar looks like two icons from
+ * different sets — the stroked arcs are just as recognisable at this size.
+ *
+ * `aria-hidden` because the surrounding anchor already carries the accessible name; without it a
+ * screen reader announces the link twice.
+ */
+function CalendarIcon() {
+  return (
+    <svg
+      className="w-3.5 h-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5" width="18" height="16" rx="2" />
+      <path d="M3 10h18M8 3v4M16 3v4" />
+    </svg>
+  );
+}
+
+function RssIcon() {
+  return (
+    <svg
+      className="w-3.5 h-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 11a9 9 0 019 9M4 4a16 16 0 0116 16" />
+      <circle cx="5" cy="19" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
   );
 }

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -81,6 +81,33 @@ export function ReleasesSection({
       {total > releases.length && (
         <p className="mt-2.5 text-center text-xs text-text-muted">and {total - releases.length} more</p>
       )}
+
+      {/*
+        The per-artist feeds had no entry point anywhere in the app — they worked, but the only
+        way to find one was to already know the URL. This is the natural place: it sits with the
+        releases it describes, and only renders when there are releases to follow.
+
+        Plain <a> rather than react-router <Link>: these are not SPA routes. They are served by
+        a Netlify function, so a client-side navigation would try to render them in-app and fail.
+      */}
+      <p className="mt-3 text-center text-xs text-text-muted">
+        Follow for new releases:{' '}
+        <a
+          href={`/a/${encodeURIComponent(artistSlug)}/releases.ics`}
+          className="text-accent-primary hover:underline"
+          title="Subscribe in Apple Calendar, Google Calendar or another calendar app"
+        >
+          ICS
+        </a>
+        {' · '}
+        <a
+          href={`/a/${encodeURIComponent(artistSlug)}/releases.xml`}
+          className="text-accent-primary hover:underline"
+          title="Subscribe in an RSS reader"
+        >
+          XML
+        </a>
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { UsernameField } from '../components/UsernameField';
 import { LocationField } from '../components/LocationField';
 import { PasswordChangeForm } from '../components/PasswordChangeForm';
 import { SharingControls } from '../components/SharingControls';
+import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 
@@ -97,6 +98,12 @@ export function SettingsPage() {
           <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
             <h2 className="text-lg font-semibold">Sharing</h2>
             <SharingControls />
+          </section>
+
+          {/* Release feed section */}
+          <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
+            <h2 className="text-lg font-semibold">Release calendar</h2>
+            <ReleaseFeedControls />
           </section>
 
           {/* Password section */}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -87,6 +87,11 @@ export default defineConfig({
           /^\/u\//,
           /^\/guides\//,
           /^\/search/,
+          // Release feeds (.ics/.xml) are served by a Netlify function, not the SPA. Calendar
+          // clients never touch the SW, but a user clicking their own feed link in the browser
+          // is a navigation, and the cached shell would hand them an HTML page instead of the
+          // calendar. /a/ and /u/ above already cover the two public feed shapes.
+          /^\/feed\//,
         ],
         runtimeCaching: [
           {

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,11 @@
 # path segments: exactly two under /a/. Netlify's `path` globs can't express that.
 [[edge_functions]]
   pattern = "^/a/[^/]+/[^/]+/?$"
+  # /a/{artist}/releases.xml is two segments too, so without this the release-page renderer
+  # would try to look up a release whose slug is "releases.xml". Feeds are served by a Netlify
+  # function (see the /a/*/releases.* redirect below) — edge functions run *before* redirects,
+  # so the exclusion has to be declared here or the redirect is never reached.
+  excludedPattern = "^/a/[^/]+/releases\\.(ics|xml)$"
   function = "release-page"
 
 [[edge_functions]]
@@ -35,6 +40,9 @@
 
 [[edge_functions]]
   path = "/a/*"
+  # Same exclusion, for the same reason: excluding the feed path from release-page above only
+  # drops it through to this entry, whose glob matches it just as happily.
+  excludedPattern = "^/a/[^/]+/releases\\.(ics|xml)$"
   function = "artist-page-static"
 
 [[edge_functions]]
@@ -47,6 +55,8 @@
 
 [[edge_functions]]
   path = "/u/*"
+  # /u/{handle}/releases.ics and .xml are feeds, not the shared-list HTML page.
+  excludedPattern = "^/u/[^/]+/releases\\.(ics|xml)$"
   function = "u-handle"
 
 [[redirects]]
@@ -233,6 +243,42 @@
 [[redirects]]
   from = "/api/v1/keys"
   to = "/.netlify/functions/api-key-generate"
+  status = 200
+
+# Release feeds. All three shapes hit one function, which reads the route off the path.
+#
+# These MUST stay above the SPA catch-all: redirects are first-match-wins, and `/*` would
+# otherwise hand a calendar client an HTML page. The two public ones also need the
+# `excludedPattern` entries on the /a/* and /u/* edge functions above, since edge functions run
+# before redirects.
+[[redirects]]
+  from = "/feed/f/*"
+  to = "/.netlify/functions/feed-releases"
+  status = 200
+
+[[redirects]]
+  from = "/u/:handle/releases.ics"
+  to = "/.netlify/functions/feed-releases"
+  status = 200
+
+[[redirects]]
+  from = "/u/:handle/releases.xml"
+  to = "/.netlify/functions/feed-releases"
+  status = 200
+
+[[redirects]]
+  from = "/a/:artist/releases.xml"
+  to = "/.netlify/functions/feed-releases"
+  status = 200
+
+[[redirects]]
+  from = "/a/:artist/releases.ics"
+  to = "/.netlify/functions/feed-releases"
+  status = 200
+
+[[redirects]]
+  from = "/api/me/feed-token"
+  to = "/.netlify/functions/me-feed-token"
   status = 200
 
 [[redirects]]

--- a/supabase/migrations/20260802000000_release-feed-tokens.sql
+++ b/supabase/migrations/20260802000000_release-feed-tokens.sql
@@ -1,0 +1,62 @@
+-- Migration: per-fan release feed tokens
+--
+-- Backs /feed/f/{token}.ics and /feed/f/{token}.xml — one private, subscribable calendar/feed
+-- of upcoming releases across everything a fan has saved (spec §3).
+--
+-- WHY A TOKEN IN THE URL AT ALL: calendar clients cannot authenticate. Apple Calendar and
+-- Google Calendar fetch a URL on a schedule with no OAuth, no bearer header and no cookies. An
+-- opaque, unguessable, rotatable path token is therefore the only workable private feed, and it
+-- is the same design Google and Apple use for their own "secret address" calendar exports.
+--
+-- WHY THE TOKEN IS STORED IN PLAINTEXT, unlike api_keys which are hashed:
+-- a hashed token could never be shown to its owner again, and a calendar feed URL is something
+-- the user has to be able to re-read and re-copy (new device, re-subscribing, moving clients).
+-- api_keys can be hashed precisely because they are shown once and replaced when lost; this
+-- cannot. It is still treated as a credential everywhere else: RLS restricts SELECT to the
+-- owner, the serving function never logs it, and it must never reach analytics or Sentry.
+--
+-- Rotation, not just revocation, is the recovery path: a leaked feed URL is fixed by issuing a
+-- new token, which instantly breaks every existing subscription to the old one.
+
+CREATE TABLE IF NOT EXISTS public.release_feed_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- One token per user. Rotation replaces the value in place rather than accumulating rows,
+  -- so an old token stops working the moment a new one is issued.
+  user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rotated_at TIMESTAMPTZ
+);
+
+-- The serving path's only query: token -> user. Unique already indexes it, named here so the
+-- intent survives a future change to the constraint.
+CREATE INDEX IF NOT EXISTS idx_release_feed_tokens_token ON public.release_feed_tokens(token);
+
+ALTER TABLE public.release_feed_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Owner-only. The feed function itself reads with the service-role client (which bypasses RLS)
+-- because an anonymous calendar client presents no session — the token *is* the authorization
+-- there. These policies exist so that a signed-in user reading their own row from the browser
+-- is safe, and so nobody else's row is ever reachable.
+DROP POLICY IF EXISTS "Users can view own feed token" ON public.release_feed_tokens;
+CREATE POLICY "Users can view own feed token"
+  ON public.release_feed_tokens FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can create own feed token" ON public.release_feed_tokens;
+CREATE POLICY "Users can create own feed token"
+  ON public.release_feed_tokens FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can rotate own feed token" ON public.release_feed_tokens;
+CREATE POLICY "Users can rotate own feed token"
+  ON public.release_feed_tokens FOR UPDATE
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can revoke own feed token" ON public.release_feed_tokens;
+CREATE POLICY "Users can revoke own feed token"
+  ON public.release_feed_tokens FOR DELETE
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE public.release_feed_tokens IS
+  'Opaque path tokens for private release feeds (/feed/f/{token}.ics). Stored in plaintext because the owner must be able to re-read the URL; treat as a credential — never log it.';

--- a/supabase/migrations/20260802120000_reread-bandcamp-track-prices.sql
+++ b/supabase/migrations/20260802120000_reread-bandcamp-track-prices.sql
@@ -1,0 +1,31 @@
+-- Migration: let the Bandcamp track-page price fix actually take effect
+--
+-- A parser fix is deployed but **inert** until whatever guards re-reading is cleared. The detail
+-- pass only re-reads a source whose `detail_checked_at` is null or older than 30 days, and every
+-- affected row was stamped during the first production catalog runs — so without this the fix
+-- would sit dead until roughly 2026-08-31 and the pages would keep saying "No formats listed on
+-- this page" for a month.
+--
+-- What was wrong: `parseBandcampReleaseDetail` only read a *top-level* `albumRelease`, which
+-- standalone `/track/` pages don't have — theirs lives at `inAlbum.albumRelease`. Measured at the
+-- time of the fix: 184 of 777 detail-read Bandcamp sources had zero offers, and 183 of those 184
+-- were `/track/` URLs (every single one of the 533 sources *with* offers was an `/album/` URL).
+-- The data was always published; we were looking in the wrong place.
+--
+-- Clearing the stamp rather than deleting anything: `detail_checked_at` is the only thing being
+-- reset, so no offer, price or release row is touched. Re-reads then happen gradually through the
+-- normal budgeted detail pass (100 requests per invocation, ~1/sec, and only for artists that get
+-- catalogued again), not as a burst — this queues work, it does not perform it.
+--
+-- Scoped as narrowly as the bug: Bandcamp only, `/track/` URLs only, and only rows that have
+-- actually been read and came back with **no offers at all**. A track page that already produced
+-- an offer was never affected and is left alone.
+
+UPDATE public.release_sources AS rs
+SET detail_checked_at = NULL
+WHERE rs.platform = 'bandcamp'
+  AND rs.url LIKE '%/track/%'
+  AND rs.detail_checked_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.release_offers ro WHERE ro.release_source_id = rs.id
+  );


### PR DESCRIPTION
Completes the Releases V1 scope. Steps 10, 5 and 6, in that order.

## Step 10 — Jam.coop ingest

**Mirlo was re-checked live rather than trusted from the spec:** `api.mirlo.space/robots.txt` still carries `Disallow: /v1/` under its `# Disallow crawling the API` comment, so it stays paused. Subvert still answers HTTP 429 to everything.

**Jam.coop was built instead, and it is the best-shaped source after Bandcamp:**
- Its `robots.txt` contains a single comment and **no `Disallow` at all**
- It is entirely server-rendered (unlike Bandwagon, which returned nothing)
- **One album-page fetch yields everything** — title, artwork, date, price, currency, format. Faircamp needs two requests and never has a date; Bandcamp needs grid-plus-detail.

Two calls worth reviewing:
- **`£7.00 or more` publishes as `7.00`.** The floor is what a fan can actually pay — the same call `ingestFaircampPurchasePage` makes about Faircamp's `data-min`. A genuine `£0.00 or more` stays `0`, which renders "Name your price".
- **Only `£ € $` are mapped.** Any other symbol yields *no offer*, because `formatMoney` defaults a null currency to USD and would render "¥800" as "$800".

Verified against live markup before the parser was written, and the four parser guards were mutation-tested.

## Step 5 — alerts come from the catalog

`check-releases` reads the catalog and falls back to the live scrape **only when an artist has never been catalogued**. That distinction is load-bearing: `null` means "we have not looked", `[]` means "we looked and there is nothing". Collapsing them would either switch alerts off for every artist nobody has saved yet, or re-scrape Bandcamp for everyone forever.

| # | Spec §5 defect | Status |
|---|---|---|
| 1 | Second release from one artist lost permanently (Mac) | ✅ Fixed — see below |
| 2 | Upcoming releases impossible to alert on | ✅ Fixed. The catalogue holds **2 future-dated releases** that could never have fired before |
| 3 | Only latest release per platform seen | ✅ Fixed on the catalog path |
| 4 | Multi-platform releases collapsed | ✅ Fixed — all platforms, artist-paying first. The hardcoded list is *deliberately* left on the live-scrape path (see code comment) |
| 5 | Closed laptop loses releases | 🟡 Partial — server accepts `sinceDays`; shipped clients don't send it yet |
| 6 | Alert state doesn't sync across devices | ❌ Not built — needs a synced table + both clients. **Decide separately** |
| 7 | Thin notification body | ✅ Fixed |

**Defect 1 is the one that lost data.** The outer dedup in `checkAllArtists` matched on artist *name* against the display list, and ran *after* `checkViaAPI` had already recorded the release as known — so an artist's genuinely-new second record was dropped from both the list and the notification while being marked as seen, making it undetectable forever after. Dedup is now a single pure `selectUnseen`, with a regression test that replays the two-check scenario. Neutralising the fix fails that test.

**Backwards-compatible:** `release` (singular) is still populated for the shipped Mac app (3.3.x) and extension (2.5.x); everything else is additive. Both decode `platform` as a plain string and ignore unknown keys.

## Step 6 — per-fan feeds

`/feed/f/{token}.ics|.xml` (private, primary), plus public `/u/{handle}/releases.*` (gated on the existing sharing opt-in) and `/a/{artist}/releases.*`. Token management in `/settings`.

**The token is stored plaintext, unlike `api_keys` which are hashed** — a hashed token could never be shown to its owner again, and a calendar URL has to be re-readable on a new device. It is treated as a credential everywhere else: owner-only RLS, never logged, `private, no-store`, `noindex`, and **404 rather than 401** on a bad token so it can't be probed.

**Deliberate deviation from spec §3, easy to revert.** §3 says *upcoming only* ("a calendar of past releases is a changelog"). This ships upcoming **plus a 30-day trailing window**. Measured first: 621 releases, 613 dated, but only **2 future-dated** and **9** within thirty-days-plus-future — upcoming-only would leave nearly every calendar empty. One constant (`FEED_TRAILING_DAYS`).

Two routing traps: `/a/{artist}/releases.xml` matches the two-segment `release-page` edge pattern and `/u/{handle}/releases.ics` matches `/u/*`, and **edge functions run before redirects** — hence `excludedPattern` on both. And `event.path` is unreliable behind a `status = 200` rewrite; `rawUrl` is not.

## Verification

- Build ✓ · **631 API tests** ✓ · **528 web unit tests** ✓ · **21 Mac XCTests** ✓
- Every new security/correctness guard was **mutation-tested** — neutralise it, confirm the test fails, restore. That caught two of my own tests passing for the wrong reason, one of which was guarding **unreachable dead code** (now deleted).
- **Rendered a real ICS from production data**, not just mocks: Boy Harsher's *GET MEAN* (2026-09-18) — valid, correctly folded, CRLF, `On Bandcamp / from $9 · ≈$7.20–$7.65 to artist`.
- Settings UI verified in dark, light and mobile.

## Migration

`20260802000000_release-feed-tokens.sql` — new `release_feed_tokens` table with owner-only RLS. Applies automatically on merge.

## Not in this PR

- **Defect 6** (cross-device alert state).
- **Native release UI** for the Mac app and extension — explored separately; needs a `get-release` endpoint first.
- **Jam.coop's payout percentage** — they take 15% (min 20p), so it isn't the `null` the registry currently has. Follow-up.

## Two pre-existing problems noticed, not fixed

- `npm run migrate:dry-run` / `migrate:list` are broken — they pass `--project-ref`, which the Supabase CLI no longer accepts.
- A junk row is in the catalogue: *"NanoPolix Nano Car Cloth: Automotive Paint Maintenance and Surface Care"*, almost certainly a bad Discogs artist match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)