### PR TITLE
Reload a tab once when its page chunk belongs to an old deploy

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, Suspense, lazy } from 'react'
+import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import * as Sentry from '@sentry/react'
@@ -9,35 +9,37 @@ import App from './App.tsx'
 import { ArtistPage } from './pages/ArtistPage.tsx'
 import { AppLoadingFallback, AppErrorFallback } from './components/AppFallback'
 import { ScrollToTop } from './components/ScrollToTop'
+import { lazyWithRetry } from './utils/lazyWithRetry'
 
 initSentry()
 
-// Lazy-load non-critical pages to reduce initial bundle size
-const ClaimPage = lazy(() => import('./pages/ClaimPage.tsx').then(m => ({ default: m.ClaimPage })))
-const LoginPage = lazy(() => import('./pages/LoginPage.tsx').then(m => ({ default: m.LoginPage })))
-const DashboardPage = lazy(() => import('./pages/DashboardPage.tsx').then(m => ({ default: m.DashboardPage })))
-const ArtistEditPage = lazy(() => import('./pages/ArtistEditPage.tsx').then(m => ({ default: m.ArtistEditPage })))
-const ArtistReleasesPage = lazy(() => import('./pages/ArtistReleasesPage.tsx').then(m => ({ default: m.ArtistReleasesPage })))
-const ArtistDirectoryPage = lazy(() => import('./pages/ArtistDirectoryPage.tsx').then(m => ({ default: m.ArtistDirectoryPage })))
-const KnownArtistsPage = lazy(() => import('./pages/KnownArtistsPage.tsx').then(m => ({ default: m.KnownArtistsPage })))
-const RoadmapPage = lazy(() => import('./pages/RoadmapPage.tsx').then(m => ({ default: m.RoadmapPage })))
-const SupportPage = lazy(() => import('./pages/SupportPage.tsx').then(m => ({ default: m.SupportPage })))
-const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage.tsx').then(m => ({ default: m.PrivacyPolicyPage })))
-const AdminMergePage = lazy(() => import('./pages/AdminMergePage.tsx').then(m => ({ default: m.AdminMergePage })))
-const AdminVerifyPage = lazy(() => import('./pages/AdminVerifyPage.tsx').then(m => ({ default: m.AdminVerifyPage })))
-const AdminLinksPage = lazy(() => import('./pages/AdminLinksPage.tsx').then(m => ({ default: m.AdminLinksPage })))
-const AdminReleaseReviewPage = lazy(() => import('./pages/AdminReleaseReviewPage.tsx').then(m => ({ default: m.AdminReleaseReviewPage })))
-const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage.tsx').then(m => ({ default: m.ResetPasswordPage })))
-const GuidesIndexPage = lazy(() => import('./pages/GuidesIndexPage.tsx').then(m => ({ default: m.GuidesIndexPage })))
-const GuidePage = lazy(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
-const DevelopersPage = lazy(() => import('./pages/DevelopersPage.tsx').then(m => ({ default: m.DevelopersPage })))
-const ChangelogPage = lazy(() => import('./pages/ChangelogPage.tsx').then(m => ({ default: m.ChangelogPage })))
-const ExtensionPage = lazy(() => import('./pages/ExtensionPage.tsx').then(m => ({ default: m.ExtensionPage })))
-const ImportPage = lazy(() => import('./pages/ImportPage.tsx').then(m => ({ default: m.ImportPage })))
-const FaqPage = lazy(() => import('./pages/FaqPage.tsx').then(m => ({ default: m.FaqPage })))
-const SettingsPage = lazy(() => import('./pages/SettingsPage.tsx').then(m => ({ default: m.SettingsPage })))
-const PublicSavedArtistsPage = lazy(() => import('./pages/PublicSavedArtistsPage.tsx').then(m => ({ default: m.PublicSavedArtistsPage })))
-const AdminAnalyticsPage = lazy(() => import('./pages/AdminAnalyticsPage.tsx').then(m => ({ default: m.AdminAnalyticsPage })))
+// Lazy-load non-critical pages to reduce initial bundle size.
+// lazyWithRetry adds a one-shot reload when a chunk belongs to a superseded deploy.
+const ClaimPage = lazyWithRetry(() => import('./pages/ClaimPage.tsx').then(m => ({ default: m.ClaimPage })))
+const LoginPage = lazyWithRetry(() => import('./pages/LoginPage.tsx').then(m => ({ default: m.LoginPage })))
+const DashboardPage = lazyWithRetry(() => import('./pages/DashboardPage.tsx').then(m => ({ default: m.DashboardPage })))
+const ArtistEditPage = lazyWithRetry(() => import('./pages/ArtistEditPage.tsx').then(m => ({ default: m.ArtistEditPage })))
+const ArtistReleasesPage = lazyWithRetry(() => import('./pages/ArtistReleasesPage.tsx').then(m => ({ default: m.ArtistReleasesPage })))
+const ArtistDirectoryPage = lazyWithRetry(() => import('./pages/ArtistDirectoryPage.tsx').then(m => ({ default: m.ArtistDirectoryPage })))
+const KnownArtistsPage = lazyWithRetry(() => import('./pages/KnownArtistsPage.tsx').then(m => ({ default: m.KnownArtistsPage })))
+const RoadmapPage = lazyWithRetry(() => import('./pages/RoadmapPage.tsx').then(m => ({ default: m.RoadmapPage })))
+const SupportPage = lazyWithRetry(() => import('./pages/SupportPage.tsx').then(m => ({ default: m.SupportPage })))
+const PrivacyPolicyPage = lazyWithRetry(() => import('./pages/PrivacyPolicyPage.tsx').then(m => ({ default: m.PrivacyPolicyPage })))
+const AdminMergePage = lazyWithRetry(() => import('./pages/AdminMergePage.tsx').then(m => ({ default: m.AdminMergePage })))
+const AdminVerifyPage = lazyWithRetry(() => import('./pages/AdminVerifyPage.tsx').then(m => ({ default: m.AdminVerifyPage })))
+const AdminLinksPage = lazyWithRetry(() => import('./pages/AdminLinksPage.tsx').then(m => ({ default: m.AdminLinksPage })))
+const AdminReleaseReviewPage = lazyWithRetry(() => import('./pages/AdminReleaseReviewPage.tsx').then(m => ({ default: m.AdminReleaseReviewPage })))
+const ResetPasswordPage = lazyWithRetry(() => import('./pages/ResetPasswordPage.tsx').then(m => ({ default: m.ResetPasswordPage })))
+const GuidesIndexPage = lazyWithRetry(() => import('./pages/GuidesIndexPage.tsx').then(m => ({ default: m.GuidesIndexPage })))
+const GuidePage = lazyWithRetry(() => import('./pages/GuidePage.tsx').then(m => ({ default: m.GuidePage })))
+const DevelopersPage = lazyWithRetry(() => import('./pages/DevelopersPage.tsx').then(m => ({ default: m.DevelopersPage })))
+const ChangelogPage = lazyWithRetry(() => import('./pages/ChangelogPage.tsx').then(m => ({ default: m.ChangelogPage })))
+const ExtensionPage = lazyWithRetry(() => import('./pages/ExtensionPage.tsx').then(m => ({ default: m.ExtensionPage })))
+const ImportPage = lazyWithRetry(() => import('./pages/ImportPage.tsx').then(m => ({ default: m.ImportPage })))
+const FaqPage = lazyWithRetry(() => import('./pages/FaqPage.tsx').then(m => ({ default: m.FaqPage })))
+const SettingsPage = lazyWithRetry(() => import('./pages/SettingsPage.tsx').then(m => ({ default: m.SettingsPage })))
+const PublicSavedArtistsPage = lazyWithRetry(() => import('./pages/PublicSavedArtistsPage.tsx').then(m => ({ default: m.PublicSavedArtistsPage })))
+const AdminAnalyticsPage = lazyWithRetry(() => import('./pages/AdminAnalyticsPage.tsx').then(m => ({ default: m.AdminAnalyticsPage })))
 
 // Redirect components for old routes
 function ArtistLoginRedirect() {

--- a/apps/web/src/utils/lazyWithRetry.ts
+++ b/apps/web/src/utils/lazyWithRetry.ts
@@ -1,0 +1,77 @@
+import { lazy, type ComponentType } from 'react'
+import { isStaleBuildAssetError } from '../services/sentry'
+
+/**
+ * `lazy()`, plus a one-shot reload when the page chunk belongs to a build that
+ * no longer exists.
+ *
+ * Every route in main.tsx is lazy-loaded, so its chunk filename carries a
+ * content hash. A tab left open across a deploy asks for a hash the new deploy
+ * doesn't have, Netlify's SPA catch-all answers `200 text/html` instead of 404,
+ * and the import rejects — which the error boundary shows as "Unstream hit an
+ * unexpected error". Reloading fetches the new index.html and the new chunk
+ * names, so we do it for the user instead of asking them to.
+ *
+ * The reload happens at most once per tab. A chunk that is genuinely broken
+ * (rather than merely old) would otherwise reload forever, so the second
+ * failure is rethrown and the error boundary takes over as before.
+ */
+
+const RELOAD_FLAG = 'unstream:stale-build-reload'
+
+export function lazyWithRetry(importPage: () => Promise<{ default: ComponentType }>) {
+  return lazy(() => importPageOrReload(importPage))
+}
+
+/** Exported for tests; use `lazyWithRetry` in app code. */
+export async function importPageOrReload<T>(importPage: () => Promise<T>): Promise<T> {
+  try {
+    const page = await importPage()
+    // The build this tab is running can serve its own chunks, so any earlier
+    // reload is spent — let a future deploy get its own attempt.
+    clearReloadFlag()
+    return page
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!isStaleBuildAssetError(message) || hasReloaded()) {
+      throw error
+    }
+    if (!markReloaded()) {
+      // Nowhere to record the attempt means no way to stop at one reload.
+      throw error
+    }
+
+    window.location.reload()
+    // Never settles: the tab is on its way out, and resolving or rejecting here
+    // would flash a page (or the error screen) in the moment before it goes.
+    return new Promise<T>(() => {})
+  }
+}
+
+function hasReloaded(): boolean {
+  try {
+    return sessionStorage.getItem(RELOAD_FLAG) === '1'
+  } catch {
+    // Storage can be unavailable (Safari private browsing). With nowhere to
+    // record the attempt we can't promise to reload only once, so don't reload.
+    return true
+  }
+}
+
+function markReloaded(): boolean {
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, '1')
+    return true
+  } catch {
+    // Same reasoning as above: an unrecorded reload is a reload loop.
+    return false
+  }
+}
+
+function clearReloadFlag(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_FLAG)
+  } catch {
+    // Storage unavailable means nothing was ever recorded.
+  }
+}

--- a/apps/web/tests/unit/lazy-with-retry.test.ts
+++ b/apps/web/tests/unit/lazy-with-retry.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { importPageOrReload } from '../../src/utils/lazyWithRetry';
+
+/**
+ * A deploy renames every hashed chunk, so a tab left open across one asks for a
+ * file the new build doesn't have. The wrapper reloads that tab once so it picks
+ * up the new index.html — and only once, so a chunk that is genuinely broken
+ * lands on the error boundary instead of reloading forever.
+ */
+const STALE_CHUNK_ERROR = new TypeError(
+  'Failed to fetch dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js'
+);
+
+const reload = vi.fn();
+
+beforeEach(() => {
+  reload.mockClear();
+  sessionStorage.clear();
+  // jsdom refuses to navigate, so stand in for the whole location object.
+  vi.stubGlobal('location', { ...window.location, reload });
+});
+
+describe('importPageOrReload', () => {
+  it('returns the module when the import succeeds', async () => {
+    const page = { default: () => null };
+    await expect(importPageOrReload(async () => page)).resolves.toBe(page);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once on a stale-chunk error', async () => {
+    const pending = importPageOrReload(async () => {
+      throw STALE_CHUNK_ERROR;
+    });
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    // The promise deliberately never settles while the reload is in flight, so
+    // React keeps showing the Suspense fallback rather than the error screen.
+    await expect(Promise.race([pending, Promise.resolve('pending')])).resolves.toBe('pending');
+  });
+
+  it('does not reload a second time in the same session', async () => {
+    void importPageOrReload(async () => {
+      throw STALE_CHUNK_ERROR;
+    });
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+
+    await expect(
+      importPageOrReload(async () => {
+        throw STALE_CHUNK_ERROR;
+      })
+    ).rejects.toBe(STALE_CHUNK_ERROR);
+    expect(reload).toHaveBeenCalledTimes(1);
+    // Short timeout: if the guard regresses, this hangs on a promise that never
+    // settles, and a fast failure beats waiting out the default.
+  }, 2000);
+
+  it('lets a later deploy reload again once a load has succeeded', async () => {
+    void importPageOrReload(async () => {
+      throw STALE_CHUNK_ERROR;
+    });
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+
+    // The reload landed on a build that can serve its own chunks.
+    await importPageOrReload(async () => ({ default: () => null }));
+
+    void importPageOrReload(async () => {
+      throw STALE_CHUNK_ERROR;
+    });
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(2));
+  });
+
+  it('rethrows a non-stale error untouched', async () => {
+    const bug = new TypeError('Cannot read properties of undefined');
+
+    await expect(
+      importPageOrReload(async () => {
+        throw bug;
+      })
+    ).rejects.toBe(bug);
+    expect(reload).not.toHaveBeenCalled();
+  }, 2000);
+});


### PR DESCRIPTION
Follow-up to #390, which made this failure legible in Sentry but left the fix itself open. This is the fix.

## The problem

A deploy renames every hashed chunk. A tab still running the previous build asks for a chunk the new deploy no longer has; Netlify's SPA catch-all answers `200 text/html` instead of `404`; the browser rejects it as a module script; `React.lazy` rejects; the error boundary shows "Unstream hit an unexpected error."

Every route in `main.tsx` is lazy-loaded, which is why this shows up most often as *"I can't log in after a deploy"* — `/login` is one of those routes.

## The fix

`apps/web/src/utils/lazyWithRetry.ts` wraps all 25 `lazy()` calls. On import failure it classifies the message with `isStaleBuildAssetError` (added in #390):

- **Stale chunk, no attempt recorded** → set a `sessionStorage` flag and `window.location.reload()`. The tab picks up the new `index.html` and the new chunk names. `registerType: 'autoUpdate'` means the service worker refreshes itself, so the reload lands on the new build rather than a cached shell.
- **Flag already set** → rethrow. A chunk that is genuinely broken, rather than merely old, must not reload forever — it falls through to the error boundary exactly as today.
- **Successful load** → clear the flag, so a *later* deploy gets its own attempt.

Two details worth a reviewer's eye:

- The reload path returns a promise that never settles. Resolving or rejecting would flash a page (or the error screen) in the moment before navigation; instead Suspense keeps showing the loading fallback.
- Storage failures (Safari private browsing, quota) resolve toward *not* reloading. An attempt that can't be recorded is a reload loop.

## Tests

`apps/web/tests/unit/lazy-with-retry.test.ts` — passthrough on success, reloads once on a stale-chunk error, does not reload a second time, reloads again after a successful load cleared the flag, rethrows a non-stale error untouched.

Mutation-tested before finalizing: removing the once-per-session guard fails "does not reload a second time"; removing the stale-error classification fails "rethrows a non-stale error untouched".

`npm run lint` (baseline unchanged), `npm run test:unit` (545), `npm run test:api` (542), and `tsc -b` at root + `apps/web` + `typecheck:api` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)