### PR TITLE
Stop reporting an in-app browser's own script as our error

### DIFF
--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -38,6 +38,29 @@ export function isStaleBuildAssetError(message: string): boolean {
   )
 }
 
+/**
+ * True when an error came from a WebKit-to-native bridge script that something
+ * outside our page injected into it.
+ *
+ * Sentry attributes these to us because the stack points at
+ * `https://unstream.stream/:1` — but our document has no inline JavaScript
+ * (`apps/web/index.html` loads the bundle and GoatCounter as external files, and
+ * the og-metadata edge function adds no scripts), so line 1 of the document is
+ * never our code. It's an in-app browser: iOS apps that open links in a WKWebView
+ * inject their own script, which reports home over `window.webkit.messageHandlers`
+ * and throws when that bridge isn't there — usually from a `pagehide` listener
+ * firing after the webview has already torn it down. The frame names in those
+ * traces (`sendDataToNative`, `sendPageHideMessage`) exist nowhere in this repo.
+ *
+ * Nothing we ship causes it and nothing we ship can fix it, so it's noise. If
+ * Unstream ever loads itself in a WKWebView of its own (the Apple app is native
+ * SwiftUI today, with no webview anywhere), delete this filter — at that point it
+ * would be hiding a real bug.
+ */
+export function isInjectedNativeBridgeError(message: string): boolean {
+  return message.includes('webkit.messageHandlers')
+}
+
 export function initSentry(): void {
   const dsn = import.meta.env.VITE_SENTRY_DSN
   const environment = import.meta.env.VITE_SENTRY_ENV || import.meta.env.MODE
@@ -76,7 +99,14 @@ export function initSentry(): void {
         return null
       }
 
-      const errorMessage = hint?.originalException?.toString() || ''
+      // Errors caught by the global handler sometimes arrive with no
+      // originalException — an injected script's TypeError is one of them — and the
+      // message only survives on the event. Read both, so a filter below can't miss
+      // an error purely because of how it happened to be captured.
+      const errorMessage = [
+        hint?.originalException?.toString() || '',
+        event.exception?.values?.[0]?.value || '',
+      ].join(' ')
 
       // Classified BEFORE the benign-error filter so a stale-build failure can
       // never be mistaken for a transient network blip and dropped.
@@ -98,6 +128,11 @@ export function initSentry(): void {
         // none of the titles mention a deploy.
         event.fingerprint = ['stale-build-asset']
         return event
+      }
+
+      // Somebody else's script failing inside our page. Not our bug to fix.
+      if (isInjectedNativeBridgeError(errorMessage)) {
+        return null
       }
 
       // Filter out common benign errors

--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -61,6 +61,22 @@ export function isInjectedNativeBridgeError(message: string): boolean {
   return message.includes('webkit.messageHandlers')
 }
 
+/**
+ * The text every filter below is matched against.
+ *
+ * Both sources are read because either one alone can be empty. Errors captured by
+ * the global handler often arrive with no `originalException` — the injected-script
+ * TypeError above is one of them — and then the message survives only on the event.
+ * Reading one source would drop an error from a filter purely because of how it
+ * happened to be captured, which is invisible and very annoying to debug.
+ */
+export function sentryErrorMessage(event: Sentry.ErrorEvent, hint?: Sentry.EventHint): string {
+  return [
+    hint?.originalException?.toString() || '',
+    event.exception?.values?.[0]?.value || '',
+  ].join(' ')
+}
+
 export function initSentry(): void {
   const dsn = import.meta.env.VITE_SENTRY_DSN
   const environment = import.meta.env.VITE_SENTRY_ENV || import.meta.env.MODE
@@ -99,14 +115,7 @@ export function initSentry(): void {
         return null
       }
 
-      // Errors caught by the global handler sometimes arrive with no
-      // originalException — an injected script's TypeError is one of them — and the
-      // message only survives on the event. Read both, so a filter below can't miss
-      // an error purely because of how it happened to be captured.
-      const errorMessage = [
-        hint?.originalException?.toString() || '',
-        event.exception?.values?.[0]?.value || '',
-      ].join(' ')
+      const errorMessage = sentryErrorMessage(event, hint)
 
       // Classified BEFORE the benign-error filter so a stale-build failure can
       // never be mistaken for a transient network blip and dropped.

--- a/apps/web/tests/unit/sentry-error-message.test.ts
+++ b/apps/web/tests/unit/sentry-error-message.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { Sentry, sentryErrorMessage, isStaleBuildAssetError, isInjectedNativeBridgeError } from '../../src/services/sentry';
+
+/**
+ * Every filter in `beforeSend` matches against the string this builds, so it has to
+ * find the message wherever Sentry happened to put it. An error thrown by our own
+ * code arrives with an `originalException`; one caught by the global handler often
+ * doesn't, and carries its message on the event instead.
+ *
+ * These cover both shapes, and assert the pre-existing filters — not just the new
+ * bridge one — still match when the message only arrives on the event.
+ */
+const eventWith = (value?: string): Sentry.ErrorEvent =>
+  ({ exception: value ? { values: [{ value }] } : undefined }) as Sentry.ErrorEvent;
+
+describe('sentryErrorMessage', () => {
+  it('reads the thrown exception', () => {
+    expect(sentryErrorMessage(eventWith(), { originalException: new Error('boom') }))
+      .toContain('Error: boom');
+  });
+
+  it('reads the event when there is no originalException', () => {
+    expect(sentryErrorMessage(eventWith('TypeError: nope'), {})).toContain('TypeError: nope');
+  });
+
+  it('reads the event when there is no hint at all', () => {
+    expect(sentryErrorMessage(eventWith('TypeError: nope'))).toContain('TypeError: nope');
+  });
+
+  it('keeps both when both are present', () => {
+    const message = sentryErrorMessage(eventWith('from the event'), {
+      originalException: new Error('from the throw'),
+    });
+    expect(message).toContain('from the throw');
+    expect(message).toContain('from the event');
+  });
+
+  it('matches nothing when the error carries no message anywhere', () => {
+    // Joining two empty strings leaves a single space, so guard against a filter
+    // deciding that blank message looks like one of its patterns.
+    const message = sentryErrorMessage(eventWith(), {});
+    expect(isStaleBuildAssetError(message)).toBe(false);
+    expect(isInjectedNativeBridgeError(message)).toBe(false);
+    expect(message.includes('Network Error')).toBe(false);
+    expect(message.includes('AbortError')).toBe(false);
+  });
+});
+
+describe('the pre-existing filters, against an event-only message', () => {
+  it('still classifies a stale build asset error', () => {
+    const message = sentryErrorMessage(
+      eventWith('TypeError: Failed to fetch dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js'),
+      {}
+    );
+    expect(isStaleBuildAssetError(message)).toBe(true);
+  });
+
+  it('still spots the benign network errors', () => {
+    expect(sentryErrorMessage(eventWith('Network Error'), {}).includes('Network Error')).toBe(true);
+    expect(sentryErrorMessage(eventWith('AbortError: Fetch is aborted'), {}).includes('AbortError')).toBe(true);
+  });
+
+  it('still catches the injected bridge error in its reported shape', () => {
+    // The reported event: global handler, no originalException.
+    const message = sentryErrorMessage(
+      eventWith("TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')"),
+      {}
+    );
+    expect(isInjectedNativeBridgeError(message)).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/sentry-injected-bridge.test.ts
+++ b/apps/web/tests/unit/sentry-injected-bridge.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isInjectedNativeBridgeError } from '../../src/services/sentry';
+
+/**
+ * An iOS in-app browser injects its own script into the page it opens. That script
+ * talks to the host app over `window.webkit.messageHandlers`, and throws when the
+ * bridge isn't there. Because the injection has no source URL of its own, the stack
+ * blames `https://unstream.stream/:1` and the event lands in our Sentry project.
+ *
+ * These are the messages WebKit produces for that access.
+ */
+describe('isInjectedNativeBridgeError', () => {
+  it('matches the reported homepage error', () => {
+    expect(isInjectedNativeBridgeError(
+      "TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')"
+    )).toBe(true);
+  });
+
+  it('matches a named handler being posted to', () => {
+    expect(isInjectedNativeBridgeError(
+      "TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers.analytics.postMessage')"
+    )).toBe(true);
+  });
+
+  it('matches the null wording older WebKit uses', () => {
+    expect(isInjectedNativeBridgeError(
+      "TypeError: null is not an object (evaluating 'webkit.messageHandlers')"
+    )).toBe(true);
+  });
+
+  it('leaves our own errors alone', () => {
+    expect(isInjectedNativeBridgeError(
+      'TypeError: Failed to fetch dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js'
+    )).toBe(false);
+    expect(isInjectedNativeBridgeError(
+      "TypeError: undefined is not an object (evaluating 'artist.releases.length')"
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
Sentry has been collecting "undefined is not an object (evaluating
'window.webkit.messageHandlers')", with frames sendDataToNative and
sendPageHideMessage, all attributed to https://unstream.stream/:1.

None of that is ours. Neither function name appears anywhere in this repo,
and our document has no inline JavaScript at all — index.html loads the
bundle and GoatCounter as external files, and the og-metadata edge function
that renders the homepage adds no scripts — so line 1 of the document can
never be our code. It's an iOS in-app browser injecting its own script into
the page it opened: that script reports back to its host app over
window.webkit.messageHandlers and throws when the bridge is gone, which the
pagehide frame explains, as the webview tears the bridge down while the
listener still fires. Injected scripts have no source URL of their own, so
WebKit blames the document and the event lands in our project.

Drop it in beforeSend. We can't cause it, fix it, or see which app the user
was in. If Unstream ever loads itself in a WKWebView, the filter has to go —
it would be hiding a real bug — and the comment says so.

Also read the message from the event as well as originalException. Errors
that arrive through the global handler often carry no originalException,
which is exactly the shape this one has, and a filter that can only read one
of the two would have missed it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NwS2rvTzx2dfXd9n6vzjvy