### PR TITLE
Stop reporting a dropped connection as a dashboard error

### DIFF
--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -62,6 +62,53 @@ export function isInjectedNativeBridgeError(message: string): boolean {
 }
 
 /**
+ * The exact wording each engine uses when a `fetch()` never produced a response.
+ *
+ * These are whole messages, not fragments — see `isDroppedRequestError` for why
+ * that matters.
+ */
+const DROPPED_REQUEST_MESSAGES = [
+  // Safari / WebKit — the wording behind the DashboardPage reports
+  'Load failed',
+  // Chrome / Edge
+  'Failed to fetch',
+  // Firefox
+  'NetworkError when attempting to fetch resource.',
+]
+
+/**
+ * True when an error is a request that never reached the server, or whose answer
+ * never got back.
+ *
+ * The user went through a tunnel, closed the tab mid-request, or (on iOS Safari,
+ * which is where most of these come from) backgrounded the page while a fetch was
+ * still open and WebKit tore the connection down. Every caller already handles it:
+ * DashboardPage, for one, catches it and shows "Failed to load your profiles.
+ * Please try again." So the browser is telling us about someone's wifi, and there
+ * is no code change that would make it stop.
+ *
+ * Matched with `endsWith` rather than `includes`, because the browser's phrasing
+ * is a substring of messages we throw ourselves for a response that *did* arrive
+ * with an error status — `Failed to fetch (500)`, `Failed to fetch embed`,
+ * `Failed to fetch sharing status`. Those mean our API is broken and have to keep
+ * reporting; only the bare browser message is dropped.
+ *
+ * A real outage — the API unreachable for everyone — is not what this hides: that
+ * shows up in uptime and Netlify monitoring, where it isn't buried under one event
+ * per flaky connection.
+ */
+export function isDroppedRequestError(message: string): boolean {
+  const trimmed = message.trim()
+  return (
+    DROPPED_REQUEST_MESSAGES.some(wording => trimmed.endsWith(wording)) ||
+    // A request we cancelled ourselves, and axios-era wording kept from the
+    // filter this replaced. Neither phrase appears in an error we throw.
+    trimmed.includes('AbortError') ||
+    trimmed.includes('Network Error')
+  )
+}
+
+/**
  * The text every filter below is matched against.
  *
  * Both sources are read because either one alone can be empty. Errors captured by
@@ -117,7 +164,7 @@ export function initSentry(): void {
 
       const errorMessage = sentryErrorMessage(event, hint)
 
-      // Classified BEFORE the benign-error filter so a stale-build failure can
+      // Classified BEFORE the dropped-request filter so a stale-build failure can
       // never be mistaken for a transient network blip and dropped.
       if (isStaleBuildAssetError(errorMessage)) {
         event.tags = {
@@ -144,8 +191,8 @@ export function initSentry(): void {
         return null
       }
 
-      // Filter out common benign errors
-      if (errorMessage.includes('Network Error') || errorMessage.includes('AbortError')) {
+      // Somebody's connection dropped mid-request. Handled in the UI already.
+      if (isDroppedRequestError(errorMessage)) {
         return null
       }
 

--- a/apps/web/tests/unit/sentry-dropped-request.test.ts
+++ b/apps/web/tests/unit/sentry-dropped-request.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { Sentry, sentryErrorMessage, isDroppedRequestError, isStaleBuildAssetError } from '../../src/services/sentry';
+
+const eventWith = (value?: string): Sentry.ErrorEvent =>
+  ({ exception: value ? { values: [{ value }] } : undefined }) as Sentry.ErrorEvent;
+
+/**
+ * A `fetch()` that never produced a response. The reported case was the dashboard's
+ * two mount-time requests failing in Safari, which words it "Load failed" — nothing
+ * in the message says "network", so it read like an application TypeError.
+ */
+describe('isDroppedRequestError', () => {
+  it('matches the Safari wording behind the DashboardPage reports', () => {
+    expect(isDroppedRequestError('TypeError: Load failed')).toBe(true);
+  });
+
+  it('matches the reported event in its captured shape', () => {
+    // Thrown by our own code, so both sources carry the message and the joined
+    // string repeats it.
+    const message = sentryErrorMessage(eventWith('Load failed'), {
+      originalException: new TypeError('Load failed'),
+    });
+    expect(isDroppedRequestError(message)).toBe(true);
+  });
+
+  it('matches the Chrome/Edge and Firefox wordings', () => {
+    expect(isDroppedRequestError('TypeError: Failed to fetch')).toBe(true);
+    expect(isDroppedRequestError('TypeError: NetworkError when attempting to fetch resource.')).toBe(true);
+  });
+
+  it('matches a cancelled request', () => {
+    expect(isDroppedRequestError('AbortError: Fetch is aborted')).toBe(true);
+    expect(isDroppedRequestError('Network Error')).toBe(true);
+  });
+
+  it('keeps reporting a response that arrived with an error status', () => {
+    // The browser's phrasing is a substring of these. They mean our API answered
+    // and answered badly — a real bug, and the whole reason this matches on the
+    // end of the message rather than anywhere in it.
+    expect(isDroppedRequestError('Error: Failed to fetch (500)')).toBe(false);
+    expect(isDroppedRequestError('Error: Failed to fetch embed')).toBe(false);
+    expect(isDroppedRequestError('Error: Failed to fetch sharing status')).toBe(false);
+    expect(isDroppedRequestError('Error: Failed to load claimed profiles')).toBe(false);
+    expect(isDroppedRequestError('Error: Failed to load saved artists')).toBe(false);
+  });
+
+  it('leaves ordinary application errors alone', () => {
+    expect(isDroppedRequestError('TypeError: Cannot read properties of undefined')).toBe(false);
+    expect(isDroppedRequestError('Invalid login credentials')).toBe(false);
+  });
+
+  it('matches nothing when the error carries no message anywhere', () => {
+    expect(isDroppedRequestError(sentryErrorMessage(eventWith(), {}))).toBe(false);
+  });
+
+  it('does not claim a stale build asset error', () => {
+    // beforeSend classifies stale builds first, but the two must not overlap
+    // either — a deploy breaking every open tab has to stay visible.
+    const staleChunk = 'TypeError: Failed to fetch dynamically imported module: https://unstream.stream/assets/LoginPage-DWG6zFx3.js';
+    expect(isStaleBuildAssetError(staleChunk)).toBe(true);
+    expect(isDroppedRequestError(staleChunk)).toBe(false);
+    expect(isDroppedRequestError('TypeError: Importing a module script failed.')).toBe(false);
+    expect(isDroppedRequestError('Unable to preload CSS for /assets/ArtistEditPage-Bq1x9fLm.css')).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/sentry-error-message.test.ts
+++ b/apps/web/tests/unit/sentry-error-message.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Sentry, sentryErrorMessage, isStaleBuildAssetError, isInjectedNativeBridgeError } from '../../src/services/sentry';
+import { Sentry, sentryErrorMessage, isStaleBuildAssetError, isInjectedNativeBridgeError, isDroppedRequestError } from '../../src/services/sentry';
 
 /**
  * Every filter in `beforeSend` matches against the string this builds, so it has to
@@ -41,8 +41,7 @@ describe('sentryErrorMessage', () => {
     const message = sentryErrorMessage(eventWith(), {});
     expect(isStaleBuildAssetError(message)).toBe(false);
     expect(isInjectedNativeBridgeError(message)).toBe(false);
-    expect(message.includes('Network Error')).toBe(false);
-    expect(message.includes('AbortError')).toBe(false);
+    expect(isDroppedRequestError(message)).toBe(false);
   });
 });
 
@@ -56,8 +55,9 @@ describe('the pre-existing filters, against an event-only message', () => {
   });
 
   it('still spots the benign network errors', () => {
-    expect(sentryErrorMessage(eventWith('Network Error'), {}).includes('Network Error')).toBe(true);
-    expect(sentryErrorMessage(eventWith('AbortError: Fetch is aborted'), {}).includes('AbortError')).toBe(true);
+    expect(isDroppedRequestError(sentryErrorMessage(eventWith('Network Error'), {}))).toBe(true);
+    expect(isDroppedRequestError(sentryErrorMessage(eventWith('AbortError: Fetch is aborted'), {}))).toBe(true);
+    expect(isDroppedRequestError(sentryErrorMessage(eventWith('TypeError: Load failed'), {}))).toBe(true);
   });
 
   it('still catches the injected bridge error in its reported shape', () => {


### PR DESCRIPTION
The reported "TypeError: Load failed" is WebKit's wording for a fetch() that
never produced a response, and the stack is the dashboard's two mount-time
requests: /api/artist-auth and /api/saved-artists. Nothing in the message says
"network", so it read like an application TypeError.

It isn't one. The user went through a tunnel, closed the tab mid-request, or
backgrounded the page on iOS while a fetch was still open. DashboardPage already
catches it and shows "Failed to load your profiles. Please try again." — there is
no code change that makes it stop happening.

Filtered in beforeSend alongside the existing stale-build and injected-bridge
filters, folding in the old Network Error / AbortError patterns so all of
"the request never completed" lives in one predicate.

Matched on the end of the message rather than anywhere in it, because the
browser's phrasing is a substring of messages we throw ourselves when a response
*did* arrive with an error status — `Failed to fetch (500)`, `Failed to fetch
embed`, `Failed to fetch sharing status`. Those mean our API is broken and keep
reporting; only the bare browser message is dropped. A test pins that boundary,
and another asserts a stale-build chunk failure is still never claimed by this
filter.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015tHqHTXRfrJQi3Bqcf7Qpx