### PR TITLE
Sweep every artist with something to crawl, not just saved ones

### DIFF
--- a/.github/workflows/recatalog-sweep.yml
+++ b/.github/workflows/recatalog-sweep.yml
@@ -1,35 +1,38 @@
 name: Release catalogue sweep
 
-# Keeps saved artists' release catalogues from going stale.
+# Builds and refreshes release catalogues in the background.
 #
 # Every other catalog trigger is demand-driven: a save, a search, a button. So an artist who is
-# saved but never searched gets catalogued once and never again, and their release alerts
-# quietly stop — the long tail this feature exists for. See api/functions/recatalog-sweep.ts.
+# catalogued once and not searched again quietly stops producing release alerts, and their
+# artist page keeps showing the releases they had that day. See api/functions/recatalog-sweep.ts.
 #
 # A GitHub Actions cron rather than a scheduled Netlify function: there are no scheduled Netlify
 # functions in this repo, and this is the established precedent (schedule-social-posts.yml,
 # upstash-keepalive.yml).
 #
-# ## Cadence: daily, 05:00 UTC
+# ## Cadence: every 6 hours
 #
-# What this actually costs the sites we crawl is one batch of at most 25 artists, run through
-# the existing background function, which paces itself: one second between artists, at most 100
-# Bandcamp release-page fetches per run on top of one grid page each. So a sweep is on the order
-# of 125 requests to Bandcamp, sequential, spread over minutes — a trickle, and less than a
-# handful of real visitors searching. 05:00 UTC keeps it off both US and European peak.
+# One run asks for at most 25 artists — one background invocation's worth — so four runs a day
+# is 100 artists daily. Measured against the pool on 2026-08-02 (2,564 artists with a
+# catalogue-able link, 9 of them saved by anybody) that means:
 #
-# Daily rather than weekly because the batch is small and the 7-day cooldown is what actually
-# bounds per-artist crawling: an artist can't be re-crawled more than once a week however often
-# this runs. Daily just means the 25 slots are spread across seven small runs instead of arriving
-# in one lump, and it caps how long a newly-saved artist waits for a first catalogue if the
-# save-time request was dropped by the hourly cap.
+#   - Saved artists come round as soon as their 7-day cooldown expires. They sort first, and
+#     there are single figures of them, so an alert never waits behind the backfill.
+#   - The rest rotate roughly monthly, which is the right order for artist-page freshness.
+#   - The ~2,400 artists with no catalogue at all drain in about three weeks.
+#
+# What it costs the sites we crawl: the background function paces itself at one second between
+# artists, at most 100 Bandcamp release-page fetches per run on top of one grid page each. Four
+# runs is on the order of 400-500 sequential Bandcamp requests a day — well under one a minute
+# averaged, against robots-permitted paths. The lever if the tail needs to be tighter is this
+# cadence, not the batch size, which is capped by what one invocation can do.
 #
 # Safe to over-run. A duplicate invocation finds the same artists claimed and does nothing, so
 # re-running by hand is free.
 
 on:
   schedule:
-    - cron: '0 5 * * *' # Daily, 05:00 UTC
+    - cron: '0 1,7,13,19 * * *' # Every 6 hours, offset off the top-of-day cron rush
   workflow_dispatch: # Manual trigger from the GitHub UI
 
 jobs:
@@ -60,7 +63,8 @@ jobs:
             exit 1
           fi
 
-          # Worth reading rather than skipping past: `requested` falling to 0 every day while
-          # `savedArtists` is large means everything is inside its cooldown (fine) or that
-          # selection has broken (not fine, and it looks identical from here).
+          # Worth reading rather than skipping past. `requested: 0` is fine when `inCooldown`
+          # accounts for the whole `catalogueable` pool — everything really is caught up. It is
+          # not fine if `catalogueable` has collapsed, which is what a broken or truncated
+          # selection query looks like, and the two are indistinguishable without these counts.
           echo "Sweep OK: $body"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,13 +220,27 @@ command — and `check-releases` only *reads* the catalogue. So without a schedu
 who is saved but never searched gets catalogued once and their release alerts quietly stop. That
 is what `api/functions/recatalog-sweep.ts` fixes, run daily by `.github/workflows/recatalog-sweep.yml`.
 
-The sweep selects the stalest catalogues **among artists somebody has saved** (`getStaleSavedArtistCatalogs`
-in `db.ts`: never-attempted first, then oldest `last_attempted_at`, savers only as a tiebreak) and
-asks `requestArtistCatalog` for up to 25 of them under the `scheduled` trigger. It adds no rate
-limiting of its own — the 7-day cooldown and the hourly cap in `claimArtistForCatalog` still decide
-— so running it twice is a no-op. It returns a real summary rather than 202, and any refusal is a
-non-2xx that fails the workflow: a scheduled job that reports success while doing nothing is the
-same silent failure it was built to fix.
+The pool is **every artist with a bandcamp, discogs, faircamp or jamcoop link** — measured
+2026-08-02: 2,564 of them, against 9 artists saved by anybody, so a saved-only sweep sat idle
+almost every run. Alerts aren't the only consumer either: `/a/:slug` renders a release list for
+any catalogued artist, and those pages exist because somebody *searched*. Keep that platform list
+identical to `catalogArtist`'s "no bandcamp, discogs, faircamp, or jam.coop link stored" check —
+an artist with only an official site is recorded as a *failure*, so sweeping them poisons
+`consecutive_failures`.
+
+`getStaleCatalogCandidates` in `db.ts` orders them: saved first (an alert is a promise to a
+person, and there are few enough that they never starve behind the backfill), then never
+catalogued, then oldest `last_attempted_at`, then savers as a pure tiebreak. It asks
+`requestArtistCatalog` for up to 25 under the `scheduled` trigger. No rate limiting of its own —
+the 7-day cooldown and the hourly cap in `claimArtistForCatalog` still decide — so running it
+twice is a no-op. It returns a real summary rather than 202, and any refusal is a non-2xx that
+fails the workflow: a scheduled job that reports success while doing nothing is the same silent
+failure it was built to fix.
+
+**Paging, not `.limit()`.** PostgREST caps every response at 1,000 rows whatever limit you ask
+for, and truncates *silently*. A single `.select()` over `artist_links` returns 1,000 of ~3,900
+rows and looks completely successful — which would hide three quarters of the sweep's pool. Use
+`readAllPages` (or `.range()` in a loop) for any read whose table can exceed 1,000 rows.
 
 ### Platform registry
 
@@ -344,7 +358,7 @@ GitHub Actions (`.github/workflows/`):
 - `schedule-social-posts.yml` — weekly (Mondays) social post generation, committed back to the repo.
 - `semantic-revert-check.yml` — runs `scripts/semantic-revert-check.py` on every PR to flag changes that quietly undo earlier fixes. If it flags your PR, take it seriously: the bug loops it was built for are described in `docs/retros/UNS-100-bifurcation-retro.md`.
 - `upstash-keepalive.yml` — twice weekly, writes one Redis key so the free-tier database isn't reaped for inactivity (which silently killed caching and rate limiting once).
-- `recatalog-sweep.yml` — daily, POSTs `/.netlify/functions/recatalog-sweep` so saved artists' release catalogues stay fresh. See "Keeping catalogues fresh" below.
+- `recatalog-sweep.yml` — every 6 hours, POSTs `/.netlify/functions/recatalog-sweep` so release catalogues get built and stay fresh. See "Keeping catalogues fresh" below.
 
 ## Engineering principles
 

--- a/api/functions/__tests__/recatalog-sweep-selection.test.ts
+++ b/api/functions/__tests__/recatalog-sweep-selection.test.ts
@@ -1,16 +1,17 @@
 // Who the scheduled sweep picks, and who it must not.
 //
-// The selection is the whole feature: get it wrong and the sweep runs every day, reports
-// success, and refreshes the wrong artists — or none — while the alerts it exists to keep
-// alive stay quiet. Every rule here is one that would fail silently.
+// The selection is the whole feature: get it wrong and the sweep runs every few hours, reports
+// success, and refreshes the wrong artists — or none — while the alerts and artist pages it
+// exists to keep current quietly go stale. Every rule here is one that would fail silently.
 //
 // Driven against a recording fake Supabase client rather than a module mock, following
-// release-order-query.test.ts, so the real query body runs.
+// release-order-query.test.ts, so the real query body runs — including the paging, which is
+// the part that silently truncated when it was a plain `.limit()`.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 interface Filter {
-  kind: 'eq' | 'not' | 'in' | 'limit';
+  kind: 'eq' | 'not' | 'in' | 'range';
   column?: string;
   value?: unknown;
 }
@@ -25,12 +26,16 @@ const queries: Query[] = [];
 
 /** Rows the fake returns, keyed by table. Tests set these. */
 const tables: Record<string, Record<string, unknown>[]> = {
+  artist_links: [],
   saved_artists: [],
   release_catalog_state: [],
 };
 
 /** Set to a table name to make that table's read fail. */
 let failingTable: string | null = null;
+
+/** PostgREST caps every response at this many rows regardless of what was asked for. */
+const MAX_ROWS = 1000;
 
 function makeClient() {
   return {
@@ -53,8 +58,8 @@ function makeClient() {
               query.filters.push({ kind: 'in', column, value });
               return builder;
             },
-            limit(n: number) {
-              query.filters.push({ kind: 'limit', value: n });
+            range(from: number, to: number) {
+              query.filters.push({ kind: 'range', value: [from, to] });
               return builder;
             },
             then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
@@ -62,13 +67,27 @@ function makeClient() {
                 return Promise.resolve({ data: null, error: { message: 'connection reset' } })
                   .then(resolve, reject);
               }
-              // Apply the `in` filter the way PostgREST would, so a chunked read behaves.
-              const inFilter = query.filters.find(f => f.kind === 'in');
+
               let rows = tables[table] ?? [];
+              const inFilter = query.filters.find(f => f.kind === 'in');
               if (inFilter) {
                 const wanted = new Set(inFilter.value as string[]);
                 rows = rows.filter(r => wanted.has(r[inFilter.column as string] as string));
               }
+              const eqFilter = query.filters.find(f => f.kind === 'eq');
+              if (eqFilter) {
+                rows = rows.filter(r => r[eqFilter.column as string] === eqFilter.value);
+              }
+
+              // The behaviour that matters: a page is capped at MAX_ROWS whatever was asked for.
+              const rangeFilter = query.filters.find(f => f.kind === 'range');
+              if (rangeFilter) {
+                const [from, to] = rangeFilter.value as [number, number];
+                rows = rows.slice(from, from + Math.min(to - from + 1, MAX_ROWS));
+              } else {
+                rows = rows.slice(0, MAX_ROWS);
+              }
+
               return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
             },
           };
@@ -84,14 +103,19 @@ vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
 process.env.SUPABASE_URL = 'https://example.supabase.co';
 process.env.SUPABASE_SERVICE_KEY = 'service-key';
 
-const { getStaleSavedArtistCatalogs, RECATALOG_COOLDOWN_HOURS } = await import('../db');
+const { getStaleCatalogCandidates, RECATALOG_COOLDOWN_HOURS } = await import('../db');
 
 const HOUR = 3600_000;
 const now = Date.now();
 const ago = (hours: number) => new Date(now - hours * HOUR).toISOString();
 
-function saved(artistId: string | null, extra: Record<string, unknown> = {}) {
-  return { artist_id: artistId, deleted: false, ...extra };
+/** Give an artist something to crawl. Without this they aren't in the pool at all. */
+function link(artistId: string | null, platform = 'bandcamp') {
+  return { artist_id: artistId, platform };
+}
+
+function saved(artistId: string | null) {
+  return { artist_id: artistId, deleted: false };
 }
 
 function state(
@@ -109,53 +133,72 @@ function state(
 
 beforeEach(() => {
   queries.length = 0;
+  tables.artist_links = [];
   tables.saved_artists = [];
   tables.release_catalog_state = [];
   failingTable = null;
 });
 
-describe('getStaleSavedArtistCatalogs — who is eligible', () => {
-  it('only considers artists somebody has saved', async () => {
-    tables.saved_artists = [saved('saved-artist')];
-    // An artist with catalog state but no saver: catalogued because they were searched once.
-    tables.release_catalog_state = [state('saved-artist', 400), state('searched-only', 900)];
+describe('getStaleCatalogCandidates — who is in the pool', () => {
+  it('includes artists nobody has saved', async () => {
+    tables.artist_links = [link('searched-only'), link('saved-too')];
+    tables.saved_artists = [saved('saved-too')];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.candidates.map(c => c.artistId)).toEqual(['saved-artist']);
+    // The whole point of widening the pool: alerts aren't the only consumer of a catalogue.
+    // /a/:slug renders a release list for any catalogued artist, and those pages exist because
+    // somebody searched.
+    expect(new Set(result.candidates.map(c => c.artistId))).toEqual(
+      new Set(['searched-only', 'saved-too'])
+    );
+    expect(result.catalogueable).toBe(2);
+    expect(result.savedArtists).toBe(1);
   });
 
-  it('asks the database only for rows that are not tombstoned', async () => {
-    tables.saved_artists = [saved('a')];
+  it('excludes artists with nothing crawlable', async () => {
+    // catalogArtist records an artist with no bandcamp/discogs/faircamp/jamcoop link as an
+    // *error*, which bumps consecutive_failures and writes last_error. Sweeping them would
+    // spend the batch on artists with nothing to fetch and turn the failure counters to noise.
+    tables.artist_links = [link('real', 'bandcamp'), link('site-only', 'officialsite')];
 
-    await getStaleSavedArtistCatalogs(10);
-
-    const savedQuery = queries.find(q => q.table === 'saved_artists');
-    // `deleted` is a soft-delete flag (migration 017): an unsaved artist keeps a row so other
-    // devices can prune it. Re-crawling for somebody who unsaved them is pure waste.
-    expect(savedQuery?.filters).toContainEqual({ kind: 'eq', column: 'deleted', value: false });
-    // artist_id is nullable since migration 014 — a save can be by slug alone.
-    expect(savedQuery?.filters).toContainEqual({ kind: 'not', column: 'artist_id', value: 'is null' });
-  });
-
-  it('ignores a saved row with no artist id', async () => {
-    tables.saved_artists = [saved(null), saved('real')];
-
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['real']);
   });
 
+  it.each(['bandcamp', 'discogs', 'faircamp', 'jamcoop'])(
+    'treats a %s link as crawlable',
+    async platform => {
+      tables.artist_links = [link('a', platform)];
+
+      const result = await getStaleCatalogCandidates(10);
+
+      expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['a']);
+    }
+  );
+
+  it('counts an artist once however many platforms they are on', async () => {
+    tables.artist_links = [link('a', 'bandcamp'), link('a', 'discogs'), link('a', 'faircamp')];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.candidates).toHaveLength(1);
+    expect(result.catalogueable).toBe(1);
+  });
+
   it('drops artists still inside the re-catalog cooldown, and counts them', async () => {
-    tables.saved_artists = [saved('fresh'), saved('stale')];
+    tables.artist_links = [link('fresh'), link('stale')];
     tables.release_catalog_state = [
       state('fresh', 2, { hoursAgo: 2, releasesFound: 12 }),
       state('stale', RECATALOG_COOLDOWN_HOURS + 24, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 24 }),
     ];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -163,58 +206,104 @@ describe('getStaleSavedArtistCatalogs — who is eligible', () => {
     // would make the sweep a no-op that still reports work.
     expect(result.candidates.map(c => c.artistId)).toEqual(['stale']);
     expect(result.inCooldown).toBe(1);
-    expect(result.savedArtists).toBe(2);
-  });
-
-  it('keeps an artist whose last success is exactly outside the cooldown', async () => {
-    tables.saved_artists = [saved('edge')];
-    tables.release_catalog_state = [
-      state('edge', RECATALOG_COOLDOWN_HOURS + 1, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 1 }),
-    ];
-
-    const result = await getStaleSavedArtistCatalogs(10);
-
-    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['edge']);
+    expect(result.eligible).toBe(1);
+    expect(result.catalogueable).toBe(2);
   });
 
   it('keeps an artist who has only ever failed, however recently attempted', async () => {
-    // last_catalogued_at null means no success ever. The cooldown is about successes; the
-    // exponential backoff on repeated failures is claimArtistForCatalog's job, not this one's.
-    tables.saved_artists = [saved('always-failing')];
+    // last_catalogued_at null means no success ever. The cooldown is about successes; backing
+    // off repeated failures is claimArtistForCatalog's job, not this one's.
+    tables.artist_links = [link('always-failing')];
     tables.release_catalog_state = [state('always-failing', 1)];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['always-failing']);
   });
+
+  it('ignores a link row with no artist id', async () => {
+    tables.artist_links = [link(null), link('real')];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['real']);
+  });
+
+  it('asks the database only for live saves', async () => {
+    tables.artist_links = [link('a')];
+    tables.saved_artists = [saved('a')];
+
+    await getStaleCatalogCandidates(10);
+
+    const savedQuery = queries.find(q => q.table === 'saved_artists');
+    // `deleted` is a soft-delete flag (migration 017): an unsaved artist keeps a row so other
+    // devices can prune it. Treating a tombstone as a save would mis-prioritise the batch.
+    expect(savedQuery?.filters).toContainEqual({ kind: 'eq', column: 'deleted', value: false });
+    expect(savedQuery?.filters).toContainEqual({ kind: 'not', column: 'artist_id', value: 'is null' });
+  });
+
+  it('does not treat a tombstoned save as saved', async () => {
+    tables.artist_links = [link('a')];
+    tables.saved_artists = [{ artist_id: 'a', deleted: true }];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.candidates[0].saved).toBe(false);
+    expect(result.savedArtists).toBe(0);
+  });
 });
 
-describe('getStaleSavedArtistCatalogs — ordering', () => {
-  it('puts never-attempted artists first, then the stalest attempt', async () => {
-    tables.saved_artists = [saved('recent'), saved('never'), saved('ancient'), saved('middling')];
+describe('getStaleCatalogCandidates — ordering', () => {
+  it('puts saved artists ahead of everyone, however fresh they are', async () => {
+    tables.artist_links = [link('saved-recent'), link('unsaved-ancient'), link('unsaved-never')];
+    tables.saved_artists = [saved('saved-recent')];
+    tables.release_catalog_state = [state('saved-recent', 200), state('unsaved-ancient', 5_000)];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // An alert is a promise to a person, so a saved artist can never starve behind the backfill
+    // of everyone else — not even behind an artist who has never been catalogued at all.
+    expect(result.candidates.map(c => c.artistId)).toEqual([
+      'saved-recent',
+      'unsaved-never',
+      'unsaved-ancient',
+    ]);
+  });
+
+  it('puts never-catalogued artists first within a group, then the stalest attempt', async () => {
+    tables.artist_links = ['recent', 'never', 'ancient', 'middling'].map(id => link(id));
     tables.release_catalog_state = [
       state('recent', 200),
       state('ancient', 5_000),
       state('middling', 900),
     ];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    // 'never' has been saved but no run has ever claimed them — usually the save-time request
-    // hit the hourly cap. Nothing else retries it, so it goes to the front.
-    expect(result.candidates.map(c => c.artistId)).toEqual(['never', 'ancient', 'middling', 'recent']);
+    // No state row at all means we have no releases for them, which is worse than having
+    // slightly old ones.
+    expect(result.candidates.map(c => c.artistId)).toEqual([
+      'never',
+      'ancient',
+      'middling',
+      'recent',
+    ]);
     expect(result.candidates[0].lastAttemptedAt).toBeNull();
   });
 
   it('breaks ties on savers, but never lets popularity outrank staleness', async () => {
+    tables.artist_links = ['popular-fresh', 'lonely-stale', 'also-fresh'].map(id => link(id));
     tables.saved_artists = [
       saved('popular-fresh'),
       saved('popular-fresh'),
       saved('popular-fresh'),
       saved('lonely-stale'),
-      saved('also-fresh'),
     ];
     tables.release_catalog_state = [
       state('popular-fresh', 200),
@@ -222,13 +311,12 @@ describe('getStaleSavedArtistCatalogs — ordering', () => {
       state('lonely-stale', 4_000),
     ];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    // The one nobody but a single fan saved still comes first. Sorting by popularity would
-    // starve exactly the long tail the sweep exists to serve — popular artists stay fresh
-    // anyway, because people search them.
+    // Both saved artists outrank the unsaved one; between them staleness decides, so the
+    // artist a single fan saved beats the one three fans saved.
     expect(result.candidates.map(c => c.artistId)).toEqual([
       'lonely-stale',
       'popular-fresh',
@@ -237,74 +325,104 @@ describe('getStaleSavedArtistCatalogs — ordering', () => {
     expect(result.candidates[1].savers).toBe(3);
   });
 
-  it('returns at most the requested batch, stalest first', async () => {
-    tables.saved_artists = Array.from({ length: 40 }, (_, i) => saved(`artist-${i}`));
+  it('returns at most the requested batch, and reports the pool behind it', async () => {
+    tables.artist_links = Array.from({ length: 40 }, (_, i) => link(`artist-${i}`));
     tables.release_catalog_state = Array.from({ length: 40 }, (_, i) => state(`artist-${i}`, 200 + i));
 
-    const result = await getStaleSavedArtistCatalogs(25);
+    const result = await getStaleCatalogCandidates(25);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.candidates).toHaveLength(25);
     expect(result.candidates[0].artistId).toBe('artist-39'); // attempted longest ago
-    expect(result.savedArtists).toBe(40); // the population, not the batch
+    expect(result.eligible).toBe(40); // the queue, not the batch
+    expect(result.catalogueable).toBe(40);
   });
 
   it('carries the previous release count, so a run can be read against it afterwards', async () => {
-    tables.saved_artists = [saved('a')];
+    tables.artist_links = [link('a')];
     tables.release_catalog_state = [
       state('a', 400, { hoursAgo: RECATALOG_COOLDOWN_HOURS + 10, releasesFound: 20 }),
     ];
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
     expect(result.ok && result.candidates[0].releasesFound).toBe(20);
   });
 });
 
-describe('getStaleSavedArtistCatalogs — failure is not emptiness', () => {
-  it('reports a failed saved-artists read rather than returning no candidates', async () => {
+describe('getStaleCatalogCandidates — paging, not truncation', () => {
+  // The bug this guards: PostgREST caps every response at 1,000 rows regardless of `.limit()`,
+  // and truncates *silently*. A single read of artist_links returned 1,000 of ~3,900 real rows
+  // and looked entirely successful — which would have hidden three quarters of the pool.
+  it('pages through a link table larger than one response', async () => {
+    tables.artist_links = Array.from({ length: 2_300 }, (_, i) => link(`artist-${i}`));
+
+    const result = await getStaleCatalogCandidates(25);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.catalogueable).toBe(2_300);
+    expect(queries.filter(q => q.table === 'artist_links')).toHaveLength(3); // 1000+1000+300
+  });
+
+  it('pages the catalog state table too, so a big table cannot fake never-attempted', async () => {
+    tables.artist_links = Array.from({ length: 1_500 }, (_, i) => link(`artist-${i}`));
+    // Everyone has been catalogued recently, so a truncated state read would wrongly report
+    // 1,500 never-attempted artists and re-crawl the lot.
+    tables.release_catalog_state = Array.from({ length: 1_500 }, (_, i) =>
+      state(`artist-${i}`, 2, { hoursAgo: 2 })
+    );
+
+    const result = await getStaleCatalogCandidates(25);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.inCooldown).toBe(1_500);
+    expect(result.candidates).toHaveLength(0);
+  });
+
+  it('pages the saved-artists table', async () => {
+    tables.artist_links = Array.from({ length: 1_200 }, (_, i) => link(`artist-${i}`));
+    tables.saved_artists = Array.from({ length: 1_200 }, (_, i) => saved(`artist-${i}`));
+
+    const result = await getStaleCatalogCandidates(25);
+
+    expect(result.ok && result.savedArtists).toBe(1_200);
+  });
+});
+
+describe('getStaleCatalogCandidates — failure is not emptiness', () => {
+  it.each([
+    ['artist_links', 'catalogue-able artist links'],
+    ['saved_artists', 'saved artists'],
+    ['release_catalog_state', 'catalog state'],
+  ])('reports a failed %s read rather than returning no candidates', async (table, label) => {
+    tables.artist_links = [link('a')];
     tables.saved_artists = [saved('a')];
-    failingTable = 'saved_artists';
+    tables.release_catalog_state = [state('a', 400)];
+    failingTable = table;
 
-    const result = await getStaleSavedArtistCatalogs(10);
+    const result = await getStaleCatalogCandidates(10);
 
-    // "We couldn't ask" must not render as "nothing needs re-cataloguing" — that is the shape
-    // of the bug the never-cache-uncertainty rule exists to prevent, and here it would make a
-    // broken sweep look like a quiet week, forever.
+    // "We couldn't ask" must not render as "nothing needs cataloguing" — that is the shape of
+    // the bug the never-cache-uncertainty rule exists to prevent, and here it would make a
+    // broken sweep look like a caught-up one, forever.
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.reason).toContain('saved artists');
+    expect(result.reason).toContain(label);
   });
 
-  it('reports a failed catalog-state read rather than treating everyone as never attempted', async () => {
-    tables.saved_artists = [saved('a')];
-    failingTable = 'release_catalog_state';
+  it('is a quiet success, not a failure, when no artist has anything to crawl', async () => {
+    const result = await getStaleCatalogCandidates(10);
 
-    const result = await getStaleSavedArtistCatalogs(10);
-
-    // Silently treating an unreadable state table as "nobody has ever been catalogued" would
-    // send every saved artist to the front of the queue and re-crawl the lot.
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.reason).toContain('catalog state');
-  });
-
-  it('is a quiet success, not a failure, when nobody has saved anything', async () => {
-    const result = await getStaleSavedArtistCatalogs(10);
-
-    expect(result).toEqual({ ok: true, candidates: [], savedArtists: 0, inCooldown: 0 });
-  });
-
-  it('chunks the state lookup so a large saved population cannot blow up the query string', async () => {
-    tables.saved_artists = Array.from({ length: 450 }, (_, i) => saved(`artist-${i}`));
-
-    await getStaleSavedArtistCatalogs(25);
-
-    const stateQueries = queries.filter(q => q.table === 'release_catalog_state');
-    expect(stateQueries).toHaveLength(3); // 200 + 200 + 50
-    for (const q of stateQueries) {
-      expect((q.filters.find(f => f.kind === 'in')?.value as string[]).length).toBeLessThanOrEqual(200);
-    }
+    expect(result).toEqual({
+      ok: true,
+      candidates: [],
+      catalogueable: 0,
+      savedArtists: 0,
+      inCooldown: 0,
+      eligible: 0,
+    });
   });
 });

--- a/api/functions/__tests__/recatalog-sweep.test.ts
+++ b/api/functions/__tests__/recatalog-sweep.test.ts
@@ -5,14 +5,14 @@
 //  1. The sweep must never answer 200 when it did nothing it was asked to do. A daily job that
 //     reports success while cataloging is disabled, or the database is unreadable, recreates
 //     precisely the bug it was built to fix — release alerts going quiet with nothing to see.
-//  2. One artist blowing up mid-sweep must not take the rest of the batch with it. A sweep runs
-//     once a day; the artists after the failure would wait another day for a slot they only get
-//     because they are the stalest.
+//  2. One artist blowing up mid-sweep must not take the rest of the batch with it. Slots are
+//     scarce — a few dozen a day against a pool in the thousands — so the artists after a
+//     failure would wait a whole rotation for a place they only reached by being the stalest.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  getStaleSavedArtistCatalogs: vi.fn(),
+  getStaleCatalogCandidates: vi.fn(),
   requestArtistCatalog: vi.fn(),
   captureMessage: vi.fn(),
   // For the background-loop isolation test:
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../db', () => ({
-  getStaleSavedArtistCatalogs: mocks.getStaleSavedArtistCatalogs,
+  getStaleCatalogCandidates: mocks.getStaleCatalogCandidates,
   claimArtistForCatalog: mocks.claimArtistForCatalog,
   getArtistForCatalog: mocks.getArtistForCatalog,
   recordCatalogOutcome: mocks.recordCatalogOutcome,
@@ -52,7 +52,19 @@ const SECRET = 'sweep-test-secret';
 const originalEnv = { ...process.env };
 
 function candidate(artistId: string, lastAttemptedAt: string | null = '2026-07-01T00:00:00+00:00') {
-  return { artistId, savers: 1, lastAttemptedAt, releasesFound: 12 };
+  return { artistId, saved: false, savers: 0, lastAttemptedAt, releasesFound: 12 };
+}
+
+function selection(candidates: ReturnType<typeof candidate>[], extra: Record<string, number> = {}) {
+  return {
+    ok: true,
+    candidates,
+    catalogueable: 2_500,
+    savedArtists: 9,
+    inCooldown: 2_400,
+    eligible: 100,
+    ...extra,
+  };
 }
 
 function post(headers: Record<string, string | undefined> = { authorization: `Bearer ${SECRET}` }) {
@@ -65,12 +77,7 @@ beforeEach(() => {
   process.env.RELEASE_CATALOG_ENABLED = 'true';
   process.env.URL = 'https://unstream.stream';
   mocks.requestArtistCatalog.mockResolvedValue(true);
-  mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
-    ok: true,
-    candidates: [candidate('a'), candidate('b')],
-    savedArtists: 40,
-    inCooldown: 38,
-  });
+  mocks.getStaleCatalogCandidates.mockResolvedValue(selection([candidate('a'), candidate('b')]));
 });
 
 afterEach(() => {
@@ -81,7 +88,7 @@ describe('recatalog-sweep auth', () => {
   it('rejects a request with no Authorization header', async () => {
     const r = await post({});
     expect(r.statusCode).toBe(401);
-    expect(mocks.getStaleSavedArtistCatalogs).not.toHaveBeenCalled();
+    expect(mocks.getStaleCatalogCandidates).not.toHaveBeenCalled();
   });
 
   it('rejects a wrong secret', async () => {
@@ -106,7 +113,7 @@ describe('recatalog-sweep auth', () => {
   it('rejects non-POST', async () => {
     const r = await handler({ httpMethod: 'GET', headers: { authorization: `Bearer ${SECRET}` } });
     expect(r.statusCode).toBe(405);
-    expect(mocks.getStaleSavedArtistCatalogs).not.toHaveBeenCalled();
+    expect(mocks.getStaleCatalogCandidates).not.toHaveBeenCalled();
   });
 });
 
@@ -127,7 +134,7 @@ describe('recatalog-sweep refuses out loud', () => {
   });
 
   it('fails when the candidates cannot be read', async () => {
-    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({ ok: false, reason: 'Could not read saved artists: down' });
+    mocks.getStaleCatalogCandidates.mockResolvedValue({ ok: false, reason: 'Could not read saved artists: down' });
 
     const r = await post();
 
@@ -168,35 +175,36 @@ describe('recatalog-sweep dispatch', () => {
     await post();
     // Matches MAX_ARTISTS_PER_RUN in catalog-artist-background: asking for more would silently
     // drop the overflow, which would look like the sweep working.
-    expect(mocks.getStaleSavedArtistCatalogs).toHaveBeenCalledWith(25);
+    expect(mocks.getStaleCatalogCandidates).toHaveBeenCalledWith(25);
   });
 
-  it('reports counts a reader can tell a quiet day from a broken sweep by', async () => {
-    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
-      ok: true,
-      candidates: [candidate('a', null), candidate('b', '2026-06-01T00:00:00+00:00')],
-      savedArtists: 40,
-      inCooldown: 38,
-    });
+  it('reports counts a reader can tell a quiet run from a broken sweep by', async () => {
+    const savedOne = { ...candidate('a', null), saved: true, savers: 3 };
+    mocks.getStaleCatalogCandidates.mockResolvedValue(
+      selection([savedOne, candidate('b', '2026-06-01T00:00:00+00:00')])
+    );
 
     const r = await post();
 
+    // `catalogueable` is the load-bearing one: requested: 0 is fine when inCooldown accounts
+    // for the pool, and alarming when the pool itself has collapsed. Without it in the body
+    // those two are indistinguishable from the workflow log.
     expect(JSON.parse(r.body)).toEqual({
       requested: 2,
-      savedArtists: 40,
-      inCooldown: 38,
-      stalestAttemptedAt: null,
+      catalogueable: 2_500,
+      savedArtists: 9,
+      inCooldown: 2_400,
+      eligible: 100,
+      savedInBatch: 1,
       neverAttempted: 1,
+      stalestAttemptedAt: null,
     });
   });
 
   it('is a quiet success when everyone is inside their cooldown', async () => {
-    mocks.getStaleSavedArtistCatalogs.mockResolvedValue({
-      ok: true,
-      candidates: [],
-      savedArtists: 40,
-      inCooldown: 40,
-    });
+    mocks.getStaleCatalogCandidates.mockResolvedValue(
+      selection([], { inCooldown: 2_500, eligible: 0 })
+    );
 
     const r = await post();
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -609,12 +609,14 @@ export async function getCatalogState(artistId: string): Promise<CatalogStateRes
   return { ok: true, state: (data as CatalogStateRow | null) ?? null };
 }
 
-/** One artist the scheduled sweep could re-crawl, with the facts it was chosen on. */
+/** One artist the scheduled sweep could crawl, with the facts it was chosen on. */
 export interface StaleCatalogCandidate {
   artistId: string;
-  /** How many people have this artist saved. Used only to break ties — see the sort below. */
+  /** Somebody has this artist saved, so an alert depends on this catalogue being current. */
+  saved: boolean;
+  /** How many people have them saved. A tiebreak only — see the sort below. */
   savers: number;
-  /** Null means never attempted: saved, but no catalog run has ever claimed them. */
+  /** Null means no catalog run has ever claimed them: this is coverage, not refresh. */
   lastAttemptedAt: string | null;
   /** What the last successful run found, so a sweep run can be read against it afterwards. */
   releasesFound: number | null;
@@ -626,64 +628,138 @@ export interface StaleCatalogCandidate {
  * a quiet, successful run, and they look identical if collapsed.
  */
 export type StaleCatalogResult =
-  | { ok: true; candidates: StaleCatalogCandidate[]; savedArtists: number; inCooldown: number }
+  | {
+      ok: true;
+      candidates: StaleCatalogCandidate[];
+      /** Artists with something to crawl — the pool, not the batch. */
+      catalogueable: number;
+      /** How many of those are saved by somebody. */
+      savedArtists: number;
+      /** Dropped because they were catalogued inside the cooldown. */
+      inCooldown: number;
+      /** Eligible right now, of which only `limit` fit in this batch. */
+      eligible: number;
+    }
   | { ok: false; reason: string };
 
-/** Bounds the sweep's first read. Well above the current saved population; a guard, not a limit. */
-const MAX_SAVED_ARTISTS_SCANNED = 10_000;
-
-/** How many ids to put in one `in()` filter, which becomes a URL query string. */
-const CATALOG_STATE_CHUNK = 200;
+/**
+ * The platforms `catalogArtist` can actually crawl.
+ *
+ * Deliberately **not** including `officialsite`: that link is only followed to *discover* other
+ * platforms, and `catalogArtist` treats an artist with nothing but an official site as having
+ * "no bandcamp, discogs, faircamp, or jam.coop link stored" — which it records as an **error**,
+ * incrementing `consecutive_failures` and writing `last_error`. Keep this list identical to that
+ * condition or the sweep will spend its batch on artists with nothing to fetch and turn the
+ * failure counters into noise.
+ */
+const CATALOGUEABLE_PLATFORMS = ['bandcamp', 'discogs', 'faircamp', 'jamcoop'] as const;
 
 /**
- * The stalest catalogues among artists somebody has actually saved.
+ * Read a whole table through PostgREST, a page at a time.
  *
- * **Saved artists only, not every artist row.** There are thousands of artists in the database
- * and only a fraction are saved by anyone; a save is what creates the obligation, because it is
- * what makes someone expect an alert. An artist nobody has saved gets catalogued when they're
- * searched, which is the demand-driven behaviour that already works.
+ * **`.limit(n)` does not do this.** PostgREST caps every response at its configured `max-rows`
+ * (1,000 on this project) regardless of the limit asked for, and it truncates *silently* — the
+ * rows simply aren't there. A single `.select()` over `artist_links` returns 1,000 of ~3,900
+ * rows and looks perfectly successful, which would quietly hide three quarters of the sweep's
+ * pool. Measured on production 2026-08-02.
+ */
+async function readAllPages<T>(
+  run: (from: number, to: number) => PromiseLike<{ data: unknown; error: { message: string } | null }>,
+  label: string
+): Promise<{ ok: true; rows: T[] } | { ok: false; reason: string }> {
+  const PAGE = 1_000;
+  /** A backstop against an unbounded loop, not an expected ceiling. */
+  const MAX_PAGES = 50;
+  const rows: T[] = [];
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const from = page * PAGE;
+    const { data, error } = await run(from, from + PAGE - 1);
+    if (error) {
+      console.error(`[DB] ${label} read failed:`, error.message);
+      return { ok: false, reason: `Could not read ${label}: ${error.message}` };
+    }
+    const batch = (data as T[]) ?? [];
+    rows.push(...batch);
+    if (batch.length < PAGE) return { ok: true, rows };
+  }
+
+  // Hitting this means the table outgrew the backstop. Say so rather than returning a truncated
+  // pool that reads as complete — the whole point of this helper.
+  console.error(`[DB] ${label} exceeded ${MAX_PAGES * PAGE} rows; refusing a truncated read`);
+  return { ok: false, reason: `${label} is larger than the sweep can page through` };
+}
+
+/**
+ * The artists whose release catalogue most needs building or refreshing.
+ *
+ * **The pool is every artist with something to crawl, not just saved artists.** It was
+ * saved-only when this shipped, on the reasoning that a save is what makes someone expect an
+ * alert. The numbers killed that: 9 distinct saved artists against 2,564 with a catalogue-able
+ * link, so the sweep's entire universe fit inside a single batch and it would have sat idle
+ * almost every run. Alerts are also not the only consumer — `/a/:slug` renders a release list
+ * for any catalogued artist, and those pages exist because somebody *searched*, so a stale
+ * catalogue there is a visibly out-of-date artist page.
  *
  * Ordering, in priority order:
  *
- *   1. **Never attempted first.** Saved but no catalog state at all means the crawl requested at
- *      save time never got through — usually the hourly cap. Nothing else will retry it, so it
- *      goes to the front.
- *   2. **Then stalest `last_attempted_at`.** Staleness is the thing that makes alerts go quiet,
- *      so it is what the sweep is for.
- *   3. **Then most savers.** A tiebreak only. Sorting by popularity first would starve exactly
- *      the long tail this exists to serve — popular artists already stay fresh because people
- *      search them.
+ *   1. **Saved artists first.** An alert is a promise to a person, so they can never starve
+ *      behind the backfill of everyone else. There are few enough of them that this costs the
+ *      rest of the pool almost nothing.
+ *   2. **Then never catalogued.** No state row at all means we have no releases for them, which
+ *      is worse than having slightly old ones.
+ *   3. **Then stalest `last_attempted_at`.** Staleness is what makes alerts go quiet and artist
+ *      pages go out of date, so it is what the sweep is for.
+ *   4. **Then most savers.** A tiebreak only. Sorting by popularity any higher would starve
+ *      exactly the long tail this exists to serve — popular artists already stay fresh because
+ *      people search them.
  *
  * Artists inside the re-catalog cooldown are dropped here rather than left for
  * `claimArtistForCatalog` to refuse. That's not a second rate limiter — the same constant, read
  * up front — it's what stops a bounded batch being spent entirely on artists that will be
  * refused a moment later. The claim remains the authority; this only decides who to ask about.
  */
-export async function getStaleSavedArtistCatalogs(limit: number): Promise<StaleCatalogResult> {
+export async function getStaleCatalogCandidates(limit: number): Promise<StaleCatalogResult> {
   const client = getClient();
   if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
 
+  const links = await readAllPages<{ artist_id: string | null }>(
+    (from, to) =>
+      client
+        .from('artist_links')
+        .select('artist_id')
+        .in('platform', CATALOGUEABLE_PLATFORMS as unknown as string[])
+        .range(from, to),
+    'catalogue-able artist links'
+  );
+  if (!links.ok) return links;
+
+  // One artist commonly has several of these platforms, so this is a set, not a count.
+  const pool = new Set<string>();
+  for (const row of links.rows) if (row.artist_id) pool.add(row.artist_id);
+
+  if (pool.size === 0) {
+    return { ok: true, candidates: [], catalogueable: 0, savedArtists: 0, inCooldown: 0, eligible: 0 };
+  }
+
   // `deleted` is a tombstone, not a hard delete (migration 017) — an unsaved artist keeps a row
   // so other devices can prune it, and re-crawling for someone who unsaved them is waste.
-  const { data: saved, error: savedError } = await client
-    .from('saved_artists')
-    .select('artist_id')
-    .eq('deleted', false)
-    .not('artist_id', 'is', null)
-    .limit(MAX_SAVED_ARTISTS_SCANNED);
-
-  if (savedError) {
-    console.error('[DB] getStaleSavedArtistCatalogs saved read failed:', savedError.message);
-    return { ok: false, reason: `Could not read saved artists: ${savedError.message}` };
-  }
+  const saved = await readAllPages<{ artist_id: string | null }>(
+    (from, to) =>
+      client
+        .from('saved_artists')
+        .select('artist_id')
+        .eq('deleted', false)
+        .not('artist_id', 'is', null)
+        .range(from, to),
+    'saved artists'
+  );
+  if (!saved.ok) return saved;
 
   const savers = new Map<string, number>();
-  for (const row of (saved as { artist_id: string | null }[]) ?? []) {
-    if (!row.artist_id) continue;
-    savers.set(row.artist_id, (savers.get(row.artist_id) ?? 0) + 1);
+  for (const row of saved.rows) {
+    if (row.artist_id) savers.set(row.artist_id, (savers.get(row.artist_id) ?? 0) + 1);
   }
-
-  if (savers.size === 0) return { ok: true, candidates: [], savedArtists: 0, inCooldown: 0 };
 
   interface StateRow {
     artist_id: string;
@@ -692,34 +768,35 @@ export async function getStaleSavedArtistCatalogs(limit: number): Promise<StaleC
     releases_found: number | null;
   }
 
-  const ids = [...savers.keys()];
+  // The whole table rather than an `in()` filter per chunk of ids: it holds one row per artist
+  // ever attempted, so it is bounded by the same population and paging it is fewer round trips.
+  const stateRows = await readAllPages<StateRow>(
+    (from, to) =>
+      client
+        .from('release_catalog_state')
+        .select('artist_id, last_attempted_at, last_catalogued_at, releases_found')
+        .range(from, to),
+    'catalog state'
+  );
+  if (!stateRows.ok) return stateRows;
+
   const state = new Map<string, StateRow>();
-
-  for (let i = 0; i < ids.length; i += CATALOG_STATE_CHUNK) {
-    const { data, error } = await client
-      .from('release_catalog_state')
-      .select('artist_id, last_attempted_at, last_catalogued_at, releases_found')
-      .in('artist_id', ids.slice(i, i + CATALOG_STATE_CHUNK));
-
-    if (error) {
-      console.error('[DB] getStaleSavedArtistCatalogs state read failed:', error.message);
-      return { ok: false, reason: `Could not read catalog state: ${error.message}` };
-    }
-    for (const row of (data as StateRow[]) ?? []) state.set(row.artist_id, row);
-  }
+  for (const row of stateRows.rows) state.set(row.artist_id, row);
 
   const cooldownCutoff = Date.now() - RECATALOG_COOLDOWN_HOURS * 3600_000;
   const candidates: StaleCatalogCandidate[] = [];
   let inCooldown = 0;
 
-  for (const [artistId, count] of savers) {
+  for (const artistId of pool) {
     const row = state.get(artistId);
     if (row?.last_catalogued_at && new Date(row.last_catalogued_at).getTime() > cooldownCutoff) {
       inCooldown++;
       continue;
     }
+    const count = savers.get(artistId) ?? 0;
     candidates.push({
       artistId,
+      saved: count > 0,
       savers: count,
       lastAttemptedAt: row?.last_attempted_at ?? null,
       releasesFound: row?.releases_found ?? null,
@@ -727,6 +804,7 @@ export async function getStaleSavedArtistCatalogs(limit: number): Promise<StaleC
   }
 
   candidates.sort((a, b) => {
+    if (a.saved !== b.saved) return a.saved ? -1 : 1;
     if (a.lastAttemptedAt === null || b.lastAttemptedAt === null) {
       if (a.lastAttemptedAt !== b.lastAttemptedAt) return a.lastAttemptedAt === null ? -1 : 1;
     } else {
@@ -740,8 +818,10 @@ export async function getStaleSavedArtistCatalogs(limit: number): Promise<StaleC
   return {
     ok: true,
     candidates: candidates.slice(0, limit),
-    savedArtists: savers.size,
+    catalogueable: pool.size,
+    savedArtists: [...savers.keys()].filter(id => pool.has(id)).length,
     inCooldown,
+    eligible: candidates.length,
   };
 }
 

--- a/api/functions/recatalog-sweep.ts
+++ b/api/functions/recatalog-sweep.ts
@@ -1,4 +1,4 @@
-// The scheduled re-catalogue sweep: keep saved artists' catalogues from going stale.
+// The scheduled catalogue sweep: build and refresh release catalogues in the background.
 //
 // ## Why this exists
 //
@@ -8,8 +8,12 @@
 // reads that same catalogue forever: `check-releases` reads the catalogue and returns, and only
 // falls back to a live scrape for an artist the catalogue has *never* seen. So if nobody ever
 // searches that artist again, their new releases are never discovered and the alerts quietly
-// stop. Popular artists stay fresh incidentally because people search them; the long tail of
-// saved-but-not-searched artists is exactly who this feature was for.
+// stop.
+//
+// Alerts are not the only thing that goes stale. `/a/:slug` renders a release list for any
+// catalogued artist, and those pages exist because somebody *searched* — so an unrefreshed
+// catalogue is also a visibly out-of-date artist page. Hence the pool is every artist with
+// something to crawl, not only the saved ones; see `getStaleCatalogCandidates`.
 //
 // This sweep is the missing half. Invoked by .github/workflows/recatalog-sweep.yml — there are
 // no scheduled Netlify functions in this repo, and a GitHub Actions cron is the precedent.
@@ -29,7 +33,7 @@
 // so this is an ordinary function: it says how many artists it asked for and how stale the
 // stalest one was, the workflow prints that, and a non-2xx fails the workflow out loud.
 
-import { getStaleSavedArtistCatalogs } from './db';
+import { getStaleCatalogCandidates } from './db';
 import { isInternalRequest } from './middleware';
 import { isCatalogEnabled, requestArtistCatalog } from './request-catalog';
 import { Sentry } from '../lib/sentry';
@@ -38,11 +42,11 @@ import { Sentry } from '../lib/sentry';
  * How many artists one sweep asks for.
  *
  * 25 matches MAX_ARTISTS_PER_RUN in catalog-artist-background, so a sweep is exactly one
- * background invocation. Combined with the daily cadence that refreshes up to 175 artists a
- * week, comfortably more than the saved population, so every saved artist comes round well
- * within their 7-day cooldown. If the saved population ever outgrows that, the stalest-first
- * ordering degrades gracefully — everyone still gets refreshed, just less often — and the
- * lever is the cron cadence, not this number, which is bounded by what one invocation can do.
+ * background invocation — asking for more would silently drop the overflow. **The lever for
+ * total throughput is the cron cadence, not this number.** At four runs a day that is 100
+ * artists daily: saved artists (single figures) come round as soon as their 7-day cooldown
+ * expires, and the ~2,500-artist tail rotates about monthly, which is the right shape for
+ * artist-page freshness. Raise the cron frequency if the tail needs to be tighter.
  */
 const SWEEP_BATCH_SIZE = 25;
 
@@ -73,7 +77,7 @@ export async function handler(event: {
     };
   }
 
-  const selection = await getStaleSavedArtistCatalogs(SWEEP_BATCH_SIZE);
+  const selection = await getStaleCatalogCandidates(SWEEP_BATCH_SIZE);
 
   if (!selection.ok) {
     Sentry.captureMessage('[recatalog-sweep] could not select artists', {
@@ -84,18 +88,24 @@ export async function handler(event: {
     return { statusCode: 503, body: JSON.stringify({ error: selection.reason }) };
   }
 
-  const { candidates, savedArtists, inCooldown } = selection;
+  const { candidates, catalogueable, savedArtists, inCooldown, eligible } = selection;
 
-  // Every saved artist catalogued inside the last 7 days is a good, quiet outcome, not a
-  // failure — so this is a 200. The counts are what tell the two apart in the workflow log:
-  // savedArtists dropping to 0, or inCooldown never falling, is the shape of a broken sweep.
+  // Every catalogue-able artist being inside their cooldown is a good, quiet outcome, not a
+  // failure — so that case is a 200. The counts are what tell the two apart in the workflow log:
+  // `catalogueable` collapsing, or `eligible` sitting at 0 while `inCooldown` doesn't account
+  // for the pool, is the shape of a broken selection rather than a caught-up one.
   const summary = {
     requested: candidates.length,
+    catalogueable,
     savedArtists,
     inCooldown,
+    eligible,
+    /** Of this batch, how many are saved — the artists an alert actually depends on. */
+    savedInBatch: candidates.filter(c => c.saved).length,
+    /** Of this batch, how many have no catalogue at all: coverage rather than refresh. */
+    neverAttempted: candidates.filter(c => c.lastAttemptedAt === null).length,
     /** How stale the stalest artist was. Null means one had never been attempted at all. */
     stalestAttemptedAt: candidates[0]?.lastAttemptedAt ?? null,
-    neverAttempted: candidates.filter(c => c.lastAttemptedAt === null).length,
   };
 
   if (candidates.length === 0) {


### PR DESCRIPTION
Follow-up to #404. You were right that saved-only was too narrow — the numbers are more lopsided than either of us assumed.

## The measurement

| | count |
|---|---|
| artists total (all created by search) | 3,421 |
| **artists with a catalogue-able link** | **2,564** |
| artists ever catalogued | 125 |
| **distinct saved artists** | **9** |

Nine. The sweep's entire eligible universe fit inside one 25-artist batch, and #404's first run consumed five of them. It would have sat idle almost every run. The cadence justification in that PR — "175/week, comfortably above the saved population" — was true and beside the point.

Alerts aren't the only consumer either. `/a/:slug` renders a release list for any catalogued artist, and those pages exist because somebody *searched* — so an unrefreshed catalogue is a visibly out-of-date artist page, not just a missed alert.

## What changed

**Pool**: every artist with a `bandcamp`, `discogs`, `faircamp` or `jamcoop` link.

Not *every searched artist*, though — 2,724 of the 3,421 have no crawlable link, and `catalogArtist` records a linkless artist as an **error**, bumping `consecutive_failures` and writing `last_error`. Sweeping them would spend the batch on artists with nothing to fetch and turn the failure counters into noise. `CATALOGUEABLE_PLATFORMS` is deliberately identical to that check, and excludes `officialsite` (only followed to *discover* other platforms).

**Ordering** gains a tier on top of the existing ones:

1. **Saved artists** — an alert is a promise to a person, and with single figures of them it costs the rest of the pool almost nothing to let them jump the backfill.
2. Never catalogued.
3. Stalest `last_attempted_at`.
4. Savers, pure tiebreak.

**Cadence**: daily → every 6 hours. Batch size can't grow (25 is one background invocation; more is silently dropped), so frequency is the only throughput lever. 4 × 25 = 100/day:

- saved artists come round as soon as their 7-day cooldown expires
- the tail rotates roughly monthly — right for artist-page freshness
- the ~2,400 artists with no catalogue drain in about three weeks
- against Bandcamp: 400–500 sequential requests/day, under one a minute averaged, robots-permitted paths

## A silent truncation fixed on the way

**PostgREST caps every response at 1,000 rows regardless of the `.limit()` you ask for, and truncates with no error.** A single `.select()` over `artist_links` returns 1,000 of ~3,900 rows and looks completely successful — my own first measurement in this session reported 697 catalogue-able artists for exactly that reason.

#404's `.limit(10_000)` was harmless only because `saved_artists` has 31 rows. A reviewer flagged the missing `ORDER BY` there; the real problem was a tenth of the size they thought. All three reads now page through `.range()` until a short page, and **refuse rather than return a truncated pool** if they exceed the backstop — a partial pool that reads as complete is the same silent-failure class as everything else in this feature.

## Verification

- `npm run build`, `test:api` (801 passing), `test:unit` (625), `typecheck:api` — clean. `dispatch.xml`/`sitemap.xml` reverted.
- **Mutation-checked**: collapsing the pager to a single read, admitting `officialsite` to the pool, dropping the saved-first tier, and counting tombstoned saves each fail the test that claims to protect them.
- New paging tests drive a fake client that reproduces the 1,000-row cap, so they'd fail against the old `.limit()` shape.

No migration, no new secrets — this is selection logic and a cron line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)