### PR TITLE
Refresh saved artists' release catalogues on a schedule

### DIFF
--- a/.github/workflows/recatalog-sweep.yml
+++ b/.github/workflows/recatalog-sweep.yml
@@ -1,0 +1,66 @@
+name: Release catalogue sweep
+
+# Keeps saved artists' release catalogues from going stale.
+#
+# Every other catalog trigger is demand-driven: a save, a search, a button. So an artist who is
+# saved but never searched gets catalogued once and never again, and their release alerts
+# quietly stop — the long tail this feature exists for. See api/functions/recatalog-sweep.ts.
+#
+# A GitHub Actions cron rather than a scheduled Netlify function: there are no scheduled Netlify
+# functions in this repo, and this is the established precedent (schedule-social-posts.yml,
+# upstash-keepalive.yml).
+#
+# ## Cadence: daily, 05:00 UTC
+#
+# What this actually costs the sites we crawl is one batch of at most 25 artists, run through
+# the existing background function, which paces itself: one second between artists, at most 100
+# Bandcamp release-page fetches per run on top of one grid page each. So a sweep is on the order
+# of 125 requests to Bandcamp, sequential, spread over minutes — a trickle, and less than a
+# handful of real visitors searching. 05:00 UTC keeps it off both US and European peak.
+#
+# Daily rather than weekly because the batch is small and the 7-day cooldown is what actually
+# bounds per-artist crawling: an artist can't be re-crawled more than once a week however often
+# this runs. Daily just means the 25 slots are spread across seven small runs instead of arriving
+# in one lump, and it caps how long a newly-saved artist waits for a first catalogue if the
+# save-time request was dropped by the hourly cap.
+#
+# Safe to over-run. A duplicate invocation finds the same artists claimed and does nothing, so
+# re-running by hand is free.
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # Daily, 05:00 UTC
+  workflow_dispatch: # Manual trigger from the GitHub UI
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request a re-catalogue of the stalest saved artists
+        env:
+          INTERNAL_FUNCTION_SECRET: ${{ secrets.INTERNAL_FUNCTION_SECRET }}
+        run: |
+          if [ -z "$INTERNAL_FUNCTION_SECRET" ]; then
+            echo "::error::INTERNAL_FUNCTION_SECRET secret is not set"
+            exit 1
+          fi
+
+          response=$(curl -sS -X POST -w '\n%{http_code}' \
+            -H "Authorization: Bearer $INTERNAL_FUNCTION_SECRET" \
+            https://unstream.stream/.netlify/functions/recatalog-sweep)
+
+          status=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          # Any non-200 fails the run on purpose. A sweep that reports success while refusing to
+          # do anything — cataloging disabled, database unreadable — is the exact silent failure
+          # this workflow exists to prevent.
+          if [ "$status" != "200" ]; then
+            echo "::error::Sweep failed with HTTP $status: $body"
+            exit 1
+          fi
+
+          # Worth reading rather than skipping past: `requested` falling to 0 every day while
+          # `savedArtists` is large means everything is inside its cooldown (fine) or that
+          # selection has broken (not fine, and it looks identical from here).
+          echo "Sweep OK: $body"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,25 @@ page from Bandcamp on demand. Only the two database reads are stubbed; there is 
 connection, so nothing can be written. One Bandcamp request per release page you open.
 
 Once ingest is live, `release_catalog_state` is the observability surface:
-`last_attempted_at`, `releases_found`, `last_error`, `consecutive_failures`. A run that suddenly
-finds 0 releases where it previously found 20 is a parser break or a bot challenge, not an
-artist deleting their catalog.
+`last_attempted_at`, `releases_found`, `last_error`, `consecutive_failures`, `last_trigger`. A run
+that suddenly finds 0 releases where it previously found 20 is a parser break or a bot challenge,
+not an artist deleting their catalog — `recordCatalogOutcome` reports exactly that transition to
+Sentry, since it is otherwise recorded as a perfectly ordinary success.
+
+### Keeping catalogues fresh
+
+Every other catalog trigger is demand-driven — a save, a search, an artist's own button, the admin
+command — and `check-releases` only *reads* the catalogue. So without a scheduled refresh an artist
+who is saved but never searched gets catalogued once and their release alerts quietly stop. That
+is what `api/functions/recatalog-sweep.ts` fixes, run daily by `.github/workflows/recatalog-sweep.yml`.
+
+The sweep selects the stalest catalogues **among artists somebody has saved** (`getStaleSavedArtistCatalogs`
+in `db.ts`: never-attempted first, then oldest `last_attempted_at`, savers only as a tiebreak) and
+asks `requestArtistCatalog` for up to 25 of them under the `scheduled` trigger. It adds no rate
+limiting of its own — the 7-day cooldown and the hourly cap in `claimArtistForCatalog` still decide
+— so running it twice is a no-op. It returns a real summary rather than 202, and any refusal is a
+non-2xx that fails the workflow: a scheduled job that reports success while doing nothing is the
+same silent failure it was built to fix.
 
 ### Platform registry
 
@@ -327,6 +343,8 @@ GitHub Actions (`.github/workflows/`):
 - `supabase-migrate.yml` — auto-applies new migrations on push to `main`.
 - `schedule-social-posts.yml` — weekly (Mondays) social post generation, committed back to the repo.
 - `semantic-revert-check.yml` — runs `scripts/semantic-revert-check.py` on every PR to flag changes that quietly undo earlier fixes. If it flags your PR, take it seriously: the bug loops it was built for are described in `docs/retros/UNS-100-bifurcation-retro.md`.
+- `upstash-keepalive.yml` — twice weekly, writes one Redis key so the free-tier database isn't reaped for inactivity (which silently killed caching and rate limiting once).
+- `recatalog-sweep.yml` — daily, POSTs `/.netlify/functions/recatalog-sweep` so saved artists' release catalogues stay fresh. See "Keeping catalogues fresh" below.
 
 ## Engineering principles
 

--- a/api/functions/__tests__/catalog-gating.test.ts
+++ b/api/functions/__tests__/catalog-gating.test.ts
@@ -191,7 +191,10 @@ describe('requestArtistCatalog only runs where cataloging is enabled', () => {
   it('deduplicates ids and never throws when the handshake fails', async () => {
     mocks.fetch.mockRejectedValue(new Error('network down'));
 
-    await expect(requestArtistCatalog([ARTIST, ARTIST, ''], 'searched')).resolves.toBeUndefined();
+    // False, not a throw: a fan saving an artist must not see an error because a crawl could
+    // not be scheduled. The scheduled sweep is the one caller that reads the return, because
+    // it has no next visitor to ask again.
+    await expect(requestArtistCatalog([ARTIST, ARTIST, ''], 'searched')).resolves.toBe(false);
 
     const body = JSON.parse(String((mocks.fetch.mock.calls[0][1] as RequestInit).body));
     expect(body.artistIds).toEqual([ARTIST]);

--- a/api/functions/__tests__/recatalog-sweep-selection.test.ts
+++ b/api/functions/__tests__/recatalog-sweep-selection.test.ts
@@ -1,0 +1,310 @@
+// Who the scheduled sweep picks, and who it must not.
+//
+// The selection is the whole feature: get it wrong and the sweep runs every day, reports
+// success, and refreshes the wrong artists — or none — while the alerts it exists to keep
+// alive stay quiet. Every rule here is one that would fail silently.
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// release-order-query.test.ts, so the real query body runs.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Filter {
+  kind: 'eq' | 'not' | 'in' | 'limit';
+  column?: string;
+  value?: unknown;
+}
+
+interface Query {
+  table: string;
+  columns: string;
+  filters: Filter[];
+}
+
+const queries: Query[] = [];
+
+/** Rows the fake returns, keyed by table. Tests set these. */
+const tables: Record<string, Record<string, unknown>[]> = {
+  saved_artists: [],
+  release_catalog_state: [],
+};
+
+/** Set to a table name to make that table's read fail. */
+let failingTable: string | null = null;
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          const query: Query = { table, columns, filters: [] };
+          queries.push(query);
+
+          const builder = {
+            eq(column: string, value: unknown) {
+              query.filters.push({ kind: 'eq', column, value });
+              return builder;
+            },
+            not(column: string, operator: string, value: unknown) {
+              query.filters.push({ kind: 'not', column, value: `${operator} ${value}` });
+              return builder;
+            },
+            in(column: string, value: unknown) {
+              query.filters.push({ kind: 'in', column, value });
+              return builder;
+            },
+            limit(n: number) {
+              query.filters.push({ kind: 'limit', value: n });
+              return builder;
+            },
+            then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
+              if (failingTable === table) {
+                return Promise.resolve({ data: null, error: { message: 'connection reset' } })
+                  .then(resolve, reject);
+              }
+              // Apply the `in` filter the way PostgREST would, so a chunked read behaves.
+              const inFilter = query.filters.find(f => f.kind === 'in');
+              let rows = tables[table] ?? [];
+              if (inFilter) {
+                const wanted = new Set(inFilter.value as string[]);
+                rows = rows.filter(r => wanted.has(r[inFilter.column as string] as string));
+              }
+              return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getStaleSavedArtistCatalogs, RECATALOG_COOLDOWN_HOURS } = await import('../db');
+
+const HOUR = 3600_000;
+const now = Date.now();
+const ago = (hours: number) => new Date(now - hours * HOUR).toISOString();
+
+function saved(artistId: string | null, extra: Record<string, unknown> = {}) {
+  return { artist_id: artistId, deleted: false, ...extra };
+}
+
+function state(
+  artistId: string,
+  attemptedHoursAgo: number,
+  catalogued: { hoursAgo: number; releasesFound?: number } | null = null
+) {
+  return {
+    artist_id: artistId,
+    last_attempted_at: ago(attemptedHoursAgo),
+    last_catalogued_at: catalogued ? ago(catalogued.hoursAgo) : null,
+    releases_found: catalogued?.releasesFound ?? null,
+  };
+}
+
+beforeEach(() => {
+  queries.length = 0;
+  tables.saved_artists = [];
+  tables.release_catalog_state = [];
+  failingTable = null;
+});
+
+describe('getStaleSavedArtistCatalogs — who is eligible', () => {
+  it('only considers artists somebody has saved', async () => {
+    tables.saved_artists = [saved('saved-artist')];
+    // An artist with catalog state but no saver: catalogued because they were searched once.
+    tables.release_catalog_state = [state('saved-artist', 400), state('searched-only', 900)];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.candidates.map(c => c.artistId)).toEqual(['saved-artist']);
+  });
+
+  it('asks the database only for rows that are not tombstoned', async () => {
+    tables.saved_artists = [saved('a')];
+
+    await getStaleSavedArtistCatalogs(10);
+
+    const savedQuery = queries.find(q => q.table === 'saved_artists');
+    // `deleted` is a soft-delete flag (migration 017): an unsaved artist keeps a row so other
+    // devices can prune it. Re-crawling for somebody who unsaved them is pure waste.
+    expect(savedQuery?.filters).toContainEqual({ kind: 'eq', column: 'deleted', value: false });
+    // artist_id is nullable since migration 014 — a save can be by slug alone.
+    expect(savedQuery?.filters).toContainEqual({ kind: 'not', column: 'artist_id', value: 'is null' });
+  });
+
+  it('ignores a saved row with no artist id', async () => {
+    tables.saved_artists = [saved(null), saved('real')];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['real']);
+  });
+
+  it('drops artists still inside the re-catalog cooldown, and counts them', async () => {
+    tables.saved_artists = [saved('fresh'), saved('stale')];
+    tables.release_catalog_state = [
+      state('fresh', 2, { hoursAgo: 2, releasesFound: 12 }),
+      state('stale', RECATALOG_COOLDOWN_HOURS + 24, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 24 }),
+    ];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Spending a bounded batch on artists claimArtistForCatalog will refuse a moment later
+    // would make the sweep a no-op that still reports work.
+    expect(result.candidates.map(c => c.artistId)).toEqual(['stale']);
+    expect(result.inCooldown).toBe(1);
+    expect(result.savedArtists).toBe(2);
+  });
+
+  it('keeps an artist whose last success is exactly outside the cooldown', async () => {
+    tables.saved_artists = [saved('edge')];
+    tables.release_catalog_state = [
+      state('edge', RECATALOG_COOLDOWN_HOURS + 1, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 1 }),
+    ];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['edge']);
+  });
+
+  it('keeps an artist who has only ever failed, however recently attempted', async () => {
+    // last_catalogued_at null means no success ever. The cooldown is about successes; the
+    // exponential backoff on repeated failures is claimArtistForCatalog's job, not this one's.
+    tables.saved_artists = [saved('always-failing')];
+    tables.release_catalog_state = [state('always-failing', 1)];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['always-failing']);
+  });
+});
+
+describe('getStaleSavedArtistCatalogs — ordering', () => {
+  it('puts never-attempted artists first, then the stalest attempt', async () => {
+    tables.saved_artists = [saved('recent'), saved('never'), saved('ancient'), saved('middling')];
+    tables.release_catalog_state = [
+      state('recent', 200),
+      state('ancient', 5_000),
+      state('middling', 900),
+    ];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // 'never' has been saved but no run has ever claimed them — usually the save-time request
+    // hit the hourly cap. Nothing else retries it, so it goes to the front.
+    expect(result.candidates.map(c => c.artistId)).toEqual(['never', 'ancient', 'middling', 'recent']);
+    expect(result.candidates[0].lastAttemptedAt).toBeNull();
+  });
+
+  it('breaks ties on savers, but never lets popularity outrank staleness', async () => {
+    tables.saved_artists = [
+      saved('popular-fresh'),
+      saved('popular-fresh'),
+      saved('popular-fresh'),
+      saved('lonely-stale'),
+      saved('also-fresh'),
+    ];
+    tables.release_catalog_state = [
+      state('popular-fresh', 200),
+      state('also-fresh', 200),
+      state('lonely-stale', 4_000),
+    ];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The one nobody but a single fan saved still comes first. Sorting by popularity would
+    // starve exactly the long tail the sweep exists to serve — popular artists stay fresh
+    // anyway, because people search them.
+    expect(result.candidates.map(c => c.artistId)).toEqual([
+      'lonely-stale',
+      'popular-fresh',
+      'also-fresh',
+    ]);
+    expect(result.candidates[1].savers).toBe(3);
+  });
+
+  it('returns at most the requested batch, stalest first', async () => {
+    tables.saved_artists = Array.from({ length: 40 }, (_, i) => saved(`artist-${i}`));
+    tables.release_catalog_state = Array.from({ length: 40 }, (_, i) => state(`artist-${i}`, 200 + i));
+
+    const result = await getStaleSavedArtistCatalogs(25);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.candidates).toHaveLength(25);
+    expect(result.candidates[0].artistId).toBe('artist-39'); // attempted longest ago
+    expect(result.savedArtists).toBe(40); // the population, not the batch
+  });
+
+  it('carries the previous release count, so a run can be read against it afterwards', async () => {
+    tables.saved_artists = [saved('a')];
+    tables.release_catalog_state = [
+      state('a', 400, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 10, releasesFound: 20 }),
+    ];
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result.ok && result.candidates[0].releasesFound).toBe(20);
+  });
+});
+
+describe('getStaleSavedArtistCatalogs — failure is not emptiness', () => {
+  it('reports a failed saved-artists read rather than returning no candidates', async () => {
+    tables.saved_artists = [saved('a')];
+    failingTable = 'saved_artists';
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    // "We couldn't ask" must not render as "nothing needs re-cataloguing" — that is the shape
+    // of the bug the never-cache-uncertainty rule exists to prevent, and here it would make a
+    // broken sweep look like a quiet week, forever.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toContain('saved artists');
+  });
+
+  it('reports a failed catalog-state read rather than treating everyone as never attempted', async () => {
+    tables.saved_artists = [saved('a')];
+    failingTable = 'release_catalog_state';
+
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    // Silently treating an unreadable state table as "nobody has ever been catalogued" would
+    // send every saved artist to the front of the queue and re-crawl the lot.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toContain('catalog state');
+  });
+
+  it('is a quiet success, not a failure, when nobody has saved anything', async () => {
+    const result = await getStaleSavedArtistCatalogs(10);
+
+    expect(result).toEqual({ ok: true, candidates: [], savedArtists: 0, inCooldown: 0 });
+  });
+
+  it('chunks the state lookup so a large saved population cannot blow up the query string', async () => {
+    tables.saved_artists = Array.from({ length: 450 }, (_, i) => saved(`artist-${i}`));
+
+    await getStaleSavedArtistCatalogs(25);
+
+    const stateQueries = queries.filter(q => q.table === 'release_catalog_state');
+    expect(stateQueries).toHaveLength(3); // 200 + 200 + 50
+    for (const q of stateQueries) {
+      expect((q.filters.find(f => f.kind === 'in')?.value as string[]).length).toBeLessThanOrEqual(200);
+    }
+  });
+});

--- a/api/functions/__tests__/recatalog-sweep.test.ts
+++ b/api/functions/__tests__/recatalog-sweep.test.ts
@@ -1,0 +1,250 @@
+// The scheduled sweep endpoint, and the per-artist isolation it depends on.
+//
+// Two things are being protected here, and both are failure-to-fail-loudly problems:
+//
+//  1. The sweep must never answer 200 when it did nothing it was asked to do. A daily job that
+//     reports success while cataloging is disabled, or the database is unreadable, recreates
+//     precisely the bug it was built to fix — release alerts going quiet with nothing to see.
+//  2. One artist blowing up mid-sweep must not take the rest of the batch with it. A sweep runs
+//     once a day; the artists after the failure would wait another day for a slot they only get
+//     because they are the stalest.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getStaleSavedArtistCatalogs: vi.fn(),
+  requestArtistCatalog: vi.fn(),
+  captureMessage: vi.fn(),
+  // For the background-loop isolation test:
+  claimArtistForCatalog: vi.fn(),
+  getArtistForCatalog: vi.fn(),
+  recordCatalogOutcome: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getStaleSavedArtistCatalogs: mocks.getStaleSavedArtistCatalogs,
+  claimArtistForCatalog: mocks.claimArtistForCatalog,
+  getArtistForCatalog: mocks.getArtistForCatalog,
+  recordCatalogOutcome: mocks.recordCatalogOutcome,
+  persistReleases: vi.fn(),
+  persistDiscogsReleases: vi.fn(),
+  persistFaircampReleases: vi.fn(),
+  persistJamcoopReleases: vi.fn(),
+  persistMusicBrainzEnrichment: vi.fn(),
+  persistReleaseDetail: vi.fn(),
+  attachDiscoveredSource: vi.fn(),
+}));
+
+vi.mock('../request-catalog', async importOriginal => {
+  const actual = await importOriginal<typeof import('../request-catalog')>();
+  return { ...actual, requestArtistCatalog: mocks.requestArtistCatalog };
+});
+
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureMessage: mocks.captureMessage, captureException: vi.fn() },
+  initSentry: vi.fn(),
+  isSentryInitialized: () => false,
+}));
+
+const { handler } = await import('../recatalog-sweep');
+
+const SECRET = 'sweep-test-secret';
+const originalEnv = { ...process.env };
+
+function candidate(artistId: string, lastAttemptedAt: string | null = '2026-07-01T00:00:00+00:00') {
+  return { artistId, savers: 1, lastAttemptedAt, releasesFound: 12 };
+}
+
+function post(headers: Record<string, string | undefined> = { authorization: `Bearer ${SECRET}` }) {
+  return handler({ httpMethod: 'POST', headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.INTERNAL_FUNCTION_SECRET = SECRET;
+  process.env.RELEASE_CATALOG_ENABLED = 'true';
+  process.env.URL = 'https://unstream.stream';
+  mocks.requestArtistCatalog.mockResolvedValue(true);
+  mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
+    ok: true,
+    candidates: [candidate('a'), candidate('b')],
+    savedArtists: 40,
+    inCooldown: 38,
+  });
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('recatalog-sweep auth', () => {
+  it('rejects a request with no Authorization header', async () => {
+    const r = await post({});
+    expect(r.statusCode).toBe(401);
+    expect(mocks.getStaleSavedArtistCatalogs).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong secret', async () => {
+    const r = await post({ authorization: 'Bearer not-the-secret' });
+    expect(r.statusCode).toBe(401);
+  });
+
+  // timingSafeEqual throws on a length mismatch, so lengths are compared first.
+  it('rejects a secret of a different length without throwing', async () => {
+    const r = await post({ authorization: 'Bearer x' });
+    expect(r.statusCode).toBe(401);
+  });
+
+  // Fail closed: an unconfigured secret closes the endpoint, it does not open it. This one
+  // makes Unstream crawl third-party sites on request.
+  it('rejects everything when no secret is configured', async () => {
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    const r = await post({ authorization: 'Bearer anything' });
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('rejects non-POST', async () => {
+    const r = await handler({ httpMethod: 'GET', headers: { authorization: `Bearer ${SECRET}` } });
+    expect(r.statusCode).toBe(405);
+    expect(mocks.getStaleSavedArtistCatalogs).not.toHaveBeenCalled();
+  });
+});
+
+describe('recatalog-sweep refuses out loud', () => {
+  it('fails, rather than quietly succeeding, when cataloging is disabled', async () => {
+    delete process.env.RELEASE_CATALOG_ENABLED;
+
+    const r = await post();
+
+    // 503 fails the GitHub Actions run. A 200 here would mean a sweep that can never do
+    // anything reports success every morning forever.
+    expect(r.statusCode).toBe(503);
+    expect(mocks.requestArtistCatalog).not.toHaveBeenCalled();
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('disabled'),
+      expect.objectContaining({ tags: expect.objectContaining({ kind: 'sweep-disabled' }) })
+    );
+  });
+
+  it('fails when the candidates cannot be read', async () => {
+    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({ ok: false, reason: 'Could not read saved artists: down' });
+
+    const r = await post();
+
+    expect(r.statusCode).toBe(503);
+    expect(mocks.requestArtistCatalog).not.toHaveBeenCalled();
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tags: expect.objectContaining({ kind: 'sweep-selection-failed' }) })
+    );
+  });
+
+  it('fails when the request to the cataloging function never leaves', async () => {
+    mocks.requestArtistCatalog.mockResolvedValue(false);
+
+    const r = await post();
+
+    // A completed handshake proves little — the dispatcher 202s anything — but a failed one
+    // proves the sweep did nothing, and for a once-a-day job there is no next caller to retry.
+    expect(r.statusCode).toBe(502);
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tags: expect.objectContaining({ kind: 'sweep-dispatch-failed' }) })
+    );
+  });
+});
+
+describe('recatalog-sweep dispatch', () => {
+  it('asks for the selected artists under the scheduled trigger', async () => {
+    const r = await post();
+
+    expect(r.statusCode).toBe(200);
+    // 'scheduled' has its own hourly ceiling, above search and below saving, and is what makes
+    // the sweep visible in release_catalog_state.last_trigger.
+    expect(mocks.requestArtistCatalog).toHaveBeenCalledWith(['a', 'b'], 'scheduled');
+  });
+
+  it('asks for one background invocation worth of artists', async () => {
+    await post();
+    // Matches MAX_ARTISTS_PER_RUN in catalog-artist-background: asking for more would silently
+    // drop the overflow, which would look like the sweep working.
+    expect(mocks.getStaleSavedArtistCatalogs).toHaveBeenCalledWith(25);
+  });
+
+  it('reports counts a reader can tell a quiet day from a broken sweep by', async () => {
+    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
+      ok: true,
+      candidates: [candidate('a', null), candidate('b', '2026-06-01T00:00:00+00:00')],
+      savedArtists: 40,
+      inCooldown: 38,
+    });
+
+    const r = await post();
+
+    expect(JSON.parse(r.body)).toEqual({
+      requested: 2,
+      savedArtists: 40,
+      inCooldown: 38,
+      stalestAttemptedAt: null,
+      neverAttempted: 1,
+    });
+  });
+
+  it('is a quiet success when everyone is inside their cooldown', async () => {
+    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
+      ok: true,
+      candidates: [],
+      savedArtists: 40,
+      inCooldown: 40,
+    });
+
+    const r = await post();
+
+    // Nothing to do is a real, correct outcome — every saved artist was catalogued this week.
+    expect(r.statusCode).toBe(200);
+    expect(mocks.requestArtistCatalog).not.toHaveBeenCalled();
+    expect(JSON.parse(r.body).requested).toBe(0);
+  });
+});
+
+describe('one artist failing does not abort the sweep', () => {
+  // The sweep's per-artist work happens inside catalog-artist-background, one artist at a time.
+  // Exercised through the real handler: what matters is that the artists *after* a thrown
+  // failure are still catalogued, and that the failure is recorded against the one that caused
+  // it rather than lost.
+  it('catalogs the rest of the batch and records the failure', async () => {
+    const { handler: catalogHandler } = await import('../catalog-artist-background');
+
+    mocks.claimArtistForCatalog.mockResolvedValue(true);
+    mocks.getArtistForCatalog.mockImplementation(async (artistId: string) => {
+      if (artistId === 'boom') throw new Error('supabase exploded');
+      return { id: artistId, name: artistId, bandcampUrl: null, discogsUrl: null, faircampUrl: null, jamcoopUrl: null };
+    });
+
+    const result = await catalogHandler({
+      httpMethod: 'POST',
+      headers: { authorization: `Bearer ${SECRET}` },
+      body: JSON.stringify({ artistIds: ['before', 'boom', 'after'], trigger: 'scheduled' }),
+    });
+
+    expect(result.statusCode).toBe(200);
+    // All three were attempted — the throw did not unwind the loop.
+    expect(mocks.getArtistForCatalog.mock.calls.map(c => c[0])).toEqual(['before', 'boom', 'after']);
+    expect(mocks.recordCatalogOutcome).toHaveBeenCalledWith('boom', { error: 'supabase exploded' });
+  }, 15_000);
+
+  it('spends the scheduled budget, not the search budget', async () => {
+    const { handler: catalogHandler } = await import('../catalog-artist-background');
+    mocks.claimArtistForCatalog.mockResolvedValue(false);
+
+    await catalogHandler({
+      httpMethod: 'POST',
+      headers: { authorization: `Bearer ${SECRET}` },
+      body: JSON.stringify({ artistIds: ['a'], trigger: 'scheduled' }),
+    });
+
+    // Before this feature the trigger was parsed as `=== 'saved' ? 'saved' : 'searched'`, so a
+    // scheduled sweep would silently have spent the smallest budget.
+    expect(mocks.claimArtistForCatalog).toHaveBeenCalledWith('a', 'scheduled');
+  });
+});

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -10,7 +10,6 @@
 // auth, and copying that here would be a mistake: an open endpoint that makes Unstream crawl
 // Bandcamp on demand is exactly the amplifier the check-releases hardening existed to close.
 
-import { timingSafeEqual } from 'crypto';
 import {
   claimArtistForCatalog,
   getArtistForCatalog,
@@ -25,7 +24,7 @@ import {
   type CatalogTrigger,
   type PersistedRelease,
 } from './db';
-import { isUrlHostnameAllowed } from './middleware';
+import { isInternalRequest, isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
 import {
   bandcampMusicUrl,
@@ -187,27 +186,6 @@ interface JamcoopBudget {
   deadline: number;
 }
 
-function isAuthorized(header: string | undefined): boolean {
-  // Reuses the secret this repo already has for internal function-to-function calls
-  // (resolve-url, search-sources, and both v1 wrappers). A second near-identically-named
-  // variable would be a footgun, and the blast radius of this one is small: cooldown and
-  // hourly caps are enforced inside this function regardless of who calls it, and only
-  // artists already in our database can be named.
-  const secret = process.env.INTERNAL_FUNCTION_SECRET;
-  // No secret configured means the endpoint is closed, not open.
-  if (!secret) {
-    console.error('[catalog] INTERNAL_FUNCTION_SECRET is not set — refusing all requests');
-    return false;
-  }
-  if (!header?.startsWith('Bearer ')) return false;
-
-  const provided = Buffer.from(header.slice(7));
-  const expected = Buffer.from(secret);
-  // timingSafeEqual throws on length mismatch, so compare lengths first.
-  if (provided.length !== expected.length) return false;
-  return timingSafeEqual(provided, expected);
-}
-
 export async function handler(event: {
   httpMethod?: string;
   headers?: Record<string, string | undefined>;
@@ -217,7 +195,9 @@ export async function handler(event: {
     return { statusCode: 405, body: '' };
   }
 
-  if (!isAuthorized(event.headers?.authorization ?? event.headers?.Authorization)) {
+  // The blast radius of the shared internal secret is small here: cooldown and hourly caps are
+  // enforced below regardless of who calls, and only artists already in our database can be named.
+  if (!isInternalRequest(event.headers?.authorization ?? event.headers?.Authorization)) {
     return { statusCode: 401, body: '' };
   }
 
@@ -239,7 +219,10 @@ export async function handler(event: {
   const artistIds = Array.isArray(body.artistIds)
     ? body.artistIds.filter((id): id is string => typeof id === 'string').slice(0, MAX_ARTISTS_PER_RUN)
     : [];
-  const trigger: CatalogTrigger = body.trigger === 'saved' ? 'saved' : 'searched';
+  // Allowlisted, not cast: an unrecognized trigger falls back to the smallest budget rather
+  // than reaching CATALOG_HOURLY_CAP as an undefined key, where the cap comparison would pass.
+  const trigger: CatalogTrigger =
+    body.trigger === 'saved' || body.trigger === 'scheduled' ? body.trigger : 'searched';
 
   if (artistIds.length === 0) return { statusCode: 400, body: '' };
 

--- a/api/functions/check-releases.ts
+++ b/api/functions/check-releases.ts
@@ -12,6 +12,11 @@
 //    has saved or searched yet has no catalog, and treating that as "no new releases" would
 //    silently switch alerts off for them.
 //
+// Note what this file does *not* do: it reads the catalog, it never refreshes it. Keeping a
+// saved artist's catalog current is the scheduled sweep's job (`recatalog-sweep.ts`). Without
+// that, path 1 would read the same catalog forever for anyone nobody searches, which is a
+// quieter version of the same bug the fallback above exists to prevent.
+//
 // The response stays backwards-compatible on purpose. `release` (singular) is still populated
 // for the shipped Mac app and browser extension, which decode exactly that field; `releases`
 // (plural) is additive and carries what a newer client can use. Both shipped clients decode

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -12,6 +12,7 @@ import {
   uniqueReleaseSlug,
 } from './release-utils';
 import { requestArtistCatalog } from './request-catalog';
+import { Sentry } from '../lib/sentry';
 
 let supabase: SupabaseClient | null = null;
 
@@ -402,7 +403,7 @@ export async function isStoredArtistLink(url: string, artistName: string): Promi
 // --- Release catalog (Unstream Releases) ---
 
 /** Don't re-crawl an artist inside this window. Repeat searches then cost nothing upstream. */
-const RECATALOG_COOLDOWN_HOURS = 24 * 7;
+export const RECATALOG_COOLDOWN_HOURS = 24 * 7;
 
 /**
  * Hourly ceilings on how many artists we will catalog, by what triggered it.
@@ -411,10 +412,18 @@ const RECATALOG_COOLDOWN_HOURS = 24 * 7;
  * budget: a traffic spike must not turn into us hammering Bandcamp. A save is one person
  * deliberately asking to follow an artist, so it gets a bigger budget and still gets through
  * when searches are being dropped.
+ *
+ * The scheduled sweep sits between the two, and the reason is the shared counter: the cap is
+ * compared against every attempt in the last hour, whatever triggered it. Give the sweep the
+ * smallest budget and an ordinary hour of search traffic would leave it nothing to spend — it
+ * runs once a day at a fixed time, so it can't wait for a quieter moment the way a search can
+ * be dropped and re-triggered by the next visitor. Give it the largest and a machine caller
+ * would outrank a person. In between, it gets through in normal conditions and still yields
+ * during a genuine spike.
  */
-const CATALOG_HOURLY_CAP = { searched: 60, saved: 240 } as const;
+const CATALOG_HOURLY_CAP = { searched: 60, saved: 240, scheduled: 120 } as const;
 
-export type CatalogTrigger = 'saved' | 'searched';
+export type CatalogTrigger = 'saved' | 'searched' | 'scheduled';
 
 /**
  * May we catalog this artist right now — and if so, claim it.
@@ -529,6 +538,27 @@ export async function recordCatalogOutcome(
         .maybeSingle();
       const prev = (data as { consecutive_failures: number } | null)?.consecutive_failures ?? 0;
       patch.consecutive_failures = prev + 1;
+    } else if (outcome.releasesFound === 0) {
+      // A run that finds 0 releases where it previously found 20 is a parser break or a bot
+      // challenge, not an artist deleting their catalogue — and it is recorded as a *success*,
+      // so nothing else about it looks wrong. Report the transition, because the alternative
+      // is a pipeline that degrades into finding nothing and never says so.
+      //
+      // Only the transition: an artist who has always had 0 releases is not news, and this
+      // fires on every trigger, not just the scheduled sweep.
+      const { data } = await client
+        .from('release_catalog_state')
+        .select('releases_found')
+        .eq('artist_id', artistId)
+        .maybeSingle();
+      const previous = (data as { releases_found: number | null } | null)?.releases_found ?? 0;
+      if (previous > 0) {
+        Sentry.captureMessage('[catalog] release count dropped to zero', {
+          level: 'warning',
+          tags: { area: 'release-catalog', kind: 'releases-dropped-to-zero' },
+          extra: { artistId, previousReleasesFound: previous },
+        });
+      }
     }
 
     const { error } = await client
@@ -577,6 +607,142 @@ export async function getCatalogState(artistId: string): Promise<CatalogStateRes
     return { ok: false, reason: 'Could not read catalog state' };
   }
   return { ok: true, state: (data as CatalogStateRow | null) ?? null };
+}
+
+/** One artist the scheduled sweep could re-crawl, with the facts it was chosen on. */
+export interface StaleCatalogCandidate {
+  artistId: string;
+  /** How many people have this artist saved. Used only to break ties — see the sort below. */
+  savers: number;
+  /** Null means never attempted: saved, but no catalog run has ever claimed them. */
+  lastAttemptedAt: string | null;
+  /** What the last successful run found, so a sweep run can be read against it afterwards. */
+  releasesFound: number | null;
+}
+
+/**
+ * Three-valued for the same reason as `CatalogStateResult`: "we couldn't ask" must not render
+ * as "nothing needs re-cataloguing". The sweep reports the first as a failure and the second as
+ * a quiet, successful run, and they look identical if collapsed.
+ */
+export type StaleCatalogResult =
+  | { ok: true; candidates: StaleCatalogCandidate[]; savedArtists: number; inCooldown: number }
+  | { ok: false; reason: string };
+
+/** Bounds the sweep's first read. Well above the current saved population; a guard, not a limit. */
+const MAX_SAVED_ARTISTS_SCANNED = 10_000;
+
+/** How many ids to put in one `in()` filter, which becomes a URL query string. */
+const CATALOG_STATE_CHUNK = 200;
+
+/**
+ * The stalest catalogues among artists somebody has actually saved.
+ *
+ * **Saved artists only, not every artist row.** There are thousands of artists in the database
+ * and only a fraction are saved by anyone; a save is what creates the obligation, because it is
+ * what makes someone expect an alert. An artist nobody has saved gets catalogued when they're
+ * searched, which is the demand-driven behaviour that already works.
+ *
+ * Ordering, in priority order:
+ *
+ *   1. **Never attempted first.** Saved but no catalog state at all means the crawl requested at
+ *      save time never got through — usually the hourly cap. Nothing else will retry it, so it
+ *      goes to the front.
+ *   2. **Then stalest `last_attempted_at`.** Staleness is the thing that makes alerts go quiet,
+ *      so it is what the sweep is for.
+ *   3. **Then most savers.** A tiebreak only. Sorting by popularity first would starve exactly
+ *      the long tail this exists to serve — popular artists already stay fresh because people
+ *      search them.
+ *
+ * Artists inside the re-catalog cooldown are dropped here rather than left for
+ * `claimArtistForCatalog` to refuse. That's not a second rate limiter — the same constant, read
+ * up front — it's what stops a bounded batch being spent entirely on artists that will be
+ * refused a moment later. The claim remains the authority; this only decides who to ask about.
+ */
+export async function getStaleSavedArtistCatalogs(limit: number): Promise<StaleCatalogResult> {
+  const client = getClient();
+  if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
+
+  // `deleted` is a tombstone, not a hard delete (migration 017) — an unsaved artist keeps a row
+  // so other devices can prune it, and re-crawling for someone who unsaved them is waste.
+  const { data: saved, error: savedError } = await client
+    .from('saved_artists')
+    .select('artist_id')
+    .eq('deleted', false)
+    .not('artist_id', 'is', null)
+    .limit(MAX_SAVED_ARTISTS_SCANNED);
+
+  if (savedError) {
+    console.error('[DB] getStaleSavedArtistCatalogs saved read failed:', savedError.message);
+    return { ok: false, reason: `Could not read saved artists: ${savedError.message}` };
+  }
+
+  const savers = new Map<string, number>();
+  for (const row of (saved as { artist_id: string | null }[]) ?? []) {
+    if (!row.artist_id) continue;
+    savers.set(row.artist_id, (savers.get(row.artist_id) ?? 0) + 1);
+  }
+
+  if (savers.size === 0) return { ok: true, candidates: [], savedArtists: 0, inCooldown: 0 };
+
+  interface StateRow {
+    artist_id: string;
+    last_attempted_at: string | null;
+    last_catalogued_at: string | null;
+    releases_found: number | null;
+  }
+
+  const ids = [...savers.keys()];
+  const state = new Map<string, StateRow>();
+
+  for (let i = 0; i < ids.length; i += CATALOG_STATE_CHUNK) {
+    const { data, error } = await client
+      .from('release_catalog_state')
+      .select('artist_id, last_attempted_at, last_catalogued_at, releases_found')
+      .in('artist_id', ids.slice(i, i + CATALOG_STATE_CHUNK));
+
+    if (error) {
+      console.error('[DB] getStaleSavedArtistCatalogs state read failed:', error.message);
+      return { ok: false, reason: `Could not read catalog state: ${error.message}` };
+    }
+    for (const row of (data as StateRow[]) ?? []) state.set(row.artist_id, row);
+  }
+
+  const cooldownCutoff = Date.now() - RECATALOG_COOLDOWN_HOURS * 3600_000;
+  const candidates: StaleCatalogCandidate[] = [];
+  let inCooldown = 0;
+
+  for (const [artistId, count] of savers) {
+    const row = state.get(artistId);
+    if (row?.last_catalogued_at && new Date(row.last_catalogued_at).getTime() > cooldownCutoff) {
+      inCooldown++;
+      continue;
+    }
+    candidates.push({
+      artistId,
+      savers: count,
+      lastAttemptedAt: row?.last_attempted_at ?? null,
+      releasesFound: row?.releases_found ?? null,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (a.lastAttemptedAt === null || b.lastAttemptedAt === null) {
+      if (a.lastAttemptedAt !== b.lastAttemptedAt) return a.lastAttemptedAt === null ? -1 : 1;
+    } else {
+      // Compared as instants, not strings: PostgREST timestamps can differ in offset notation.
+      const diff = new Date(a.lastAttemptedAt).getTime() - new Date(b.lastAttemptedAt).getTime();
+      if (diff !== 0) return diff;
+    }
+    return b.savers - a.savers;
+  });
+
+  return {
+    ok: true,
+    candidates: candidates.slice(0, limit),
+    savedArtists: savers.size,
+    inCooldown,
+  };
 }
 
 /**

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -261,6 +261,36 @@ export async function authenticateApiKey(
 }
 
 // ---------------------------------------------------------------------------
+// Internal function-to-function auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Is this request from one of our own callers — another function, or the scheduled sweep?
+ *
+ * Authenticated with INTERNAL_FUNCTION_SECRET, the secret this repo already uses for
+ * function-to-function calls (resolve-url, search-sources, both v1 wrappers,
+ * catalog-artist-background). A second near-identically-named variable would be a footgun.
+ *
+ * **Fails closed.** No secret configured closes the endpoint rather than opening it: the
+ * endpoints behind this make Unstream crawl third-party sites, which is exactly the amplifier
+ * an unauthenticated route would hand to anyone who found it.
+ */
+export function isInternalRequest(header: string | undefined): boolean {
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+  if (!secret) {
+    console.error('[internal-auth] INTERNAL_FUNCTION_SECRET is not set — refusing all requests');
+    return false;
+  }
+  if (!header?.startsWith('Bearer ')) return false;
+
+  const provided = Buffer.from(header.slice(7));
+  const expected = Buffer.from(secret);
+  // timingSafeEqual throws on length mismatch, so compare lengths first.
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
+}
+
+// ---------------------------------------------------------------------------
 // Query validation
 // ---------------------------------------------------------------------------
 

--- a/api/functions/recatalog-sweep.ts
+++ b/api/functions/recatalog-sweep.ts
@@ -1,0 +1,123 @@
+// The scheduled re-catalogue sweep: keep saved artists' catalogues from going stale.
+//
+// ## Why this exists
+//
+// Every other catalog trigger is demand-driven — a fan saves an artist, someone searches them,
+// an artist or admin presses a button. That leaves a hole the release-alerts feature falls
+// straight into. A fan saves an artist, the catalogue is built once, and the weekly alert check
+// reads that same catalogue forever: `check-releases` reads the catalogue and returns, and only
+// falls back to a live scrape for an artist the catalogue has *never* seen. So if nobody ever
+// searches that artist again, their new releases are never discovered and the alerts quietly
+// stop. Popular artists stay fresh incidentally because people search them; the long tail of
+// saved-but-not-searched artists is exactly who this feature was for.
+//
+// This sweep is the missing half. Invoked by .github/workflows/recatalog-sweep.yml — there are
+// no scheduled Netlify functions in this repo, and a GitHub Actions cron is the precedent.
+//
+// ## Why it is safe to run repeatedly
+//
+// It requests; it does not crawl. All the gating stays where it already is: the 7-day cooldown
+// and the hourly ceiling in `claimArtistForCatalog`, and the claim itself, which stamps
+// `last_attempted_at` before any work starts. A second invocation five minutes after the first
+// therefore finds the same artists claimed and does nothing. There is deliberately no second
+// rate limiter here.
+//
+// ## Why it returns a real summary rather than 202
+//
+// A `-background` function would answer 202 whatever happened, and a scheduled job that reports
+// success unconditionally is the same silent failure this fixes. Selection is two cheap reads,
+// so this is an ordinary function: it says how many artists it asked for and how stale the
+// stalest one was, the workflow prints that, and a non-2xx fails the workflow out loud.
+
+import { getStaleSavedArtistCatalogs } from './db';
+import { isInternalRequest } from './middleware';
+import { isCatalogEnabled, requestArtistCatalog } from './request-catalog';
+import { Sentry } from '../lib/sentry';
+
+/**
+ * How many artists one sweep asks for.
+ *
+ * 25 matches MAX_ARTISTS_PER_RUN in catalog-artist-background, so a sweep is exactly one
+ * background invocation. Combined with the daily cadence that refreshes up to 175 artists a
+ * week, comfortably more than the saved population, so every saved artist comes round well
+ * within their 7-day cooldown. If the saved population ever outgrows that, the stalest-first
+ * ordering degrades gracefully — everyone still gets refreshed, just less often — and the
+ * lever is the cron cadence, not this number, which is bounded by what one invocation can do.
+ */
+const SWEEP_BATCH_SIZE = 25;
+
+export async function handler(event: {
+  httpMethod?: string;
+  headers?: Record<string, string | undefined>;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  if (!isInternalRequest(event.headers?.authorization ?? event.headers?.Authorization)) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  // Reported, not logged. On a deploy where cataloging is off this sweep can never do anything,
+  // and a scheduled job whose whole output is "200, nothing to do" is indistinguishable from one
+  // that is working — which is how release cataloging stayed broken for days before a refusal
+  // was said out loud. 503 fails the workflow.
+  if (!isCatalogEnabled()) {
+    Sentry.captureMessage('[recatalog-sweep] refused — cataloging is disabled on this deploy', {
+      level: 'warning',
+      tags: { area: 'release-catalog', kind: 'sweep-disabled' },
+    });
+    return {
+      statusCode: 503,
+      body: JSON.stringify({ error: 'Cataloging is disabled on this deploy (RELEASE_CATALOG_ENABLED is not set).' }),
+    };
+  }
+
+  const selection = await getStaleSavedArtistCatalogs(SWEEP_BATCH_SIZE);
+
+  if (!selection.ok) {
+    Sentry.captureMessage('[recatalog-sweep] could not select artists', {
+      level: 'error',
+      tags: { area: 'release-catalog', kind: 'sweep-selection-failed' },
+      extra: { reason: selection.reason },
+    });
+    return { statusCode: 503, body: JSON.stringify({ error: selection.reason }) };
+  }
+
+  const { candidates, savedArtists, inCooldown } = selection;
+
+  // Every saved artist catalogued inside the last 7 days is a good, quiet outcome, not a
+  // failure — so this is a 200. The counts are what tell the two apart in the workflow log:
+  // savedArtists dropping to 0, or inCooldown never falling, is the shape of a broken sweep.
+  const summary = {
+    requested: candidates.length,
+    savedArtists,
+    inCooldown,
+    /** How stale the stalest artist was. Null means one had never been attempted at all. */
+    stalestAttemptedAt: candidates[0]?.lastAttemptedAt ?? null,
+    neverAttempted: candidates.filter(c => c.lastAttemptedAt === null).length,
+  };
+
+  if (candidates.length === 0) {
+    console.log('[recatalog-sweep] nothing to do:', JSON.stringify(summary));
+    return { statusCode: 200, body: JSON.stringify(summary) };
+  }
+
+  // Awaited: the 202 handshake only, but an un-awaited fetch is killed when the Lambda freezes
+  // after the response, so a floating promise here would mean the sweep sometimes never leaves.
+  const dispatched = await requestArtistCatalog(candidates.map(c => c.artistId), 'scheduled');
+
+  if (!dispatched) {
+    // A completed handshake doesn't prove the crawl ran — the dispatcher answers 202 to
+    // anything — but a *failed* one proves it didn't, and that is worth failing the workflow on.
+    Sentry.captureMessage('[recatalog-sweep] could not reach the cataloging function', {
+      level: 'error',
+      tags: { area: 'release-catalog', kind: 'sweep-dispatch-failed' },
+      extra: summary,
+    });
+    return { statusCode: 502, body: JSON.stringify({ error: 'Could not reach the cataloging function', ...summary }) };
+  }
+
+  console.log('[recatalog-sweep]', JSON.stringify(summary));
+  return { statusCode: 200, body: JSON.stringify(summary) };
+}

--- a/api/functions/request-catalog.ts
+++ b/api/functions/request-catalog.ts
@@ -46,13 +46,19 @@ export function isCatalogEnabled(): boolean {
  *
  * Never throws and never blocks meaningfully — cataloging is opportunistic, and a fan saving
  * an artist must not see an error because a crawl couldn't be scheduled.
+ *
+ * Returns whether the handshake completed. **That is not "the crawl was accepted"** — Netlify's
+ * dispatcher answers 202 to anything, including a request the background function then refuses,
+ * so the only thing false rules out is that the request left at all. The user-facing callers
+ * ignore it; the scheduled sweep reads it, because for a job that runs once a day a request that
+ * never left is the difference between working and silently doing nothing.
  */
 export async function requestArtistCatalog(
   artistIds: string[],
   trigger: CatalogTrigger
-): Promise<void> {
+): Promise<boolean> {
   const ids = [...new Set(artistIds.filter(Boolean))].slice(0, MAX_ARTISTS_PER_REQUEST);
-  if (ids.length === 0) return;
+  if (ids.length === 0) return false;
 
   // Deploy previews and branch deploys share the *production* Supabase, so an ungated one would
   // write real releases and spend the real hourly crawl budget on traffic that isn't real.
@@ -62,7 +68,7 @@ export async function requestArtistCatalog(
   // the real fetch, parse and mapping and prints what would be written.
   if (!isCatalogEnabled()) {
     console.log('[catalog] not requested — RELEASE_CATALOG_ENABLED is not set on this deploy');
-    return;
+    return false;
   }
 
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
@@ -75,7 +81,7 @@ export async function requestArtistCatalog(
   if (!secret || !siteUrl) {
     // Not an error worth surfacing: without configuration the feature is simply off.
     console.log('[catalog] not requested — INTERNAL_FUNCTION_SECRET or site URL not configured');
-    return;
+    return false;
   }
 
   try {
@@ -94,10 +100,14 @@ export async function requestArtistCatalog(
     } finally {
       clearTimeout(timeoutId);
     }
+    return true;
   } catch (error) {
-    // A failed handshake means these artists don't get catalogued this time. The next search
-    // or save asks again, so there's nothing to retry and nothing a user should see.
+    // A failed handshake means these artists don't get catalogued this time. For a search or a
+    // save the next one asks again, so there's nothing to retry and nothing a user should see —
+    // which is why this is a return value rather than a throw. The scheduled sweep, which has no
+    // "next one" for another day, is the caller that reports it.
     console.warn('[catalog] request failed:', error instanceof Error ? error.message : String(error));
+    return false;
   }
 }
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -39,6 +39,8 @@
     "functions/release-detail.ts",
     "functions/redis.ts",
     "functions/cache.ts",
+    "functions/recatalog-sweep.ts",
+    "functions/catalog-artist-background.ts",
     "shared/feed-format.ts",
     "functions/__tests__/artist-profile-remove.test.ts",
     "functions/__tests__/me-settings.test.ts",
@@ -48,6 +50,8 @@
     "functions/__tests__/feed-releases.test.ts",
     "functions/__tests__/release-detail.test.ts",
     "functions/__tests__/release-detail-query.test.ts",
-    "functions/__tests__/redis-resilience.test.ts"
+    "functions/__tests__/redis-resilience.test.ts",
+    "functions/__tests__/recatalog-sweep.test.ts",
+    "functions/__tests__/recatalog-sweep-selection.test.ts"
   ]
 }

--- a/supabase/migrations/20260802180000_catalog-trigger-scheduled.sql
+++ b/supabase/migrations/20260802180000_catalog-trigger-scheduled.sql
@@ -1,0 +1,32 @@
+-- Migration: allow 'scheduled' as a release-catalog trigger
+--
+-- Until now every catalog attempt was demand-driven — a fan saved an artist, or someone
+-- searched them. That left a hole the release-alerts feature falls straight into: an artist
+-- who is saved but never searched is catalogued once and then never again, so their new
+-- releases are never discovered and their alerts silently stop. A scheduled sweep
+-- (`recatalog-sweep`) now re-crawls the stalest saved artists, and this is the trigger label
+-- it stamps.
+--
+-- It gets its own label rather than reusing 'saved' for two reasons:
+--
+--   1. Budget. CATALOG_HOURLY_CAP in api/functions/db.ts is keyed by trigger, so a separate
+--      label lets the sweep have a ceiling of its own — higher than search (so a busy hour of
+--      searches can't starve it) and lower than saving (so it can never outrun a person
+--      deliberately following an artist).
+--   2. Observability. `last_trigger = 'scheduled'` is how you tell, from the table alone,
+--      whether the sweep is still running. A sweep that quietly stops working recreates the
+--      exact bug it was built to fix, so being able to see it matters.
+--
+-- No new index: the sweep's candidate query reads saved_artists (a few thousand rows at most)
+-- and looks up their catalog state by primary key. Both are cheap at this size, and an index
+-- added speculatively is one more thing to keep true.
+
+ALTER TABLE release_catalog_state
+  DROP CONSTRAINT IF EXISTS release_catalog_state_last_trigger_check;
+
+ALTER TABLE release_catalog_state
+  ADD CONSTRAINT release_catalog_state_last_trigger_check
+  CHECK (last_trigger IN ('saved', 'searched', 'scheduled'));
+
+COMMENT ON COLUMN release_catalog_state.last_trigger IS
+  'What triggered the most recent attempt: a save, a search, or the scheduled sweep. Each has its own hourly ceiling.';


### PR DESCRIPTION
## The problem

Every release-catalog trigger was demand-driven — a fan saving an artist, a search resolving one, an artist's own button, the admin command. And `check-releases` only *reads* the catalogue; it never refreshes it, and only falls back to a live scrape for an artist the catalogue has **never** seen.

So: a fan saves an artist → the catalogue is built once → the weekly alert check reads that same catalogue forever. If nobody ever searches that artist again, **their new releases are never discovered**. Popular artists stayed fresh incidentally because people search them; the long tail of saved-but-not-searched artists silently stopped producing alerts. That's worse than the pre-catalogue behaviour, where the client re-scraped weekly, and it undermines pillar 3 of the V1 Releases scope.

## What this adds

`api/functions/recatalog-sweep.ts`, run daily by `.github/workflows/recatalog-sweep.yml` (GitHub Actions cron — there are no scheduled Netlify functions in this repo).

It selects the stalest catalogues **among artists somebody has saved**, ordered:

1. Never attempted first — saved, but the save-time request never got through (usually the hourly cap). Nothing else retries those.
2. Then oldest `last_attempted_at`.
3. Then most savers, **as a tiebreak only**. Popularity-first would starve exactly the long tail the sweep exists for.

Then it asks `requestArtistCatalog` for up to 25 of them. **No second rate limiter** — the 7-day cooldown and the hourly cap in `claimArtistForCatalog` still decide, which is also what makes a duplicate invocation a no-op. The cooldown is read up front only to pick who to ask about, so a bounded batch isn't spent on artists that'll be refused a moment later.

## Cadence, and what it costs Bandcamp

**Daily, 05:00 UTC** — off both US and European peak.

One sweep is at most 25 artists through the existing background function, which paces itself: a second between artists, at most 100 release-page fetches per run on top of one grid page each. On the order of 125 sequential requests spread over minutes — a trickle, less than a handful of real visitors searching.

Daily rather than weekly because the **7-day cooldown, not the cron, is what bounds per-artist crawling**: an artist can't be re-crawled more than once a week however often this runs. Daily just spreads the same work across seven small runs instead of one lump, and it shortens how long a newly-saved artist waits for a first catalogue if their save-time request was dropped by the cap.

## Why a new `scheduled` trigger

- **Budget.** `CATALOG_HOURLY_CAP` is keyed by trigger and counted across *all* attempts in the last hour. Give the sweep the smallest budget and an ordinary hour of search traffic leaves it nothing — it runs once a day at a fixed time and can't wait for a quieter moment the way a search can be dropped and re-triggered by the next visitor. Give it the largest and a machine outranks a person. So: 120, between `searched` (60) and `saved` (240).
- **Observability.** `last_trigger = 'scheduled'` is how you tell from the table alone whether the sweep is still running.

## Observability

A sweep that silently stops working recreates the exact bug it fixes, so:

- **Every refusal is a non-2xx that fails the workflow, plus a Sentry event** — disabled deploy, unreadable database, handshake that never left. It returns a real summary rather than 202 for this reason (a `-background` function would 202 whatever happened).
- `200` with `requested: 0` is a legitimate quiet day. The counts in the body (`savedArtists`, `inCooldown`, `neverAttempted`, `stalestAttemptedAt`) are what let a reader tell that from broken selection.
- **`recordCatalogOutcome` now reports the "found 0 where it previously found 20" transition to Sentry.** That case is recorded as a *success*, so nothing else about it looks wrong. Fires on every trigger, not just the sweep, and only on the transition — an artist who has always had 0 isn't news.
- `requestArtistCatalog` now returns whether the handshake completed. Not "the crawl was accepted" — the dispatcher 202s anything — but a failed handshake proves it didn't, and the sweep has no next visitor to ask again. User-facing callers ignore it and still never see an error.

## Also in here

- The background function's private copy of the internal-secret check moved into `middleware.ts` as `isInternalRequest()`, so both endpoints authenticate identically instead of via a third copy.
- Fixed the trigger parse (`=== 'saved' ? 'saved' : 'searched'`) that would have silently spent the *search* budget on a scheduled sweep.
- `recatalog-sweep.ts` and `catalog-artist-background.ts` added to `api/tsconfig.json`'s narrow include, so they're actually typechecked.
- CLAUDE.md: a "Keeping catalogues fresh" section, and the workflow list — which was missing `upstash-keepalive.yml` too.

## Verification

- `npm run build`, `npm run test:api` (791 passing), `npm run test:unit` (625 passing), `npm run typecheck:api` — all clean. `dispatch.xml` / `sitemap.xml` reverted after the build.
- **The migration was validated against a real `postgres:16`.** The risk was the auto-generated constraint name: if `DROP CONSTRAINT IF EXISTS` had named it wrong it would silently no-op, `ADD CONSTRAINT` would succeed, and *both* constraints would remain — the old one still rejecting `'scheduled'` while the migration reported success. Confirmed: exactly one constraint afterwards, `'scheduled'` accepted, `'saved'`/`'searched'` still accepted, garbage still rejected, re-running is a no-op.
- **Every test was checked by mutation** — dropping the `deleted = false` filter, inverting never-attempted ordering, removing the cooldown filter, reverting the trigger allowlist, removing the per-artist `try/catch`, and turning a failed read into an empty result each fail the test that claims to protect it.

## Deploy note

Needs a GitHub repo secret: **`INTERNAL_FUNCTION_SECRET`**, matching the Netlify value. Without it the workflow fails loudly on the first run rather than reporting a fake success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)