### PR TITLE
Stop synthesising Bandcamp search links, and delete the stored ones

### DIFF
--- a/api/functions/__tests__/direct-link-gate.test.ts
+++ b/api/functions/__tests__/direct-link-gate.test.ts
@@ -1,0 +1,45 @@
+// What `isDirectLink` lets into artist_links.
+//
+// It reads like a labelling helper and is easy to mistake for one, but `persistSearchResults`
+// filters on it (`db.ts`: `!EXCLUDED_PLATFORMS.has(p.sourceId) && isDirectLink(p.url)`), so it
+// decides whether a link gets a row at all. That makes it the last check standing between a
+// synthesised search URL and every downstream consumer that assumes a stored link is a real
+// destination — including the release crawler, which derives `/music` from it and fetches.
+//
+// The gap it had: `bandcamp.com/search` was not on the list, so 189 placeholder rows were
+// written and later crawled as artist pages, 404ing every time (#407).
+
+import { describe, it, expect } from 'vitest';
+import { isDirectLink } from '../db';
+
+describe('isDirectLink — what reaches artist_links', () => {
+  it.each([
+    ['a Bandcamp search placeholder', 'https://bandcamp.com/search?q=Mount%20Eerie'],
+    ['the same with different casing', 'https://BandCamp.com/Search?q=Mount%20Eerie'],
+    ['a Ko-fi DuckDuckGo fallback', 'https://duckduckgo.com/?q=site:ko-fi.com+Artist'],
+    ['a Google search', 'https://google.com/search?q=Artist'],
+    ['the Ampwall explore fallback', 'https://ampwall.com/explore?searchStyle=search&query=Artist'],
+    ['the BuyMeACoffee explore page', 'https://buymeacoffee.com/explore-creators'],
+  ])('rejects %s', (_label, url) => {
+    expect(isDirectLink(url)).toBe(false);
+  });
+
+  it.each([
+    ['a bare artist subdomain', 'https://melondruie.bandcamp.com'],
+    ['an album page', 'https://warrenharrison.bandcamp.com/album/some-record'],
+    ['a /music page', 'https://nixienoise.bandcamp.com/music'],
+    ['a Bandcamp Pro custom domain', 'https://music.sufjan.com'],
+    ['a Mirlo artist page', 'https://mirlo.space/warren-harrison'],
+    ['a Discogs artist page', 'https://www.discogs.com/artist/4861285'],
+  ])('accepts %s', (_label, url) => {
+    expect(isDirectLink(url)).toBe(true);
+  });
+
+  it('does not reject an artist whose own domain contains the word search', () => {
+    // The check is substring-based, so it is worth pinning that it keys on the Bandcamp host
+    // and path together rather than the bare word — an artist site could legitimately be called
+    // this, and silently dropping their link would be invisible.
+    expect(isDirectLink('https://searchparty.bandcamp.com')).toBe(true);
+    expect(isDirectLink('https://research.example.com')).toBe(true);
+  });
+});

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -37,11 +37,17 @@ export function artistSlug(name: string): string {
 
 // Determine if a platform URL is a direct link (not a search URL).
 // Exported so scripts/backfill-published-artist-rows.ts stores exactly what a search would store.
+//
+// This is not only a label: persistSearchResults filters on it, so it decides which links get a
+// row at all. `bandcamp.com/search` is listed because it did not used to be — the search-link
+// fallback that produced it is gone now, but 189 rows reached the database through this gate
+// first, and the crawler then treated every one of them as an artist page (#407).
 export function isDirectLink(url: string): boolean {
   const lower = url.toLowerCase();
   return (
     !lower.includes('duckduckgo.com') &&
     !lower.includes('google.com/search') &&
+    !lower.includes('bandcamp.com/search') &&
     !lower.includes('searchstyle=search') &&
     !lower.includes('explore-creators')
   );

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1806,11 +1806,11 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
     );
     if (!existingMatch) {
       const mbPlatforms = [];
-      // Add Bandcamp direct URL from MB if available, otherwise search fallback
+      // Bandcamp only when MusicBrainz gave us a real artist URL. No search-link fallback —
+      // see the note in attachAmpwallAndSearchLinks: a placeholder here is stored as an
+      // ordinary bandcamp link and later crawled as if it were an artist page.
       if (mbData.bandcampUrl) {
         mbPlatforms.push({ sourceId: 'bandcamp' as SourceId, url: mbData.bandcampUrl });
-      } else {
-        mbPlatforms.push({ sourceId: 'bandcamp' as SourceId, url: `https://bandcamp.com/search?q=${encodeURIComponent(mbData.artistName)}` });
       }
       mbPlatforms.push(
         { sourceId: 'ampwall' as SourceId, url: `https://ampwall.com/explore?searchStyle=search&query=${encodeURIComponent(mbData.artistName)}` },

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -829,9 +829,15 @@ export function attachAmpwallAndSearchLinks(
       { sourceId: 'buymeacoffee', url: 'https://buymeacoffee.com/explore-creators' },
     );
 
-    // Bandcamp: prefer direct URL from MusicBrainz relations, fall back to search link
+    // Bandcamp: a direct URL from MusicBrainz relations, or nothing.
+    //
+    // There used to be a `https://bandcamp.com/search?q=<name>` fallback here — "go search
+    // Bandcamp yourself". It is gone deliberately. It claimed a presence we had not found, and
+    // because it was stored as an ordinary `bandcamp` link it became indistinguishable from a
+    // real artist page downstream: the release crawler dutifully derived `/music` from it and
+    // got a 404 every time (#407). Saying nothing is the honest answer when the probe came back
+    // absent, and it is what the probe's verdict already means.
     if (!result.platforms.some(p => p.sourceId === 'bandcamp')) {
-      // Check if MusicBrainz has a direct Bandcamp URL for this artist
       const mbBandcampUrl = mbData?.bandcampUrl && mbData.artistName &&
         normalizeForComparison(mbData.artistName) === normalizedName
         ? mbData.bandcampUrl
@@ -839,11 +845,6 @@ export function attachAmpwallAndSearchLinks(
 
       if (mbBandcampUrl) {
         result.platforms.push({ sourceId: 'bandcamp', url: mbBandcampUrl });
-      } else {
-        result.platforms.push({
-          sourceId: 'bandcamp',
-          url: `https://bandcamp.com/search?q=${encodeURIComponent(result.name)}`,
-        });
       }
     }
 

--- a/apps/web/server/search/index.ts
+++ b/apps/web/server/search/index.ts
@@ -101,13 +101,8 @@ export async function searchAllPlatforms(query: string): Promise<AggregatedResul
         url: 'https://buymeacoffee.com/explore-creators',
       });
 
-      // Fallback Bandcamp search link when no direct Bandcamp URL from MusicBrainz
-      if (!result.platforms.some(p => p.sourceId === 'bandcamp')) {
-        result.platforms.push({
-          sourceId: 'bandcamp',
-          url: `https://bandcamp.com/search?q=${encodeURIComponent(result.name)}`,
-        });
-      }
+      // No Bandcamp search-link fallback — kept in step with api/functions/search-utils.ts,
+      // where it was removed because it claimed a presence we hadn't found.
 
       const normalizedName = normalizeForComparison(result.name);
 

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -644,9 +644,10 @@ export function buildMusicBrainzFallbackResult(
       platforms.push({ sourceId: social.platform, url: social.url });
     }
   }
-  // Search links last, so real destinations stay on top.
+  // Search links last, so real destinations stay on top. No Bandcamp one: a
+  // `bandcamp.com/search` placeholder claims a presence we haven't found, and the backend
+  // stores it as an ordinary bandcamp link that later gets crawled as an artist page (#407).
   platforms.push(
-    { sourceId: 'bandcamp', url: `https://bandcamp.com/search?q=${encoded}` },
     { sourceId: 'ampwall', url: `https://ampwall.com/explore?searchStyle=search&query=${encoded}` },
     { sourceId: 'subvert', url: `https://www.subvert.fm/discover?q=${encoded}&type=artist` },
     { sourceId: 'kofi', url: `https://duckduckgo.com/?q=site:ko-fi.com+${encoded}` },

--- a/apps/web/tests/unit/disambiguation.test.ts
+++ b/apps/web/tests/unit/disambiguation.test.ts
@@ -196,6 +196,61 @@ describe('attachAmpwallAndSearchLinks', () => {
     const platformIds = results[0].platforms.map(p => p.sourceId);
     expect(platformIds[0]).toBe('bandcamp');
   });
+
+  it('adds no Bandcamp link at all when nothing resolved one', () => {
+    // There used to be a `https://bandcamp.com/search?q=` fallback here. It claimed a presence
+    // we had not found, and being stored as an ordinary `bandcamp` link made it
+    // indistinguishable from a real artist page: the release crawler derived `/music` from each
+    // one and got a 404 every time (#407, 189 rows). Saying nothing is the honest answer.
+    const results = [makeResult('Darkitecture', [
+      { sourceId: 'subvert', url: 'https://www.subvert.fm/discover?q=Darkitecture&type=artist' },
+    ])];
+
+    attachAmpwallAndSearchLinks(results, new Map());
+
+    expect(results[0].platforms.find(p => p.sourceId === 'bandcamp')).toBeUndefined();
+    expect(results[0].platforms.every(p => !p.url.includes('bandcamp.com/search'))).toBe(true);
+  });
+
+  it('still adds a real Bandcamp URL from MusicBrainz when the name matches', () => {
+    // Removing the fallback must not cost us the genuine URLs. This is the branch that survives.
+    const results = [makeResult('Warren Harrison', [
+      { sourceId: 'subvert', url: 'https://www.subvert.fm/discover?q=x&type=artist' },
+    ])];
+
+    attachAmpwallAndSearchLinks(results, new Map(), {
+      artistName: 'Warren Harrison',
+      bandcampUrl: 'https://warrenharrison.bandcamp.com',
+    } as Parameters<typeof attachAmpwallAndSearchLinks>[2]);
+
+    expect(results[0].platforms.find(p => p.sourceId === 'bandcamp')?.url)
+      .toBe('https://warrenharrison.bandcamp.com');
+  });
+
+  it('leaves a Bandcamp link that a platform search already found', () => {
+    const results = [makeResult('Artist', [
+      { sourceId: 'bandcamp', url: 'https://artist.bandcamp.com' },
+    ])];
+
+    attachAmpwallAndSearchLinks(results, new Map());
+
+    const bandcamp = results[0].platforms.filter(p => p.sourceId === 'bandcamp');
+    expect(bandcamp).toHaveLength(1);
+    expect(bandcamp[0].url).toBe('https://artist.bandcamp.com');
+  });
+
+  it('keeps a result alive that has no Bandcamp link', () => {
+    // The placeholder was never counted as search-only, so it used to prop results up in
+    // filterAndSort. Subvert still does that job, but assert it rather than assume — dropping
+    // real artists from search results would be a silent, serious regression.
+    const results = [makeResult('Darkitecture', [
+      { sourceId: 'subvert', url: 'https://www.subvert.fm/discover?q=Darkitecture&type=artist' },
+    ])];
+
+    attachAmpwallAndSearchLinks(results, new Map());
+
+    expect(filterAndSort(results, 'Darkitecture')).toHaveLength(1);
+  });
 });
 
 describe('filterAndSort', () => {

--- a/apps/web/tests/unit/sources-service.test.ts
+++ b/apps/web/tests/unit/sources-service.test.ts
@@ -591,7 +591,11 @@ describe('buildMusicBrainzFallbackResult', () => {
     expect(result!.unverifiedReason).toBeUndefined();
     const ids = result!.platforms.map(p => p.sourceId);
     expect(ids.slice(0, 4)).toEqual(['officialsite', 'discogs', 'instagram', 'youtube']);
-    expect(ids).toContain('bandcamp');
+    // No Bandcamp entry: MusicBrainz gave us no Bandcamp URL, and the card used to fill that
+    // silence with `bandcamp.com/search?q=`. That placeholder claimed a presence we had not
+    // found, and the backend stored it as an ordinary bandcamp link (#407).
+    expect(ids).not.toContain('bandcamp');
+    expect(result!.platforms.every(p => !p.url.includes('bandcamp.com/search'))).toBe(true);
     expect(result!.location?.city).toBe('Abingdon-on-Thames');
   });
 
@@ -607,7 +611,9 @@ describe('buildMusicBrainzFallbackResult', () => {
       socialLinks: [],
     });
     const ids = bare!.platforms.map(p => p.sourceId);
-    expect(ids[0]).toBe('bandcamp');
+    // Ampwall now leads, because the Bandcamp placeholder that used to sit here is gone.
+    expect(ids[0]).toBe('ampwall');
+    expect(ids).not.toContain('bandcamp');
     expect(ids).not.toContain('officialsite');
   });
 

--- a/supabase/migrations/20260803120000_drop-bandcamp-search-placeholder-links.sql
+++ b/supabase/migrations/20260803120000_drop-bandcamp-search-placeholder-links.sql
@@ -1,0 +1,29 @@
+-- Migration: delete the stored `bandcamp.com/search` placeholder links
+--
+-- These rows are the "go search Bandcamp yourself" fallback that `attachAmpwallAndSearchLinks`
+-- used to synthesise when nothing resolved a real artist page. The fallback is removed in this
+-- PR, so nothing produces them any more; this clears the ones already stored.
+--
+-- Why they are worth deleting rather than leaving in place:
+--
+--   * They claim a Bandcamp presence we never found. On `/a/:slug` and in search results they
+--     render as a platform the artist is on.
+--   * Stored as an ordinary `bandcamp` link, they are indistinguishable from a real artist page
+--     downstream. #407 had to teach the release crawler to skip them, because it was deriving
+--     `/music` from each one and getting a 404 every time — 18 artists, and the only error
+--     message present anywhere in `release_catalog_state`.
+--
+-- Measured immediately before writing this migration: 189 rows, **all** with `source = 'search'`
+-- (no artist-curated `claimed` rows among them, so nothing here is somebody's own edit), and
+-- every affected artist keeps at least one other link — 0 would be left with none. #407's
+-- migration already cleared their catalogue backoff, so no state rows need touching here.
+--
+-- Scoped by URL shape rather than by platform alone: a real `*.bandcamp.com` artist page must
+-- survive. `bandcamp.com/search` cannot appear in one — an artist page lives on a subdomain or
+-- a Bandcamp Pro custom domain, never on the apex with a `/search` path.
+--
+-- Idempotent: re-running deletes nothing, because the fallback that created these is gone.
+
+DELETE FROM public.artist_links
+WHERE platform = 'bandcamp'
+  AND url ILIKE '%bandcamp.com/search%';


### PR DESCRIPTION
Your call: *"that's not a critical feature, I don't think it's worth showing anymore."*

## What this removes

`https://bandcamp.com/search?q=<name>` was the fallback written whenever nothing resolved a real Bandcamp artist page. It claimed a presence we hadn't found, and because it was stored as an ordinary `bandcamp` link it was indistinguishable from a real artist page downstream — the release crawler derived `/music` from each one and got a 404 every time. #407 taught the crawler to skip them; this removes the source.

Three live producers, all now silent when there's no real URL:

| File | Path |
|---|---|
| `attachAmpwallAndSearchLinks` | `api/functions/search-utils.ts` — the main path |
| MusicBrainz-only result card | `api/functions/search-sources.ts` |
| Client-side MusicBrainz fallback card | `apps/web/src/services/sources.ts` |

The dev API (`apps/web/server/`) is updated in step, so local search matches production rather than drifting further.

## The gate, not just the label

`isDirectLink` now rejects the pattern too. That isn't cosmetic: `persistSearchResults` filters on it —

```ts
p => !EXCLUDED_PLATFORMS.has(p.sourceId) && isDirectLink(p.url)
```

— so it decides whether a link gets a row **at all**. Had it listed `bandcamp.com/search`, none of the 189 rows would ever have been written and #407 wouldn't have needed a guard at the catalogue boundary. This is the upstream fix; #407 was the downstream one.

## Data cleanup

The migration deletes the 189 stored rows. Measured immediately beforehand: **all** are `source = 'search'` (none artist-curated, so nothing here is somebody's own edit), and every affected artist keeps at least one other link — **0 would be left with none**. #407's migration already cleared their catalogue backoff, so no state rows need touching.

Validated against a throwaway Postgres 16: both placeholder shapes deleted including mixed case, while `https://warrenharrison.bandcamp.com`, `.../album/x`, a Bandcamp Pro custom domain, and Discogs' and Subvert's own search links all survived. Second run is a no-op.

## This is invisible to users — deliberately checked

I ran the change and `origin/main` side by side in the browser against a search for `Darkitecture` (an artist with genuinely no Bandcamp presence). **The rendered card is identical.** The client already filtered the placeholder out of the display via its own `isDirectLink` check in `ResultCardUtils.ts`, so the link was in the data and the API response but never on screen.

So the value here is entirely in what stops reaching the database. Worth knowing if you were expecting a visible difference — there isn't one.

Separately, and pre-existing: that `Darkitecture` card renders with **no platform pills at all**, before and after. A result with nothing actionable on it may be worth a look on its own, but it isn't this change.

## Testing

- New `api/functions/__tests__/direct-link-gate.test.ts` — `isDirectLink` had no test at all despite gating every stored link.
- New cases in `disambiguation.test.ts`, including one asserting a result with no Bandcamp link still survives `filterAndSort`. The placeholder was never counted as search-only, so it used to prop results up; Subvert still does that job, but it's pinned now rather than assumed.
- Two tests in `sources-service.test.ts` updated — they asserted the placeholder was present and first. They encoded the old behaviour.
- `npm run build`, `test:api` (825), `test:unit` (629), `typecheck:api` all green. Lint unchanged from the `apps/web` baseline.

## Also confirmed harmless

`splitSuspiciousPlatforms` treats Bandcamp as a `RELIABLE_RELEASE_PLATFORMS` member, so I checked whether removing the placeholder changes disambiguation. It doesn't: a placeholder carries no `allReleaseTitles`, so it always landed in the "no release data, keep with verified" branch and could never trigger a split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)