### PR TITLE
Typecheck the search backend, and declare the display name it already returns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ npm run migrate:list      # List applied vs pending migrations
 
 `npm run build` runs, in order: guides manifest → dispatch feed → root `tsc -b` → API function tests → `apps/web` `tsc -b` → web unit tests → `vite build` → sitemap. **Any failure blocks the Netlify deploy.** Run `npm run build` (or at minimum `npm run lint`, `npm run test:unit`, `npm run test:api`) before considering work done.
 
-**Typecheck coverage gotcha:** `api/tsconfig.json` has a narrow `include` — only the `me-*` functions and their tests. So neither `tsc -b` nor `npm run typecheck:api` typechecks most of `api/`. A type error in `search-sources.ts` will not fail the build; it will fail at runtime in production. When you touch `api/`, rely on the function tests and read carefully — and if you add a file worth typechecking, add it to that `include` list.
+**Typecheck coverage gotcha:** `api/tsconfig.json` has a narrow `include` — the `me-*` functions, `search-sources.ts`, and their tests. Files reachable from those *are* checked, so the search backend (`db.ts`, `search-utils.ts`, `search-parsers.ts`, `middleware.ts`, `api/search/*`) is now covered. Everything else in `api/` — the edge functions, `artist-profile.ts`, the release and admin endpoints — is not: a type error there won't fail the build, it will fail at runtime in production. When you touch an unlisted file, rely on the function tests and read carefully — and if it's worth typechecking, add it to that `include` list and fix whatever strict mode surfaces.
 
 ## Key patterns
 

--- a/api/functions/__tests__/to-stored-result.test.ts
+++ b/api/functions/__tests__/to-stored-result.test.ts
@@ -44,4 +44,22 @@ describe('toStoredResult', () => {
     expect(result!.knownSlug).toBe('patrick-hardy');
     expect(result!.claimedSlug).toBeUndefined();
   });
+
+  // artist_links.display_name is the custom label an artist typed in the profile
+  // editor for an "other" link. It has to survive the DB -> card mapping or the
+  // link renders as a bare platform id on the most polished results we serve.
+  it('carries a stored display name through to the card', () => {
+    const result = toStoredResult(
+      dbArtist({
+        matchConfidence: 'claimed',
+        platforms: [
+          { sourceId: 'other_0', url: 'https://example.com/shop', displayName: 'Tape store' },
+          { sourceId: 'bandcamp', url: 'https://artist.bandcamp.com' },
+        ],
+      }),
+      'kid-lightbulbs',
+    );
+    expect(result!.platforms[0].displayName).toBe('Tape store');
+    expect(result!.platforms[1].displayName).toBeUndefined();
+  });
 });

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -58,6 +58,9 @@ const FRESHNESS_TTL_MS = 24 * 60 * 60 * 1000;
 interface PlatformLink {
   sourceId: string;
   url: string;
+  // Custom label an artist set in the profile editor (artist_links.display_name).
+  // Only "other" links normally carry one; search-discovered links leave it null.
+  displayName?: string;
   latestRelease?: {
     title: string;
     type: 'album' | 'track';

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -42,17 +42,16 @@ import {
 
 // Import shared enrichment functions
 import {
-  SocialLink,
-  DiscoveredPlatformLink,
-  ArtistLocation,
-  SocialPlatform,
+  type SocialLink,
+  type DiscoveredPlatformLink,
+  type ArtistLocation,
+  type SocialPlatform,
   parseSocialUrl,
   fetchDiscogsSocialLinks,
   fetchOfficialSiteSocialLinks,
   mergeSocialLinks,
   searchPeerTubeChannels,
   fetchLinktreeLinks,
-  parseLocationString,
   mergeLocations,
   fetchBandcampLocation,
   checkBandcampSubdomain,
@@ -682,8 +681,8 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
 
     // Scrape Linktree if found
     let linktreeSocialLinks: SocialLink[] = [];
-    if (linktreeUrl || officialSiteResult.linktreeUrl) {
-      const finalLinktreeUrl = linktreeUrl || officialSiteResult.linktreeUrl;
+    const finalLinktreeUrl = linktreeUrl || officialSiteResult.linktreeUrl;
+    if (finalLinktreeUrl) {
       linktreeSocialLinks = await fetchLinktreeLinks(finalLinktreeUrl);
     }
 
@@ -1195,7 +1194,7 @@ async function searchEven(query: string): Promise<Map<string, NameOnlyEntry>> {
 
         if (!response.ok) { fetchFailed = true; return results; }
 
-        const json = await response.json();
+        const json = await response.json() as { hits?: { name?: string; slug?: string; username?: string }[] };
         const queryNormalized = normalizeForComparison(query);
         const seen = new Set<string>();
 
@@ -1895,52 +1894,6 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
   // hasPendingEnrichment: false and never called Phase 2 to fill the gap.
   const enrichmentApplied = mbData !== null && mbData.artistName !== null && mbData.enrichmentComplete;
   return { results: finalResults, enrichmentApplied };
-}
-
-// Search a Bandcamp artist page for a specific album title
-// Uses /music endpoint to access full discography (base URL may redirect to a single release)
-async function searchBandcampForAlbum(artistUrl: string, albumTitle: string): Promise<string | undefined> {
-  try {
-    // Extract base artist URL and append /music for full discography
-    const baseUrl = artistUrl.replace(/\/(music|album|track).*$/, '');
-    const musicUrl = `${baseUrl}/music`;
-
-    const response = await fetchWithTimeout(musicUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    }, 3000);
-
-    if (!response.ok) return undefined;
-
-    const html = await response.text();
-    const root = parse(html);
-    const normalizedSearchTitle = normalizeForComparison(albumTitle);
-
-    // Look through all music grid items for matching title
-    const musicGridItems = root.querySelectorAll('.music-grid-item');
-    for (const item of musicGridItems) {
-      const titleEl = item.querySelector('.title');
-      const title = titleEl?.textContent?.trim();
-      if (!title) continue;
-
-      const normalizedTitle = normalizeForComparison(title);
-      // Check for match (allowing partial matches for long titles)
-      if (normalizedTitle === normalizedSearchTitle ||
-          normalizedTitle.includes(normalizedSearchTitle) ||
-          normalizedSearchTitle.includes(normalizedTitle)) {
-        const link = item.querySelector('a');
-        const href = link?.getAttribute('href');
-        if (href) {
-          return href.startsWith('http') ? href : new URL(href, artistUrl).toString();
-        }
-      }
-    }
-
-    return undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 // Shape a DB artist row into a result card. Claimed rows become full profile

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -799,7 +799,9 @@ export function aggregateResults(allResults: PlatformResult[], query?: string): 
 export function attachAmpwallAndSearchLinks(
   aggregated: AggregatedResult[],
   ampwallMatches: Map<string, string>,
-  mbData?: { artistName: string; bandcampUrl?: string } | null,
+  // artistName is null when MusicBrainz had no match — the Bandcamp relation
+  // below is only trusted when it belongs to a named artist.
+  mbData?: { artistName: string | null; bandcampUrl?: string | null } | null,
 ): void {
   const usedPlatformUrls = new Set<string>();
 
@@ -830,7 +832,7 @@ export function attachAmpwallAndSearchLinks(
     // Bandcamp: prefer direct URL from MusicBrainz relations, fall back to search link
     if (!result.platforms.some(p => p.sourceId === 'bandcamp')) {
       // Check if MusicBrainz has a direct Bandcamp URL for this artist
-      const mbBandcampUrl = mbData?.bandcampUrl &&
+      const mbBandcampUrl = mbData?.bandcampUrl && mbData.artistName &&
         normalizeForComparison(mbData.artistName) === normalizedName
         ? mbData.bandcampUrl
         : undefined;

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -166,9 +166,6 @@ export async function fetchWikipediaSummary(wikipediaUrl: string): Promise<{ ext
   }
 }
 
-// Helper to delay execution (for rate limiting)
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
 // Fetch and parse links from a Linktree page
 export async function fetchLinktreeLinks(linktreeUrl: string): Promise<SocialLink[]> {
   const socialLinks: SocialLink[] = [];

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -22,7 +22,14 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
+  // Only the files listed here are typechecked. Everything reachable from them
+  // (db.ts, middleware.ts, search-utils.ts, the parsers, api/search/*) is
+  // checked too, which is why search-sources.ts earns its place: it pulls in
+  // most of the search backend. Adding a file here means committing to keeping
+  // it clean under strict mode.
   "include": [
+    "functions/search-sources.ts",
+    "functions/__tests__/to-stored-result.test.ts",
     "functions/me-settings.ts",
     "functions/me-username.ts",
     "functions/me-password.ts",


### PR DESCRIPTION
## What this fixes

`toStoredResult` in `api/functions/search-sources.ts` maps `displayName: p.displayName` for every card served from the database — claimed profiles and `known-` cards — but the `PlatformLink` interface in `api/functions/db.ts` never declared the field.

**The display name was never actually being dropped.** `getArtistBySlug` has been populating it all along (`db.ts:2405`), the frontend has been rendering it, and `ResultCardPlatforms` reads it. The reason it compiled is that the value is attached with a conditional spread:

```ts
...(link.display_name ? { displayName: link.display_name } : {}),
```

Spreads skip TypeScript's excess-property check, so the field flowed at runtime while the type forgot it existed. This was a missing declaration, not a lost feature — deleting the read would have thrown away the custom labels artists type into the profile editor for "other" links. Declared it instead, and added a test that fails if the mapping is removed (verified by neutralizing the line).

## Why nobody caught it

`api/tsconfig.json` only typechecked the `me-*` functions, so most of `api/` never saw `tsc`. Adding `functions/search-sources.ts` to the `include` list pulls its **whole reachable import graph** — `db.ts`, `search-utils.ts`, `search-parsers.ts`, `middleware.ts`, `api/search/*` — under the build's `tsc -b`. This class of error now fails the build instead of shipping.

Widening surfaced nine more errors, all fixed here:

- Four type-only import violations under `verbatimModuleSyntax`.
- Dead code removed: `searchBandcampForAlbum` in `search-sources.ts` (unreferenced — the *live* copy is the dev server's `apps/web/server/search/bandcamp.ts`, untouched), an unused `delay` helper in `api/search/enrichment.ts`, and an unused `parseLocationString` import.
- `fetchLinktreeLinks` was being passed `string | null`; restructured so the computed value is the thing checked.
- `attachAmpwallAndSearchLinks` declared `artistName: string` / `bandcampUrl?: string`, but `EnrichedMusicBrainzResult` has both nullable. Widened the parameter and added a guard — safe in practice today (a null `artistName` never travels with a `bandcampUrl`), but `normalizeForComparison(null)` would throw if that ever changed.
- Typed the Algolia `response.json()` in `searchEven`.

`CLAUDE.md`'s "Typecheck coverage gotcha" note is updated, since it now overstated the gap. Edge functions, `artist-profile.ts`, and the release/admin endpoints are still unchecked.

## Verification

| Check | Result |
|---|---|
| `npx tsc -b` (the build's typecheck) | clean |
| `npm run test:api` | 542 passed / 33 files |
| `npm run test:unit` | 540 passed / 39 files |

Rebased onto `main` after #390 landed; all three re-run green on the rebased tree.

**Note on `npm run lint`:** it exits 1 with 69 errors, all in `apps/web/tests/unit/` files this PR doesn't touch. I confirmed this is pre-existing by stashing and re-running on clean `main` — identical 77 problems / 69 errors. `npm run build` doesn't run lint, which is presumably how it drifted. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)