### PR TITLE
Stop cataloguing Bandcamp search placeholders that can only 404

### DIFF
--- a/api/functions/__tests__/catalog-artist-links.test.ts
+++ b/api/functions/__tests__/catalog-artist-links.test.ts
@@ -1,0 +1,147 @@
+// Which stored links getArtistForCatalog hands the crawler.
+//
+// This is the other half of the pool decision made in recatalog-sweep-selection.test.ts, and the
+// two must agree: getStaleCatalogCandidates decides who is worth a run, catalogArtist decides
+// what to fetch for them. If one counts a link the other refuses, the sweep spends its batch on
+// artists it then records as failures — which is precisely the loop this pair of checks closes.
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// recatalog-sweep-selection.test.ts, so the real query body runs.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const tables: Record<string, Record<string, unknown>[]> = {
+  artists: [],
+  artist_links: [],
+};
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(_columns: string) {
+          const filters: { column: string; value: unknown }[] = [];
+          let wantedPlatforms: string[] | null = null;
+
+          const rows = () => {
+            let out = tables[table] ?? [];
+            for (const f of filters) out = out.filter(r => r[f.column] === f.value);
+            if (wantedPlatforms) {
+              const wanted = new Set(wantedPlatforms);
+              out = out.filter(r => wanted.has(r.platform as string));
+            }
+            return out;
+          };
+
+          const builder = {
+            eq(column: string, value: unknown) {
+              filters.push({ column, value });
+              return builder;
+            },
+            in(_column: string, value: string[]) {
+              wantedPlatforms = value;
+              return builder;
+            },
+            maybeSingle() {
+              return Promise.resolve({ data: rows()[0] ?? null, error: null });
+            },
+            then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
+              return Promise.resolve({ data: rows(), error: null }).then(resolve, reject);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getArtistForCatalog } = await import('../db');
+
+const ARTIST_ID = 'artist-1';
+
+function link(platform: string, url: string) {
+  return { artist_id: ARTIST_ID, platform, url };
+}
+
+beforeEach(() => {
+  tables.artists = [{ id: ARTIST_ID, name: 'Warren Harrison' }];
+  tables.artist_links = [];
+});
+
+describe('getArtistForCatalog', () => {
+  it('returns a real Bandcamp artist page', async () => {
+    tables.artist_links = [link('bandcamp', 'https://warrenharrison.bandcamp.com')];
+
+    const artist = await getArtistForCatalog(ARTIST_ID);
+
+    expect(artist?.bandcampUrl).toBe('https://warrenharrison.bandcamp.com');
+  });
+
+  it('refuses a bandcamp.com/search placeholder', async () => {
+    // The placeholder search-utils writes when nothing resolved a real page. bandcampMusicUrl
+    // reduces it to https://bandcamp.com/music, which 404s every single time — so handing it to
+    // the crawler can only ever produce a failure and a longer backoff.
+    tables.artist_links = [link('bandcamp', 'https://bandcamp.com/search?q=Warren%20Harrison')];
+
+    const artist = await getArtistForCatalog(ARTIST_ID);
+
+    // Not the string, and not a truthy fallback: catalogArtist branches on this being null.
+    expect(artist?.bandcampUrl).toBeNull();
+  });
+
+  it('leaves the other platforms alone when the Bandcamp link is a placeholder', async () => {
+    // 116 of the 189 placeholder rows measured on 2026-08-03 sat alongside a real Discogs,
+    // Faircamp or jam.coop link. Dropping those artists would lose catalogues we can build.
+    tables.artist_links = [
+      link('bandcamp', 'https://bandcamp.com/search?q=bgm'),
+      link('discogs', 'https://www.discogs.com/artist/4861285'),
+      link('faircamp', 'https://fromabasement.com/faircamp'),
+      link('jamcoop', 'https://jam.coop/artists/melondruie'),
+      link('officialsite', 'https://example.com'),
+    ];
+
+    const artist = await getArtistForCatalog(ARTIST_ID);
+
+    expect(artist?.bandcampUrl).toBeNull();
+    expect(artist?.discogsUrl).toBe('https://www.discogs.com/artist/4861285');
+    expect(artist?.faircampUrl).toBe('https://fromabasement.com/faircamp');
+    expect(artist?.jamcoopUrl).toBe('https://jam.coop/artists/melondruie');
+    expect(artist?.officialSiteUrl).toBe('https://example.com');
+  });
+
+  it('leaves an artist with nothing but a placeholder with no crawlable link at all', async () => {
+    // 73 of the 189 were in the pool *only* because of the placeholder. With every URL null,
+    // catalogArtist takes its "no bandcamp, discogs, faircamp, or jam.coop link stored" branch
+    // instead of throwing a 404 — the same outcome it would reach if the row weren't there.
+    tables.artist_links = [link('bandcamp', 'https://bandcamp.com/search?q=Darkitecture')];
+
+    const artist = await getArtistForCatalog(ARTIST_ID);
+
+    expect(artist).not.toBeNull();
+    expect(artist?.bandcampUrl).toBeNull();
+    expect(artist?.discogsUrl).toBeNull();
+    expect(artist?.faircampUrl).toBeNull();
+    expect(artist?.jamcoopUrl).toBeNull();
+  });
+
+  it.each([
+    ['a bare artist subdomain', 'https://melondruie.bandcamp.com'],
+    ['an album-depth page', 'https://warrenharrison.bandcamp.com/album/some-record'],
+    ['a /music page', 'https://nixienoise.bandcamp.com/music'],
+    ['a Bandcamp Pro custom domain', 'https://music.sufjan.com'],
+  ])('keeps %s', async (_label, url) => {
+    // Only the search URL is a placeholder. Every other shape is a real page, and
+    // bandcampMusicUrl strips it back to origin + /music.
+    tables.artist_links = [link('bandcamp', url)];
+
+    const artist = await getArtistForCatalog(ARTIST_ID);
+
+    expect(artist?.bandcampUrl).toBe(url);
+  });
+});

--- a/api/functions/__tests__/recatalog-sweep-selection.test.ts
+++ b/api/functions/__tests__/recatalog-sweep-selection.test.ts
@@ -109,9 +109,20 @@ const HOUR = 3600_000;
 const now = Date.now();
 const ago = (hours: number) => new Date(now - hours * HOUR).toISOString();
 
-/** Give an artist something to crawl. Without this they aren't in the pool at all. */
-function link(artistId: string | null, platform = 'bandcamp') {
-  return { artist_id: artistId, platform };
+/**
+ * Give an artist something to crawl. Without this they aren't in the pool at all.
+ *
+ * The URL is part of the fixture because the pool now judges shape as well as platform: a
+ * `bandcamp.com/search?q=` row is a placeholder, not an artist page. `artist_links.url` is
+ * `not null` in the schema, so every row here carries one.
+ */
+function link(artistId: string | null, platform = 'bandcamp', url?: string) {
+  return { artist_id: artistId, platform, url: url ?? `https://${platform}.example/artist` };
+}
+
+/** The "go search Bandcamp yourself" placeholder search-utils writes when nothing resolved. */
+function searchPlaceholder(artistId: string, name = 'Some Artist') {
+  return link(artistId, 'bandcamp', `https://bandcamp.com/search?q=${encodeURIComponent(name)}`);
 }
 
 function saved(artistId: string | null) {
@@ -179,6 +190,42 @@ describe('getStaleCatalogCandidates — who is in the pool', () => {
       expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['a']);
     }
   );
+
+  it('excludes an artist whose only Bandcamp link is a search placeholder', async () => {
+    // `https://bandcamp.com/search?q=X` is a UI affordance, not an artist page. bandcampMusicUrl
+    // reduces any URL to origin + /music, so every one of these derives https://bandcamp.com/music
+    // — a hard 404. Measured 2026-08-03: 189 such rows, and the 16 that had been swept were the
+    // *only* failures in release_catalog_state, each climbing a backoff it could never escape.
+    tables.artist_links = [searchPlaceholder('placeholder-only'), link('real')];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['real']);
+    expect(result.ok && result.catalogueable).toBe(1);
+  });
+
+  it('keeps an artist who has a placeholder Bandcamp link but a real Discogs one', async () => {
+    // The placeholder is worthless; the Discogs link is not. Dropping the artist entirely would
+    // lose a catalogue we can actually build.
+    tables.artist_links = [
+      searchPlaceholder('mixed'),
+      link('mixed', 'discogs', 'https://www.discogs.com/artist/12345'),
+    ];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['mixed']);
+  });
+
+  it('keeps a real Bandcamp artist page whose path happens to be deep', async () => {
+    // Only the search URL is the placeholder. An album-depth link is a perfectly good artist
+    // page — bandcampMusicUrl strips it back to the origin.
+    tables.artist_links = [link('deep', 'bandcamp', 'https://warrenharrison.bandcamp.com/album/x')];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['deep']);
+  });
 
   it('counts an artist once however many platforms they are on', async () => {
     tables.artist_links = [link('a', 'bandcamp'), link('a', 'discogs'), link('a', 'faircamp')];

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2,7 +2,7 @@
 // All operations are optional — if Supabase is not configured, they no-op gracefully.
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
+import { isBandcampSearchLink, normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
 import {
   deriveStatus,
   isFuzzyReleaseMatch,
@@ -655,6 +655,25 @@ export type StaleCatalogResult =
 const CATALOGUEABLE_PLATFORMS = ['bandcamp', 'discogs', 'faircamp', 'jamcoop'] as const;
 
 /**
+ * Whether a stored link is something the catalog pass can actually crawl.
+ *
+ * The platform being catalogue-able is not enough: a `bandcamp` row may hold
+ * `https://bandcamp.com/search?q=<name>`, the "go search Bandcamp yourself" placeholder that
+ * `attachAmpwallAndSearchLinks` writes when nothing resolved a real artist page. It is a UI
+ * affordance, not an artist link, and `bandcampMusicUrl()` reduces any URL to its origin plus
+ * `/music` — so every one of them derives `https://bandcamp.com/music`, which 404s. Measured
+ * 2026-08-03: 189 such rows, and the 16 that had been swept were the *only* failures in
+ * `release_catalog_state`, each climbing a backoff it could never escape.
+ *
+ * Used by both `getStaleCatalogCandidates` and `getArtistForCatalog` so the sweep's pool and
+ * `catalogArtist`'s "is there anything to fetch" check cannot disagree about who is worth a run.
+ */
+function isCatalogueableLink(platform: string, url: string): boolean {
+  if (platform === 'bandcamp') return !isBandcampSearchLink(url);
+  return true;
+}
+
+/**
  * Read a whole table through PostgREST, a page at a time.
  *
  * **`.limit(n)` does not do this.** PostgREST caps every response at its configured `max-rows`
@@ -723,11 +742,11 @@ export async function getStaleCatalogCandidates(limit: number): Promise<StaleCat
   const client = getClient();
   if (!client) return { ok: false, reason: 'Supabase is not configured on this deploy' };
 
-  const links = await readAllPages<{ artist_id: string | null }>(
+  const links = await readAllPages<{ artist_id: string | null; platform: string; url: string }>(
     (from, to) =>
       client
         .from('artist_links')
-        .select('artist_id')
+        .select('artist_id, platform, url')
         .in('platform', CATALOGUEABLE_PLATFORMS as unknown as string[])
         .range(from, to),
     'catalogue-able artist links'
@@ -736,7 +755,11 @@ export async function getStaleCatalogCandidates(limit: number): Promise<StaleCat
 
   // One artist commonly has several of these platforms, so this is a set, not a count.
   const pool = new Set<string>();
-  for (const row of links.rows) if (row.artist_id) pool.add(row.artist_id);
+  for (const row of links.rows) {
+    if (!row.artist_id) continue;
+    if (!isCatalogueableLink(row.platform, row.url)) continue;
+    pool.add(row.artist_id);
+  }
 
   if (pool.size === 0) {
     return { ok: true, candidates: [], catalogueable: 0, savedArtists: 0, inCooldown: 0, eligible: 0 };
@@ -1270,7 +1293,13 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
     }
     if (linkError) console.error('[DB] getArtistForCatalog link read failed:', linkError.message);
 
-    const links = (linkRows as { platform: string; url: string }[] | null) || [];
+    // A placeholder search link is dropped here rather than handed to the crawler, so an artist
+    // whose only Bandcamp row is one falls through to catalogArtist's "nothing stored" branch
+    // instead of failing on a 404 forever. `officialsite` is not catalogue-able on its own and
+    // is filtered by platform above, so it needs no URL-shape check.
+    const links = ((linkRows as { platform: string; url: string }[] | null) || []).filter(l =>
+      isCatalogueableLink(l.platform, l.url)
+    );
     return {
       name: (artistRow as { name: string }).name,
       bandcampUrl: links.find(l => l.platform === 'bandcamp')?.url ?? null,

--- a/supabase/migrations/20260803000000_clear-bandcamp-placeholder-404-backoff.sql
+++ b/supabase/migrations/20260803000000_clear-bandcamp-placeholder-404-backoff.sql
@@ -1,0 +1,44 @@
+-- Migration: clear the backoff left behind by the Bandcamp search-placeholder 404s
+--
+-- These artists were never crawlable in the first place. Their stored `bandcamp` link was
+-- `https://bandcamp.com/search?q=<name>` — the "go search Bandcamp yourself" placeholder that
+-- `attachAmpwallAndSearchLinks` writes when nothing resolved a real artist page. It is a UI
+-- affordance, not an artist link, and `bandcampMusicUrl()` reduces any URL to its origin plus
+-- `/music`, so every one of them derived `https://bandcamp.com/music` — a hard 404, every time.
+--
+-- Measured 2026-08-03: 189 such link rows (10.4% of all 1,822 stored Bandcamp links), and the
+-- 18 that the sweep had reached by then were the **only** failures in `release_catalog_state` —
+-- "bandcamp responded 404" was the sole error message in the entire table. #406 had just widened
+-- the sweep to all 2,564 catalogue-able artists every 6 hours, so the remaining ~171 were queued
+-- to fail the same way, each burning a batch slot and climbing a backoff it could never escape.
+--
+-- The code fix (this PR) stops the placeholder ever reaching the crawler: `isCatalogueableLink`
+-- in `api/functions/db.ts` filters it out of both `getStaleCatalogCandidates`'s pool and
+-- `getArtistForCatalog`'s result, so the two cannot disagree about who is worth a run. This
+-- migration only cleans up the damage already recorded — without it, the artists who *do* have a
+-- real Discogs, Faircamp or jam.coop link would keep serving out an exponential backoff earned
+-- entirely by a link we will no longer even look at.
+--
+-- Resetting the counter rather than deleting the row: `consecutive_failures` is what
+-- `claimArtistForCatalog` exponentiates (`2^min(failures,6) × 15min`, measured against
+-- `last_attempted_at`), so zeroing it clears the backoff completely while `last_attempted_at`
+-- survives as the audit trail of when we tried. No release, source or link row is touched.
+--
+-- Scoped as narrowly as the bug:
+--
+--   * `last_error` is exactly the 404 message — nothing else is in scope.
+--   * `last_catalogued_at IS NULL` — an artist who ever catalogued successfully has a real
+--     Bandcamp presence, so a later 404 from them is a genuine dead link and its backoff is
+--     doing its job. All 18 rows measured had never succeeded.
+--
+-- Idempotent: the WHERE clause stops matching once `last_error` is null, so re-running is a
+-- no-op. This queues nothing — the next scheduled sweep picks these artists up normally.
+
+UPDATE public.release_catalog_state
+SET
+  consecutive_failures = 0,
+  last_error = NULL,
+  updated_at = now()
+WHERE
+  last_error = 'bandcamp responded 404'
+  AND last_catalogued_at IS NULL;


### PR DESCRIPTION
## What was wrong

`release_catalog_state` had exactly one error message in it: `bandcamp responded 404`. All 18 rows carrying it turned out to be the same thing.

The stored `bandcamp` link was `https://bandcamp.com/search?q=<name>` — the "go search Bandcamp yourself" placeholder `attachAmpwallAndSearchLinks` writes when nothing resolved a real artist page. `bandcampMusicUrl()` reduces any URL to its origin plus `/music`, so every one of them derives the same URL:

```
https://bandcamp.com/search?q=Mount%20Eerie  →  https://bandcamp.com/music  →  404
```

One failure reproduced 18 times, not 18 failures. Checked against the three candidate causes: **wrong slug 0, stale-once-valid 0, URL shape 18/18.**

## Why now

Measured 2026-08-03: **189 placeholder rows, 10.4% of all 1,822 stored Bandcamp links**, every one of them in the sweep pool. #406 had just widened the scheduled sweep to all 2,564 catalogue-able artists every 6 hours, so the ~171 not yet reached were queued to fail identically — each burning one of 25 batch slots and climbing an exponential backoff it could never escape.

- **73** were in the pool *only* because of the placeholder — no other catalogue-able link at all.
- **116** also had a real Discogs/Faircamp/jam.coop link. Those passes still ran, but `if (bandcampError && totalFound === 0)` stamped the Bandcamp 404 as `last_error` — which is why it was the only message in the table. It was masking what the other passes actually did.

## The probe is not at fault

The placeholder is the probe's *negative* answer being written to disk as a link, not a false-accept. Spot-checking all 18 against `bandcamp_slug_probes` and independently curling the candidate slugs:

| Probe verdict | n | Verified |
|---|---|---|
| `absent` | 7 | ✅ both slug candidates 404 |
| `rejected_empty` (parked) | 3 | ✅ Viagra Boys / Mount Eerie / ChatGPT — 200 with 0 grid items |
| `accepted`, placeholder stored anyway | 1 | Vienna Vienna |
| no probe row | 5 | 3 have live populated pages |

The probe's design premise held: it correctly refused three parked accounts a naive slug check would have accepted.

## The fix

`isBandcampSearchLink()` already existed in `search-utils.ts` with a comment drawing exactly this distinction; it just wasn't consulted at the catalogue boundary. `isCatalogueableLink` in `db.ts` now applies it in both places — `getStaleCatalogCandidates`'s pool and `getArtistForCatalog`'s result — sharing one predicate so "who is worth a run" and "is there anything to fetch" cannot drift, as CLAUDE.md requires.

The migration clears the backoff already recorded, scoped to rows that never catalogued successfully so a genuine dead link keeps backing off. Validated against a throwaway Postgres 16 including idempotency; a 404 from an artist who *had* succeeded, a bot-challenge row and a healthy row were all left untouched.

## Testing

- New `catalog-artist-links.test.ts` — `getArtistForCatalog` was mocked everywhere and never tested directly. Driven against a recording fake client so the real query body runs.
- Extended `recatalog-sweep-selection.test.ts`; its `link()` fixture now carries a URL, since the pool judges shape as well as platform.
- Verified the 4 new assertions fail without the predicate.
- `npm run build`, `test:api` (812 passed), `typecheck:api` all green. Lint unchanged from the pre-existing `apps/web` baseline — nothing here is in lint scope.

## Deliberately not included

Two things I found and left alone, happy to take either as follow-ups:

1. **A coverage bug**, separate from this one: 5 of the 18 were never probed at all, and **Warren Harrison (16 releases), melondruie (16) and Nixienoise (6)** have live catalogues sitting at the obvious `<name>.bandcamp.com`. Different fix, different blast radius.
2. All 189 placeholder rows carry **`is_direct: true`**, which is a lie about what the row is — but changing it touches search display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)