### PR TITLE
Let claimed artists arrange their releases by hand

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -256,12 +256,16 @@ export default async function handler(request: Request, context: Context) {
 
       links = linksData || [];
 
-      // Releases, newest first. `count: 'exact'` alongside a limit gives the full total in the
-      // same round trip, so the "and N more" line is a real number rather than a guess.
+      // Releases, in the artist's own order where they set one and newest first otherwise.
+      // `count: 'exact'` alongside a limit gives the full total in the same round trip, so the
+      // "and N more" line is a real number rather than a guess.
       //
-      // Ordered to match idx_releases_artist_chrono: many releases have no date yet (grid ingest
-      // gets identity and artwork but no dates), and without the created_at tiebreaker those
-      // undated rows would shuffle between requests.
+      // The ordering must stay identical to `getArtistReleases` in api/functions/db.ts — this is
+      // the crawler's view of the same page the SPA renders, and the two disagreeing on release
+      // order is the two-renderers trap in miniature. display_order leads (NULLS LAST, so it's
+      // inert until a claimed artist arranges their catalogue); the chronological part matches
+      // idx_releases_artist_chrono, where created_at is the tiebreaker that stops undated rows —
+      // grid ingest gets identity and artwork but no dates — shuffling between requests.
       const { data: releasesData, count } = await supabase
         .from('releases')
         .select(
@@ -271,6 +275,7 @@ export default async function handler(request: Request, context: Context) {
         )
         .eq('artist_id', artist.id)
         .eq('is_hidden', false)
+        .order('display_order', { ascending: true, nullsFirst: false })
         .order('release_date', { ascending: false, nullsFirst: false })
         .order('created_at', { ascending: false })
         .limit(MAX_RELEASES_SHOWN)

--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   createArtistRelease: vi.fn(),
   dismissReleaseReview: vi.fn(),
   mergeReleases: vi.fn(),
+  setReleaseDisplayOrder: vi.fn(),
   getCatalogState: vi.fn(),
   clearCatalogCooldown: vi.fn(),
   clearReleaseDetailCooldown: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock('../db', () => ({
   createArtistRelease: mocks.createArtistRelease,
   dismissReleaseReview: mocks.dismissReleaseReview,
   mergeReleases: mocks.mergeReleases,
+  setReleaseDisplayOrder: mocks.setReleaseDisplayOrder,
   getCatalogState: mocks.getCatalogState,
   clearCatalogCooldown: mocks.clearCatalogCooldown,
   clearReleaseDetailCooldown: mocks.clearReleaseDetailCooldown,
@@ -99,6 +101,7 @@ beforeEach(() => {
   mocks.createArtistRelease.mockResolvedValue({ ok: true, releaseId: RELEASE_A });
   mocks.dismissReleaseReview.mockResolvedValue(true);
   mocks.mergeReleases.mockResolvedValue({ ok: true });
+  mocks.setReleaseDisplayOrder.mockResolvedValue(true);
   mocks.getCatalogState.mockResolvedValue({ ok: true, state: null });
   mocks.clearCatalogCooldown.mockResolvedValue(undefined);
   mocks.clearReleaseDetailCooldown.mockResolvedValue(undefined);
@@ -245,6 +248,64 @@ describe('POST — create', () => {
     mocks.createArtistRelease.mockResolvedValue({ ok: false, error: 'Title needs at least one letter or number' });
     const r = await post({ action: 'create', slug: SLUG, title: '!!!', platform: 'bandcamp', url: 'https://x.bandcamp.com' });
     expect(r.statusCode).toBe(400);
+  });
+});
+
+describe('POST — reorder', () => {
+  const RELEASE_C = '33333333-3333-3333-3333-333333333333';
+
+  it('stores the arrangement exactly as sent', async () => {
+    const r = await post({ action: 'reorder', slug: SLUG, releaseIds: [RELEASE_B, RELEASE_A, RELEASE_C] });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.setReleaseDisplayOrder).toHaveBeenCalledWith('artist-1', [RELEASE_B, RELEASE_A, RELEASE_C]);
+  });
+
+  // The same rule every other release-id action follows: owning the profile says nothing about
+  // who owns the ids in the body, so an artist can't rearrange (and thereby confirm the
+  // existence of) releases that aren't theirs.
+  it('refuses ids that are not this artist\'s', async () => {
+    mocks.verifyReleaseOwnership.mockResolvedValue(false);
+    const r = await post({ action: 'reorder', slug: SLUG, releaseIds: [RELEASE_A, RELEASE_B] });
+    expect(r.statusCode).toBe(403);
+    expect(mocks.setReleaseDisplayOrder).not.toHaveBeenCalled();
+  });
+
+  it.each([[RELEASE_A], [['nope']], [[RELEASE_A, 42]], [[null]], [{}]])(
+    'rejects releaseIds that are not all UUIDs (%o)',
+    async bad => {
+      const r = await post({ action: 'reorder', slug: SLUG, releaseIds: bad });
+      expect(r.statusCode).toBe(400);
+      expect(mocks.setReleaseDisplayOrder).not.toHaveBeenCalled();
+    }
+  );
+
+  // A repeated id isn't an arrangement: the last occurrence would win and a release the artist
+  // can see would drop out of their order without saying so.
+  it('rejects a repeated id', async () => {
+    const r = await post({ action: 'reorder', slug: SLUG, releaseIds: [RELEASE_A, RELEASE_A] });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.setReleaseDisplayOrder).not.toHaveBeenCalled();
+  });
+
+  it('rejects an implausibly long arrangement rather than handing it to Postgres', async () => {
+    const many = Array.from({ length: 501 }, (_, i) => `${i.toString(16).padStart(8, '0')}-1111-1111-1111-111111111111`);
+    const r = await post({ action: 'reorder', slug: SLUG, releaseIds: many });
+    expect(r.statusCode).toBe(400);
+    expect(mocks.setReleaseDisplayOrder).not.toHaveBeenCalled();
+  });
+
+  // Reset is an empty arrangement — the RPC reads that as "clear every position". It must not
+  // trip the ownership check, which reports false for an empty id list.
+  it('resets to date order with an empty arrangement, without an ownership lookup', async () => {
+    const r = await post({ action: 'resetOrder', slug: SLUG });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.verifyReleaseOwnership).not.toHaveBeenCalled();
+    expect(mocks.setReleaseDisplayOrder).toHaveBeenCalledWith('artist-1', []);
+  });
+
+  it('purges the artist caches so the public page picks the new order up', async () => {
+    await post({ action: 'reorder', slug: SLUG, releaseIds: [RELEASE_A] });
+    expect(mocks.cacheDeleteByArtist).toHaveBeenCalledWith('Kid Lightbulbs');
   });
 });
 

--- a/api/functions/__tests__/release-order-query.test.ts
+++ b/api/functions/__tests__/release-order-query.test.ts
@@ -1,0 +1,122 @@
+// The reads and the write behind manual release ordering.
+//
+// What's worth locking down is that the sort happens **in SQL, display_order first**. Both
+// artist-page reads are limited (60 for the SPA payload, 24 for the crawler render), so a
+// well-meaning refactor that fetched by date and re-sorted in JS would silently drop a release
+// the artist had pinned to the top out of the query altogether — the arrangement would look
+// obeyed on a short catalogue and lose records on a long one.
+//
+// `nullsFirst: false` is the other half: display_order is null for every release until an artist
+// arranges one, so NULLS LAST is what keeps this inert for everyone who never touches it, and is
+// also what puts a release catalogued later at the end of an existing arrangement instead of on
+// top of it.
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// release-detail-query.test.ts, because the point is to exercise the real query body.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface OrderCall {
+  table: string;
+  column: string;
+  options: { ascending: boolean; nullsFirst?: boolean };
+}
+
+const orders: OrderCall[] = [];
+const selects: string[] = [];
+const rpcCalls: { name: string; params: Record<string, unknown> }[] = [];
+
+type QueryResult = { data: unknown[]; count: number; error: null };
+
+interface Builder extends PromiseLike<QueryResult> {
+  eq(column: string, value: unknown): Builder;
+  order(column: string, options: { ascending: boolean; nullsFirst?: boolean }): Builder;
+  limit(n: number): Builder;
+}
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          selects.push(columns);
+          const builder: Builder = {
+            eq: () => builder,
+            order(column, options) {
+              orders.push({ table, column, options });
+              return builder;
+            },
+            limit: () => builder,
+            then: (resolve, reject) =>
+              Promise.resolve<QueryResult>({ data: [], count: 0, error: null }).then(resolve, reject),
+          };
+          return builder;
+        },
+      };
+    },
+    rpc(name: string, params: Record<string, unknown>) {
+      rpcCalls.push({ name, params });
+      return Promise.resolve({ error: null });
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getArtistReleases, getArtistReleasesForOwner, setReleaseDisplayOrder } = await import('../db');
+
+/** The ordering both artist-page renderers must apply, and must keep applying identically. */
+const EXPECTED_ORDER = [
+  { column: 'display_order', options: { ascending: true, nullsFirst: false } },
+  { column: 'release_date', options: { ascending: false, nullsFirst: false } },
+  { column: 'created_at', options: { ascending: false } },
+];
+
+beforeEach(() => {
+  orders.length = 0;
+  selects.length = 0;
+  rpcCalls.length = 0;
+});
+
+describe('the public artist-page read', () => {
+  it('sorts by the artist\'s arrangement first, then newest, in the query itself', async () => {
+    await getArtistReleases('artist-1', 60);
+    expect(orders.map(o => ({ column: o.column, options: o.options }))).toEqual(EXPECTED_ORDER);
+  });
+});
+
+describe('the owner\'s editing read', () => {
+  it('applies the same ordering, so the editor shows what fans see', async () => {
+    await getArtistReleasesForOwner('artist-1');
+    expect(orders.map(o => ({ column: o.column, options: o.options }))).toEqual(EXPECTED_ORDER);
+  });
+
+  // The page decides whether to offer "Reset to newest first" from this field. Without it, an
+  // artist who has arranged their catalogue has no way back to date order.
+  it('returns display_order, so the editor can tell an arrangement exists', async () => {
+    await getArtistReleasesForOwner('artist-1');
+    expect(selects[0]).toContain('display_order');
+  });
+});
+
+describe('storing an arrangement', () => {
+  // One RPC, one transaction: a half-written order is an arrangement the artist never chose,
+  // live on their public page.
+  it('goes through the transactional RPC with the ids in order', async () => {
+    const ids = ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'];
+    await expect(setReleaseDisplayOrder('artist-1', ids)).resolves.toBe(true);
+    expect(rpcCalls).toEqual([
+      { name: 'set_release_display_order', params: { p_artist_id: 'artist-1', p_release_ids: ids } },
+    ]);
+  });
+
+  // An empty arrangement is how "reset to newest first" reaches the database — the function
+  // clears every position that isn't in the array it was given.
+  it('sends an empty array through unchanged for a reset', async () => {
+    await setReleaseDisplayOrder('artist-1', []);
+    expect(rpcCalls[0].params.p_release_ids).toEqual([]);
+  });
+});

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -2,8 +2,8 @@
 //
 // The artist-facing half of release curation (spec §11): review what ingest catalogued, hide
 // what's wrong, fix a title/date/artwork, merge a release the tier-3 dedup pass flagged as a
-// possible duplicate (or one it didn't), add a platform link that's missing, or add a release
-// ingest never found at all.
+// possible duplicate (or one it didn't), add a platform link that's missing, add a release
+// ingest never found at all, or arrange the catalogue in the order fans should see it.
 //
 // Ownership is the security boundary here, not an RLS policy — `releases`/`release_sources`
 // have no auth.uid()-keyed write policy (see the `releases` migration's own comment), so every
@@ -21,6 +21,7 @@ import {
   createArtistRelease,
   dismissReleaseReview,
   mergeReleases,
+  setReleaseDisplayOrder,
   getCatalogState,
   clearCatalogCooldown,
   clearReleaseDetailCooldown,
@@ -35,6 +36,13 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 /** Longest title we'll store. Matches the slice in `updateArtistReleaseFields`. */
 const MAX_TITLE_LENGTH = 200;
+
+/**
+ * Most releases one `reorder` may arrange. The editor sends every release it knows about, so
+ * this is a bound on the array handed to Postgres, not a product limit: the largest catalogue
+ * measured so far is 33.
+ */
+const MAX_ORDERED_RELEASES = 500;
 
 /** Same rule as artist-profile.ts's link validation: only a protocol check, no domain allowlist. */
 function isHttpUrl(url: string): boolean {
@@ -171,8 +179,19 @@ export async function handler(event: {
 
   let body: {
     slug?: string;
-    action?: 'hide' | 'unhide' | 'dismiss' | 'merge' | 'update' | 'addLink' | 'create' | 'catalog';
+    action?:
+      | 'hide'
+      | 'unhide'
+      | 'dismiss'
+      | 'merge'
+      | 'update'
+      | 'addLink'
+      | 'create'
+      | 'catalog'
+      | 'reorder'
+      | 'resetOrder';
     releaseId?: string;
+    releaseIds?: unknown;
     keepId?: string;
     dropId?: string;
     title?: string;
@@ -200,7 +219,18 @@ export async function handler(event: {
   }
   const artistId = owned.artistId;
 
-  const VALID_ACTIONS = ['hide', 'unhide', 'dismiss', 'merge', 'update', 'addLink', 'create', 'catalog'];
+  const VALID_ACTIONS = [
+    'hide',
+    'unhide',
+    'dismiss',
+    'merge',
+    'update',
+    'addLink',
+    'create',
+    'catalog',
+    'reorder',
+    'resetOrder',
+  ];
   if (!action || !VALID_ACTIONS.includes(action)) {
     return {
       statusCode: 400,
@@ -299,6 +329,28 @@ export async function handler(event: {
       }
     }
     ok = await updateArtistReleaseFields(artistId, releaseId, { title, releaseDate, artworkUrl });
+  } else if (action === 'reorder' || action === 'resetOrder') {
+    // Two actions, one write: `resetOrder` is an empty arrangement, which the RPC reads as
+    // "clear every position and go back to newest first".
+    const releaseIds: unknown = action === 'resetOrder' ? [] : body.releaseIds;
+    if (!Array.isArray(releaseIds) || releaseIds.some(id => typeof id !== 'string' || !UUID_REGEX.test(id))) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseIds must be an array of UUIDs' }) };
+    }
+    if (releaseIds.length > MAX_ORDERED_RELEASES) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: `releaseIds must contain ${MAX_ORDERED_RELEASES} ids or fewer` }) };
+    }
+    // A repeated id means the editor sent an arrangement that isn't one — the last occurrence
+    // would silently win and a release the artist can see would vanish from their order.
+    if (new Set(releaseIds).size !== releaseIds.length) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'releaseIds must not repeat' }) };
+    }
+    // Same rule as hide/merge: owning the profile says nothing about who owns the ids in the
+    // body. `verifyReleaseOwnership` reports false for an empty list, so only ask when there's
+    // something to check — a reset touches nothing but this artist's own rows.
+    if (releaseIds.length > 0 && !(await verifyReleaseOwnership(artistId, releaseIds as string[]))) {
+      return { statusCode: 403, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not your release' }) };
+    }
+    ok = await setReleaseDisplayOrder(artistId, releaseIds as string[]);
   } else if (action === 'addLink') {
     const { releaseId, platform, url } = body;
     if (!releaseId || !UUID_REGEX.test(releaseId)) {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2080,6 +2080,8 @@ export interface OwnerReleaseItem {
   isHidden: boolean;
   needsReview: boolean;
   flaggedAgainst: { id: string; title: string } | null;
+  /** Position in the artist's manual order, or null if they haven't arranged this one. */
+  displayOrder: number | null;
   sources: { platform: string; url: string }[];
 }
 
@@ -2087,6 +2089,9 @@ export interface OwnerReleaseItem {
  * Every release under this artist — including hidden ones and needs_review ones, unlike the
  * public `getArtistReleases`, because the whole point of this view is letting the artist see
  * what ingest did (right or wrong) rather than only what a fan would see.
+ *
+ * Ordered exactly as the public page orders them, so what the artist arranges here is what a
+ * fan sees rather than a second arrangement that only exists in the editor.
  */
 export async function getArtistReleasesForOwner(artistId: string): Promise<OwnerReleaseItem[]> {
   const client = getClient();
@@ -2097,9 +2102,10 @@ export async function getArtistReleasesForOwner(artistId: string): Promise<Owner
       .from('releases')
       .select(
         'id, title, slug, release_type, release_date, date_precision, artwork_url, is_hidden,' +
-        ' needs_review, flagged_against_release_id, release_sources ( platform, url )'
+        ' needs_review, flagged_against_release_id, display_order, release_sources ( platform, url )'
       )
       .eq('artist_id', artistId)
+      .order('display_order', { ascending: true, nullsFirst: false })
       .order('release_date', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
 
@@ -2119,6 +2125,7 @@ export async function getArtistReleasesForOwner(artistId: string): Promise<Owner
       is_hidden: boolean;
       needs_review: boolean;
       flagged_against_release_id: string | null;
+      display_order: number | null;
       release_sources: { platform: string; url: string }[] | null;
     };
 
@@ -2142,12 +2149,40 @@ export async function getArtistReleasesForOwner(artistId: string): Promise<Owner
         r.flagged_against_release_id && titleById.has(r.flagged_against_release_id)
           ? { id: r.flagged_against_release_id, title: titleById.get(r.flagged_against_release_id)! }
           : null,
+      displayOrder: r.display_order,
       sources: (r.release_sources || []).map(s => ({ platform: s.platform, url: s.url })),
     }));
   } catch (error) {
     console.error('[DB] getArtistReleasesForOwner error:', error);
     return [];
   }
+}
+
+/**
+ * Store a claimed artist's manual release order.
+ *
+ * `releaseIds` is the complete arrangement the editor is showing, in display order. Releases
+ * left out of it are reset to unpositioned, so an empty array is "back to newest first", and a
+ * release catalogued between the page loading and saving isn't handed a position nobody chose —
+ * it stays null and sorts to the end.
+ *
+ * One RPC because it's one transaction: a half-written order is an arrangement the artist never
+ * picked, showing on their public page. Same reasoning as `replace_artist_links`.
+ */
+export async function setReleaseDisplayOrder(artistId: string, releaseIds: string[]): Promise<boolean> {
+  const client = getClient();
+  if (!client) return false;
+
+  const { error } = await client.rpc('set_release_display_order', {
+    p_artist_id: artistId,
+    p_release_ids: releaseIds,
+  });
+
+  if (error) {
+    console.error('[DB] setReleaseDisplayOrder failed:', error.message);
+    return false;
+  }
+  return true;
 }
 
 /** "This shouldn't be on my page." Ingest must never write `is_hidden` — only this, or an admin. */
@@ -3004,12 +3039,19 @@ export interface ArtistPageRelease {
 }
 
 /**
- * An artist's releases for their page, newest first, plus the total.
+ * An artist's releases for their page, in the artist's order where they set one and newest
+ * first otherwise, plus the total.
  *
  * `count: 'exact'` rides along with the limit in one round trip, so an "and N more" line is a
- * real number rather than a guess. Ordering matches idx_releases_artist_chrono: many releases
- * have no date yet — grid ingest gets identity and artwork but no dates — and without the
- * created_at tiebreaker those undated rows would shuffle between requests.
+ * real number rather than a guess. The chronological part of the ordering matches
+ * idx_releases_artist_chrono: many releases have no date yet — grid ingest gets identity and
+ * artwork but no dates — and without the created_at tiebreaker those undated rows would shuffle
+ * between requests.
+ *
+ * `display_order` leads, NULLS LAST: it's null for every release until a claimed artist arranges
+ * their catalogue on /artist-edit/:slug/releases, so this is unchanged behaviour for everyone
+ * else. Sorted in SQL rather than after the fetch on purpose — re-sorting a date-limited page in
+ * JS would drop a release the artist had pinned to the top out of the query entirely.
  *
  * Hidden releases are filtered in the query rather than after, so a suppressed release is
  * indistinguishable from one that was never catalogued. That's the point of the column.
@@ -3031,6 +3073,7 @@ export async function getArtistReleases(
       )
       .eq('artist_id', artistId)
       .eq('is_hidden', false)
+      .order('display_order', { ascending: true, nullsFirst: false })
       .order('release_date', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false })
       .limit(limit);
@@ -3281,6 +3324,12 @@ export interface AlertReleases {
  * delightful possible alert ("your artist just announced an album for September") could not fire
  * at all. Undated releases are excluded: with no date there is nothing to say is new, and grid
  * ingest produces plenty of them.
+ *
+ * Strictly chronological, and `releases.display_order` deliberately does not apply — that's not
+ * an oversight. An artist's manual arrangement answers "what should fans see first on my page";
+ * an alert answers "what came out". Honouring the arrangement here would let a pinned back
+ * catalogue release be announced as the new one, and `release[0]` — which the shipped Mac app
+ * and extension read as *the* new release — would stop meaning newest.
  */
 export async function getReleasesForAlerts(
   artistName: string,
@@ -3513,6 +3562,10 @@ export const FEED_TRAILING_DAYS = 30;
 
 /** Cap on events in one feed, so a fan with hundreds of saved artists still gets a usable file. */
 const FEED_MAX_RELEASES = 200;
+
+// Every feed read below is ordered by date, and `releases.display_order` deliberately does not
+// apply to any of them. A calendar is keyed on dates and a reader sorts an Atom feed by them, so
+// an artist's page arrangement has nothing to say here — the same line drawn for alerts above.
 
 type FeedQueryRow = {
   slug: string;

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -9,6 +9,7 @@ import { PlatformIcon } from '../components/PlatformIcon';
 import { PLATFORMS } from '../../../../api/shared/platform-registry';
 import { formatReleaseDate } from '../../../../api/shared/release-display';
 import { sources } from '../services/sources';
+import { applyPendingOrder } from '../utils/releaseOrder';
 import type { SourceId } from '../types';
 
 const PLATFORM_OPTIONS = (Object.values(sources) as { id: SourceId; name: string }[])
@@ -50,6 +51,8 @@ interface OwnerRelease {
   isHidden: boolean;
   needsReview: boolean;
   flaggedAgainst: { id: string; title: string } | null;
+  /** Position in the artist's manual order, or null if this one has never been placed. */
+  displayOrder: number | null;
   sources: { platform: string; url: string }[];
 }
 
@@ -86,6 +89,7 @@ export function ArtistReleasesPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const [catalog, setCatalog] = useState<CatalogInfo | null>(null);
+  const [pendingOrder, setPendingOrder] = useState<string[] | null>(null);
 
   const fetchReleases = useCallback(async () => {
     if (!session?.access_token || !slug) return;
@@ -150,6 +154,28 @@ export function ArtistReleasesPage() {
 
   if (!slug) return null;
 
+  // What the page shows: the saved order from the server, with any unsaved rearrangement on top.
+  const ordered = applyPendingOrder(releases, pendingOrder);
+  const hasCustomOrder = releases.some(r => r.displayOrder !== null);
+
+  function moveRelease(index: number, direction: -1 | 1) {
+    const target = index + direction;
+    if (target < 0 || target >= ordered.length) return;
+    const rearranged = [...ordered];
+    [rearranged[index], rearranged[target]] = [rearranged[target], rearranged[index]];
+    setPendingOrder(rearranged.map(r => r.id));
+  }
+
+  async function saveOrder() {
+    const saved = await runAction('reorder', { action: 'reorder', releaseIds: ordered.map(r => r.id) });
+    if (saved) setPendingOrder(null);
+  }
+
+  async function resetOrder() {
+    const reset = await runAction('resetOrder', { action: 'resetOrder' });
+    if (reset) setPendingOrder(null);
+  }
+
   return (
     <div className="min-h-screen">
       <Header />
@@ -164,8 +190,8 @@ export function ArtistReleasesPage() {
             </Link>
             <h1 className="font-display text-2xl font-bold text-text-primary mt-1">Manage Releases</h1>
             <p className="text-text-muted text-sm mt-1">
-              Hide anything that isn't yours, fix a title or date, merge a duplicate, or add
-              something we missed.
+              Hide anything that isn't yours, fix a title or date, merge a duplicate, add
+              something we missed, or put them in the order you want fans to see.
             </p>
           </div>
 
@@ -209,16 +235,39 @@ export function ArtistReleasesPage() {
                 />
               )}
 
-              {releases.length === 0 ? (
+              {ordered.length > 1 && (
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className="text-xs text-text-muted">
+                    Fans see your releases in this order. Use the arrows to arrange them — anything
+                    catalogued later is added to the end.
+                  </p>
+                  {hasCustomOrder && (
+                    <button
+                      onClick={resetOrder}
+                      disabled={actionLoading === 'resetOrder'}
+                      className="text-xs text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+                    >
+                      {actionLoading === 'resetOrder' ? 'Resetting...' : 'Reset to newest first'}
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {ordered.length === 0 ? (
                 <p className="text-text-muted text-sm">No releases catalogued yet.</p>
               ) : (
                 <div className="space-y-3">
-                  {releases.map(release => (
+                  {ordered.map((release, index) => (
                     <ReleaseCard
                       key={release.id}
                       release={release}
                       editing={editingId === release.id}
                       actionLoading={actionLoading}
+                      showReorder={ordered.length > 1}
+                      canMoveUp={index > 0}
+                      canMoveDown={index < ordered.length - 1}
+                      onMoveUp={() => moveRelease(index, -1)}
+                      onMoveDown={() => moveRelease(index, 1)}
                       onToggleEdit={() => setEditingId(editingId === release.id ? null : release.id)}
                       onHide={() =>
                         runAction(`hide-${release.id}`, {
@@ -241,6 +290,28 @@ export function ArtistReleasesPage() {
                       }
                     />
                   ))}
+                </div>
+              )}
+
+              {/* Sticky, because a rearranged release can be a long scroll away from the top of
+                  a real catalogue — and an unsaved order that looks saved is the whole failure
+                  mode worth designing out here. */}
+              {pendingOrder && (
+                <div className="sticky bottom-4 flex flex-wrap items-center gap-3 p-3 rounded-xl bg-surface border border-border shadow-lg">
+                  <span className="text-sm text-text-primary">Your new order isn't saved yet.</span>
+                  <button
+                    onClick={saveOrder}
+                    disabled={actionLoading === 'reorder'}
+                    className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-500 transition-colors disabled:opacity-50"
+                  >
+                    {actionLoading === 'reorder' ? 'Saving...' : 'Save order'}
+                  </button>
+                  <button
+                    onClick={() => setPendingOrder(null)}
+                    className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-xs font-medium hover:bg-bg-hover transition-colors"
+                  >
+                    Discard
+                  </button>
                 </div>
               )}
             </>
@@ -442,6 +513,11 @@ function ReleaseCard({
   release,
   editing,
   actionLoading,
+  showReorder,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
   onToggleEdit,
   onHide,
   onDismiss,
@@ -452,6 +528,11 @@ function ReleaseCard({
   release: OwnerRelease;
   editing: boolean;
   actionLoading: string | null;
+  showReorder: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
   onToggleEdit: () => void;
   onHide: () => void;
   onDismiss: () => void;
@@ -467,6 +548,31 @@ function ReleaseCard({
   return (
     <div className={`p-4 rounded-xl bg-surface border border-border space-y-3 ${release.isHidden ? 'opacity-60' : ''}`}>
       <div className="flex items-start gap-3">
+        {/* Same control as the platform-link editor on /artist-edit/:slug — one arrangement
+            gesture across the two lists an artist curates. */}
+        {showReorder && (
+          <div className="flex flex-col gap-0.5 pt-1 shrink-0">
+            <button
+              onClick={onMoveUp}
+              disabled={!canMoveUp}
+              aria-label={`Move ${release.title} up`}
+              title="Move up"
+              className="text-text-muted hover:text-text-primary disabled:opacity-20 text-xs leading-none"
+            >
+              ▲
+            </button>
+            <button
+              onClick={onMoveDown}
+              disabled={!canMoveDown}
+              aria-label={`Move ${release.title} down`}
+              title="Move down"
+              className="text-text-muted hover:text-text-primary disabled:opacity-20 text-xs leading-none"
+            >
+              ▼
+            </button>
+          </div>
+        )}
+
         {release.artworkUrl ? (
           <img
             src={release.artworkUrl}

--- a/apps/web/src/utils/releaseOrder.ts
+++ b/apps/web/src/utils/releaseOrder.ts
@@ -1,0 +1,24 @@
+/**
+ * The release list as the artist has rearranged it on /artist-edit/:slug/releases but not yet
+ * saved.
+ *
+ * An arrangement in progress is held as ids rather than a reordered copy of the list, so the
+ * refetch that every other action on that page triggers — hiding a release, fixing a title —
+ * can't quietly discard it. That's what this function puts back together.
+ *
+ * A release the artist hasn't placed (one catalogued since the page loaded) keeps its server
+ * position at the end rather than appearing somewhere in the middle of an order it was never
+ * part of. Ranks are real numbers for exactly that case: `Infinity - Infinity` is NaN, and a
+ * comparator returning NaN leaves the whole list in arbitrary order.
+ */
+export function applyPendingOrder<T extends { id: string }>(
+  releases: T[],
+  pendingOrder: string[] | null
+): T[] {
+  if (!pendingOrder) return releases;
+  const rank = new Map(pendingOrder.map((id, index) => [id, index]));
+  return releases
+    .map((release, index) => ({ release, rank: rank.get(release.id) ?? pendingOrder.length + index }))
+    .sort((a, b) => a.rank - b.rank)
+    .map(entry => entry.release);
+}

--- a/apps/web/tests/unit/ArtistReleasesPage.test.tsx
+++ b/apps/web/tests/unit/ArtistReleasesPage.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ArtistReleasesPage } from 'src/pages/ArtistReleasesPage';
+import { applyPendingOrder } from 'src/utils/releaseOrder';
 
 const mockSession = { access_token: 'user-token' };
 vi.mock('src/contexts/AuthContext', () => ({
@@ -38,6 +39,7 @@ function releaseItem(overrides: Record<string, unknown> = {}) {
     isHidden: false,
     needsReview: false,
     flaggedAgainst: null,
+    displayOrder: null,
     sources: [{ platform: 'bandcamp', url: 'https://x.bandcamp.com/album/ruined-castle' }],
     ...overrides,
   };
@@ -209,6 +211,118 @@ describe('ArtistReleasesPage', () => {
     setupFetchMock([]);
     renderPage();
     await waitFor(() => expect(screen.getByText('No releases catalogued yet.')).toBeTruthy());
+  });
+});
+
+describe('applyPendingOrder', () => {
+  const a = { id: 'a' };
+  const b = { id: 'b' };
+  const c = { id: 'c' };
+
+  it('leaves the server order alone when nothing is pending', () => {
+    expect(applyPendingOrder([a, b, c], null)).toEqual([a, b, c]);
+  });
+
+  it('applies the artist\'s arrangement', () => {
+    expect(applyPendingOrder([a, b, c], ['c', 'a', 'b'])).toEqual([c, a, b]);
+  });
+
+  // The case this helper exists for: any other action on the page refetches, and a release
+  // catalogued since the page loaded arrives with no place in the pending arrangement. It has to
+  // land at the end, in its server order — not in the middle of an order it was never part of,
+  // and not by way of a NaN comparator that leaves the whole list arbitrary.
+  it('puts releases the artist has not placed after the ones they have, in server order', () => {
+    const d = { id: 'd' };
+    expect(applyPendingOrder([a, b, c, d], ['c', 'a'])).toEqual([c, a, b, d]);
+  });
+});
+
+describe('ArtistReleasesPage — manual ordering', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  const FIRST = releaseItem({ id: '11111111-1111-1111-1111-111111111111', title: 'Ruined Castle' });
+  const SECOND = releaseItem({ id: '22222222-2222-2222-2222-222222222222', title: 'Infinite Normal' });
+
+  /** Titles in DOM order — what the artist actually sees, rather than what state holds. */
+  function titlesInOrder() {
+    return screen.getAllByText(/^(Ruined Castle|Infinite Normal)$/).map(el => el.textContent);
+  }
+
+  it('offers no arrows when there is only one release to arrange', async () => {
+    setupFetchMock([FIRST]);
+    renderPage();
+    await waitFor(() => screen.getByText('Ruined Castle'));
+    expect(screen.queryByLabelText(/Move Ruined Castle/)).toBeNull();
+  });
+
+  it('moves a release down and saves the whole arrangement in order', async () => {
+    setupFetchMock([FIRST, SECOND]);
+    renderPage();
+
+    await waitFor(() => screen.getByLabelText('Move Ruined Castle down'));
+    fireEvent.click(screen.getByLabelText('Move Ruined Castle down'));
+
+    // Nothing is written until the artist says so — the arrows rearrange locally.
+    expect(mockFetch.mock.calls.some(call => call[1]?.method === 'POST')).toBe(false);
+    fireEvent.click(screen.getByText('Save order'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(postCall![1].body)).toEqual({
+        slug: 'kid-lightbulbs',
+        action: 'reorder',
+        releaseIds: [SECOND.id, FIRST.id],
+      });
+    });
+  });
+
+  it('discards an unsaved arrangement without writing anything', async () => {
+    setupFetchMock([FIRST, SECOND]);
+    renderPage();
+
+    await waitFor(() => screen.getByLabelText('Move Infinite Normal up'));
+    fireEvent.click(screen.getByLabelText('Move Infinite Normal up'));
+    fireEvent.click(screen.getByText('Discard'));
+
+    expect(screen.queryByText('Save order')).toBeNull();
+    expect(mockFetch.mock.calls.some(call => call[1]?.method === 'POST')).toBe(false);
+  });
+
+  // An unsaved arrangement must survive the refetch that every other action triggers, or the
+  // artist loses their work to a click on "Hide".
+  it('keeps an unsaved arrangement across another action\'s refetch', async () => {
+    setupFetchMock([FIRST, SECOND]);
+    renderPage();
+
+    await waitFor(() => screen.getByLabelText('Move Infinite Normal up'));
+    fireEvent.click(screen.getByLabelText('Move Infinite Normal up'));
+    fireEvent.click(screen.getAllByText('Hide')[0]);
+
+    await waitFor(() => expect(mockFetch.mock.calls.filter(call => !call[1]?.method).length).toBe(2));
+    expect(screen.getByText('Save order')).toBeTruthy();
+    expect(titlesInOrder()).toEqual(['Infinite Normal', 'Ruined Castle']);
+  });
+
+  it('offers a reset only once an order has been stored, and clears it', async () => {
+    setupFetchMock([FIRST, SECOND]);
+    renderPage();
+    await waitFor(() => screen.getByText('Ruined Castle'));
+    expect(screen.queryByText('Reset to newest first')).toBeNull();
+
+    cleanup();
+    setupFetchMock([{ ...FIRST, displayOrder: 0 }, { ...SECOND, displayOrder: 1 }]);
+    renderPage();
+
+    await waitFor(() => screen.getByText('Reset to newest first'));
+    fireEvent.click(screen.getByText('Reset to newest first'));
+
+    await waitFor(() => {
+      const postCall = mockFetch.mock.calls.find(call => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(postCall![1].body)).toEqual({ slug: 'kid-lightbulbs', action: 'resetOrder' });
+    });
   });
 });
 

--- a/supabase/migrations/20260802150000_release-display-order.sql
+++ b/supabase/migrations/20260802150000_release-display-order.sql
@@ -1,0 +1,68 @@
+-- Migration: manual release ordering for claimed artists
+--
+-- Releases are listed newest first everywhere they appear. A claimed artist may
+-- want a different arrangement — lead with the record they're promoting, push a
+-- compilation down — exactly as they already arrange their platform links with
+-- artist_links.display_order. Same column name, same idea.
+--
+-- Nullable, and null for every existing row: reads order by
+--   display_order ASC NULLS LAST, release_date DESC, created_at DESC
+-- so an artist who never touches this keeps today's behaviour precisely, and a
+-- release catalogued *after* an artist arranged theirs lands at the end of that
+-- arrangement rather than silently displacing what they chose.
+--
+-- No index. The sort only ever runs over one artist's releases after the
+-- artist_id filter — tens of rows, the largest catalogue measured so far is 33 —
+-- so idx_releases_artist_id already does the work that matters.
+ALTER TABLE releases ADD COLUMN IF NOT EXISTS display_order integer;
+
+COMMENT ON COLUMN releases.display_order IS
+  'Position in the artist''s manual release order. NULL means unpositioned; those sort after every positioned release, newest first.';
+
+-- ---------------------------------------------------------------------------
+-- Storing an arrangement
+-- ---------------------------------------------------------------------------
+--
+-- One function in one transaction, for the same reason replace_artist_links is
+-- one function: a save applied halfway is an arrangement the artist never chose,
+-- visible on their public page.
+--
+-- p_release_ids is the complete arrangement the editor is showing, in order.
+-- Ids absent from it are cleared back to unpositioned, which makes an empty
+-- array mean "reset to date order" and stops a release catalogued between the
+-- editor loading and saving from being handed a position nobody picked.
+CREATE OR REPLACE FUNCTION public.set_release_display_order(
+  p_artist_id uuid,
+  p_release_ids uuid[]
+) RETURNS void
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE releases
+     SET display_order = NULL
+   WHERE artist_id = p_artist_id
+     AND display_order IS NOT NULL
+     AND NOT (id = ANY (COALESCE(p_release_ids, ARRAY[]::uuid[])));
+
+  IF array_length(p_release_ids, 1) > 0 THEN
+    UPDATE releases r
+       SET display_order = arranged.ord - 1
+      FROM unnest(p_release_ids) WITH ORDINALITY AS arranged(release_id, ord)
+     WHERE r.artist_id = p_artist_id
+       AND r.id = arranged.release_id;
+  END IF;
+END;
+$$;
+
+-- PostgREST publishes every public-schema function as an RPC endpoint, so
+-- without this the anon key could rearrange any artist's releases. Only the
+-- service-role client may call it — and it does so from artist-releases.ts,
+-- which checks ownership of the artist *and* of every release id first.
+REVOKE ALL ON FUNCTION public.set_release_display_order(uuid, uuid[]) FROM public;
+REVOKE ALL ON FUNCTION public.set_release_display_order(uuid, uuid[]) FROM anon;
+REVOKE ALL ON FUNCTION public.set_release_display_order(uuid, uuid[]) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.set_release_display_order(uuid, uuid[]) TO service_role;
+
+COMMENT ON FUNCTION public.set_release_display_order(uuid, uuid[]) IS
+  'Stores an artist''s manual release order in one transaction. Releases omitted from the array are reset to unpositioned.';


### PR DESCRIPTION
Releases have always been listed newest first. An artist may want a different order — lead with the record they're promoting, push a compilation down — the same way they already arrange their platform links, so this reuses that control: ▲▼ on each row in **Manage Releases**, with one explicit save.

## Storage

`releases.display_order` (nullable integer), matching `artist_links.display_order`. Writes go through a transactional `set_release_display_order()` RPC, service-role only, for the same reason `replace_artist_links` is one function: a half-applied order is an arrangement the artist never picked, live on their public page. Ids omitted from the array are cleared, so an empty array is "reset" and a release catalogued between page-load and save isn't handed a position nobody chose.

## Which reads honour it

Every surface that returns a list of an artist's releases now sorts `display_order ASC NULLS LAST, release_date DESC, created_at DESC`:

| Surface | |
|---|---|
| `/api/artist-page` | the SPA artist page |
| `/a/:slug` edge render | identical clause — the two renderers of one URL must not disagree |
| `/api/artist-releases` | the editor, so it shows what fans see |

Sorted **in SQL**, not after the fetch: both page reads are limited (60 and 24), so a JS re-sort would drop a release pinned to the top out of the query on a long catalogue while looking correct on a short one.

## Which deliberately don't

`getReleasesForAlerts` and the ICS/Atom feed reads stay chronological, with a comment saying so at each one. An arrangement answers "what should fans see first"; an alert answers "what came out" — and `releases[0]`, which the shipped Mac app and extension read as *the* new release, has to keep meaning newest. `/api/release/{artist}/{release}` (#393) returns a single release and is untouched.

## Behaviour when new releases arrive

`display_order` is null until an artist arranges their catalogue, so this is inert for everyone else. A release catalogued *after* an arrangement lands at the end of it rather than displacing what the artist chose — the page says so, and "Reset to newest first" undoes the whole thing.

## Verification

- Migration and RPC run against a real Postgres 16: arrangement stored, a later release joining unpositioned, reset via empty array, another artist's id ignored rather than stolen, `NULL` array handled.
- `release-order-query.test.ts` locks the SQL ordering for both page reads and the RPC call; API tests cover reorder validation, ownership of every id in the body, duplicate ids, the length cap and reset; page tests cover move → save payload, discard, reset, and that an unsaved arrangement survives the refetch another action triggers. Each new test was confirmed to fail with the logic broken.
- `npm run build` passes. Lint: touched files clean.

No screenshot — `/artist-edit/:slug/releases` is auth-gated and the dev API has no release endpoints, so the jsdom tests are the real-DOM verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)