### PR TITLE
Make zero-result searches and post-deploy login failures legible in Sentry

### DIFF
--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2053,6 +2053,21 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       if (shouldCapture) {
         Sentry.captureMessage('Search returned 0 results', {
           level: 'info',
+          // The query has to be a TAG, not just an extra. Every zero-result event
+          // shares one message, so Sentry folds them into a single issue where
+          // `extra` is only readable one event at a time — you can't see which
+          // searches came back empty without paging through them. Tags get an
+          // aggregated value distribution on the issue page and are searchable
+          // (`search_query:radiohead`), which is the whole point of this signal.
+          // Both values are already length-capped by validateQuery (200 chars),
+          // which is also Sentry's tag-value limit.
+          tags: {
+            search_query: normalizedQuery,
+            // 'exact' means a playback-detection client (extension, Mac app) sent a
+            // real artist name and we have no coverage; 'fuzzy' means a human typed
+            // it and it may just be a typo. Very different follow-ups.
+            search_mode: mode,
+          },
           extra: {
             query,
             normalizedQuery,

--- a/apps/web/src/components/AppFallback.tsx
+++ b/apps/web/src/components/AppFallback.tsx
@@ -23,14 +23,28 @@ export function AppErrorFallback() {
     <div className="min-h-screen bg-bg-primary text-text-primary flex flex-col items-center justify-center gap-4 p-6 text-center">
       <h1 className="font-display text-2xl font-semibold">Something went wrong</h1>
       <p className="text-text-muted max-w-md">
-        Unstream hit an unexpected error. Reloading usually clears it.
+        Unstream hit an unexpected error. Reloading usually clears it — that
+        normally means a new version shipped while this page was open.
       </p>
-      <a
-        href="/"
-        className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
-      >
-        Back to Unstream
-      </a>
+      <div className="flex items-center gap-3">
+        {/* Reload beats the "Back to Unstream" link for the common cause: a page
+            left open across a deploy, whose old JS files no longer exist. It
+            re-fetches the current URL on the new build instead of dumping the
+            person back on the homepage. */}
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
+        >
+          Reload
+        </button>
+        <a
+          href="/"
+          className="px-4 py-2 rounded-lg border border-border text-text-primary text-sm font-medium hover:bg-bg-secondary transition-colors"
+        >
+          Back to Unstream
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import * as Sentry from '@sentry/react';
 import { getSupabaseClient, waitForMagicLinkSession } from '../services/auth';
@@ -43,6 +43,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [savedArtistIds, setSavedArtistIds] = useState<Set<string>>(new Set());
   const [artistsLoaded, setArtistsLoaded] = useState(false);
 
+  // The auth listener below is installed once, so it cannot read `session` state:
+  // that closure is pinned to the initial null forever, which is why the
+  // "session ended unexpectedly" report has never fired a single time. A ref
+  // holds the live value instead.
+  const sessionRef = useRef<Session | null>(null);
+  // Set while our own signOut() runs, so a deliberate sign-out isn't reported as
+  // a session dropping out from under the user.
+  const signingOutRef = useRef(false);
+
   useEffect(() => {
     const supabase = getSupabaseClient();
     if (!supabase) {
@@ -59,6 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Clear the hash from the URL
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
         if (!cancelled && magicSession) {
+          sessionRef.current = magicSession;
           setSession(magicSession);
           setUser(magicSession.user);
         }
@@ -66,6 +76,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Check for existing session — fast, no domain data
         const { data } = await supabase!.auth.getSession();
         if (!cancelled && data.session) {
+          sessionRef.current = data.session;
           setSession(data.session);
           setUser(data.session.user);
         }
@@ -77,15 +88,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     init();
 
     // Listen for auth state changes (sign in, sign out, token refresh)
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, newSession) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, newSession) => {
       if (!cancelled) {
-        if (newSession === null && session !== null) {
+        const previous = sessionRef.current;
+        if (newSession === null && previous !== null && !signingOutRef.current) {
           Sentry.captureMessage('Auth session ended unexpectedly', {
-            level: 'info',
-            extra: { previousUserId: session?.user?.id, previousExpiry: session?.expires_at },
-            tags: { context: 'auth.session' },
+            level: 'warning',
+            extra: {
+              previousUserId: previous.user?.id,
+              previousExpiry: previous.expires_at,
+              // Whether the token was already past its expiry when it dropped
+              // separates an ordinary expiry from a session vanishing early.
+              expiredBeforeDrop: previous.expires_at
+                ? previous.expires_at * 1000 < Date.now()
+                : null,
+            },
+            tags: { context: 'auth.session', auth_event: event },
           });
         }
+        sessionRef.current = newSession;
         setSession(newSession);
         setUser(newSession?.user ?? null);
         // Clear saved artists on sign out
@@ -105,8 +126,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const handleSignOut = useCallback(async () => {
     const supabase = getSupabaseClient();
-    if (supabase) {
-      await supabase.auth.signOut();
+    signingOutRef.current = true;
+    try {
+      if (supabase) {
+        await supabase.auth.signOut();
+      }
+    } finally {
+      signingOutRef.current = false;
     }
     setSavedArtists([]);
     setSavedArtistIds(new Set());

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -50,7 +50,17 @@ function ArtistDashboardRedirect() {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Sentry.ErrorBoundary fallback={<AppErrorFallback />}>
+    <Sentry.ErrorBoundary
+      fallback={<AppErrorFallback />}
+      // Without this, a boundary crash arrives in Sentry as a bare error with no
+      // clue where the user was. Every route below is lazy-loaded, so the route
+      // path is what turns "TypeError: Failed to fetch dynamically imported
+      // module" into "sign-in was broken for this person".
+      beforeCapture={scope => {
+        scope.setTag('context', 'app.errorBoundary')
+        scope.setTag('route', window.location.pathname)
+      }}
+    >
       <AuthProvider>
         <BrowserRouter>
           <ScrollToTop />

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -1,9 +1,30 @@
 // Supabase client-side auth for artist claim flow.
 // Uses the anon key (safe to expose) — RLS policies control access.
 
-import { createClient, type SupabaseClient, type Session } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient, type Session, type AuthError } from '@supabase/supabase-js';
+import * as Sentry from '@sentry/react';
 
 let client: SupabaseClient | null = null;
+
+/**
+ * Report an auth failure that Supabase *returned* rather than threw.
+ *
+ * Every function here hands back `{ error }`, so callers surface the message in
+ * the UI and their try/catch never runs — which meant no failed sign-in has ever
+ * reached Sentry. Wrong-password is excluded deliberately: it's the user's typo,
+ * it happens constantly, and burying the real failures under it defeats the point.
+ * What's left is the set worth waking up to — rate limits, disabled providers,
+ * Supabase 5xx, and network failures during sign-in.
+ */
+function reportAuthFailure(operation: string, error: AuthError): void {
+  if (error.message === 'Invalid login credentials') return;
+
+  Sentry.captureMessage(`Auth failed: ${operation}`, {
+    level: 'warning',
+    tags: { context: 'auth.service', auth_operation: operation, auth_status: String(error.status ?? 'none') },
+    extra: { errorMessage: error.message, errorCode: error.code, errorName: error.name },
+  });
+}
 
 export function getSupabaseClient(): SupabaseClient | null {
   if (client) return client;
@@ -26,6 +47,7 @@ export async function signInWithMagicLink(email: string, redirectTo: string): Pr
     options: { emailRedirectTo: redirectTo },
   });
 
+  if (error) reportAuthFailure('magicLink', error);
   return { error: error?.message ?? null };
 }
 
@@ -80,6 +102,7 @@ export async function signInWithPassword(email: string, password: string): Promi
   if (!supabase) return { error: 'Auth not configured' };
 
   const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) reportAuthFailure('passwordLogin', error);
   return { error: error?.message ?? null };
 }
 
@@ -88,6 +111,7 @@ export async function resetPasswordForEmail(email: string, redirectTo: string): 
   if (!supabase) return { error: 'Auth not configured' };
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
+  if (error) reportAuthFailure('resetPassword', error);
   return { error: error?.message ?? null };
 }
 

--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -10,6 +10,34 @@ import * as Sentry from '@sentry/react'
 
 export { Sentry }
 
+/**
+ * True when an error is a page asking for a JS chunk its deploy no longer has.
+ *
+ * This is what a deploy does to an already-open tab. Pages are lazy-loaded
+ * (`lazy(() => import('./pages/LoginPage.tsx'))` and friends in main.tsx), so the
+ * chunk filename carries a content hash. A tab still running build N clicks a link,
+ * requests `/assets/LoginPage-<oldHash>.js`, and build N+1 doesn't have that file.
+ * Netlify's SPA catch-all then answers `200 text/html` instead of 404, so the
+ * browser rejects it as a module and the import promise rejects — which React
+ * surfaces through the error boundary as "Unstream hit an unexpected error".
+ *
+ * Each engine words it differently, hence the list.
+ */
+export function isStaleBuildAssetError(message: string): boolean {
+  return (
+    // Chrome / Edge
+    message.includes('Failed to fetch dynamically imported module') ||
+    // Firefox
+    message.includes('error loading dynamically imported module') ||
+    // Safari
+    message.includes('Importing a module script failed') ||
+    // Any engine, when the SPA catch-all serves index.html in place of the chunk
+    message.includes('Expected a JavaScript module script') ||
+    // Vite's preload helper, when a stylesheet for a route chunk is missing
+    message.includes('Unable to preload CSS for')
+  )
+}
+
 export function initSentry(): void {
   const dsn = import.meta.env.VITE_SENTRY_DSN
   const environment = import.meta.env.VITE_SENTRY_ENV || import.meta.env.MODE
@@ -48,8 +76,31 @@ export function initSentry(): void {
         return null
       }
 
-      // Filter out common benign errors
       const errorMessage = hint?.originalException?.toString() || ''
+
+      // Classified BEFORE the benign-error filter so a stale-build failure can
+      // never be mistaken for a transient network blip and dropped.
+      if (isStaleBuildAssetError(errorMessage)) {
+        event.tags = {
+          ...event.tags,
+          error_type: 'stale-build-asset',
+          // Which route the user was trying to reach — the reason this shows up
+          // as a login bug is that /login is one of the lazy-loaded routes.
+          route: window.location.pathname,
+        }
+        event.extra = {
+          ...event.extra,
+          runningRelease: version,
+          hasServiceWorker: !!navigator.serviceWorker?.controller,
+        }
+        // One issue for all of them, titled for what it actually is. Left to
+        // group itself, every browser's wording becomes a separate issue and
+        // none of the titles mention a deploy.
+        event.fingerprint = ['stale-build-asset']
+        return event
+      }
+
+      // Filter out common benign errors
       if (errorMessage.includes('Network Error') || errorMessage.includes('AbortError')) {
         return null
       }

--- a/apps/web/tests/unit/auth-service-reporting.test.ts
+++ b/apps/web/tests/unit/auth-service-reporting.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const captureMessage = vi.fn();
+const signInWithPassword = vi.fn();
+const signInWithOtp = vi.fn();
+const resetPasswordForEmail = vi.fn();
+
+vi.mock('@sentry/react', () => ({ captureMessage: (...args: unknown[]) => captureMessage(...args) }));
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ auth: { signInWithPassword, signInWithOtp, resetPasswordForEmail } }),
+}));
+
+vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+
+const authError = (message: string, status?: number, code?: string) => ({
+  name: 'AuthApiError',
+  message,
+  status,
+  code,
+});
+
+/**
+ * Supabase hands auth failures back as `{ error }` rather than throwing, so the
+ * try/catch in LoginPage never runs for them and nothing was ever reported.
+ * These cover the reporting added at the service boundary — including the one
+ * failure deliberately left silent.
+ */
+describe('auth service failure reporting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('reports a rate-limited sign-in', async () => {
+    signInWithPassword.mockResolvedValue({ error: authError('Request rate limit reached', 429, 'over_request_rate_limit') });
+    const { signInWithPassword: signIn } = await import('../../src/services/auth');
+
+    const { error } = await signIn('artist@example.com', 'hunter2');
+
+    expect(error).toBe('Request rate limit reached');
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    const [message, options] = captureMessage.mock.calls[0];
+    expect(message).toBe('Auth failed: passwordLogin');
+    expect(options.tags).toMatchObject({ context: 'auth.service', auth_operation: 'passwordLogin', auth_status: '429' });
+    expect(options.extra).toMatchObject({ errorMessage: 'Request rate limit reached', errorCode: 'over_request_rate_limit' });
+  });
+
+  it('stays silent on a wrong password', async () => {
+    // The common case by a wide margin. Reporting it would bury every real
+    // failure under thousands of user typos.
+    signInWithPassword.mockResolvedValue({ error: authError('Invalid login credentials', 400, 'invalid_credentials') });
+    const { signInWithPassword: signIn } = await import('../../src/services/auth');
+
+    const { error } = await signIn('artist@example.com', 'wrong');
+
+    expect(error).toBe('Invalid login credentials');
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports a magic link failure', async () => {
+    signInWithOtp.mockResolvedValue({ error: authError('Email logins are disabled', 422, 'email_provider_disabled') });
+    const { signInWithMagicLink } = await import('../../src/services/auth');
+
+    await signInWithMagicLink('artist@example.com', 'https://unstream.stream/login');
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage.mock.calls[0][0]).toBe('Auth failed: magicLink');
+  });
+
+  it('reports a password reset failure', async () => {
+    resetPasswordForEmail.mockResolvedValue({ error: authError('Database error', 500) });
+    const { resetPasswordForEmail: reset } = await import('../../src/services/auth');
+
+    await reset('artist@example.com', 'https://unstream.stream/reset-password');
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage.mock.calls[0][0]).toBe('Auth failed: resetPassword');
+  });
+
+  it('reports nothing when a call succeeds', async () => {
+    signInWithPassword.mockResolvedValue({ error: null });
+    const { signInWithPassword: signIn } = await import('../../src/services/auth');
+
+    const { error } = await signIn('artist@example.com', 'correct');
+
+    expect(error).toBeNull();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/sentry-stale-build.test.ts
+++ b/apps/web/tests/unit/sentry-stale-build.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isStaleBuildAssetError } from '../../src/services/sentry';
+
+/**
+ * A deploy replaces every hashed chunk filename. A tab still running the previous
+ * build then asks for a chunk that no longer exists, and because Netlify's SPA
+ * catch-all answers `200 text/html` instead of 404, the browser rejects it as a
+ * module script. These are the real strings each engine produces for that.
+ */
+describe('isStaleBuildAssetError', () => {
+  it('matches the Chrome/Edge dynamic import failure', () => {
+    expect(isStaleBuildAssetError(
+      'TypeError: Failed to fetch dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js'
+    )).toBe(true);
+  });
+
+  it('matches the Firefox wording', () => {
+    expect(isStaleBuildAssetError(
+      'TypeError: error loading dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js'
+    )).toBe(true);
+  });
+
+  it('matches the Safari wording', () => {
+    expect(isStaleBuildAssetError('TypeError: Importing a module script failed.')).toBe(true);
+  });
+
+  it('matches the MIME rejection the SPA catch-all causes', () => {
+    expect(isStaleBuildAssetError(
+      "Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of 'text/html'."
+    )).toBe(true);
+  });
+
+  it("matches Vite's CSS preload failure", () => {
+    expect(isStaleBuildAssetError(
+      'Unable to preload CSS for /assets/ArtistEditPage-Bq1x9fLm.css'
+    )).toBe(true);
+  });
+
+  it('does not match ordinary application errors', () => {
+    expect(isStaleBuildAssetError('TypeError: Cannot read properties of undefined')).toBe(false);
+    expect(isStaleBuildAssetError('AbortError: The operation was aborted')).toBe(false);
+    expect(isStaleBuildAssetError('Invalid login credentials')).toBe(false);
+    expect(isStaleBuildAssetError('')).toBe(false);
+  });
+
+  it('does not match a fetch failure for a non-module resource', () => {
+    // Plain `fetch()` failures say "Failed to fetch" without the module clause.
+    // Treating those as a stale build would misattribute every flaky API call.
+    expect(isStaleBuildAssetError('TypeError: Failed to fetch')).toBe(false);
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,6 +27,14 @@ if (sentryEnabled && !env.SENTRY_AUTH_TOKEN) {
   console.warn('⚠️  SENTRY_AUTH_TOKEN is not set. Source map upload will fail.')
 }
 
+// The Sentry release, injected as VITE_APP_VERSION. Netlify exposes the deployed
+// commit as COMMIT_REF at build time; without it every event reports release
+// 'unknown', which makes the deploy-shaped errors unattributable — a tab running
+// an old build asking for that build's chunks is only diagnosable if you can see
+// *which* build it was running. Passed to sentryVitePlugin too so uploaded source
+// maps land on the same release the client reports.
+const release = env.VITE_APP_VERSION || env.COMMIT_REF || 'dev'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -100,6 +108,7 @@ export default defineConfig({
       org: env.SENTRY_ORG,
       project: env.SENTRY_PROJECT || 'unstream-web',
       authToken: env.SENTRY_AUTH_TOKEN,
+      release: { name: release },
     })] : []),
     {
       name: 'api-server',
@@ -124,4 +133,7 @@ export default defineConfig({
       },
     },
   ],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(release),
+  },
 })


### PR DESCRIPTION
Two Sentry blind spots, both about not being able to see what actually happened.

## 1. Zero-result searches didn't show the query

The query was already being sent — as `extra`. That's the problem. Every zero-result event shares one message, so Sentry folds them into a single issue where `extra` belongs to whichever event you happen to be looking at. Seeing *which* searches come back empty meant paging through events one at a time.

Query and mode are now **tags** (`api/functions/search-sources.ts`), which get an aggregated value distribution on the issue page and are searchable (`search_query:radiohead`). The raw form stays in `extra`.

`search_mode` is included because it changes the follow-up: `exact` means a playback-detection client (extension, Mac app) sent a real artist name and we have no coverage; `fuzzy` means a human typed it and it may just be a typo.

Both values are already capped at 200 chars by `validateQuery`, which is also Sentry's tag-value limit. Volume is bounded by the existing 24h-per-query `checkSentryDedup`.

## 2. The "unexpected error" on login after a deploy

**It's a stale build chunk, and it isn't really about auth.** Reproduced end-to-end against a real production build with the chunk removed.

Every page in `main.tsx` is `lazy(() => import(...))`, so chunk filenames carry a content hash. A tab left open across a deploy clicks Login and asks for `LoginPage-<oldHash>.js`, which the new deploy doesn't have. `netlify.toml`'s SPA catch-all (`/*` → `/index.html`, 200) then answers with **`200 text/html` rather than 404** — verified against production:

```
curl -sI https://unstream.stream/assets/does-not-exist.js   # 200, content-type: text/html
```

So the browser rejects it as a module script, `React.lazy` rejects, and the error boundary renders "Unstream hit an unexpected error". Reloading works because it fetches the new `index.html`. The PWA compounds it: `registerType: 'autoUpdate'` + `skipWaiting` + `clientsClaim` lets the new service worker claim the *live* page without a reload, so the page is old while its precache is new.

**It was reaching Sentry all along** — as a bare `TypeError: Failed to fetch dynamically imported module`, with no route, no build, and a different title per browser engine. Delivery was confirmed by wrapping `client.getTransport().send` in the live page; note that `read_network_requests` never shows Sentry envelopes (keepalive fetch), so an empty network log is a false negative there.

Now classified in `beforeSend` with `error_type: stale-build-asset`, the `route` the user was trying to reach, the running release, and a single fingerprint. Classification happens *before* the existing benign-error filter so it can't be mistaken for a transient network blip and dropped.

The Sentry release now comes from Netlify's `COMMIT_REF` instead of the literal string `'unknown'` — "which build was this tab running" is the whole question here, and it was unanswerable. Passed to `sentryVitePlugin` too so uploaded source maps land on the same release the client reports.

## Two nearby gaps found along the way

- **`Auth session ended unexpectedly` has never fired once.** The auth listener is installed in an effect with no deps, so its read of `session` is pinned to the initial `null` forever and the condition is unreachable. ESLint had been flagging the missing dependency the whole time. A ref holds the live value, a deliberate sign-out is no longer reported as an unexpected one, and the Supabase event name is attached as a tag.
- **Supabase returns auth failures instead of throwing them**, so `LoginPage`'s `try/catch` never ran and no failed sign-in has ever been reported. Now reported at the service boundary in `services/auth.ts` — except wrong-password, which is the user's typo and would bury every real failure (rate limits, disabled providers, Supabase 5xx) underneath it.

## User-facing change

The error screen gains a **Reload** button that retries the current URL on the new build, instead of only offering a link back to the homepage. Verified: on the reproduced failure it recovers straight to `/login`.

## Verification

- Reproduced the real failure against a production build served through a Netlify-equivalent SPA catch-all, and confirmed the captured event carries `error_type: stale-build-asset`, `route: /login`, `context: app.errorBoundary`, and the running release.
- `npm run lint` — clean for these changes. Three pre-existing `AuthContext.tsx` findings disappear, including the exact stale-dependency warning fixed here; none added.
- `npm run test:unit` — 540 passing, including 12 new. `npm run test:api` — 541 passing.
- Both new tests were checked to actually fail when the code they cover is neutralised.

## Deliberately not included

The permanent fix — a `lazy()` wrapper that reloads once on import failure — is a behaviour change worth deciding on with data in hand. Tracked separately.

Also spotted but out of scope: `toStoredResult` in `search-sources.ts` reads `p.displayName` off a `PlatformLink` type that has no such field, so platform display names are silently blank on every claimed and known artist card. The narrow `include` in `api/tsconfig.json` means the build never typechecks that file. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)