### PR TITLE
Add Mirlo as a release source via the Canimus federation catalog

### DIFF
--- a/api/functions/__tests__/mirlo-canimus.test.ts
+++ b/api/functions/__tests__/mirlo-canimus.test.ts
@@ -1,0 +1,293 @@
+// Parsing Mirlo's Fairplayer/Canimus federation catalog into release rows.
+//
+// The fixtures here are built from the documented response shape in Mirlo's API docs, not
+// captured from a live response — Mirlo's robots.txt disallows `/v1/`, which is where the
+// federation endpoint lives, so no request has been made pending Mirlo's own answer on that.
+// What that means for these tests: they pin *our* decisions (host pinning, empty-title drafts,
+// the 2925 date, opted-out artists) rather than certifying Mirlo's field names. The first live
+// response is what confirms the shape, and `ingestCanimusCatalog` returning null on anything
+// that isn't a Canimus root is what makes a shape mismatch loud instead of silent.
+
+import { describe, it, expect } from 'vitest';
+import {
+  ingestCanimusCatalog,
+  buildMirloReleases,
+  mirloArtistSlug,
+  type CanimusArtist,
+} from '../release-ingest';
+
+const CATALOG_URL = 'https://mirlo.space/v1/sm/canimus.json';
+const NOW = new Date('2026-08-02T00:00:00Z');
+
+function album(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'album',
+    name: 'Garden Invicta',
+    url: 'https://mirlo.space/m-corp/release/garden-invicta',
+    release_date: '2024-01-15T00:00:00.000Z',
+    license: 'CC BY-SA 4.0',
+    artist: 'M Corp',
+    images: { cover: { src: 'https://mirlo.space/img/cover.jpg', alt: null, width: 600, height: 600 } },
+    description: 'About this album',
+    children: [],
+    ...overrides,
+  };
+}
+
+function root(children: unknown[], deleted: unknown[] = []) {
+  return { type: 'root', url: 'https://mirlo.space', children, deleted };
+}
+
+function artistNode(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'artist',
+    name: 'M Corp',
+    url: 'https://mirlo.space/m-corp',
+    images: { cover: { src: 'https://mirlo.space/img/artist.jpg' } },
+    summary: 'Short description',
+    description: 'Full bio',
+    links: [{ name: 'Bandcamp', href: 'https://mcorp.bandcamp.com', type: 'bandcamp' }],
+    children: [album()],
+    ...overrides,
+  };
+}
+
+describe('ingestCanimusCatalog', () => {
+  it('parses artists and their releases from a root document', () => {
+    const catalog = ingestCanimusCatalog(root([artistNode()]), CATALOG_URL, NOW);
+
+    expect(catalog).not.toBeNull();
+    expect(catalog!.artists).toHaveLength(1);
+
+    const artist = catalog!.artists[0];
+    expect(artist.name).toBe('M Corp');
+    expect(artist.slug).toBe('m-corp');
+    expect(artist.releases).toHaveLength(1);
+    expect(artist.releases[0]).toMatchObject({
+      title: 'Garden Invicta',
+      url: 'https://mirlo.space/m-corp/release/garden-invicta',
+      releaseDate: '2024-01-15',
+      datePrecision: 'day',
+      status: 'released',
+      artworkUrl: 'https://mirlo.space/img/cover.jpg',
+    });
+  });
+
+  it('returns null — not an empty catalog — for a body that is not a Canimus root', () => {
+    // A login wall, an error envelope or a challenge page must be distinguishable from
+    // "nobody has opted in", or a bad response silently wipes every Mirlo artist.
+    expect(ingestCanimusCatalog({ error: 'unauthorized' }, CATALOG_URL, NOW)).toBeNull();
+    expect(ingestCanimusCatalog('<html>Just a moment…</html>', CATALOG_URL, NOW)).toBeNull();
+    expect(ingestCanimusCatalog(null, CATALOG_URL, NOW)).toBeNull();
+    expect(ingestCanimusCatalog(root([]), CATALOG_URL, NOW)).toEqual({ artists: [], deletedSlugs: [] });
+  });
+
+  it('drops a release whose url points at another host', () => {
+    // A federation document exists to name other hosts, and release_sources.url is rendered as
+    // a link a fan clicks. An off-host release URL is never attributed to the artist.
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ children: [album({ url: 'https://evil.example/m-corp/release/x' })] })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists[0].releases).toHaveLength(0);
+  });
+
+  it('drops an artist whose url points at another host', () => {
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ url: 'https://evil.example/m-corp' })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists).toHaveLength(0);
+  });
+
+  it('drops empty-title drafts rather than storing them as untitled', () => {
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ children: [album({ name: '   ' }), album({ name: 'Real Record' })] })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists[0].releases.map(r => r.title)).toEqual(['Real Record']);
+  });
+
+  it('rejects the live 2925 date rather than sorting it to the top of every chronology', () => {
+    // Mirlo genuinely carries a release dated 2925-11-02. Unbounded it lands in every
+    // calendar subscriber's feed forever.
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ children: [album({ release_date: '2925-11-02T00:00:00.000Z' })] })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    const release = catalog!.artists[0].releases[0];
+    expect(release.releaseDate).toBeNull();
+    expect(release.datePrecision).toBe('unknown');
+    // Undated reads as released: promising a fan something is "coming" when we don't know is
+    // the worse error.
+    expect(release.status).toBe('released');
+  });
+
+  it('marks a genuine future date as announced', () => {
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ children: [album({ release_date: '2027-09-07T00:00:00.000Z' })] })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists[0].releases[0]).toMatchObject({
+      releaseDate: '2027-09-07',
+      status: 'announced',
+    });
+  });
+
+  it('refuses a non-http artwork src', () => {
+    const catalog = ingestCanimusCatalog(
+      root([artistNode({ children: [album({ images: { cover: { src: 'javascript:alert(1)' } } })] })]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists[0].releases[0].artworkUrl).toBeNull();
+  });
+
+  it('reads opted-out artists off the deleted array', () => {
+    const catalog = ingestCanimusCatalog(
+      root([artistNode()], [{ type: 'artist', name: 'Gone Artist', url: 'https://mirlo.space/gone-artist' }]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.deletedSlugs).toEqual(['gone-artist']);
+  });
+
+  it('keeps artist-declared off-host links, which are compared but never fetched', () => {
+    const catalog = ingestCanimusCatalog(root([artistNode()]), CATALOG_URL, NOW);
+
+    expect(catalog!.artists[0].links).toEqual([
+      { type: 'bandcamp', href: 'https://mcorp.bandcamp.com' },
+    ]);
+  });
+
+  it('ignores nodes that are not artists, and releases that are not albums', () => {
+    const catalog = ingestCanimusCatalog(
+      root([
+        { type: 'playlist', name: 'Staff picks', url: 'https://mirlo.space/playlists/1' },
+        artistNode({ children: [album(), { type: 'track', name: 'A Track', url: 'https://mirlo.space/x' }] }),
+      ]),
+      CATALOG_URL,
+      NOW
+    );
+
+    expect(catalog!.artists).toHaveLength(1);
+    expect(catalog!.artists[0].releases).toHaveLength(1);
+  });
+});
+
+describe('buildMirloReleases', () => {
+  const base: CanimusArtist = {
+    name: 'M Corp',
+    url: 'https://mirlo.space/m-corp',
+    slug: 'm-corp',
+    links: [],
+    releases: [],
+  };
+
+  it('maps a release to a persistable row', () => {
+    const [row] = buildMirloReleases({
+      ...base,
+      releases: [
+        {
+          title: 'Garden Invicta',
+          url: 'https://mirlo.space/m-corp/release/garden-invicta',
+          releaseDate: '2024-01-15',
+          datePrecision: 'day',
+          status: 'released',
+          artworkUrl: 'https://mirlo.space/img/cover.jpg',
+        },
+      ],
+    });
+
+    expect(row).toMatchObject({
+      title: 'Garden Invicta',
+      slug: 'garden-invicta',
+      matchKey: 'gardeninvicta',
+      releaseDate: '2024-01-15',
+      externalUrl: 'https://mirlo.space/m-corp/release/garden-invicta',
+    });
+  });
+
+  it('infers type from the title, since Canimus types everything as album', () => {
+    const rows = buildMirloReleases({
+      ...base,
+      releases: [
+        { title: 'Some Record EP', url: 'https://mirlo.space/m-corp/release/a', releaseDate: null, datePrecision: 'unknown', status: 'released', artworkUrl: null },
+        { title: 'Just A Record', url: 'https://mirlo.space/m-corp/release/b', releaseDate: null, datePrecision: 'unknown', status: 'released', artworkUrl: null },
+      ],
+    });
+
+    expect(rows[0].releaseType).toBe('ep');
+    // Not 'single' — a one-entry release is as likely to be a long-form piece, so 'other' is the
+    // honest answer where a guess would be a claim.
+    expect(rows[1].releaseType).toBe('other');
+  });
+
+  it('gives two same-slug titles distinct slugs within one artist', () => {
+    const rows = buildMirloReleases({
+      ...base,
+      releases: [
+        { title: 'Live!', url: 'https://mirlo.space/m-corp/release/live-1', releaseDate: null, datePrecision: 'unknown', status: 'released', artworkUrl: null },
+        { title: 'Live?', url: 'https://mirlo.space/m-corp/release/live-2', releaseDate: null, datePrecision: 'unknown', status: 'released', artworkUrl: null },
+      ],
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].slug).not.toBe(rows[1].slug);
+  });
+
+  it('skips a title that normalizes to nothing', () => {
+    const rows = buildMirloReleases({
+      ...base,
+      releases: [
+        { title: '!!!', url: 'https://mirlo.space/m-corp/release/x', releaseDate: null, datePrecision: 'unknown', status: 'released', artworkUrl: null },
+      ],
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('mirloArtistSlug', () => {
+  it('accepts the three link shapes that appear in live data', () => {
+    // Measured against the 66 stored mirlo artist_links: 50 bare, 15 with a second segment
+    // (mostly /releases), and trailing slashes throughout.
+    expect(mirloArtistSlug('https://mirlo.space/h220')).toBe('h220');
+    expect(mirloArtistSlug('https://mirlo.space/sknob/')).toBe('sknob');
+    expect(mirloArtistSlug('https://mirlo.space/helen-bell/releases')).toBe('helen-bell');
+  });
+
+  it('folds case so the catalog join is not case-sensitive', () => {
+    expect(mirloArtistSlug('https://mirlo.space/M-Corp')).toBe('m-corp');
+  });
+
+  it('refuses a non-Mirlo host', () => {
+    // A claimed artist can store any URL against the platform, so this is the check that stops
+    // a mislabelled row joining against someone else's slug.
+    expect(mirloArtistSlug('https://evil.example/m-corp')).toBeNull();
+    expect(mirloArtistSlug('https://notmirlo.space/m-corp')).toBeNull();
+  });
+
+  it('refuses api and reserved paths, which are pages rather than artists', () => {
+    expect(mirloArtistSlug('https://mirlo.space/v1/sm/canimus.json')).toBeNull();
+    expect(mirloArtistSlug('https://mirlo.space/login')).toBeNull();
+    expect(mirloArtistSlug('https://mirlo.space/')).toBeNull();
+  });
+
+  it('refuses a non-http scheme', () => {
+    expect(mirloArtistSlug('javascript:alert(1)')).toBeNull();
+    expect(mirloArtistSlug('not a url')).toBeNull();
+  });
+});

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -17,6 +17,7 @@ import {
   persistDiscogsReleases,
   persistFaircampReleases,
   persistJamcoopReleases,
+  persistMirloReleases,
   persistMusicBrainzEnrichment,
   persistReleaseDetail,
   persistReleases,
@@ -25,13 +26,18 @@ import {
   type CatalogTrigger,
   type PersistedRelease,
 } from './db';
+import { cacheGetOrFetch } from './cache';
 import { isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
 import {
   bandcampMusicUrl,
   buildFaircampRelease,
   buildJamcoopRelease,
+  buildMirloReleases,
   findDiscoveredReleaseLinks,
+  ingestCanimusCatalog,
+  mirloArtistSlug,
+  type CanimusCatalog,
   ingestBandcampDetail,
   ingestBandcampGrid,
   ingestDiscogsMasters,
@@ -187,6 +193,35 @@ interface JamcoopBudget {
   deadline: number;
 }
 
+// --- Mirlo (Fairplayer/Canimus federation) --------------------------------------
+//
+// Structurally unlike every source above. There is no per-artist request: the Canimus catalog
+// is one document covering every artist who opted in to federated syndication, so the whole
+// batch shares a single fetch, memoized for the invocation and cached in Redis across them.
+// An artist's pass is then a lookup in an already-fetched document and costs Mirlo nothing.
+//
+// Gated off by default. Mirlo's robots.txt disallows `/v1/`, which is where the documented
+// federation endpoint lives, and that tension is Mirlo's to resolve rather than ours to assume
+// away — see the Mirlo section in release-ingest.ts. The flag exists so this can ship,
+// reviewed and tested, without adding a single request until Mirlo says yes.
+
+const CANIMUS_CATALOG_URL = 'https://mirlo.space/v1/sm/canimus.json';
+
+/**
+ * One document, refreshed a few times a day at most. Mirlo's catalogue is small and opt-in, and
+ * new releases are not so time-critical that a stale half-day matters against the cost of
+ * re-pulling a whole platform's catalogue on every batch.
+ */
+const CANIMUS_CACHE_TTL_SECONDS = 6 * 60 * 60;
+
+/** Pages of `take`, so one bad response can't turn into an unbounded pagination loop. */
+const CANIMUS_MAX_PAGES = 10;
+const CANIMUS_PAGE_SIZE = 200;
+
+function isMirloCanimusEnabled(): boolean {
+  return process.env.MIRLO_CANIMUS_ENABLED === 'true';
+}
+
 function isAuthorized(header: string | undefined): boolean {
   // Reuses the secret this repo already has for internal function-to-function calls
   // (resolve-url, search-sources, and both v1 wrappers). A second near-identically-named
@@ -242,6 +277,11 @@ export async function handler(event: {
   const trigger: CatalogTrigger = body.trigger === 'saved' ? 'saved' : 'searched';
 
   if (artistIds.length === 0) return { statusCode: 400, body: '' };
+
+  // A warm Lambda outlives an invocation, and the memo has no TTL of its own — without this a
+  // container could serve the same Canimus snapshot for as long as it stays warm, well past the
+  // six hours the Redis entry is allowed to live.
+  __resetCanimusMemo();
 
   let catalogued = 0;
   let skipped = 0;
@@ -321,8 +361,11 @@ async function catalogArtist(
     await recordCatalogOutcome(artistId, { error: 'artist not found' });
     return null;
   }
-  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl && !artist.jamcoopUrl) {
-    await recordCatalogOutcome(artistId, { error: 'no bandcamp, discogs, faircamp, or jam.coop link stored' });
+  const mirloUrl = isMirloCanimusEnabled() ? artist.mirloUrl : null;
+  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl && !artist.jamcoopUrl && !mirloUrl) {
+    await recordCatalogOutcome(artistId, {
+      error: 'no bandcamp, discogs, faircamp, jam.coop, or mirlo link stored',
+    });
     return null;
   }
 
@@ -356,6 +399,11 @@ async function catalogArtist(
       const { found, detailed } = await catalogJamcoop(artistId, artist.jamcoopUrl, jamcoopBudget);
       totalFound += found;
       totalDetailed += detailed;
+    }
+    // No budget parameter: the Canimus catalog is one shared fetch for the whole invocation,
+    // so an extra artist here costs Mirlo nothing and there is no per-artist spend to bound.
+    if (mirloUrl) {
+      totalFound += await catalogMirlo(artistId, mirloUrl);
     }
     if (artist.officialSiteUrl) {
       await catalogOfficialSite(artistId, artist.officialSiteUrl);
@@ -708,6 +756,134 @@ async function catalogFaircampPrices(
  * Never throws: a Jam.coop hiccup is worth logging, not worth failing an artist whose Bandcamp
  * pass may have already succeeded this run.
  */
+/**
+ * Fetch and parse the Canimus catalog, once per invocation.
+ *
+ * `undefined` distinguishes "not fetched yet" from a cached `null` meaning "the fetch failed
+ * this invocation" — so a failure is not retried 25 times inside one batch, and equally is not
+ * written to Redis as if Mirlo had said nobody opted in. That distinction is the rule this
+ * codebase keeps relearning: never cache uncertainty.
+ */
+let canimusMemo: CanimusCatalog | null | undefined;
+
+/** Reset between invocations in tests; a warm Lambda would otherwise reuse a stale memo. */
+export function __resetCanimusMemo(): void {
+  canimusMemo = undefined;
+}
+
+async function loadCanimusCatalog(): Promise<CanimusCatalog | null> {
+  if (canimusMemo !== undefined) return canimusMemo;
+
+  const { data } = await cacheGetOrFetch<CanimusCatalog | null>(
+    'canimus:mirlo:v1',
+    fetchCanimusCatalog,
+    CANIMUS_CACHE_TTL_SECONDS,
+    // A failed or unparseable fetch is not "the catalogue is empty". Caching that would hide
+    // every opted-in Mirlo artist for six hours on one bad response.
+    catalog => catalog !== null
+  );
+
+  canimusMemo = data;
+  return data;
+}
+
+/**
+ * Page through `/v1/sm/canimus.json` and merge the pages.
+ *
+ * Returns null on any failure — a refused fetch, a non-OK status, a body that isn't JSON, or a
+ * body that parses but isn't a Canimus root (a challenge page or an error envelope). All four
+ * mean "Mirlo did not answer", which is categorically different from an empty catalogue.
+ */
+async function fetchCanimusCatalog(): Promise<CanimusCatalog | null> {
+  const merged: CanimusCatalog = { artists: [], deletedSlugs: [] };
+  const seenSlugs = new Set<string>();
+
+  for (let page = 0; page < CANIMUS_MAX_PAGES; page++) {
+    const url = `${CANIMUS_CATALOG_URL}?skip=${page * CANIMUS_PAGE_SIZE}&take=${CANIMUS_PAGE_SIZE}`;
+
+    // Same two questions as every other source: the allowlist answers "is this really Mirlo",
+    // safeFetch answers "is this safe to fetch".
+    if (!isUrlHostnameAllowed(url)) {
+      console.warn('[catalog] canimus url not allowlisted');
+      return null;
+    }
+
+    let parsed: unknown;
+    try {
+      const response = await safeFetch(url, 15_000);
+      if (!response) {
+        console.warn('[catalog] canimus fetch refused');
+        return null;
+      }
+      if (!response.ok) {
+        console.warn(`[catalog] canimus responded ${response.status}`);
+        return null;
+      }
+      parsed = await response.json();
+    } catch (error) {
+      console.warn('[catalog] canimus fetch failed:', error instanceof Error ? error.message : String(error));
+      return null;
+    }
+
+    const catalog = ingestCanimusCatalog(parsed, CANIMUS_CATALOG_URL);
+    if (!catalog) {
+      // A 200 that doesn't parse as a Canimus root is a silent failure, and silent failures are
+      // the thing this codebase reports rather than swallows.
+      console.error('[catalog] canimus response was not a Canimus root document');
+      return null;
+    }
+
+    for (const artist of catalog.artists) {
+      if (seenSlugs.has(artist.slug)) continue;
+      seenSlugs.add(artist.slug);
+      merged.artists.push(artist);
+    }
+    merged.deletedSlugs.push(...catalog.deletedSlugs);
+
+    // A short page is the last page. An empty one ends it too, and guards against a host that
+    // ignores `skip` and would otherwise return page 1 ten times.
+    if (catalog.artists.length < CANIMUS_PAGE_SIZE) break;
+
+    await sleep(DELAY_BETWEEN_ARTISTS_MS);
+  }
+
+  console.log(`[catalog] canimus catalog: ${merged.artists.length} opted-in artists`);
+  return merged;
+}
+
+/**
+ * The Mirlo pass: find this artist in the shared Canimus catalog and write their releases.
+ *
+ * Never fetches per artist and never throws — a Mirlo miss is worth logging, not worth failing
+ * an artist whose Bandcamp pass already succeeded this run.
+ */
+async function catalogMirlo(artistId: string, storedUrl: string): Promise<number> {
+  try {
+    const slug = mirloArtistSlug(storedUrl);
+    if (!slug) {
+      console.warn(`[catalog] could not derive mirlo slug for artist ${artistId}`);
+      return 0;
+    }
+
+    const catalog = await loadCanimusCatalog();
+    if (!catalog) return 0;
+
+    const entry = catalog.artists.find(a => a.slug === slug);
+    // Not an error: the catalogue only carries artists who opted in to federated syndication,
+    // so most Mirlo artists we have a link for are legitimately absent from it.
+    if (!entry) return 0;
+
+    const toPersist = buildMirloReleases(entry);
+    if (toPersist.length === 0) return 0;
+
+    const written = await persistMirloReleases(artistId, toPersist);
+    return written.length;
+  } catch (error) {
+    console.warn('[catalog] mirlo ingest failed:', error instanceof Error ? error.message : String(error));
+    return 0;
+  }
+}
+
 async function catalogJamcoop(
   artistId: string,
   storedUrl: string,

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -994,6 +994,7 @@ export interface ArtistForCatalog {
   discogsUrl: string | null;
   faircampUrl: string | null;
   jamcoopUrl: string | null;
+  mirloUrl: string | null;
   officialSiteUrl: string | null;
 }
 
@@ -1015,7 +1016,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
         .from('artist_links')
         .select('platform, url')
         .eq('artist_id', artistId)
-        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'officialsite']),
+        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'mirlo', 'officialsite']),
     ]);
 
     if (artistError || !artistRow) {
@@ -1031,6 +1032,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
       discogsUrl: links.find(l => l.platform === 'discogs')?.url ?? null,
       faircampUrl: links.find(l => l.platform === 'faircamp')?.url ?? null,
       jamcoopUrl: links.find(l => l.platform === 'jamcoop')?.url ?? null,
+      mirloUrl: links.find(l => l.platform === 'mirlo')?.url ?? null,
       officialSiteUrl: links.find(l => l.platform === 'officialsite')?.url ?? null,
     };
   } catch (error) {
@@ -1657,6 +1659,182 @@ export async function persistJamcoopReleases(
     return written;
   } catch (error) {
     console.error('[DB] persistJamcoopReleases error:', error);
+    return [];
+  }
+}
+
+/**
+ * Write a Mirlo catalog pass, from the Canimus federation document.
+ *
+ * Matches on `match_key` alone, for the same reason `persistJamcoopReleases` and
+ * `persistFaircampReleases` do: Canimus types every release `"album"`, so the type we store is
+ * inferred from the title and is far too weak to partition identity by. Partitioning on it
+ * would mint a duplicate row every time Bandcamp had already typed the same record correctly —
+ * which, on the artists most likely to be on both, is most of them.
+ *
+ * Dates behave like the Jam.coop writer: Canimus publishes one, so this fills
+ * `release_date`/`date_precision` on a row that lacks them, under the same never-overwrite
+ * rules — a stored date wins over a new one, and a date a verified artist curated is never
+ * touched at all.
+ *
+ * No offers are written. The Canimus shape carries no price (see the Mirlo section of
+ * release-ingest), and a source row with no offer is an honest "we know it's here, we don't
+ * know what it costs" — whereas inventing a zero would read as "name your price" and misstate
+ * an artist's own terms.
+ */
+interface MirloReleaseToPersistRow {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+export async function persistMirloReleases(
+  artistId: string,
+  releases: MirloReleaseToPersistRow[]
+): Promise<PersistedRelease[]> {
+  const client = getClient();
+  if (!client || releases.length === 0) return [];
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, release_date, artwork_url, curated_fields')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistMirloReleases read failed:', readError.message);
+      return [];
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      artwork_url: string | null;
+      curated_fields: string[] | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
+    const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+
+    const written: PersistedRelease[] = [];
+
+    for (const release of releases) {
+      const prior = byMatchKey.get(release.matchKey);
+
+      let releaseId: string;
+      let curatedFields: string[];
+
+      if (prior) {
+        const curated = new Set(prior.curated_fields ?? []);
+        curatedFields = [...curated];
+        const patch: Record<string, unknown> = {};
+
+        if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
+          patch.artwork_url = release.artworkUrl;
+        }
+        if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
+          patch.release_date = release.releaseDate;
+          patch.date_precision = release.datePrecision;
+          // Status moves with the date, but only when this pass is the one supplying it.
+          patch.status = release.status;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistMirloReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        const fuzzy = existing.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
+
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            release_date: release.releaseDate,
+            date_precision: release.datePrecision,
+            status: release.status,
+            artwork_url: release.artworkUrl,
+            source: 'auto',
+            ...(fuzzy && { needs_review: true, flagged_against_release_id: fuzzy.id }),
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistMirloReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        curatedFields = [];
+
+        const createdRow: ExistingRow = {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          release_date: release.releaseDate,
+          artwork_url: release.artworkUrl,
+          curated_fields: [],
+        };
+        byMatchKey.set(release.matchKey, createdRow);
+        existing.push(createdRow);
+
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true, flagged_against_release_id: releaseId })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistMirloReleases fuzzy-flag failed:', flagError.message);
+        }
+      }
+
+      const source = await upsertReleaseSource(
+        client,
+        releaseId,
+        'mirlo',
+        release.externalUrl,
+        release.externalUrl,
+        claimedKeys
+      );
+      if (!source) {
+        console.error('[DB] persistMirloReleases source write failed for release', releaseId);
+        continue;
+      }
+
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields,
+      });
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistMirloReleases error:', error);
     return [];
   }
 }

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -799,8 +799,9 @@ export function buildFaircampRelease(
 // feature has added since Bandcamp, for three reasons worth writing down:
 //
 // - **robots.txt permits everything.** Fetched and checked before a line of this was written:
-//   the file contains a single comment and no `Disallow` at all — unlike Mirlo, whose genuinely
-//   better API is `Disallow: /v1/` and therefore stays unbuilt (spec §10).
+//   the file contains a single comment and no `Disallow` at all — unlike Mirlo, whose richer
+//   REST API is `Disallow: /v1/` and is still not read for that reason (see the Mirlo section
+//   below, which goes through the federation catalog instead).
 // - **It is entirely server-rendered.** No client-side hydration to defeat, unlike Bandwagon's
 //   `/albums` listing, which returned nothing.
 // - **One request per release gets everything.** Title, artwork, date, price, currency and
@@ -1039,6 +1040,319 @@ export function jamcoopArtistUrl(storedUrl: string): string | null {
     return null;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Mirlo — via the Fairplayer/Canimus federation catalog, not the REST API
+// ---------------------------------------------------------------------------
+//
+// Mirlo publishes two ways in. The obvious one, `/v1/artists/{slug}`, returns any public
+// artist's whole discography with prices attached — richer than what's used here. It is not
+// what this reads, for a reason worth stating plainly: Mirlo's robots.txt disallows `/v1/`
+// under a hand-written `# Disallow crawling the API` comment, and per-artist fan-out against
+// it is exactly the crawling that comment is defending against.
+//
+// The Canimus catalog endpoint (`/v1/sm/canimus.json`) is a different proposition. It is a
+// single whole-platform document, published and documented by Mirlo specifically so that
+// aggregators and players can syndicate — and it contains **only artists who individually
+// opted in** to federated syndication. So the consent is per-artist and explicit, and the
+// cost to Mirlo is one request per refresh for the entire catalogue rather than one per
+// artist per run.
+//
+// Two consequences fall out of that choice and both are deliberate:
+//
+// - **Narrower coverage than the REST API.** Opted-in artists only. A Mirlo artist who
+//   hasn't ticked the box is invisible here, and that is the correct outcome, not a gap to
+//   work around.
+// - **No prices.** The Canimus shape carries no price, currency or pre-order flag (the REST
+//   `trackGroup` shape does). A Mirlo release therefore lands with sources but no offers,
+//   so the payout comparison — the product's whole thesis — can't be rendered for it yet.
+//   The honest fix is Mirlo's own REST API under an agreed key, not scraping around this.
+//
+// Structurally this is closest to Discogs: one cheap listing request yields many artists'
+// worth of releases, so the fetch is shared across a whole batch rather than per artist.
+
+/** Ceiling on releases taken from one artist in the catalog, before any per-run budget. */
+const CANIMUS_MAX_RELEASES_PER_ARTIST = 60;
+
+export interface CanimusRelease {
+  title: string;
+  url: string;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  artworkUrl: string | null;
+}
+
+export interface CanimusArtistLink {
+  type: string;
+  href: string;
+}
+
+export interface CanimusArtist {
+  name: string;
+  url: string;
+  /** Lowercased Mirlo artist slug — the join key against a stored `mirlo` artist link. */
+  slug: string;
+  /**
+   * The artist's own declared off-platform links. Not used by ingest; read by the
+   * Mirlo↔Bandcamp overlap measurement, where an artist-asserted Bandcamp URL is far better
+   * evidence of "same artist" than any name match we could compute.
+   */
+  links: CanimusArtistLink[];
+  releases: CanimusRelease[];
+}
+
+export interface CanimusCatalog {
+  artists: CanimusArtist[];
+  /** Artist slugs the host reports as opted-out or removed since the requested `fromDate`. */
+  deletedSlugs: string[];
+}
+
+/**
+ * Parse a `canimus.json` document into artists and their releases.
+ *
+ * `catalogUrl` is the URL the document was actually fetched from, and every URL in the
+ * response is pinned to its host. This is not paranoia about Mirlo: the document is
+ * network input, `release_sources.url` is rendered as a link fans click, and the codebase
+ * already applies exactly this rule to hrefs pulled out of fetched markup
+ * (`resolveReleaseUrl`, `resolveSameHost`). A federation format whose whole purpose is
+ * pointing at other hosts makes the rule more load-bearing here, not less — cross-host
+ * entries are dropped rather than trusted, because a release we attribute to an artist is a
+ * durable public claim about what they made and where to buy it.
+ *
+ * Returns null when the document isn't a Canimus root at all — a login wall, an error body
+ * or an HTML challenge page parses as "not this shape" rather than as an empty catalogue.
+ * That distinction is the difference between "nobody has opted in" and "we were blocked",
+ * and conflating them is the most repeated bug class in this codebase.
+ */
+export function ingestCanimusCatalog(
+  raw: unknown,
+  catalogUrl: string,
+  now: Date = new Date()
+): CanimusCatalog | null {
+  if (!isRecord(raw) || raw.type !== 'root' || !Array.isArray(raw.children)) return null;
+
+  let host: string;
+  try {
+    host = new URL(catalogUrl).host;
+  } catch {
+    return null;
+  }
+
+  const artists: CanimusArtist[] = [];
+  const seenSlugs = new Set<string>();
+
+  for (const node of raw.children) {
+    const artist = parseCanimusArtist(node, host, now);
+    if (!artist || seenSlugs.has(artist.slug)) continue;
+    seenSlugs.add(artist.slug);
+    artists.push(artist);
+  }
+
+  const deletedSlugs: string[] = [];
+  if (Array.isArray(raw.deleted)) {
+    for (const node of raw.deleted) {
+      if (!isRecord(node) || node.type !== 'artist') continue;
+      const slug = canimusArtistSlug(node.url, host);
+      if (slug) deletedSlugs.push(slug);
+    }
+  }
+
+  return { artists, deletedSlugs };
+}
+
+function parseCanimusArtist(node: unknown, host: string, now: Date): CanimusArtist | null {
+  if (!isRecord(node) || node.type !== 'artist') return null;
+
+  const slug = canimusArtistSlug(node.url, host);
+  if (!slug) return null;
+
+  const name = typeof node.name === 'string' ? node.name.trim() : '';
+  if (!name) return null;
+
+  const links: CanimusArtistLink[] = [];
+  if (Array.isArray(node.links)) {
+    for (const link of node.links) {
+      if (!isRecord(link) || typeof link.href !== 'string') continue;
+      // Artist-declared links deliberately point off-host, so the host pin does not apply —
+      // but they are only ever compared, never fetched and never written as a source.
+      links.push({ type: typeof link.type === 'string' ? link.type : '', href: link.href });
+    }
+  }
+
+  const releases: CanimusRelease[] = [];
+  const seenUrls = new Set<string>();
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      if (releases.length >= CANIMUS_MAX_RELEASES_PER_ARTIST) break;
+      const release = parseCanimusRelease(child, host, now);
+      if (!release || seenUrls.has(release.url)) continue;
+      seenUrls.add(release.url);
+      releases.push(release);
+    }
+  }
+
+  return { name, url: String(node.url), slug, links, releases };
+}
+
+function parseCanimusRelease(node: unknown, host: string, now: Date): CanimusRelease | null {
+  if (!isRecord(node) || node.type !== 'album') return null;
+
+  // Drafts reach the catalogue with an empty name. A release row is a public claim that an
+  // artist made a record, so an untitled one is dropped rather than shown as "Untitled".
+  const title = typeof node.name === 'string' ? node.name.trim() : '';
+  if (!title) return null;
+
+  const url = sameHostUrl(node.url, host);
+  if (!url) return null;
+
+  const { date, precision } = parseReleaseDate(
+    typeof node.release_date === 'string' ? node.release_date.slice(0, 10) : null,
+    now
+  );
+
+  return {
+    title,
+    url,
+    releaseDate: date,
+    datePrecision: precision,
+    // Canimus exposes no pre-order flag, unlike the REST shape's `isPreorder`, so a future
+    // date is the only signal available.
+    status: deriveStatus(date, false, now),
+    artworkUrl: canimusCoverUrl(node.images),
+  };
+}
+
+function canimusCoverUrl(images: unknown): string | null {
+  if (!isRecord(images)) return null;
+  const cover = images.cover;
+  if (!isRecord(cover) || typeof cover.src !== 'string') return null;
+  const src = cover.src.trim();
+  // Artwork is rendered in an <img>, so http(s) only — a data: or javascript: src has no
+  // business reaching the page.
+  if (!/^https?:\/\//i.test(src)) return null;
+  return src;
+}
+
+/** The artist slug from a `https://{host}/{slug}` artist URL, or null if it isn't one. */
+function canimusArtistSlug(raw: unknown, host: string): string | null {
+  const url = sameHostUrl(raw, host);
+  if (!url) return null;
+
+  const segments = new URL(url).pathname.split('/').filter(Boolean);
+  if (segments.length !== 1) return null;
+  return segments[0].toLowerCase();
+}
+
+function sameHostUrl(raw: unknown, host: string): string | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    if (url.host !== host) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export interface MirloReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+/**
+ * Turn one artist's Canimus entry into rows ready to persist.
+ *
+ * Release type comes from the title alone, the same fallback Faircamp and Jam.coop use.
+ * Canimus types every release `"album"` regardless of length, so the field carries no
+ * information. The track list is right there and a count was again considered and rejected
+ * for the reason recorded on `buildJamcoopRelease`: a one-track release is as likely to be a
+ * long-form ambient piece as a single, and `'other'` is an honest "we don't know".
+ */
+export function buildMirloReleases(artist: CanimusArtist): MirloReleaseToPersist[] {
+  const out: MirloReleaseToPersist[] = [];
+  const takenSlugs = new Set<string>();
+
+  for (const release of artist.releases) {
+    const matchKey = releaseMatchKey(release.title);
+    if (!matchKey) continue;
+
+    const slug = uniqueReleaseSlug(release.title, takenSlugs);
+    takenSlugs.add(slug);
+
+    out.push({
+      title: release.title,
+      slug,
+      matchKey,
+      releaseType: mapDiscogsFormatToReleaseType(null, release.title),
+      releaseDate: release.releaseDate,
+      datePrecision: release.datePrecision,
+      status: release.status,
+      artworkUrl: release.artworkUrl,
+      externalUrl: release.url,
+    });
+  }
+
+  return out;
+}
+
+/**
+ * The Mirlo artist slug for a stored `mirlo` link, for joining against the Canimus catalog.
+ *
+ * Stored links come from the search fan-out and from claimed artists editing their own
+ * profile, so the shapes in the database vary: `/{slug}`, `/{slug}/`, and `/{slug}/releases`
+ * all appear in live data. All three resolve to the same artist. Anything that isn't a Mirlo
+ * host, or that has no slug at all, returns null rather than a guess.
+ */
+export function mirloArtistSlug(storedUrl: string): string | null {
+  try {
+    const url = new URL(storedUrl);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+
+    const host = url.hostname.toLowerCase();
+    if (host !== 'mirlo.space' && !host.endsWith('.mirlo.space')) return null;
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length === 0) return null;
+
+    // Reserved first segments that are pages, not artists. `/v1/...` in particular must never
+    // be mistaken for an artist slug.
+    const slug = segments[0].toLowerCase();
+    if (MIRLO_RESERVED_SEGMENTS.has(slug)) return null;
+
+    return slug;
+  } catch {
+    return null;
+  }
+}
+
+const MIRLO_RESERVED_SEGMENTS = new Set([
+  'v1',
+  'api',
+  'auth',
+  'login',
+  'signup',
+  'profile',
+  'widget',
+  'pages',
+  'releases',
+  'artists',
+  'about',
+  'docs',
+  'admin',
+]);
 
 // ---------------------------------------------------------------------------
 // Discovered links — a specific release, spotted on a page we fetched for another reason

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -37,6 +37,10 @@
     "functions/me-feed-token.ts",
     "functions/feed-releases.ts",
     "functions/release-detail.ts",
+    // Pulls in release-ingest.ts, release-utils.ts and the whole catalog write path — the
+    // release feature's parsers and its only writer of `releases` rows.
+    "functions/catalog-artist-background.ts",
+    "functions/__tests__/mirlo-canimus.test.ts",
     "functions/redis.ts",
     "functions/cache.ts",
     "shared/feed-format.ts",

--- a/scripts/measure-mirlo-overlap.ts
+++ b/scripts/measure-mirlo-overlap.ts
@@ -1,0 +1,235 @@
+/**
+ * Measure the real Mirlo↔Bandcamp release overlap rate.
+ *
+ * Usage:
+ *   npx tsx scripts/measure-mirlo-overlap.ts
+ *   npx tsx scripts/measure-mirlo-overlap.ts --json
+ *   npx tsx scripts/measure-mirlo-overlap.ts --pairs     (print every matched pair)
+ *
+ * This exists to answer the one question the v1 scope doc has flagged as unmeasured since the
+ * start (§9.2): *"Real Mirlo↔Bandcamp overlap rate. Every dedup rule depends on it and I'm
+ * guessing."* The tier-1/2/3 thresholds were chosen without it.
+ *
+ * ## What it compares, and why that way
+ *
+ * For every artist in Mirlo's Canimus federation catalog who we already have a `mirlo` link
+ * for, it compares their Mirlo releases against the releases **already in our own database**
+ * for that same artist — not against a fresh Bandcamp crawl.
+ *
+ * That choice is deliberate on three grounds:
+ *
+ * 1. **It costs Bandcamp nothing.** Zero outbound requests to Bandcamp; the comparison runs
+ *    against rows we already catalogued. The whole run is one request, to Mirlo.
+ * 2. **It measures the production path.** The question isn't an abstract "do these catalogues
+ *    resemble each other" — it's "when the Mirlo pass runs, how often will it land on a
+ *    release row Bandcamp already created?" That is exactly what this computes, using the
+ *    same `releaseMatchKey` and `isFuzzyReleaseMatch` the writers use.
+ * 3. **The join is artist-asserted, not guessed.** Artists are matched on the Mirlo slug in
+ *    their stored link, so no name-similarity heuristic sits between the two catalogues
+ *    contaminating the number the heuristics are being measured for.
+ *
+ * ## Reading the output
+ *
+ * Every Mirlo release falls into exactly one bucket, named for the dedup tier that would
+ * handle it:
+ *
+ * - `tier2_exact`   — identical `match_key` on an existing row. Auto-merges today.
+ * - `tier3_fuzzy`   — `isFuzzyReleaseMatch` hit but not an exact key. Queues for review today.
+ * - `distinct`      — no candidate at all. Becomes a new release row.
+ *
+ * The overlap rate is `(tier2_exact + tier3_fuzzy) / total`. What makes the number actionable
+ * is the split: a high `tier3_fuzzy` share means the fuzzy rule is carrying real merges and
+ * the admin queue will be busy; a high `tier2_exact` share means exact matching is doing the
+ * work and tier 3 is mostly noise.
+ *
+ * READ-ONLY. No writes, no --write flag. One request to Mirlo per run; don't loop it.
+ *
+ * ⚠️ Requires MIRLO_CANIMUS_ENABLED=true, the same flag that gates the production pass, so
+ * that this cannot make a request to Mirlo before that question is settled.
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
+
+const { createClient } = await import('@supabase/supabase-js');
+const { safeFetch } = await import('../api/functions/safe-fetch.js');
+const { isUrlHostnameAllowed } = await import('../api/functions/middleware.js');
+const { ingestCanimusCatalog, buildMirloReleases, mirloArtistSlug } =
+  await import('../api/functions/release-ingest.js');
+const { isFuzzyReleaseMatch } = await import('../api/functions/release-utils.js');
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const showPairs = args.includes('--pairs');
+
+const CATALOG_URL = 'https://mirlo.space/v1/sm/canimus.json';
+
+if (process.env.MIRLO_CANIMUS_ENABLED !== 'true') {
+  console.error(
+    'Refusing to run: MIRLO_CANIMUS_ENABLED is not "true".\n\n' +
+      "Mirlo's robots.txt disallows /v1/, which is where the Canimus federation endpoint lives.\n" +
+      'This script makes a real request to that endpoint, so it is gated behind the same flag as\n' +
+      'the production pass. Set it only once Mirlo has confirmed the endpoint is ours to call.'
+  );
+  process.exit(1);
+}
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY;
+if (!supabaseUrl || !supabaseKey) {
+  console.error('SUPABASE_URL and a Supabase key must be set in .env');
+  process.exit(1);
+}
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// --- 1. The catalog: one request -------------------------------------------------
+
+if (!isUrlHostnameAllowed(CATALOG_URL)) {
+  console.error('Canimus URL is not on the outbound allowlist');
+  process.exit(1);
+}
+
+const response = await safeFetch(CATALOG_URL, 20_000);
+if (!response?.ok) {
+  console.error(`Canimus fetch failed: ${response ? response.status : 'refused'}`);
+  process.exit(1);
+}
+
+const catalog = ingestCanimusCatalog(await response.json(), CATALOG_URL);
+if (!catalog) {
+  console.error('Response was not a Canimus root document — not treating this as an empty catalog.');
+  process.exit(1);
+}
+
+// --- 2. Our side: stored mirlo links, and each artist's existing releases ---------
+
+const { data: linkRows, error: linkError } = await supabase
+  .from('artist_links')
+  .select('artist_id, url')
+  .eq('platform', 'mirlo');
+
+if (linkError) {
+  console.error('Failed to read mirlo artist_links:', linkError.message);
+  process.exit(1);
+}
+
+/** Mirlo slug -> our artist id. Built with the same slug parser production joins on. */
+const artistIdBySlug = new Map<string, string>();
+for (const row of (linkRows ?? []) as { artist_id: string; url: string }[]) {
+  const slug = mirloArtistSlug(row.url);
+  if (slug) artistIdBySlug.set(slug, row.artist_id);
+}
+
+const matchedArtists = catalog.artists.filter(a => artistIdBySlug.has(a.slug));
+
+interface Bucket {
+  tier2_exact: number;
+  tier3_fuzzy: number;
+  distinct: number;
+}
+const totals: Bucket = { tier2_exact: 0, tier3_fuzzy: 0, distinct: 0 };
+const pairs: { artist: string; mirlo: string; existing: string; tier: string; platforms: string[] }[] = [];
+const artistRows: Record<string, unknown>[] = [];
+
+for (const artist of matchedArtists) {
+  const artistId = artistIdBySlug.get(artist.slug)!;
+
+  const { data: existingRows, error: releaseError } = await supabase
+    .from('releases')
+    .select('id, title, match_key, release_sources(platform)')
+    .eq('artist_id', artistId);
+
+  if (releaseError) {
+    console.error(`Failed to read releases for ${artist.slug}:`, releaseError.message);
+    continue;
+  }
+
+  type ExistingRow = { id: string; title: string; match_key: string; release_sources: { platform: string }[] | null };
+  const existing = ((existingRows ?? []) as ExistingRow[]).filter(r =>
+    // Only rows some *other* platform already contributed. A Mirlo row we wrote on an earlier
+    // run of the real pass would otherwise match itself and inflate the overlap to 100%.
+    (r.release_sources ?? []).some(s => s.platform !== 'mirlo')
+  );
+  const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
+
+  const mirloReleases = buildMirloReleases(artist);
+  const artistBucket: Bucket = { tier2_exact: 0, tier3_fuzzy: 0, distinct: 0 };
+
+  for (const release of mirloReleases) {
+    const exact = byMatchKey.get(release.matchKey);
+    const fuzzy = exact ? undefined : existing.find(r => isFuzzyReleaseMatch(r.match_key, release.matchKey));
+    const hit = exact ?? fuzzy;
+    const tier = exact ? 'tier2_exact' : fuzzy ? 'tier3_fuzzy' : 'distinct';
+
+    artistBucket[tier as keyof Bucket]++;
+    totals[tier as keyof Bucket]++;
+
+    if (hit) {
+      pairs.push({
+        artist: artist.name,
+        mirlo: release.title,
+        existing: hit.title,
+        tier,
+        platforms: [...new Set((hit.release_sources ?? []).map(s => s.platform))],
+      });
+    }
+  }
+
+  artistRows.push({
+    artist: artist.name,
+    slug: artist.slug,
+    mirloReleases: mirloReleases.length,
+    existingReleases: existing.length,
+    ...artistBucket,
+  });
+}
+
+// --- 3. Report -------------------------------------------------------------------
+
+const totalMirloReleases = totals.tier2_exact + totals.tier3_fuzzy + totals.distinct;
+const overlapping = totals.tier2_exact + totals.tier3_fuzzy;
+const rate = totalMirloReleases === 0 ? null : overlapping / totalMirloReleases;
+
+const summary = {
+  catalogArtists: catalog.artists.length,
+  ourMirloLinks: artistIdBySlug.size,
+  measurableArtists: matchedArtists.length,
+  totalMirloReleases,
+  ...totals,
+  overlapRate: rate,
+};
+
+if (asJson) {
+  console.log(JSON.stringify({ summary, artists: artistRows, pairs }, null, 2));
+} else {
+  console.log('\nMirlo ↔ existing-catalogue release overlap');
+  console.log('==========================================\n');
+  console.log(`Canimus catalog (opted-in artists) : ${summary.catalogArtists}`);
+  console.log(`Our stored mirlo artist links      : ${summary.ourMirloLinks}`);
+  console.log(`Artists in both — the sample       : ${summary.measurableArtists}`);
+  console.log(`Mirlo releases across that sample  : ${summary.totalMirloReleases}\n`);
+  console.log(`  tier2_exact (auto-merges)        : ${totals.tier2_exact}`);
+  console.log(`  tier3_fuzzy (queues for review)  : ${totals.tier3_fuzzy}`);
+  console.log(`  distinct    (new release row)    : ${totals.distinct}\n`);
+  console.log(
+    rate === null
+      ? 'Overlap rate                       : n/a — no Mirlo releases in the sample'
+      : `Overlap rate                       : ${(rate * 100).toFixed(1)}%`
+  );
+
+  if (summary.measurableArtists < 10) {
+    console.log(
+      '\n⚠️  Sample is under 10 artists. Report the count alongside any rate quoted from it —\n' +
+        '   a percentage off a handful of artists is a number with no confidence attached.'
+    );
+  }
+
+  if (showPairs && pairs.length > 0) {
+    console.log('\nMatched pairs\n-------------');
+    for (const p of pairs) {
+      console.log(`  [${p.tier}] ${p.artist}: "${p.mirlo}" ↔ "${p.existing}" (${p.platforms.join(', ')})`);
+    }
+  }
+}


### PR DESCRIPTION
Adds Mirlo — the last source in the locked V1 Releases scope — through the **Fairplayer/Canimus federation catalog** rather than Mirlo's REST API.

**Merged only once Mirlo confirms the robots.txt question below.** The code is gated off by default, so merging it changes nothing until a flag is set.

## What the federation angle actually changes

The hope was that Canimus would federate across Fairplayer-family platforms and widen coverage. It doesn't, and that's the headline finding:

- `/v1/sm/canimus.json` is **per-host**. `{host}` is `mirlo.space`. Canimus is a *protocol* other platforms could adopt (Mirlo's docs name Faircamp as a hope), not a cross-platform index that exists today.
- It carries **only artists who individually opted in** to federated syndication — so it is **narrower** than the REST API, not wider.

What it does change is the cost shape, and that's a genuine win:

| | REST `/v1/artists/{slug}` | Canimus `/v1/sm/canimus.json` |
|---|---|---|
| Requests | one **per artist, per run** | one **per six hours, for everyone** |
| Coverage | every public Mirlo artist | opted-in artists only |
| Price / currency / pre-order | yes | **no** |
| Artist's declared off-platform links | no | yes |
| Opt-out signal | no | yes (`deleted[]`) |
| Sanctioned for aggregators | not stated | **documented for exactly this** |

So the trade is: give up prices and some coverage, get a per-artist cost of zero and an endpoint Mirlo published specifically so aggregators could use it.

**The missing price matters for the product.** A Mirlo release lands with a source and no offer, so the payout comparison — the thesis — can't render for it. No zero is invented: a fabricated "name your price" would misstate an artist's own terms. The honest fix is Mirlo's REST API under an agreed key.

## Design

- **One shared fetch.** Memoized per invocation, cached in Redis for 6h. The Mirlo pass is the only source with no budget parameter, because an extra artist costs Mirlo nothing.
- **Never caches uncertainty.** A refused fetch, a non-200, a non-JSON body, or a 200 that isn't a Canimus root all return `null` and are never cached. `ingestCanimusCatalog` returns `null` rather than an empty catalog for a non-root document, so a challenge page can't read as "nobody opted in".
- **Every URL host-pinned.** A federation format exists to name other hosts, and `release_sources.url` is a link fans click. Off-host artist and release URLs are dropped, not trusted.
- **Dedup unchanged, under-merge preserved.** Matches on `match_key` alone (Canimus types everything `"album"`, so the stored type is title-inferred and too weak to partition identity by). Exact key merges; `isFuzzyReleaseMatch` queues for review; nothing new auto-merges.
- **Live data guarded.** Mirlo carries a release dated **2925-11-02**; `parseReleaseDate` bounds it out. Empty-title drafts are dropped rather than stored as untitled.

## Typecheck coverage

`catalog-artist-background.ts` joins `api/tsconfig.json`'s include, bringing `release-ingest.ts`, `release-utils.ts` and the catalog write path under strict mode for the first time. It was already clean — verified the include has teeth by breaking a signature and watching six errors appear.

## The overlap measurement (§9's open question)

`scripts/measure-mirlo-overlap.ts` answers *"real Mirlo↔Bandcamp overlap rate — every dedup rule depends on it and I'm guessing."* It compares the catalog against releases **already in our database**, so it costs one request to Mirlo and none to Bandcamp, and it measures the production path rather than an abstract resemblance. Gated behind the same flag.

**Sample size is much better than the spec assumed.** The "Mirlo on 0 of 791 artists" figure came from the static SEO set. Live `artist_links` has **66 Mirlo links, 64 of which are on artists who also have a Bandcamp link** — a real sample, not a handful.

## Verification

- `npm run build` ✅ · `npm run test:api` ✅ 783 passing (20 new) · `npm run test:unit` ✅ · typecheck ✅
- Lint unchanged from baseline (71 problems / 64 errors both with and without this diff)
- Host-pinning tests proven to have teeth: disabling the pin fails exactly the two tests that assert it

**Not verified against a live response.** No request has been made to Mirlo. Fixtures are built from the documented shape, so these tests pin *our* decisions, not Mirlo's field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)