### PR TITLE
Move artist removal from the dashboard to a danger zone

### DIFF
--- a/api/functions/__tests__/artist-profile-remove.test.ts
+++ b/api/functions/__tests__/artist-profile-remove.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// DELETE /api/artist-profile removes an artist's claim. It is the only destructive action an
+// artist can take on their own profile, so these pin down that it can't be reached without
+// ownership, that it doesn't delete another user's row, and that a page whose claim is gone
+// doesn't stay flagged as claimed (which would freeze it — see db.ts getArtistBySlug).
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockResolveOwnedArtist: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  mockCacheDeleteByArtist: vi.fn(() => Promise.resolve()),
+  mockCaptureException: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({ from: mocks.mockFrom }),
+  resolveOwnedArtist: mocks.mockResolveOwnedArtist,
+}));
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mocks.mockCreateClient,
+}));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+vi.mock('../cache', () => ({
+  cacheDeleteByArtist: mocks.mockCacheDeleteByArtist,
+}));
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureException: mocks.mockCaptureException },
+}));
+
+import { handler } from '../artist-profile';
+
+// The delete chain is `.delete({count}).eq(artist_id).eq(user_id)`; the artist revert is
+// `.update(...).eq(id)`. One fake covers both tables and records what each was called with.
+function mockTables(deleteResult: { error: unknown; count?: number }, revertError: unknown = null) {
+  const deleteFn = vi.fn(() => {
+    const chain = {
+      eq: vi.fn(() => chain),
+      then: (resolve: (v: unknown) => void) => resolve(deleteResult),
+    };
+    return chain;
+  });
+  const updateFn = vi.fn(() => ({
+    eq: vi.fn(() => Promise.resolve({ error: revertError })),
+  }));
+
+  mocks.mockFrom.mockImplementation((table: string) =>
+    table === 'artist_profiles' ? { delete: deleteFn } : { update: updateFn }
+  );
+
+  return { deleteFn, updateFn };
+}
+
+describe('artist-profile DELETE (remove claim)', () => {
+  const deleteEvent = {
+    httpMethod: 'DELETE',
+    headers: { authorization: 'Bearer valid-token' },
+    queryStringParameters: { slug: 'example-artist' },
+    body: null,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    delete process.env.NETLIFY_SITE_ID;
+    delete process.env.SITE_ID;
+    delete process.env.NETLIFY_API_TOKEN;
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCacheDeleteByArtist.mockResolvedValue(undefined);
+    mocks.mockCreateClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'artist@example.com' } },
+          error: null,
+        }),
+      },
+    });
+    mocks.mockResolveOwnedArtist.mockResolvedValue({
+      ok: true,
+      status: 200,
+      artistId: 'artist-1',
+      artistName: 'Example Artist',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await handler({ ...deleteEvent, headers: {} });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('returns 400 when slug is missing', async () => {
+    const res = await handler({ ...deleteEvent, queryStringParameters: {} });
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it("returns 403 for someone else's profile", async () => {
+    mocks.mockResolveOwnedArtist.mockResolvedValue({
+      ok: false,
+      status: 403,
+      error: 'You do not own this profile',
+    });
+    const { deleteFn } = mockTables({ error: null, count: 1 });
+
+    const res = await handler(deleteEvent);
+    expect(res!.statusCode).toBe(403);
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+
+  it('deletes the profile scoped to the owner and reverts the artist to auto-discovered', async () => {
+    const { deleteFn, updateFn } = mockTables({ error: null, count: 1 });
+
+    const res = await handler(deleteEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).success).toBe(true);
+
+    expect(deleteFn).toHaveBeenCalledWith({ count: 'exact' });
+    const deleteChain = deleteFn.mock.results[0].value as { eq: ReturnType<typeof vi.fn> };
+    expect(deleteChain.eq).toHaveBeenCalledWith('artist_id', 'artist-1');
+    expect(deleteChain.eq).toHaveBeenCalledWith('user_id', 'user-1');
+
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ match_confidence: 'unverified', source: 'auto' })
+    );
+    expect(mocks.mockCacheDeleteByArtist).toHaveBeenCalledWith('Example Artist');
+  });
+
+  it('returns 409 and leaves the artist row alone when nothing was deleted', async () => {
+    const { updateFn } = mockTables({ error: null, count: 0 });
+
+    const res = await handler(deleteEvent);
+    expect(res!.statusCode).toBe(409);
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 without reverting the artist row when the delete fails', async () => {
+    const { updateFn } = mockTables({ error: { message: 'boom' }, count: null as unknown as number });
+
+    const res = await handler(deleteEvent);
+    expect(res!.statusCode).toBe(500);
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(mocks.mockCaptureException).toHaveBeenCalled();
+  });
+
+  it('reports a failed revert to Sentry but still confirms the removal', async () => {
+    mockTables({ error: null, count: 1 }, { message: 'revert failed' });
+
+    const res = await handler(deleteEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(mocks.mockCaptureException).toHaveBeenCalled();
+  });
+});

--- a/api/functions/artist-profile.ts
+++ b/api/functions/artist-profile.ts
@@ -1,9 +1,10 @@
-// API endpoint: PUT /api/artist-profile
-// Authenticated endpoint for updating a claimed artist profile.
-// Handles: slug changes, bio updates, platform link edits.
+// API endpoint: /api/artist-profile
+// Authenticated endpoints for a claimed artist profile.
+// PUT    — update the profile: slug changes, bio updates, platform link edits.
+// DELETE — remove the claim, handing the page back to its unclaimed state.
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { getClient } from './db';
+import { getClient, resolveOwnedArtist } from './db';
 import { cacheDeleteByArtist } from './cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { Sentry } from '../lib/sentry';
@@ -31,7 +32,7 @@ const CORS_HEADERS = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'PUT, OPTIONS',
+  'Access-Control-Allow-Methods': 'PUT, DELETE, OPTIONS',
 };
 
 // Allowed embed domains for featured releases
@@ -135,7 +136,98 @@ function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
-export async function handler(event: { httpMethod: string; headers: Record<string, string | undefined>; body: string | null }) {
+// Search results and the artist's server-rendered page are both cached; anything that changes
+// what the page says has to clear them or the edit looks like it didn't save.
+async function purgeArtistCaches(artistName: string, slug: string): Promise<void> {
+  try {
+    await cacheDeleteByArtist(artistName);
+  } catch (e) {
+    console.error('[Profile] Redis cache purge failed:', e);
+  }
+
+  try {
+    const siteId = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
+    const token = process.env.NETLIFY_API_TOKEN;
+    if (siteId && token) {
+      await fetch('https://api.netlify.com/api/v1/purge', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ site_id: siteId, cache_tags: [`artist-${slug}`] }),
+      });
+      console.log(`[Profile] Purged CDN cache for artist-${slug}`);
+    } else {
+      console.warn('[Profile] NETLIFY_SITE_ID or NETLIFY_API_TOKEN not set, skipping CDN purge');
+    }
+  } catch (e) {
+    console.error('[Profile] CDN cache purge failed:', e);
+  }
+}
+
+// Removing a claim un-verifies the artist rather than deleting them. The artists row is public
+// search data that existed before the claim and still describes a real artist; what goes is
+// everything the claim added — bio, photo, featured release, divider layout — all of which live
+// on the artist_profiles row. Platform links stay: they were discoverable before the claim too.
+async function handleRemoveClaim(client: SupabaseClient, slug: string, userId: string) {
+  const owned = await resolveOwnedArtist(slug, userId);
+  if (!owned.ok || !owned.artistId || !owned.artistName) {
+    return { statusCode: owned.status, headers: CORS_HEADERS, body: JSON.stringify({ error: owned.error }) };
+  }
+
+  // Scoped to user_id as well as artist_id even though ownership is already proven: this is the
+  // one destructive action an artist can take on their own profile, so it shouldn't rely on a
+  // check made a few milliseconds earlier.
+  const { error: deleteError, count } = await client
+    .from('artist_profiles')
+    .delete({ count: 'exact' })
+    .eq('artist_id', owned.artistId)
+    .eq('user_id', userId);
+
+  if (deleteError) {
+    console.error('[Profile] Claim removal failed:', deleteError);
+    Sentry.captureException(new Error(`artist_profiles delete failed: ${deleteError.message}`), {
+      tags: { subsystem: 'artist-profile' },
+      extra: { artistId: owned.artistId, slug },
+    });
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to remove this artist. Please try again.' }) };
+  }
+
+  if (!count) {
+    return { statusCode: 409, headers: CORS_HEADERS, body: JSON.stringify({ error: 'This artist is no longer claimed by your account.' }) };
+  }
+
+  // Back to auto-discovered. Left flagged as claimed, the row would never expire and enrichment
+  // would keep skipping it (see getArtistBySlug and the enrichment guard in db.ts), so the page
+  // would stay frozen on the last edit of an artist who just asked to be removed.
+  const { error: revertError } = await client
+    .from('artists')
+    .update({ match_confidence: 'unverified', source: 'auto', updated_at: new Date().toISOString() })
+    .eq('id', owned.artistId);
+
+  if (revertError) {
+    // The removal itself stands — the page renders unclaimed with no profile row either way —
+    // but the artist row is now in a state only a human can fix, so say so loudly.
+    console.error('[Profile] Artist revert after claim removal failed:', revertError);
+    Sentry.captureException(new Error(`artist revert after claim removal failed: ${revertError.message}`), {
+      tags: { subsystem: 'artist-profile' },
+      extra: { artistId: owned.artistId, slug },
+    });
+  }
+
+  await purgeArtistCaches(owned.artistName, slug);
+  console.log(`[Profile] Claim removed for "${owned.artistName}" (${slug})`);
+
+  return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ success: true }) };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string> | null;
+  body: string | null;
+}) {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
@@ -144,7 +236,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
   const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
-  if (event.httpMethod !== 'PUT') {
+  if (event.httpMethod !== 'PUT' && event.httpMethod !== 'DELETE') {
     return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
@@ -156,6 +248,16 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
   const userId = await authenticateRequest(event.headers.authorization || event.headers.Authorization);
   if (!userId) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Authentication required' }) };
+  }
+
+  // DELETE takes its slug from the query string like the other delete endpoints here — a body
+  // on DELETE is inconsistently forwarded, and there's nothing else to send.
+  if (event.httpMethod === 'DELETE') {
+    const slug = event.queryStringParameters?.slug;
+    if (!slug) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'slug is required' }) };
+    }
+    return handleRemoveClaim(client, slug, userId);
   }
 
   let body: {
@@ -411,37 +513,7 @@ export async function handler(event: { httpMethod: string; headers: Record<strin
     console.log(`[Profile] Updated ${links.length} links and ${dividers.length} dividers for artist "${artist.name}"`);
   }
 
-  // --- Bust caches ---
-  // 1. Purge Redis cache for search results containing this artist
-  try {
-    await cacheDeleteByArtist(artist.name);
-  } catch (e) {
-    console.error('[Profile] Redis cache purge failed:', e);
-  }
-
-  // 2. Purge Netlify CDN cache for this artist's page via cache tag
-  try {
-    const siteId = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
-    const token = process.env.NETLIFY_API_TOKEN;
-    if (siteId && token) {
-      await fetch(`https://api.netlify.com/api/v1/purge`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          site_id: siteId,
-          cache_tags: [`artist-${finalSlug}`],
-        }),
-      });
-      console.log(`[Profile] Purged CDN cache for artist-${finalSlug}`);
-    } else {
-      console.warn('[Profile] NETLIFY_SITE_ID or NETLIFY_API_TOKEN not set, skipping CDN purge');
-    }
-  } catch (e) {
-    console.error('[Profile] CDN cache purge failed:', e);
-  }
+  await purgeArtistCaches(artist.name, finalSlug);
 
   return {
     statusCode: 200,

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -30,6 +30,7 @@
   "include": [
     "functions/search-sources.ts",
     "functions/__tests__/to-stored-result.test.ts",
+    "functions/artist-profile.ts",
     "functions/me-settings.ts",
     "functions/me-username.ts",
     "functions/me-password.ts",
@@ -39,6 +40,7 @@
     "functions/redis.ts",
     "functions/cache.ts",
     "shared/feed-format.ts",
+    "functions/__tests__/artist-profile-remove.test.ts",
     "functions/__tests__/me-settings.test.ts",
     "functions/__tests__/me-username.test.ts",
     "functions/__tests__/me-password.test.ts",

--- a/apps/web/src/pages/ArtistEditPage.tsx
+++ b/apps/web/src/pages/ArtistEditPage.tsx
@@ -101,6 +101,9 @@ interface FormState {
   links: LinkEntry[];
   city: string;
   country: string;
+  removeOpen: boolean;
+  removeConfirmText: string;
+  removing: boolean;
 }
 
 type FormAction =
@@ -134,6 +137,9 @@ const initialFormState: FormState = {
   links: [],
   city: '',
   country: '',
+  removeOpen: false,
+  removeConfirmText: '',
+  removing: false,
 };
 
 export function ArtistEditPage() {
@@ -381,6 +387,37 @@ export function ArtistEditPage() {
     set('saving', false);
   }
 
+  async function handleRemoveArtist() {
+    set('error', null);
+    set('success', null);
+
+    if (!session) {
+      set('error', 'Session expired. Please sign in again.');
+      return;
+    }
+
+    set('removing', true);
+    try {
+      const response = await fetch(`/api/artist-profile?slug=${encodeURIComponent(form.currentSlug)}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${session.access_token}` },
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        set('error', data.error || 'Failed to remove this artist. Please try again.');
+        set('removing', false);
+        return;
+      }
+
+      navigate('/dashboard', { replace: true });
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'artistEdit.removeArtist' } });
+      set('error', 'Network error. Please try again.');
+      set('removing', false);
+    }
+  }
+
   if (form.loading) {
     return (
       <PageSkeleton label="Loading artist profile">
@@ -390,6 +427,11 @@ export function ArtistEditPage() {
   }
 
   const usedPlatforms = new Set(form.links.map(l => l.platform));
+
+  // Case-insensitive: the point of typing the name is deliberation, not spelling.
+  const removeConfirmed =
+    form.removeConfirmText.trim().length > 0 &&
+    form.removeConfirmText.trim().toLowerCase() === form.originalName.trim().toLowerCase();
 
   return (
     <div className="min-h-screen bg-bg-primary text-text-primary flex flex-col">
@@ -778,6 +820,60 @@ export function ArtistEditPage() {
               Cancel
             </Link>
           </div>
+
+          {/* Danger zone — removing the claim lives here rather than on the dashboard, where it
+              sat one click away from Edit and View. */}
+          <section className="rounded-lg border border-red-500/30 bg-red-500/5 p-4 space-y-3">
+            <h2 className="text-sm font-semibold text-red-400">Danger zone</h2>
+            <p className="text-xs text-text-muted">
+              Removing {form.originalName} takes this artist off your account. Your bio, profile
+              photo, featured release and link dividers are deleted, and unstream.stream/a/
+              {form.currentSlug} goes back to being an unclaimed page built from search results.
+              Your platform links stay on it. You can claim the page again later.
+            </p>
+
+            {!form.removeOpen ? (
+              <button
+                onClick={() => set('removeOpen', true)}
+                className="px-4 py-2 rounded-lg border border-red-500/40 text-red-400 text-sm font-medium hover:bg-red-500/10 transition-colors"
+              >
+                Remove this artist
+              </button>
+            ) : (
+              <div className="space-y-3">
+                <label htmlFor="remove-confirm" className="block text-xs text-text-muted">
+                  Type <span className="font-medium text-text-primary">{form.originalName}</span> to confirm.
+                </label>
+                <input
+                  id="remove-confirm"
+                  type="text"
+                  value={form.removeConfirmText}
+                  onChange={e => set('removeConfirmText', e.target.value)}
+                  autoComplete="off"
+                  className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary focus:outline-none focus:border-red-500/50"
+                />
+                <div className="flex items-center gap-4">
+                  <button
+                    onClick={handleRemoveArtist}
+                    disabled={form.removing || !removeConfirmed}
+                    className="px-4 py-2 rounded-lg bg-red-500 text-white text-sm font-medium hover:bg-red-500/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {form.removing ? 'Removing...' : 'Remove this artist'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      set('removeOpen', false);
+                      set('removeConfirmText', '');
+                    }}
+                    disabled={form.removing}
+                    className="text-sm text-text-muted hover:text-text-primary transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </section>
         </div>
       </main>
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -41,7 +41,7 @@ export function DashboardPage() {
   const [error, setError] = useState<string | null>(null);
 
   // Toast state
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const [undoToast, setUndoToast] = useState<{ message: string; artistId: string; onUndo: () => void } | null>(null);
   const [supportingSlug, setSupportingSlug] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -182,11 +182,6 @@ export function DashboardPage() {
     }
   };
 
-  const handleRemoveClaimedProfile = async (_profileId: string, _artistId: string, _slug: string) => {
-    // For now, just show a message - actual removal would require additional API
-    setToast({ message: 'Profile management coming soon!', type: 'info' });
-  };
-
   const handleToggleSupport = async (artist: SavedArtist) => {
     const newSupported = !artist.supported;
     const slug = artist.artistId;
@@ -321,13 +316,6 @@ export function DashboardPage() {
                           >
                             Releases
                           </Link>
-                          <button
-                            onClick={() => handleRemoveClaimedProfile(profile.id, profile.artistId, profile.slug)}
-                            className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-red-400 hover:border-red-500/30 transition-colors"
-                            title="Remove profile (coming soon)"
-                          >
-                            Remove
-                          </button>
                         </div>
                       </div>
                     </div>
@@ -483,14 +471,11 @@ export function DashboardPage() {
         {toast && (
           <div className={`pointer-events-auto px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 animate-in slide-in-from-right duration-300 ${
             toast.type === 'error' ? 'bg-red-500/10 border border-red-500/20 text-red-400' :
-            toast.type === 'info' ? 'bg-accent-primary/10 border border-accent-primary/20 text-accent-primary' :
             'bg-green-500/10 border border-green-500/20 text-green-400'
           }`}>
             <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               {toast.type === 'error' ? (
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              ) : toast.type === 'info' ? (
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               ) : (
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               )}


### PR DESCRIPTION
Removing a claimed artist sat one click away from Edit and View on the
dashboard, which is too easy for an action that hands the page back. The
button is gone from there; removal now lives at the bottom of the edit
page in a danger-zone container behind typing the artist's name.

The dashboard button was a stub that only showed a "coming soon" toast,
so this adds the real thing: DELETE /api/artist-profile deletes the
artist_profiles row (bio, photo, featured release, dividers) and reverts
the artists row to auto-discovered. The artist row itself stays — it is
public search data that existed before the claim — as do the platform
links, and the artist can claim the page again later.

Left flagged as claimed, the artist row would never expire and enrichment
would keep skipping it, so the page would stay frozen on the last edit of
an artist who just asked to be removed. A failed revert can't be fixed
automatically, so it reports to Sentry.

Also adds artist-profile.ts to the API typecheck include (it passes
strict cleanly) and pulls the shared cache purge out of the PUT path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WVFKxLzSw5nvK2K72bc1aM