### PR TITLE
Handle service worker registration failures gracefully

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import * as Sentry from '@sentry/react'
 import { initSentry } from './services/sentry'
+import { registerServiceWorker } from './services/registerServiceWorker'
 import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 import App from './App.tsx'
@@ -12,6 +13,11 @@ import { ScrollToTop } from './components/ScrollToTop'
 import { lazyWithRetry } from './utils/lazyWithRetry'
 
 initSentry()
+
+// Ours rather than vite-plugin-pwa's injected registerSW.js, which reports a
+// declined registration as an unhandled rejection. Guarded on PROD because the
+// plugin only emits /sw.js for a build, exactly as the injected script was.
+if (import.meta.env.PROD) registerServiceWorker()
 
 // Lazy-load non-critical pages to reduce initial bundle size.
 // lazyWithRetry adds a one-shot reload when a chunk belongs to a superseded deploy.

--- a/apps/web/src/services/registerServiceWorker.ts
+++ b/apps/web/src/services/registerServiceWorker.ts
@@ -1,0 +1,41 @@
+import * as Sentry from '@sentry/react'
+
+/**
+ * Register the PWA service worker, and treat a refusal as a refusal rather than
+ * a crash.
+ *
+ * vite-plugin-pwa injects this for us by default, but the `registerSW.js` it
+ * generates is one unguarded line:
+ *
+ *   navigator.serviceWorker.register('/sw.js', { scope: '/' })
+ *
+ * No `.catch()`, so anything that declines to register becomes an unhandled
+ * promise rejection, which Sentry's global handler reports at error level. The
+ * declines are all routine:
+ *
+ * - Google's Web Rendering Service — Googlebot and Google-Read-Aloud — replaces
+ *   `register` with a stub that rejects `Error: Rejected` on purpose. Crawlers
+ *   don't run service workers. This is what filled the issue: a Read-Aloud fetch
+ *   of the homepage, reported as if a person had hit an error on page one.
+ * - Chrome incognito and Firefox private browsing refuse registration.
+ * - Enterprise policy, or a browser set to block site data, refuses it too.
+ *
+ * None of those are broken pages. Without a service worker the app is simply
+ * online-only, which is a state it supports. So `injectRegister` is off in
+ * vite.config.ts and we register from here instead, recording a failure as a
+ * breadcrumb — there to explain a later error, not to be an error itself.
+ */
+export function registerServiceWorker(): void {
+  if (!('serviceWorker' in navigator)) return
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((error: unknown) => {
+      Sentry.addBreadcrumb({
+        category: 'pwa',
+        level: 'info',
+        message: 'Service worker registration declined',
+        data: { reason: error instanceof Error ? error.message : String(error) },
+      })
+    })
+  })
+}

--- a/apps/web/src/services/registerServiceWorker.ts
+++ b/apps/web/src/services/registerServiceWorker.ts
@@ -28,14 +28,25 @@ import * as Sentry from '@sentry/react'
 export function registerServiceWorker(): void {
   if (!('serviceWorker' in navigator)) return
 
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((error: unknown) => {
-      Sentry.addBreadcrumb({
-        category: 'pwa',
-        level: 'info',
-        message: 'Service worker registration declined',
-        data: { reason: error instanceof Error ? error.message : String(error) },
-      })
+  // Held until load so registration never competes with the first paint, which
+  // is what the injected script did too. Checking readyState rather than
+  // trusting the listener: main.tsx runs as a deferred module, so today it is
+  // reliably before 'load' — but a listener added after 'load' has fired never
+  // runs, and that failure is silent, a service worker that simply never exists.
+  if (document.readyState === 'complete') {
+    register()
+  } else {
+    window.addEventListener('load', register, { once: true })
+  }
+}
+
+function register(): void {
+  navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((error: unknown) => {
+    Sentry.addBreadcrumb({
+      category: 'pwa',
+      level: 'info',
+      message: 'Service worker registration declined',
+      data: { reason: error instanceof Error ? error.message : String(error) },
     })
   })
 }

--- a/apps/web/tests/unit/register-service-worker.test.ts
+++ b/apps/web/tests/unit/register-service-worker.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { addBreadcrumb } from '@sentry/react';
+import { registerServiceWorker } from '../../src/services/registerServiceWorker';
+
+vi.mock('@sentry/react', () => ({ addBreadcrumb: vi.fn() }));
+
+/**
+ * Google's crawler stubs out navigator.serviceWorker.register so it rejects
+ * `Error: Rejected`, and vite-plugin-pwa's injected registerSW.js never caught
+ * it — so a Read-Aloud fetch of the homepage arrived in Sentry looking like a
+ * person hitting an error on their first page view. A declined registration is
+ * a breadcrumb, not an event.
+ */
+const register = vi.fn();
+// Registration is deferred to window 'load'. Capturing the listener beats
+// dispatching the real event, which would also re-run listeners left behind by
+// earlier tests, against a navigator they no longer expect.
+const listen = vi.spyOn(window, 'addEventListener');
+
+function stubServiceWorker(value: unknown) {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** Runs this test's 'load' listener, as page load would. */
+async function fireLoad() {
+  for (const [type, handler] of listen.mock.calls) {
+    if (type === 'load') (handler as EventListener)(new Event('load'));
+  }
+  // Let the rejection handler attached inside the listener run.
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  register.mockReset().mockResolvedValue({});
+  vi.mocked(addBreadcrumb).mockClear();
+  listen.mockClear();
+  stubServiceWorker({ register });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, 'serviceWorker');
+});
+
+describe('registerServiceWorker', () => {
+  it('registers /sw.js at the root scope once the page has loaded', async () => {
+    registerServiceWorker();
+    expect(register).not.toHaveBeenCalled();
+
+    await fireLoad();
+
+    expect(register).toHaveBeenCalledWith('/sw.js', { scope: '/' });
+    expect(addBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it('records a declined registration as a breadcrumb rather than an error', async () => {
+    register.mockRejectedValue(new Error('Rejected'));
+
+    registerServiceWorker();
+    await fireLoad();
+
+    // Reaching the breadcrumb is the proof the rejection was consumed. Drop the
+    // .catch() and this rejection goes unhandled, which is the whole bug.
+    expect(addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'pwa',
+        level: 'info',
+        data: { reason: 'Rejected' },
+      })
+    );
+  });
+
+  it('does nothing where the browser has no service worker support', async () => {
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+
+    expect(() => registerServiceWorker()).not.toThrow();
+    await fireLoad();
+
+    expect(register).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/register-service-worker.test.ts
+++ b/apps/web/tests/unit/register-service-worker.test.ts
@@ -26,12 +26,20 @@ function stubServiceWorker(value: unknown) {
   });
 }
 
+function setReadyState(state: DocumentReadyState) {
+  Object.defineProperty(document, 'readyState', { value: state, configurable: true });
+}
+
 /** Runs this test's 'load' listener, as page load would. */
 async function fireLoad() {
   for (const [type, handler] of listen.mock.calls) {
     if (type === 'load') (handler as EventListener)(new Event('load'));
   }
-  // Let the rejection handler attached inside the listener run.
+  await settle();
+}
+
+/** Lets the rejection handler attached inside the registration run. */
+async function settle() {
   await Promise.resolve();
   await Promise.resolve();
 }
@@ -41,6 +49,7 @@ beforeEach(() => {
   vi.mocked(addBreadcrumb).mockClear();
   listen.mockClear();
   stubServiceWorker({ register });
+  setReadyState('loading');
 });
 
 afterEach(() => {
@@ -56,6 +65,17 @@ describe('registerServiceWorker', () => {
 
     expect(register).toHaveBeenCalledWith('/sw.js', { scope: '/' });
     expect(addBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it('registers straight away when load has already fired', async () => {
+    // A listener added after 'load' never runs, which would leave the app with
+    // no service worker and nothing to show for it.
+    setReadyState('complete');
+
+    registerServiceWorker();
+    await settle();
+
+    expect(register).toHaveBeenCalledWith('/sw.js', { scope: '/' });
   });
 
   it('records a declined registration as a breadcrumb rather than an error', async () => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -42,6 +42,11 @@ export default defineConfig({
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
+      // The generated registerSW.js calls navigator.serviceWorker.register()
+      // with no .catch(), so every browser and crawler that declines to
+      // register one raised an unhandled `Error: Rejected` in Sentry. We
+      // register from src/services/registerServiceWorker.ts instead.
+      injectRegister: false,
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {
         name: 'Unstream',


### PR DESCRIPTION
## Summary

Fixes unhandled promise rejections from service worker registration failures being reported as errors in Sentry. Service worker registration can be declined for legitimate reasons (Google's crawlers, incognito/private browsing, enterprise policy) that don't indicate a broken page. These are now recorded as breadcrumbs instead of errors.

## Changes

- **New service**: `apps/web/src/services/registerServiceWorker.ts` — registers the PWA service worker with proper error handling. Catches registration failures and logs them as Sentry breadcrumbs rather than unhandled rejections.
- **Updated entry point**: `apps/web/src/main.tsx` — calls `registerServiceWorker()` on production builds instead of relying on vite-plugin-pwa's auto-injected `registerSW.js`.
- **Vite config**: `apps/web/vite.config.ts` — disabled `injectRegister` in VitePWA plugin to prevent the unguarded registration call.
- **Test coverage**: `apps/web/tests/unit/register-service-worker.test.ts` — comprehensive unit tests covering successful registration, declined registration (breadcrumb recording), and browsers without service worker support.

## Implementation Details

The original issue: vite-plugin-pwa injects a single unguarded line (`navigator.serviceWorker.register('/sw.js', { scope: '/' })`) with no `.catch()` handler. When registration is declined (e.g., by Google's Web Rendering Service for Read-Aloud, or in private browsing), the unhandled rejection is caught by Sentry's global handler and reported as an error-level event, polluting error metrics.

The solution defers registration to the window `load` event and wraps it with a `.catch()` that records the failure as an info-level breadcrumb with the rejection reason. This preserves the information for debugging while correctly classifying declined registrations as non-errors.

The implementation is guarded behind `import.meta.env.PROD` since vite-plugin-pwa only emits `/sw.js` during production builds.

https://claude.ai/code/session_01UJ5mKPVKjJRzY5MpQSkkaW