### PR TITLE
Open self-serve release scanning to all verified artists

### DIFF
--- a/api/functions/__tests__/artist-releases.test.ts
+++ b/api/functions/__tests__/artist-releases.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   authenticateBearer: vi.fn(),
-  authenticateAdmin: vi.fn(),
   resolveOwnedArtist: vi.fn(),
   verifyReleaseOwnership: vi.fn(),
   getArtistReleasesForOwner: vi.fn(),
@@ -49,7 +48,6 @@ vi.mock('../db', () => ({
 // non-API-key behaviour (pin to the canonical origin).
 vi.mock('../middleware', () => ({
   authenticateBearer: mocks.authenticateBearer,
-  authenticateAdmin: mocks.authenticateAdmin,
   buildCorsHeaders: (origin: string | undefined, apiKeyPresent: boolean) => ({
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': apiKeyPresent
@@ -90,8 +88,6 @@ function post(body: unknown) {
 
 beforeEach(() => {
   mocks.authenticateBearer.mockResolvedValue({ userId: 'u1', email: 'artist@example.com' });
-  // Admin by default so the catalog path is reachable; the gate has its own tests below.
-  mocks.authenticateAdmin.mockResolvedValue({ userId: 'u1', email: 'admin@example.com' });
   mocks.resolveOwnedArtist.mockResolvedValue({ ok: true, status: 200, artistId: 'artist-1', artistName: 'Kid Lightbulbs' });
   mocks.verifyReleaseOwnership.mockResolvedValue(true);
   mocks.getArtistReleasesForOwner.mockResolvedValue([]);
@@ -309,6 +305,8 @@ describe('POST — reorder', () => {
   });
 });
 
+// Open to every verified owner — there is no admin gate on this action, only the once-a-day
+// ceiling below. Ownership (`resolveOwnedArtist`) is what authorizes it.
 describe('POST — catalog (self-serve scan)', () => {
   it('clears the cooldown before queuing, or the button silently does nothing for a week', async () => {
     const r = await post({ action: 'catalog', slug: SLUG });
@@ -320,21 +318,45 @@ describe('POST — catalog (self-serve scan)', () => {
     expect(mocks.triggerCatalogNow).toHaveBeenCalledWith('artist-1');
   });
 
-  // The rollout gate. Ownership authorizes the action; this is a separate, temporary limit on
-  // who can reach it at all — so a verified non-admin owner is refused for now.
-  it('refuses a verified owner who is not an admin while the rollout gate is on', async () => {
-    mocks.authenticateAdmin.mockResolvedValue(null);
+  // Ownership is still the security boundary — nobody, admin or not, may catalog a profile that
+  // isn't theirs through this endpoint (that's what /api/admin/catalog-artist is for).
+  it('still requires ownership', async () => {
+    mocks.resolveOwnedArtist.mockResolvedValue({ ok: false, status: 403, error: 'You do not own this profile' });
     const r = await post({ action: 'catalog', slug: SLUG });
     expect(r.statusCode).toBe(403);
     expect(mocks.triggerCatalogNow).not.toHaveBeenCalled();
   });
 
-  // Ownership still has to hold on top of the gate — an admin may not catalog a profile that
-  // isn't theirs through this endpoint (that's what /api/admin/catalog-artist is for).
-  it('still requires ownership even for an admin', async () => {
-    mocks.resolveOwnedArtist.mockResolvedValue({ ok: false, status: 403, error: 'You do not own this profile' });
+  // The once-a-day ceiling. Every press is a fresh crawl of this artist's Bandcamp, Discogs and
+  // Faircamp pages, so an owner who can press the button repeatedly is an amplifier.
+  it('refuses a second scan inside the cooldown, and does not clear anything', async () => {
+    mocks.getCatalogState.mockResolvedValue({
+      ok: true,
+      state: { last_attempted_at: new Date(Date.now() - 3600_000).toISOString(), last_catalogued_at: null, releases_found: null, releases_detailed: null, last_error: null, consecutive_failures: 0 },
+    });
     const r = await post({ action: 'catalog', slug: SLUG });
-    expect(r.statusCode).toBe(403);
+    expect(r.statusCode).toBe(429);
+    expect(mocks.triggerCatalogNow).not.toHaveBeenCalled();
+    // Clearing the cooldowns is itself a write, and it would let the *next* press through even
+    // though this one was refused.
+    expect(mocks.clearCatalogCooldown).not.toHaveBeenCalled();
+    expect(mocks.clearReleaseDetailCooldown).not.toHaveBeenCalled();
+  });
+
+  it('allows a scan once the cooldown has elapsed', async () => {
+    mocks.getCatalogState.mockResolvedValue({
+      ok: true,
+      state: { last_attempted_at: new Date(Date.now() - 25 * 3600_000).toISOString(), last_catalogued_at: null, releases_found: null, releases_detailed: null, last_error: null, consecutive_failures: 0 },
+    });
+    expect((await post({ action: 'catalog', slug: SLUG })).statusCode).toBe(202);
+  });
+
+  // Not knowing whether a scan is allowed is not permission to run one — the same answer
+  // claimArtistForCatalog gives itself when it can't read the row.
+  it('refuses rather than guessing when the catalog state cannot be read', async () => {
+    mocks.getCatalogState.mockResolvedValue({ ok: false, reason: 'Could not read catalog state' });
+    const r = await post({ action: 'catalog', slug: SLUG });
+    expect(r.statusCode).toBe(503);
     expect(mocks.triggerCatalogNow).not.toHaveBeenCalled();
   });
 
@@ -359,26 +381,31 @@ describe('POST — catalog (self-serve scan)', () => {
 });
 
 describe('GET — catalog state for the button', () => {
-  it('reports canTrigger true and the state for an admin', async () => {
+  it('reports the state and a scan that is ready to run', async () => {
     mocks.getCatalogState.mockResolvedValue({
       ok: true,
-      state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 12, releases_detailed: 9, last_error: null, consecutive_failures: 0 },
+      state: { last_attempted_at: '2026-07-01T00:00:00Z', last_catalogued_at: '2026-07-01T00:00:00Z', releases_found: 12, releases_detailed: 9, last_error: null, consecutive_failures: 0 },
     });
     const body = JSON.parse((await get()).body);
-    expect(body.catalog.canTrigger).toBe(true);
     expect(body.catalog.state.releases_found).toBe(12);
     expect(body.catalog.stateError).toBeNull();
+    expect(body.catalog.nextScanAvailableAt).toBeNull();
   });
 
-  it('reports canTrigger false for a non-admin owner, and does not read state at all', async () => {
-    mocks.authenticateAdmin.mockResolvedValue(null);
+  // The page disables its button from this rather than re-deriving the rule, so a scan that
+  // would come back 429 reads as "not yet" instead of a button that errors when pressed.
+  it('reports when the next scan is due while the cooldown is running', async () => {
+    const lastAttempt = new Date(Date.now() - 3600_000);
+    mocks.getCatalogState.mockResolvedValue({
+      ok: true,
+      state: { last_attempted_at: lastAttempt.toISOString(), last_catalogued_at: null, releases_found: null, releases_detailed: null, last_error: null, consecutive_failures: 0 },
+    });
     const body = JSON.parse((await get()).body);
-    expect(body.catalog.canTrigger).toBe(false);
-    expect(mocks.getCatalogState).not.toHaveBeenCalled();
+    expect(new Date(body.catalog.nextScanAvailableAt).getTime()).toBe(lastAttempt.getTime() + 24 * 3600_000);
   });
 
   // A failed read must not arrive as a null state — that renders as a confident
-  // "Never catalogued" when the truth is "we couldn't ask".
+  // "Never catalogued" when the truth is "we couldn't ask" — nor as a scan that's ready to go.
   it('reports an unreadable state distinctly from never-catalogued', async () => {
     mocks.getCatalogState.mockResolvedValue({ ok: false, reason: 'Could not read catalog state' });
     const body = JSON.parse((await get()).body);

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -26,7 +26,7 @@ import {
   clearCatalogCooldown,
   clearReleaseDetailCooldown,
 } from './db';
-import { authenticateAdmin, authenticateBearer, buildCorsHeaders } from './middleware';
+import { authenticateBearer, buildCorsHeaders } from './middleware';
 import { cacheDeleteByArtist } from './cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { triggerCatalogNow } from './request-catalog';
@@ -68,21 +68,37 @@ function isKnownPlatform(platform: string): boolean {
 }
 
 /**
- * Is self-serve cataloguing available to this caller yet?
+ * How long an artist waits between self-serve scans.
  *
- * **A rollout gate, deliberately separate from the permission model.** Ownership is what
- * *authorizes* the `catalog` action — the artist asking is the artist whose catalog it is. This
- * extra admin check is a temporary limit on who can reach it at all, while the crawl behaviour
- * is watched on real traffic: an artist-triggered crawl spends the same shared hourly budget
- * every fan-triggered one does, and the newer sources (Faircamp, discovered links) have never
- * run against anything but one test instance.
+ * This replaces the admin-only rollout gate the feature launched behind, and it is deliberately
+ * a *different* kind of limit. Ownership is what authorizes a scan — the artist asking is the
+ * artist whose catalog it is — but authorization puts no ceiling on how *often* the button may
+ * be pressed, and every press is a fresh crawl of that artist's Bandcamp, Discogs and Faircamp
+ * pages, spending the same shared hourly budget fan-driven cataloguing spends. Now that any
+ * verified owner can reach it, that ceiling has to exist somewhere.
  *
- * **To open this to all verified artists, delete this function and its two call sites.** Nothing
- * about the ownership checks changes — which is the point of keeping the two ideas apart rather
- * than folding the admin test into the authorization path.
+ * A day is generous for the real need: a catalogue changes when a release ships, not hourly.
+ *
+ * Admins are not exempt — `/api/admin/catalog-artist` (the button on the public artist page) is
+ * the unthrottled path, and keeping this one rule for everybody means the artist-facing surface
+ * behaves the same way whoever is looking at it.
  */
-async function canTriggerCatalog(authHeader: string | undefined): Promise<boolean> {
-  return (await authenticateAdmin(authHeader)) !== null;
+const SCAN_COOLDOWN_HOURS = 24;
+
+/**
+ * When may this artist be scanned again — or null if now.
+ *
+ * Measured from `release_catalog_state.last_attempted_at`, which is the last time we crawled
+ * this artist *for any reason*, so the honest phrasing in the UI is "we last checked your
+ * links", not "you last scanned". Ordinary fan traffic can't hold the button down:
+ * `claimArtistForCatalog` only stamps that column when a crawl actually proceeds, which for
+ * demand-driven triggers is at most once every seven days.
+ */
+function nextScanAvailableAt(lastAttemptedAt: string | null | undefined): string | null {
+  if (!lastAttemptedAt) return null;
+  const readyAt = new Date(lastAttemptedAt).getTime() + SCAN_COOLDOWN_HOURS * 3600_000;
+  if (!Number.isFinite(readyAt) || readyAt <= Date.now()) return null;
+  return new Date(readyAt).toISOString();
 }
 
 async function purgeArtistCaches(artistName: string, slug: string): Promise<void> {
@@ -152,12 +168,11 @@ export async function handler(event: {
 
     const releases = await getArtistReleasesForOwner(owned.artistId);
 
-    // `canTrigger` comes from the server rather than being re-derived in the page, so the
-    // button's visibility follows the real rule instead of a copy of it — same reasoning as
-    // AdminCatalogButton. `state` is three-valued (see getCatalogState): a failed read must not
-    // render as a confident "never catalogued".
-    const canTrigger = await canTriggerCatalog(authHeader);
-    const stateResult = canTrigger ? await getCatalogState(owned.artistId) : null;
+    // The cooldown is computed here rather than re-derived in the page, so the button's
+    // disabled state follows the real rule instead of a copy of it. `state` is three-valued
+    // (see getCatalogState): a failed read must not render as a confident "never catalogued",
+    // and it must not render as a scan that's ready to run either.
+    const stateResult = await getCatalogState(owned.artistId);
 
     return {
       statusCode: 200,
@@ -165,9 +180,11 @@ export async function handler(event: {
       body: JSON.stringify({
         releases,
         catalog: {
-          canTrigger,
-          state: stateResult?.ok ? stateResult.state : null,
-          stateError: stateResult && !stateResult.ok ? stateResult.reason : null,
+          state: stateResult.ok ? stateResult.state : null,
+          stateError: stateResult.ok ? null : stateResult.reason,
+          nextScanAvailableAt: stateResult.ok
+            ? nextScanAvailableAt(stateResult.state?.last_attempted_at)
+            : null,
         },
       }),
     };
@@ -242,18 +259,35 @@ export async function handler(event: {
   // Cataloguing returns 202 and is settled by polling the GET, so it doesn't fit the
   // ok/responseExtra shape the editing actions share below — handled on its own here.
   if (action === 'catalog') {
-    if (!(await canTriggerCatalog(authHeader))) {
+    // Read the state *before* clearing the cooldown below — `clearCatalogCooldown` backdates
+    // `last_attempted_at` two hours to let the crawl through, so checking afterwards would be
+    // checking a value this same request just wrote.
+    const stateResult = await getCatalogState(artistId);
+    if (!stateResult.ok) {
+      // Not knowing whether a scan is allowed is not permission to run one. The same answer
+      // `claimArtistForCatalog` gives itself when it can't read the row.
+      return { statusCode: 503, headers: CORS_HEADERS, body: JSON.stringify({ error: stateResult.reason }) };
+    }
+
+    const readyAt = nextScanAvailableAt(stateResult.state?.last_attempted_at);
+    if (readyAt) {
       return {
-        statusCode: 403,
-        headers: CORS_HEADERS,
-        body: JSON.stringify({ error: 'Self-serve cataloguing is not available yet.' }),
+        statusCode: 429,
+        headers: {
+          ...CORS_HEADERS,
+          'Retry-After': String(Math.ceil((new Date(readyAt).getTime() - Date.now()) / 1000)),
+        },
+        body: JSON.stringify({
+          error: 'We checked your links in the last day — a scan runs at most once a day.',
+          nextScanAvailableAt: readyAt,
+        }),
       };
     }
 
     // Both, always: the cooldown lets the crawl run, and the detail reset is what makes it
-  // re-read prices rather than only re-confirming the release list. See db.ts.
-  await clearCatalogCooldown(artistId);
-  await clearReleaseDetailCooldown(artistId);
+    // re-read prices rather than only re-confirming the release list. See db.ts.
+    await clearCatalogCooldown(artistId);
+    await clearReleaseDetailCooldown(artistId);
     const queued = await triggerCatalogNow(artistId);
     if (!queued.ok) {
       return { statusCode: queued.status, headers: CORS_HEADERS, body: JSON.stringify({ error: queued.error }) };

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -64,9 +64,10 @@ interface CatalogState {
 }
 
 interface CatalogInfo {
-  canTrigger: boolean;
   state: CatalogState | null;
   stateError: string | null;
+  /** ISO timestamp the next scan is allowed, or null if one can run now. Decided server-side. */
+  nextScanAvailableAt: string | null;
 }
 
 /** How long to keep asking before giving up. A full catalogue with prices takes a few minutes. */
@@ -209,7 +210,7 @@ export function ArtistReleasesPage() {
             <>
               {/* Above the list, not below it: scanning is where an artist starts, and on a real
                   catalogue the bottom of the page is a long scroll away. */}
-              {catalog?.canTrigger && (
+              {catalog && (
                 <CatalogNowPanel
                   slug={slug}
                   token={session?.access_token}
@@ -331,12 +332,23 @@ function describeCatalogState(state: CatalogState | null): string {
   return `${state.releases_found ?? 0} releases found, ${state.releases_detailed ?? 0} with prices`;
 }
 
+/** "in about 5 hours" / "in about 20 minutes" — enough precision for a once-a-day limit. */
+function describeWait(readyAt: string): string {
+  const minutes = Math.ceil((new Date(readyAt).getTime() - Date.now()) / 60_000);
+  if (minutes <= 1) return 'in a moment';
+  if (minutes < 60) return `in about ${minutes} minutes`;
+  const hours = Math.round(minutes / 60);
+  return hours === 1 ? 'in about an hour' : `in about ${hours} hours`;
+}
+
 /**
- * "Scan my links for releases" — the self-serve version of the admin catalog button.
+ * "Scan my links for releases" — the self-serve version of the admin catalog button, available
+ * to any artist who owns a verified profile.
  *
- * Visibility is decided by the server (`catalog.canTrigger`), not re-derived here, so the
- * rollout gate can't drift out of sync with a copy of the rule in page code. While that gate is
- * admin-only the copy says so plainly rather than pretending to be generally available.
+ * Whether a scan may run *right now* is decided by the server (`catalog.nextScanAvailableAt`)
+ * rather than re-derived here, so the once-a-day limit can't drift out of sync with a copy of
+ * the rule in page code. The button is disabled ahead of a refusal on purpose: a scan that would
+ * come back 429 should read as "not yet", not as a button that errors when you press it.
  *
  * Polls for the outcome the same way `AdminCatalogButton` does, and for the same reason: Netlify
  * answers a background invocation with 202 the moment it's queued and discards the handler's
@@ -458,6 +470,10 @@ function CatalogNowPanel({
     }
   }, [slug, token, poll]);
 
+  // Read from the prop at render time rather than held in state, so a scan that finishes and
+  // refetches re-disables the button with its new cooldown without any extra wiring.
+  const readyAt = catalog.nextScanAvailableAt;
+
   return (
     <div className="p-4 rounded-xl border border-dashed border-border space-y-2">
       <h2 className="font-display text-base font-semibold text-text-primary">
@@ -471,7 +487,7 @@ function CatalogNowPanel({
       <div className="flex flex-wrap items-center gap-3 pt-1">
         <button
           onClick={start}
-          disabled={running || !token}
+          disabled={running || !token || readyAt !== null}
           className="px-4 py-2 rounded-lg bg-bg-secondary border border-border text-sm text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {running ? 'Scanning…' : 'Scan my links for releases'}
@@ -479,7 +495,9 @@ function CatalogNowPanel({
         <span className="text-xs text-text-muted">{status}</span>
       </div>
       <p className="text-[11px] text-text-muted pt-1">
-        Admin only for now, while we watch how it behaves.
+        {readyAt
+          ? `We checked your links in the last day — you can scan again ${describeWait(readyAt)}.`
+          : 'You can run this once a day. Scanning re-reads every release page, so it takes a few minutes.'}
       </p>
     </div>
   );

--- a/apps/web/tests/unit/ArtistReleasesPage.test.tsx
+++ b/apps/web/tests/unit/ArtistReleasesPage.test.tsx
@@ -332,15 +332,6 @@ describe('ArtistReleasesPage — self-serve catalog scan', () => {
 
   const SCAN_LABEL = 'Scan my links for releases';
 
-  // Visibility follows the server's `canTrigger`, not a copy of the rule in page code — so the
-  // rollout gate can't drift out of sync with the client.
-  it('hides the scan control when the server says the caller cannot trigger', async () => {
-    setupFetchMock([], { canTrigger: false, state: null, stateError: null });
-    renderPage();
-    await waitFor(() => screen.getByText('No releases catalogued yet.'));
-    expect(screen.queryByText(SCAN_LABEL)).toBeNull();
-  });
-
   it('hides the scan control entirely when the response carries no catalog block at all', async () => {
     setupFetchMock([]);
     renderPage();
@@ -348,19 +339,33 @@ describe('ArtistReleasesPage — self-serve catalog scan', () => {
     expect(screen.queryByText(SCAN_LABEL)).toBeNull();
   });
 
-  it('shows the scan control, and says it is admin-only for now', async () => {
-    setupFetchMock([], { canTrigger: true, state: null, stateError: null });
+  // Every verified owner gets the control now — the admin-only rollout gate is gone, and what
+  // replaced it is a once-a-day limit rather than a limit on who may press the button.
+  it('shows the scan control to any owner, ready to run', async () => {
+    setupFetchMock([], { state: null, stateError: null, nextScanAvailableAt: null });
     renderPage();
     await waitFor(() => expect(screen.getByText(SCAN_LABEL)).toBeTruthy());
-    expect(screen.getByText(/Admin only for now/)).toBeTruthy();
+    expect((screen.getByText(SCAN_LABEL) as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByText(/once a day/)).toBeTruthy();
     expect(screen.getByText('Never catalogued')).toBeTruthy();
+  });
+
+  // The cooldown is the server's answer, not a rule re-derived here — and a scan that would come
+  // back 429 has to read as "not yet" rather than a button that errors when pressed.
+  it('disables the scan control while the server says a scan is not due yet', async () => {
+    const readyAt = new Date(Date.now() + 5 * 3600_000).toISOString();
+    setupFetchMock([], { state: null, stateError: null, nextScanAvailableAt: readyAt });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(SCAN_LABEL)).toBeTruthy());
+    expect((screen.getByText(SCAN_LABEL) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/you can scan again in about 5 hours/)).toBeTruthy();
   });
 
   it('summarizes a previous run', async () => {
     setupFetchMock([], {
-      canTrigger: true,
       state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 12, releases_detailed: 9, last_error: null },
       stateError: null,
+      nextScanAvailableAt: null,
     });
     renderPage();
     await waitFor(() => expect(screen.getByText('12 releases found, 9 with prices')).toBeTruthy());
@@ -368,7 +373,7 @@ describe('ArtistReleasesPage — self-serve catalog scan', () => {
 
   // "We couldn't ask" must not render as a confident "Never catalogued".
   it('reports an unreadable state instead of claiming never-catalogued', async () => {
-    setupFetchMock([], { canTrigger: true, state: null, stateError: 'Could not read catalog state' });
+    setupFetchMock([], { state: null, stateError: 'Could not read catalog state', nextScanAvailableAt: null });
     renderPage();
     await waitFor(() => expect(screen.getByText('Could not read catalog state')).toBeTruthy());
     expect(screen.queryByText('Never catalogued')).toBeNull();
@@ -376,16 +381,16 @@ describe('ArtistReleasesPage — self-serve catalog scan', () => {
 
   it('reports a failed previous run rather than a count', async () => {
     setupFetchMock([], {
-      canTrigger: true,
       state: { last_catalogued_at: '2026-08-01T00:00:00Z', releases_found: 0, releases_detailed: 0, last_error: 'bandcamp bot challenge' },
       stateError: null,
+      nextScanAvailableAt: null,
     });
     renderPage();
     await waitFor(() => expect(screen.getByText(/Last run failed: bandcamp bot challenge/)).toBeTruthy());
   });
 
   it('posts the catalog action for this artist when clicked', async () => {
-    setupFetchMock([], { canTrigger: true, state: null, stateError: null });
+    setupFetchMock([], { state: null, stateError: null, nextScanAvailableAt: null });
     renderPage();
     await waitFor(() => screen.getByText(SCAN_LABEL));
 
@@ -406,7 +411,10 @@ describe('ArtistReleasesPage — self-serve catalog scan', () => {
       if (!init || init.method === undefined) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ releases: [], catalog: { canTrigger: true, state: null, stateError: null } }),
+          json: async () => ({
+            releases: [],
+            catalog: { state: null, stateError: null, nextScanAvailableAt: null },
+          }),
         });
       }
       return Promise.resolve({


### PR DESCRIPTION
"Scan my links for releases" on Manage Releases was gated to admins while
we watched the crawl behave on real traffic. Ownership already authorized
the action — the artist asking is the artist whose catalog it is — so the
admin check was only a limit on who could reach it. It's gone.

What replaces it is a limit on how *often*, not on who: one scan per
artist per day. Every press is a fresh crawl of that artist's Bandcamp,
Discogs and Faircamp pages against the same hourly budget fan-driven
cataloguing spends, and an owner who can press the button in a loop is an
amplifier. Admins keep the unthrottled path at /api/admin/catalog-artist.

The cooldown is measured from release_catalog_state.last_attempted_at —
the last time we crawled this artist for any reason — so the copy says
"we checked your links", not "you scanned". Fan traffic can't hold the
button down: claimArtistForCatalog only stamps that column when a crawl
actually proceeds, at most once every seven days for demand-driven
triggers. It's read before clearCatalogCooldown backdates the column, and
an unreadable state refuses the scan rather than guessing.

The server sends nextScanAvailableAt so the page disables the button
ahead of a refusal — a scan that would come back 429 reads as "not yet"
rather than a button that errors when pressed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013EswHFyVUiKjGft7H51ZvH