### PR TITLE
Fix migrate:dry-run and migrate:list, which had stopped checking anything

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ npm run generate:social   # Generate social media posts via Buffer
 npm run sync:bandcamp-dates  # Sync Bandcamp release dates
 npm run ingest:try -- <artist>   # Dry-run release ingest against a real Bandcamp page
 npm run sentry:sourcemaps    # Upload source maps to Sentry
+npm run migrate:link      # One-time: link this checkout to the Supabase project
 npm run migrate:dry-run   # supabase db push --dry-run against the linked project
 npm run migrate:list      # List applied vs pending migrations
 ```
@@ -334,7 +335,17 @@ Schema lives in `supabase/schema.sql`; changes are applied as timestamp-prefixed
 
 When adding a table or column: create a new migration in `supabase/migrations/`, include RLS policies, use `IF NOT EXISTS` / `DROP ... IF EXISTS` guards for idempotency, and explain the change in comments. Server-only tables (like `bandcamp_slug_probes`) enable RLS with *no* policies — the service-role client bypasses RLS, anon gets nothing — and should say so in a comment so the missing policies don't read as an oversight.
 
-**Auto-deploy:** `.github/workflows/supabase-migrate.yml` runs `supabase db push --linked` on every push to `main` that changes `supabase/migrations/`. Migrations deploy automatically — no manual SQL editor needed. Required GitHub secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`. Local dry-run: `npm run migrate:dry-run`.
+**Auto-deploy:** `.github/workflows/supabase-migrate.yml` runs `supabase db push --linked` on every push to `main` that changes `supabase/migrations/`. Migrations deploy automatically — no manual SQL editor needed. Required GitHub secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`.
+
+**Local dry-run:** `npm run migrate:link` once per checkout, then `npm run migrate:dry-run`. Both
+that and `migrate:list` use `--linked`, matching the workflow — the CLI dropped `--project-ref`
+from these commands, and passing it makes them print a help blob and exit *without* checking
+anything, which reads like a clean run. If you see `Cannot find project ref`, run the link step.
+`supabase link` writes only to the gitignored `supabase/.temp/`.
+
+The dry run needs credentials, so it can't be a substitute for validating a migration's SQL. For
+that, run it against a throwaway Postgres in Docker — that's what caught the scoping on
+`20260803000000_clear-bandcamp-placeholder-404-backoff.sql`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "lint": "cd apps/web && npx eslint .",
     "preview": "cd apps/web && npx vite preview",
     "sentry:sourcemaps": "bash scripts/sentry-sourcemaps.sh",
-    "migrate:dry-run": "supabase db push --dry-run --project-ref bwogclqzpsbvqbyhhqbz",
-    "migrate:list": "supabase migration list --project-ref bwogclqzpsbvqbyhhqbz"
+    "migrate:link": "supabase link --project-ref bwogclqzpsbvqbyhhqbz",
+    "migrate:dry-run": "supabase db push --dry-run --linked",
+    "migrate:list": "supabase migration list --linked"
   },
   "dependencies": {
     "@sentry/node": "^10.56.0",


### PR DESCRIPTION
## The problem

Both scripts passed `--project-ref`, which `supabase db push` and `supabase migration list` no longer accept (CLI 2.111.0).

The failure mode is the bad kind. The CLI didn't error — it printed a help blob and exited, so a dry run **appeared to complete without validating a single migration**:

```
$ npm run migrate:dry-run
{"_tag":"Help","doc":{"description":"Push new migrations to the remote database.", ... }}
{"_tag":"Errors","errors":[{"code":"UnrecognizedOption","message":"Unrecognized flag: --project-ref ..."}]}
```

Found while trying to validate the migration in #407. CLAUDE.md documents `npm run migrate:dry-run` as the local safety net before a migration auto-deploys on merge to `main`, so it has been quietly not being one.

## The fix

`--linked` is what both commands take now, and what `.github/workflows/supabase-migrate.yml` already uses — so the local check and the deploy path agree again.

That requires a one-time link, so `migrate:link` is added alongside. It writes only to the gitignored `supabase/.temp/`.

```bash
npm run migrate:link      # once per checkout
npm run migrate:dry-run
```

## Verification

Both commands now parse their flags and reach the real check, failing with an actionable error rather than a help dump:

```
Cannot find project ref. Have you run supabase link?
```

I stopped there rather than authenticating as you — `supabase projects list` hung on an interactive login prompt, so there's no access token in my shell. Completing the link and confirming a green dry run is one command on your side.

CLAUDE.md updated with the link step, and with a note that the dry run needs credentials so it isn't a substitute for validating a migration's SQL against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)