### PR TITLE
Brighten dark-mode muted text for readability

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17,7 +17,7 @@
 
   --color-text-primary: #f0f0f0;
   --color-text-secondary: #999999;
-  --color-text-muted: #666666;
+  --color-text-muted: #808080;
 
   --color-border: #2a2a2a;
   --color-border-hover: #3a3a3a;


### PR DESCRIPTION
The location, bio, and Save/Share/Embed text on artist pages all use
--color-text-muted, which at #666666 against the #121212 dark
background sits around 3.3:1 contrast, under WCAG AA's 4.5:1 minimum.
Bumping to #808080 (~4.7:1) fixes it everywhere that token is used
without touching the light theme.