### PR TITLE
Fix duplicate artist profiles: fold accents in slugs, and merge the duplicates that exist

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -232,11 +232,37 @@ export default async function handler(request: Request, context: Context) {
         .single()
         .abortSignal(controller.signal);
 
-      if (!artistData) {
-        clearTimeout(timeoutId);
-        return context.next();
-      }
       artist = artistData;
+
+      // A retired slug still resolves: the artist was merged into another row, or re-slugged when
+      // accent folding was fixed (`bj-rk` -> `bjork`). Checked only *after* the live slug misses, so
+      // a real artist who later takes that slug always wins.
+      //
+      // A 301 rather than rendering the page here — this branch only ever serves crawlers, and
+      // rendering identical content at two URLs is duplicate content plus a second page competing
+      // with the canonical one. Humans never reach this code (see the crawler check above): they
+      // fall through to the SPA, whose data endpoint resolves the alias itself.
+      //
+      // Duplicates resolveArtistSlugAlias in api/functions/db.ts — edge functions run on Deno and
+      // cannot import from api/functions.
+      if (!artist) {
+        const { data: alias } = await supabase
+          .from('artist_slug_aliases')
+          .select('artists!inner(slug)')
+          .eq('alias', slug.toLowerCase())
+          .maybeSingle()
+          .abortSignal(controller.signal);
+
+        const canonical = (alias as { artists?: { slug?: string } } | null)?.artists?.slug;
+        clearTimeout(timeoutId);
+        if (!canonical) return context.next();
+
+        const prefix = url.pathname.startsWith('/artist/') ? '/artist/' : '/a/';
+        return new Response(null, {
+          status: 301,
+          headers: { Location: `${prefix}${canonical}`, 'Cache-Control': 'public, max-age=3600' },
+        });
+      }
 
       const { data: profileData } = await supabase
         .from('artist_profiles')

--- a/api/functions/__tests__/artist-merge.test.ts
+++ b/api/functions/__tests__/artist-merge.test.ts
@@ -1,0 +1,453 @@
+// Merging duplicate artist rows: what counts as evidence, and what the merge actually writes.
+//
+// This is the most destructive code in the repo — it deletes artist rows and rewrites six tables —
+// so the tests assert the *sequence* of writes, not just the outcome. Two rules carry the most
+// weight, both learned from real data on 2026-08-03:
+//
+//   - Name similarity is NOT evidence. `Tiger Cub` and `Tigercub` are different bands (zero shared
+//     release titles), as are `Honeycrush` (Brooklyn) and `Honey Crush` (Orlando). Merging on names
+//     alone would recombine what an earlier fix deliberately separated.
+//   - `saved_artists` has no foreign key and is keyed by (user_id, artist_slug), with artist_id set
+//     to NULL on delete. So a merge that only reassigns artist_id leaves fans' saves pointing at a
+//     dead slug — silently, because the row survives by design.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Op { table: string; kind: 'select' | 'update' | 'delete' | 'upsert'; payload?: unknown }
+
+const ops: Op[] = [];
+const tables: Record<string, Record<string, unknown>[]> = {};
+
+function makeClient() {
+  const match = (rows: Record<string, unknown>[], filters: [string, unknown][], ins: [string, unknown[]][]) =>
+    rows.filter(r => filters.every(([c, v]) => r[c] === v) && ins.every(([c, vs]) => vs.includes(r[c])));
+
+  return {
+    from(table: string) {
+      const filters: [string, unknown][] = [];
+      const ins: [string, unknown[]][] = [];
+      const rowsOf = () => (tables[table] ??= []);
+
+      const builder: Record<string, unknown> = {
+        select() {
+          ops.push({ table, kind: 'select' });
+          return builder;
+        },
+        eq(c: string, v: unknown) { filters.push([c, v]); return builder; },
+        in(c: string, v: unknown[]) { ins.push([c, v]); return builder; },
+        order() { return builder; },
+        range(from: number, to: number) {
+          const rows = match(rowsOf(), filters, ins).slice(from, to + 1);
+          return Promise.resolve({ data: rows, error: null });
+        },
+        maybeSingle() {
+          const rows = match(rowsOf(), filters, ins);
+          return Promise.resolve({ data: rows[0] ?? null, error: null });
+        },
+        update(patch: Record<string, unknown>) {
+          const apply = () => {
+            const hit = match(rowsOf(), filters, ins);
+            ops.push({ table, kind: 'update', payload: { patch, count: hit.length } });
+            for (const r of hit) Object.assign(r, patch);
+            return Promise.resolve({ data: null, error: null });
+          };
+          return { eq: (c: string, v: unknown) => { filters.push([c, v]); return apply(); },
+                   in: (c: string, v: unknown[]) => { ins.push([c, v]); return apply(); } };
+        },
+        delete() {
+          const apply = () => {
+            const hit = match(rowsOf(), filters, ins);
+            ops.push({ table, kind: 'delete', payload: { count: hit.length } });
+            tables[table] = rowsOf().filter(r => !hit.includes(r));
+            return Promise.resolve({ data: null, error: null });
+          };
+          return { eq: (c: string, v: unknown) => { filters.push([c, v]); return apply(); },
+                   in: (c: string, v: unknown[]) => { ins.push([c, v]); return apply(); } };
+        },
+        upsert(row: Record<string, unknown>) {
+          ops.push({ table, kind: 'upsert', payload: row });
+          rowsOf().push(row);
+          return Promise.resolve({ data: null, error: null });
+        },
+        then(res: (r: unknown) => unknown) {
+          return Promise.resolve({ data: match(rowsOf(), filters, ins), error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { findDuplicateArtistPairs, mergeArtistPair, findReslugCandidates, reslugArtist } =
+  await import('../artist-merge');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const client = makeClient() as any;
+
+function artist(id: string, name: string, slug: string, confidence = 'unverified') {
+  return { id, name, slug, match_confidence: confidence };
+}
+
+beforeEach(() => {
+  ops.length = 0;
+  for (const k of Object.keys(tables)) delete tables[k];
+  tables.artists = [];
+  tables.artist_links = [];
+  tables.releases = [];
+  tables.artist_profiles = [];
+  tables.artist_analytics = [];
+  tables.release_catalog_state = [];
+  tables.verification_requests = [];
+  tables.saved_artists = [];
+  tables.artist_slug_aliases = [];
+});
+
+async function onlyPair() {
+  const r = await findDuplicateArtistPairs(client);
+  expect(r.ok).toBe(true);
+  if (!r.ok) throw new Error('unreachable');
+  expect(r.pairs).toHaveLength(1);
+  return r.pairs[0];
+}
+
+describe('findDuplicateArtistPairs — evidence', () => {
+  it('calls a machine-key duplicate provenance', async () => {
+    // The #338 signature: the loser's name IS normalizeForComparison(winner's name). Nothing else
+    // produces that, so the pair is one artist by construction.
+    tables.artists = [artist('w', 'Kid Lightbulbs', 'kid-lightbulbs', 'claimed'),
+                      artist('l', 'kidlightbulbs', 'kidlightbulbs')];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('provenance');
+    expect(pair.winner.id).toBe('w');
+    expect(pair.blockers).toEqual([]);
+  });
+
+  it('calls a pair with shared release titles release-overlap', async () => {
+    tables.artists = [artist('w', 'Big Thief', 'big-thief'), artist('l', 'Bigthief', 'bigthief')];
+    tables.releases = [
+      { id: 'r1', artist_id: 'w', match_key: 'dandelion' },
+      { id: 'r2', artist_id: 'l', match_key: 'dandelion' },
+      { id: 'r3', artist_id: 'l', match_key: 'vampireempire' },
+    ];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('release-overlap');
+    expect(pair.sharedTitles).toEqual(['dandelion']);
+  });
+
+  it('calls a pair that differs only by accents accent-fold', async () => {
+    // What fans actually reported: searching "bjork" landed on the 1-link stub, not the real row.
+    tables.artists = [artist('w', 'Björk', 'bj-rk'), artist('l', 'Bjork', 'bjork')];
+    tables.artist_links = [{ id: 'a', artist_id: 'w' }];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('accent-fold');
+    expect(pair.blockers).toEqual([]);
+  });
+
+  it('does NOT call Boto / Błoto accent-fold', async () => {
+    // The discriminating case, and the reason this uses foldToAscii rather than
+    // normalizeForComparison: folding maps "Błoto" to "Bloto", which is not "Boto". Under
+    // normalizeForComparison both collapse to "boto" and this pair would look mergeable.
+    tables.artists = [artist('w', 'Boto', 'boto'), artist('l', 'Błoto', 'b-oto')];
+    tables.artist_links = [{ id: 'a', artist_id: 'w' }];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('name-only');
+  });
+
+  it('calls a lookalike with no corroboration name-only', async () => {
+    tables.artists = [artist('w', 'Honeycrush', 'honeycrush'), artist('l', 'Honey Crush', 'honey-crush')];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('name-only');
+  });
+
+  it('blocks a pair whose releases prove they are different artists', async () => {
+    // The real Tiger Cub / Tigercub data.
+    tables.artists = [artist('w', 'Tigercub', 'tigercub'), artist('l', 'Tiger Cub', 'tiger-cub')];
+    tables.releases = [
+      { id: 'r1', artist_id: 'w', match_key: 'repressedsemanticsep' },
+      { id: 'r2', artist_id: 'l', match_key: 'thesun' },
+    ];
+    const pair = await onlyPair();
+    expect(pair.evidence).toBe('name-only');
+    expect(pair.blockers.join(' ')).toContain('share none');
+  });
+
+  it('blocks when both rows are claimed', async () => {
+    tables.artists = [artist('a', 'Stan Stewart', 'muz4now', 'claimed'),
+                      artist('b', 'Stan Stewart', 'stan-stewart', 'claimed')];
+    const pair = await onlyPair();
+    expect(pair.blockers.join(' ')).toContain('both rows are claimed');
+  });
+
+  it('blocks when both rows have a profile', async () => {
+    // artist_profiles is UNIQUE(artist_id), so a merge discards one artist's edits outright.
+    tables.artists = [artist('w', 'Choan Gálvez', 'choan-g-lvez'), artist('l', 'Choan Galvez', 'choan-galvez')];
+    tables.artist_profiles = [{ artist_id: 'w' }, { artist_id: 'l' }];
+    const pair = await onlyPair();
+    expect(pair.blockers.join(' ')).toContain('artist_profiles');
+  });
+
+  it('ignores a three-way name collision rather than guessing a pair', async () => {
+    tables.artists = [artist('a', 'Anna', 'anna'), artist('b', 'ANNA', 'anna-2'), artist('c', 'a n n a', 'a-n-n-a')];
+    const r = await findDuplicateArtistPairs(client);
+    expect(r.ok && r.pairs).toEqual([]);
+  });
+});
+
+describe('findDuplicateArtistPairs — picking the winner', () => {
+  it('prefers the claimed row even when it has fewer links', async () => {
+    tables.artists = [artist('claimed', 'Snap Infraction', 'snap-infraction', 'claimed'),
+                      artist('rich', 'snapinfraction', 'snapinfraction')];
+    tables.artist_links = [
+      { id: 'l1', artist_id: 'rich' }, { id: 'l2', artist_id: 'rich' }, { id: 'l3', artist_id: 'rich' },
+      { id: 'l4', artist_id: 'claimed' },
+    ];
+    const pair = await onlyPair();
+    // The artist owns that URL and may have shared it.
+    expect(pair.winner.id).toBe('claimed');
+  });
+
+  it('never lets a machine-key name survive, even on an equal link count', async () => {
+    // Both rows have one link, so link count decides nothing and the id tiebreak was picking rows
+    // literally named "snapinfractionfeatmadeline" and "controlfreakstudio" as the winner. Found by
+    // running the CLI against production, not by the earlier tests.
+    tables.artists = [
+      artist('aaa', 'snapinfractionfeatmadeline', 'snapinfractionfeatmadeline'),
+      artist('zzz', 'Snap Infraction (feat. madeline)', 'snap-infraction-feat-madeline'),
+    ];
+    tables.artist_links = [{ id: 'l1', artist_id: 'aaa' }, { id: 'l2', artist_id: 'zzz' }];
+    const pair = await onlyPair();
+    expect(pair.winner.name).toBe('Snap Infraction (feat. madeline)');
+    // And the direction matters for classify(), which reads provenance off the *loser*.
+    expect(pair.evidence).toBe('provenance');
+  });
+
+  it('still lets a claimed row beat a machine-key row', async () => {
+    tables.artists = [artist('key', 'kidlightbulbs', 'kidlightbulbs'),
+                      artist('real', 'Kid Lightbulbs', 'kid-lightbulbs', 'claimed')];
+    const pair = await onlyPair();
+    expect(pair.winner.id).toBe('real');
+  });
+
+  it('otherwise prefers the row with more links', async () => {
+    tables.artists = [artist('thin', 'kidlightbulbs', 'kidlightbulbs'),
+                      artist('fat', 'Kid Lightbulbs', 'kid-lightbulbs')];
+    tables.artist_links = [{ id: 'a', artist_id: 'fat' }, { id: 'b', artist_id: 'fat' }, { id: 'c', artist_id: 'thin' }];
+    const pair = await onlyPair();
+    expect(pair.winner.id).toBe('fat');
+  });
+});
+
+describe('mergeArtistPair — refusals', () => {
+  it('refuses a name-only pair', async () => {
+    tables.artists = [artist('w', 'Honeycrush', 'honeycrush'), artist('l', 'Honey Crush', 'honey-crush')];
+    const result = await mergeArtistPair(client, await onlyPair(), { dryRun: false });
+    expect(result.ok).toBe(false);
+    expect(result.refused).toContain('name similarity');
+    expect(tables.artists).toHaveLength(2);
+  });
+
+  it('refuses a blocked pair', async () => {
+    tables.artists = [artist('a', 'Stan Stewart', 'muz4now', 'claimed'),
+                      artist('b', 'Stan Stewart', 'stan-stewart', 'claimed')];
+    const result = await mergeArtistPair(client, await onlyPair(), { dryRun: false });
+    expect(result.refused).toContain('blocked');
+    expect(tables.artists).toHaveLength(2);
+  });
+
+  it('proceeds on a blocked pair only with force', async () => {
+    tables.artists = [artist('w', 'Choan Gálvez', 'choan-g-lvez'), artist('l', 'Choan Galvez', 'choan-galvez')];
+    tables.artist_profiles = [{ artist_id: 'w' }, { artist_id: 'l' }];
+    const result = await mergeArtistPair(client, await onlyPair(), { dryRun: false, force: true });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('mergeArtistPair — what it writes', () => {
+  async function provenancePair() {
+    tables.artists = [artist('w', 'Kid Lightbulbs', 'kid-lightbulbs', 'claimed'),
+                      artist('l', 'kidlightbulbs', 'kidlightbulbs')];
+    return onlyPair();
+  }
+
+  it('writes nothing on a dry run, and dry run is the default', async () => {
+    const pair = await provenancePair();
+    tables.artist_links = [{ id: 'x', artist_id: 'l', platform: 'mirlo' }];
+
+    const result = await mergeArtistPair(client, pair); // no opts at all
+    expect(result.dryRun).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.steps.length).toBeGreaterThan(0);
+    expect(ops.some(o => o.kind !== 'select')).toBe(false);
+    expect(tables.artists).toHaveLength(2);
+  });
+
+  it('moves only the platforms the winner lacks', async () => {
+    const pair = await provenancePair();
+    tables.artist_links = [
+      { id: 'keep', artist_id: 'w', platform: 'bandcamp' },
+      { id: 'dupe', artist_id: 'l', platform: 'bandcamp' },  // winner already has bandcamp
+      { id: 'move', artist_id: 'l', platform: 'mirlo' },
+    ];
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    expect(tables.artist_links.find(l => l.id === 'move')?.artist_id).toBe('w');
+    // The loser's bandcamp row is never reassigned — UNIQUE(artist_id, platform) would reject it.
+    // It is left on the loser and Postgres cascades it away with the row (`on delete cascade`);
+    // this fake doesn't model cascades, so the assertion is "not moved", not "gone".
+    expect(tables.artist_links.find(l => l.id === 'dupe')?.artist_id).toBe('l');
+  });
+
+  it('moves only releases the winner does not already have', async () => {
+    tables.artists = [artist('w', 'Big Thief', 'big-thief'), artist('l', 'Bigthief', 'bigthief')];
+    // The winner has to be pinned by link count — with both rows at zero links the tiebreak is the
+    // artist id, which is not what this test is about.
+    tables.artist_links = [{ id: 'lk', artist_id: 'w', platform: 'bandcamp' }];
+    tables.releases = [
+      { id: 'shared-w', artist_id: 'w', match_key: 'dandelion' },
+      { id: 'shared-l', artist_id: 'l', match_key: 'dandelion' },
+      { id: 'unique-l', artist_id: 'l', match_key: 'vampireempire' },
+    ];
+    const pair = await onlyPair();
+    expect(pair.winner.id).toBe('w');
+
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    expect(tables.releases.find(r => r.id === 'unique-l')?.artist_id).toBe('w');
+    // Reassigning the shared one would duplicate the album on the surviving page. Left on the loser
+    // and cascaded away by Postgres, which this fake doesn't model.
+    expect(tables.releases.find(r => r.id === 'shared-l')?.artist_id).toBe('l');
+  });
+
+  it('moves all analytics so the surviving dashboard keeps both histories', async () => {
+    const pair = await provenancePair();
+    tables.artist_analytics = [{ id: 'a1', artist_id: 'l' }, { id: 'a2', artist_id: 'l' }];
+    await mergeArtistPair(client, pair, { dryRun: false });
+    expect(tables.artist_analytics.every(a => a.artist_id === 'w')).toBe(true);
+  });
+
+  it('repoints a fan save at the winner by SLUG, not just artist_id', async () => {
+    const pair = await provenancePair();
+    tables.saved_artists = [{ id: 's1', user_id: 'u1', artist_slug: 'kidlightbulbs', artist_id: 'l' }];
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    // artist_id is ON DELETE SET NULL and there is no FK, so a save survives the delete pointing at
+    // a dead slug unless the slug itself is rewritten. That is a silent break for the Mac app.
+    expect(tables.saved_artists[0].artist_slug).toBe('kid-lightbulbs');
+    expect(tables.saved_artists[0].artist_id).toBe('w');
+  });
+
+  it('drops a save that would collide with one the user already has', async () => {
+    const pair = await provenancePair();
+    tables.saved_artists = [
+      { id: 'winner-save', user_id: 'u1', artist_slug: 'kid-lightbulbs', artist_id: 'w' },
+      { id: 'loser-save', user_id: 'u1', artist_slug: 'kidlightbulbs', artist_id: 'l' },
+    ];
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    // UNIQUE(user_id, artist_slug) would reject the rewrite.
+    expect(tables.saved_artists.map(s => s.id)).toEqual(['winner-save']);
+  });
+
+  it('reassigns a profile only when the winner has none', async () => {
+    const pair = await provenancePair();
+    tables.artist_profiles = [{ artist_id: 'l' }];
+    await mergeArtistPair(client, pair, { dryRun: false });
+    expect(tables.artist_profiles[0].artist_id).toBe('w');
+  });
+
+  it('aliases the loser slug BEFORE deleting the row', async () => {
+    const pair = await provenancePair();
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    const aliasAt = ops.findIndex(o => o.table === 'artist_slug_aliases' && o.kind === 'upsert');
+    const deleteAt = ops.findIndex(o => o.table === 'artists' && o.kind === 'delete');
+    expect(aliasAt).toBeGreaterThan(-1);
+    expect(deleteAt).toBeGreaterThan(-1);
+    // Reversed, the URL 404s for however long the delete-then-alias window lasts — and if the alias
+    // write fails, permanently.
+    expect(aliasAt).toBeLessThan(deleteAt);
+    expect(tables.artist_slug_aliases[0]).toMatchObject({
+      alias: 'kidlightbulbs', artist_id: 'w', reason: 'merge',
+    });
+  });
+
+  it('deletes the loser row last of all', async () => {
+    const pair = await provenancePair();
+    tables.artist_links = [{ id: 'x', artist_id: 'l', platform: 'mirlo' }];
+    tables.artist_analytics = [{ id: 'a', artist_id: 'l' }];
+    await mergeArtistPair(client, pair, { dryRun: false });
+
+    const writes = ops.filter(o => o.kind !== 'select');
+    expect(writes.at(-1)).toMatchObject({ table: 'artists', kind: 'delete' });
+    expect(tables.artists.map(a => a.id)).toEqual(['w']);
+  });
+});
+
+describe('findReslugCandidates', () => {
+  it('re-slugs a mangled accent slug', async () => {
+    tables.artists = [artist('a', 'Björk', 'bj-rk')];
+    const r = await findReslugCandidates(client);
+    expect(r.ok && r.candidates).toEqual([{ id: 'a', name: 'Björk', from: 'bj-rk', to: 'bjork' }]);
+  });
+
+  it('never touches a slug an artist chose', async () => {
+    // The stored slug is not what any version of artistSlug would produce, so a human set it.
+    // Re-slugging these breaks URLs artists share — 11 of the 24 real cases are claimed profiles.
+    tables.artists = [
+      artist('a', 'Stan Stewart (aka @muz4now)', 'muz4now', 'claimed'),
+      artist('b', 'Michael Boezi', 'boezi', 'claimed'),
+      artist('c', 'Court Lee', 'courstellation', 'claimed'),
+      artist('d', 'MinusOne', 'minus-one'),
+    ];
+    const r = await findReslugCandidates(client);
+    expect(r.ok && r.candidates).toEqual([]);
+    expect(r.ok && r.skippedChosen).toBe(4);
+  });
+
+  it('leaves rows whose slug already matches', async () => {
+    tables.artists = [artist('a', 'Warren Harrison', 'warren-harrison')];
+    const r = await findReslugCandidates(client);
+    expect(r.ok && r.candidates).toEqual([]);
+    expect(r.ok && r.skippedChosen).toBe(0);
+  });
+});
+
+describe('reslugArtist', () => {
+  const candidate = { id: 'a', name: 'Björk', from: 'bj-rk', to: 'bjork' };
+
+  it('refuses while the target slug is held by the duplicate', async () => {
+    tables.artists = [artist('a', 'Björk', 'bj-rk'), artist('b', 'Bjork', 'bjork')];
+    const r = await reslugArtist(client, candidate, { dryRun: false });
+    expect(r.ok).toBe(false);
+    expect(r.refused).toContain('merge that pair first');
+    expect(tables.artists.find(a => a.id === 'a')?.slug).toBe('bj-rk');
+  });
+
+  it('moves the slug and aliases the old one', async () => {
+    tables.artists = [artist('a', 'Björk', 'bj-rk')];
+    const r = await reslugArtist(client, candidate, { dryRun: false });
+    expect(r.ok).toBe(true);
+    expect(tables.artists[0].slug).toBe('bjork');
+    expect(tables.artist_slug_aliases[0]).toMatchObject({ alias: 'bj-rk', artist_id: 'a', reason: 'reslug' });
+  });
+
+  it('follows the slug in saved_artists', async () => {
+    tables.artists = [artist('a', 'Björk', 'bj-rk')];
+    tables.saved_artists = [{ id: 's', user_id: 'u', artist_slug: 'bj-rk' }];
+    await reslugArtist(client, candidate, { dryRun: false });
+    expect(tables.saved_artists[0].artist_slug).toBe('bjork');
+  });
+
+  it('writes nothing on a dry run', async () => {
+    tables.artists = [artist('a', 'Björk', 'bj-rk')];
+    const r = await reslugArtist(client, candidate);
+    expect(r.ok).toBe(true);
+    expect(r.dryRun).toBe(true);
+    expect(tables.artists[0].slug).toBe('bj-rk');
+    expect(tables.artist_slug_aliases).toEqual([]);
+  });
+});

--- a/api/functions/__tests__/artist-slug-accents.test.ts
+++ b/api/functions/__tests__/artist-slug-accents.test.ts
@@ -1,0 +1,99 @@
+// Accent folding in artistSlug, and the letters NFD alone cannot handle.
+//
+// Fans reported being unable to find accented artists. The cause was not only an ugly URL: the
+// mangled slug is what persistSearchResults upserts `on conflict (slug)`, so "Björk" typed with the
+// umlaut and "Bjork" typed without produced two artist rows and two half-populated pages. Every
+// case below is a real name measured against production on 2026-08-03.
+
+import { describe, it, expect } from 'vitest';
+import { artistSlug } from '../db';
+import { foldToAscii, normalizeAccents } from '../search-utils';
+
+describe('artistSlug — accents are folded, not turned into separators', () => {
+  it.each([
+    ['Björk', 'bjork'],
+    ['Sébastien Tellier', 'sebastien-tellier'],
+    ['Choan Gálvez', 'choan-galvez'],
+    ['Das Mörtal', 'das-mortal'],
+    ['Jónsi', 'jonsi'],
+    ['Hüsker Dü', 'husker-du'],
+    ['José González', 'jose-gonzalez'],
+    ['Sigur Rós', 'sigur-ros'],
+    ['Mötley Crüe', 'motley-crue'],
+  ])('%s -> %s', (name, expected) => {
+    expect(artistSlug(name)).toBe(expected);
+  });
+
+  it('no longer emits a hyphen where an accented letter stood', () => {
+    // The old behaviour: /[^a-z0-9]+/ matched the accented character itself.
+    expect(artistSlug('Björk')).not.toBe('bj-rk');
+    expect(artistSlug('Sigur Rós')).not.toBe('sigur-r-s');
+  });
+
+  it('handles the letters NFD cannot decompose', () => {
+    // These carry the stroke or slash in the codepoint, so there is no combining mark to remove and
+    // normalizeAccents leaves them untouched. Without an explicit map they become hyphens — or
+    // vanish, which is how "Łukasz" used to lose its first letter.
+    expect(artistSlug('Błoto')).toBe('bloto');
+    expect(artistSlug('Nørden')).toBe('norden');
+    expect(artistSlug('Łukasz')).toBe('lukasz');
+    expect(artistSlug('Æther')).toBe('aether');
+    expect(artistSlug('Đevo')).toBe('devo');
+  });
+
+  it('keeps distinct artists distinct', () => {
+    // Błoto (Polish jazz) and Boto are different acts. Before folding, both produced slugs that
+    // collapsed together under comparison; the fold gives them separate URLs.
+    expect(artistSlug('Błoto')).not.toBe(artistSlug('Boto'));
+  });
+
+  it('leaves plain ASCII names exactly as they were', () => {
+    // The overwhelming majority of rows must not move, or every existing URL breaks.
+    for (const [name, slug] of [
+      ['Kid Lightbulbs', 'kid-lightbulbs'],
+      ['Warren Harrison', 'warren-harrison'],
+      ['girl in red', 'girl-in-red'],
+      ['j:dead', 'j-dead'],
+      ['Snap Infraction (feat. madeline)', 'snap-infraction-feat-madeline'],
+      ['Various Artists', 'various-artists'],
+    ]) {
+      expect(artistSlug(name)).toBe(slug);
+    }
+  });
+
+  it('still strips leading and trailing separators', () => {
+    expect(artistSlug('!!! Wow !!!')).toBe('wow');
+    expect(artistSlug('  spaced  ')).toBe('spaced');
+  });
+
+  it('never returns a slug outside [a-z0-9-]', () => {
+    for (const name of ['Björk', 'Błoto', '日本語', 'Æther', 'Ångström', 'ß']) {
+      expect(artistSlug(name)).toMatch(/^[a-z0-9-]*$/);
+    }
+  });
+});
+
+describe('foldToAscii', () => {
+  it('does what normalizeAccents does, plus the non-decomposing letters', () => {
+    expect(foldToAscii('Björk')).toBe('Bjork');
+    expect(normalizeAccents('Błoto')).toBe('Błoto'); // NFD cannot touch it...
+    expect(foldToAscii('Błoto')).toBe('Bloto');      // ...this can
+  });
+
+  it('preserves case', () => {
+    expect(foldToAscii('ŁUKASZ')).toBe('LUKASZ');
+    expect(foldToAscii('łukasz')).toBe('lukasz');
+  });
+
+  it('expands the multi-letter transliterations', () => {
+    expect(foldToAscii('Æther')).toBe('Aether');
+    expect(foldToAscii('Straße')).toBe('Strasse');
+    expect(foldToAscii('Þór')).toBe('Thor');
+  });
+
+  it('leaves non-Latin scripts alone rather than mangling them', () => {
+    // artistSlug drops these anyway; foldToAscii's job is Latin, and pretending otherwise would
+    // invent transliterations nobody asked for.
+    expect(foldToAscii('日本語')).toBe('日本語');
+  });
+});

--- a/api/functions/__tests__/attach-artist-page-slugs.test.ts
+++ b/api/functions/__tests__/attach-artist-page-slugs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { attachArtistPageSlugs } from '../search-sources';
+import { artistSlug } from '../db';
 import type { AggregatedResult } from '../search-utils';
 
 // The address of an artist's page, returned so a native client can actually reach their releases.
@@ -74,9 +75,23 @@ describe('attachArtistPageSlugs', () => {
     attachArtistPageSlugs(results);
 
     expect(results[0].knownSlug).toBe('godspeed-you-black-emperor');
-    // Non-ASCII collapses to a separator, and leading/trailing separators are trimmed — the
-    // point is only that it agrees with `artistSlug`, which is what wrote the row.
-    expect(results[1].knownSlug).toBe('sigur-r-s');
+    // Accents fold rather than collapsing to a separator (they used to give `sigur-r-s`), and
+    // leading/trailing separators are trimmed.
+    expect(results[1].knownSlug).toBe('sigur-ros');
+  });
+
+  it('agrees with artistSlug rather than with a hardcoded string', () => {
+    // The assertion above is a readable example; this is the actual invariant. `knownSlug` is used
+    // to link a search result at the row `persistSearchResults` wrote, so the two must derive the
+    // slug identically — a hand-maintained expected value silently drifts the day artistSlug
+    // changes, which is exactly what happened when accent folding landed.
+    const names = ['Sigur Rós', 'Björk', 'Błoto', 'Hüsker Dü', 'j:dead', 'girl in red', '  padded  '];
+    const results = names.map((name, i) => result({ id: `id-${i}`, name }));
+    attachArtistPageSlugs(results);
+
+    for (const [i, name] of names.entries()) {
+      expect(results[i].knownSlug).toBe(artistSlug(name));
+    }
   });
 
   it('handles a mixed result set without cross-contamination', () => {

--- a/api/functions/__tests__/persist-identity-match.test.ts
+++ b/api/functions/__tests__/persist-identity-match.test.ts
@@ -1,0 +1,282 @@
+// Stop a second artist row being created when a different source spells the name differently.
+//
+// `artistSlug` derives the slug from whichever name won aggregation, and that varies between
+// searches with which platforms answered — so "Big Thief" and "Bigthief" became two rows, two pages
+// and two half-populated link sets. 13 of the 27 duplicate pairs on production arose this way, and
+// unlike the machine-key cause they were still arriving.
+//
+// The fix matches on a shared *identity* URL. What makes it safe is the platforms it excludes:
+// measured on production, `Honeycrush`/`Honey Crush` share `patreon.com/honeycrush` and
+// `Boto`/`Błoto` share `facebook.com/blotoquartet` — links mis-attached by the homonym bug fixed in
+// July. Treating those as evidence would re-fuse two genuinely different bands. Every one of those
+// cases is pinned below; if a future change adds socials to IDENTITY_PLATFORMS, these fail.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Row { [k: string]: unknown }
+
+const tables: Record<string, Row[]> = {};
+const queries: { table: string; platforms?: unknown; or?: string }[] = [];
+
+function makeClient() {
+  return {
+    from(table: string) {
+      const eqs: [string, unknown][] = [];
+      let inFilter: [string, unknown[]] | null = null;
+      let orFilter: string | null = null;
+
+      const rowsOf = () => (tables[table] ??= []);
+      const matched = () =>
+        rowsOf().filter(r => {
+          if (!eqs.every(([c, v]) => r[c] === v)) return false;
+          if (inFilter && !inFilter[1].includes(r[inFilter[0]])) return false;
+          if (orFilter) {
+            // Mirror PostgREST `url.ilike.%needle%` — the only or() shape used here.
+            const needles = orFilter.split(',').map(c => c.replace(/^url\.ilike\.%|%$/g, '').replace(/\\(.)/g, '$1'));
+            if (!needles.some(n => String(r.url ?? '').toLowerCase().includes(n.toLowerCase()))) return false;
+          }
+          return true;
+        });
+
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        eq(c: string, v: unknown) { eqs.push([c, v]); return builder; },
+        in(c: string, v: unknown[]) { inFilter = [c, v]; return builder; },
+        or(f: string) { orFilter = f; queries.push({ table, platforms: inFilter?.[1], or: f }); return builder; },
+        single() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        maybeSingle() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        upsert(rows: Row | Row[]) {
+          const list = Array.isArray(rows) ? rows : [rows];
+          for (const r of list) rowsOf().push(r);
+          return { select: () => ({ single: () => Promise.resolve({ data: list[0], error: null }) }),
+                   then: (res: (v: unknown) => unknown) => Promise.resolve({ data: null, error: null }).then(res) };
+        },
+        then(res: (v: unknown) => unknown) {
+          // Embedded `artists!inner(slug)` — resolve it from the artists table by artist_id.
+          const rows = matched().map(r => ({
+            ...r,
+            artists: tables.artists?.find(a => a.id === r.artist_id) ?? null,
+          }));
+          return Promise.resolve({ data: rows, error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+vi.mock('../request-catalog', () => ({ requestArtistCatalog: async () => true }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { persistSearchResults, artistSlug } = await import('../db');
+
+/** A search result shaped as persistSearchResults expects. */
+function result(name: string, platforms: { sourceId: string; url: string }[]) {
+  return {
+    id: `r-${name}`,
+    name,
+    type: 'artist' as const,
+    platforms,
+    matchConfidence: 'verified' as const,
+  };
+}
+
+function existingArtist(id: string, name: string, links: { sourceId: string; url: string }[], confidence = 'unverified') {
+  tables.artists.push({ id, slug: artistSlug(name), name, match_confidence: confidence });
+  for (const l of links) tables.artist_links.push({ artist_id: id, platform: l.sourceId, url: l.url });
+}
+
+/**
+ * The distinct artist slugs in the table — i.e. how many artist rows exist.
+ *
+ * Deduped because this fake's `upsert` appends rather than merging on conflict, while the real table
+ * has `unique(slug)`. Two entries with the same slug therefore mean one row, and what these tests are
+ * actually about is whether a *second* row appears.
+ */
+const slugs = () => [...new Set((tables.artists as { slug: string }[]).map(a => a.slug))].sort();
+
+beforeEach(() => {
+  queries.length = 0;
+  tables.artists = [];
+  tables.artist_links = [];
+  tables.artist_profiles = [];
+});
+
+describe('persistSearchResults — reuses an artist stored under a different spelling', () => {
+  it('does not create a second row when a Bandcamp URL is already held', async () => {
+    existingArtist('a1', 'Big Thief', [{ sourceId: 'bandcamp', url: 'https://bigthief.bandcamp.com' }]);
+
+    // A later search where a different source won the name.
+    await persistSearchResults([
+      result('Bigthief', [{ sourceId: 'bandcamp', url: 'https://bigthief.bandcamp.com' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['big-thief']);
+  });
+
+  it('matches through a trailing slash', async () => {
+    // Measured: 581 of 4,782 stored identity links carry a trailing slash, so exact matching would
+    // miss a large share. The prefilter strips it.
+    existingArtist('a1', 'Rue Oberkampf', [{ sourceId: 'bandcamp', url: 'https://rueoberkampf.bandcamp.com/' }]);
+
+    await persistSearchResults([
+      result('Rueoberkampf', [{ sourceId: 'bandcamp', url: 'https://rueoberkampf.bandcamp.com' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['rue-oberkampf']);
+  });
+
+  it('matches through www. and http', async () => {
+    // 2,804 stored identity links carry www.
+    existingArtist('a1', 'Creepy Nuts', [{ sourceId: 'discogs', url: 'http://www.discogs.com/artist/3939097' }]);
+
+    await persistSearchResults([
+      result('Creepynuts', [{ sourceId: 'discogs', url: 'https://discogs.com/artist/3939097' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['creepy-nuts']);
+  });
+
+  it('still creates a row for a genuinely new artist', async () => {
+    await persistSearchResults([
+      result('Someone New', [{ sourceId: 'bandcamp', url: 'https://someonenew.bandcamp.com' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['someone-new']);
+  });
+});
+
+describe('persistSearchResults — must NOT fuse different artists', () => {
+  it('keeps Honeycrush and Honey Crush apart despite a shared Patreon', async () => {
+    // The Brooklyn and Orlando bands. Their shared patreon.com/honeycrush is mis-attached data from
+    // the bug fixed in July; treating it as evidence would undo that fix.
+    existingArtist('a1', 'Honey Crush', [
+      { sourceId: 'bandcamp', url: 'https://honeycrush.bandcamp.com' },
+      { sourceId: 'patreon', url: 'https://patreon.com/honeycrush' },
+    ]);
+
+    await persistSearchResults([
+      result('Honeycrush', [
+        { sourceId: 'bandcamp', url: 'https://honeycrushing.bandcamp.com' },
+        { sourceId: 'patreon', url: 'https://patreon.com/honeycrush' },
+      ]),
+    ] as never);
+
+    expect(slugs()).toEqual(['honey-crush', 'honeycrush']);
+  });
+
+  it('keeps Boto and Błoto apart despite a shared Facebook', async () => {
+    existingArtist('a1', 'Boto', [{ sourceId: 'facebook', url: 'https://facebook.com/blotoquartet' }]);
+
+    await persistSearchResults([
+      result('Błoto', [{ sourceId: 'facebook', url: 'https://facebook.com/blotoquartet' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['bloto', 'boto']);
+  });
+
+  it('keeps Tiger Cub and Tigercub apart — they share nothing', async () => {
+    existingArtist('a1', 'Tigercub', [{ sourceId: 'bandcamp', url: 'https://tigercub.bandcamp.com' }]);
+
+    await persistSearchResults([
+      result('Tiger Cub', [{ sourceId: 'bandcamp', url: 'https://tigercubband.bandcamp.com' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['tiger-cub', 'tigercub']);
+  });
+
+  it('does not match a URL that is merely a prefix of another', async () => {
+    // The prefilter is a substring match, so discogs.com/artist/123 would otherwise hit
+    // discogs.com/artist/1234. The normalized re-check is what stops it.
+    existingArtist('a1', 'Artist Twelve Thirty Four', [
+      { sourceId: 'discogs', url: 'https://www.discogs.com/artist/1234' },
+    ]);
+
+    await persistSearchResults([
+      result('Someone Else', [{ sourceId: 'discogs', url: 'https://www.discogs.com/artist/123' }]),
+    ] as never);
+
+    expect(slugs()).toEqual(['artist-twelve-thirty-four', 'someone-else']);
+  });
+
+  it('refuses to guess when two artists both hold the URL', async () => {
+    // Already-broken data. Picking one would attach this result to a coin flip.
+    existingArtist('a1', 'First Claimant', [{ sourceId: 'bandcamp', url: 'https://shared.bandcamp.com' }]);
+    existingArtist('a2', 'Second Claimant', [{ sourceId: 'bandcamp', url: 'https://shared.bandcamp.com' }]);
+
+    await persistSearchResults([
+      result('Third Spelling', [{ sourceId: 'bandcamp', url: 'https://shared.bandcamp.com' }]),
+    ] as never);
+
+    expect(slugs()).toContain('third-spelling');
+  });
+});
+
+describe('persistSearchResults — the identity lookup is scoped and cheap', () => {
+  it('only queries identity platforms, never socials', async () => {
+    existingArtist('a1', 'Someone', [{ sourceId: 'bandcamp', url: 'https://someone.bandcamp.com' }]);
+
+    await persistSearchResults([
+      result('Someone Different', [
+        { sourceId: 'instagram', url: 'https://instagram.com/x' },
+        { sourceId: 'facebook', url: 'https://facebook.com/x' },
+        { sourceId: 'bandcamp', url: 'https://other.bandcamp.com' },
+      ]),
+    ] as never);
+
+    const q = queries.find(x => x.table === 'artist_links');
+    expect(q).toBeDefined();
+    const platforms = q!.platforms as string[];
+    expect(platforms).toContain('bandcamp');
+    expect(platforms).not.toContain('instagram');
+    expect(platforms).not.toContain('facebook');
+    expect(platforms).not.toContain('patreon');
+    // Only the bandcamp URL should be in the or() filter.
+    expect(q!.or).toContain('other.bandcamp.com');
+    expect(q!.or).not.toContain('instagram');
+  });
+
+  it('does not run the lookup at all when the artist already has a row', async () => {
+    // persistSearchResults is awaited before the search response is sent, so a known artist must not
+    // pay for an extra round trip.
+    existingArtist('a1', 'Known Artist', [{ sourceId: 'bandcamp', url: 'https://known.bandcamp.com' }]);
+
+    await persistSearchResults([
+      result('Known Artist', [{ sourceId: 'bandcamp', url: 'https://known.bandcamp.com' }]),
+    ] as never);
+
+    expect(queries.filter(q => q.table === 'artist_links')).toHaveLength(0);
+  });
+
+  it('skips the lookup when the result has no identity platform at all', async () => {
+    await persistSearchResults([
+      result('Socials Only', [
+        { sourceId: 'instagram', url: 'https://instagram.com/y' },
+        { sourceId: 'officialsite', url: 'https://example.test' },
+      ]),
+    ] as never);
+
+    expect(queries.filter(q => q.table === 'artist_links')).toHaveLength(0);
+    expect(slugs()).toEqual(['socials-only']);
+  });
+});
+
+describe('persistSearchResults — the claimed guard follows the match', () => {
+  it('does not overwrite a claimed row reached via an identity URL', async () => {
+    // The guard checks the slug it is about to write. Redirecting to another row without re-checking
+    // would let a stranger's search overwrite a claimed profile — the exact thing the guard exists
+    // for, bypassed by the new path.
+    existingArtist('a1', 'Kid Lightbulbs',
+      [{ sourceId: 'bandcamp', url: 'https://kidlightbulbs.bandcamp.com' }], 'claimed');
+
+    await persistSearchResults([
+      result('kidlightbulbs', [{ sourceId: 'bandcamp', url: 'https://kidlightbulbs.bandcamp.com' }]),
+    ] as never);
+
+    // No new row, and no upsert against the claimed one.
+    expect(slugs()).toEqual(['kid-lightbulbs']);
+    expect((tables.artists as { name: string }[]).map(a => a.name)).toEqual(['Kid Lightbulbs']);
+  });
+});

--- a/api/functions/admin-artist-duplicates.ts
+++ b/api/functions/admin-artist-duplicates.ts
@@ -1,0 +1,143 @@
+// API endpoint: GET/POST /api/admin/artist-duplicates
+// Admin-only. Lists duplicate artist rows with the evidence for merging them, and performs a merge
+// or a slug re-slug on request. Surfaced on /admin/verify (the Artist Review page).
+//
+// The merge logic itself lives in artist-merge.ts so this endpoint and
+// scripts/merge-duplicate-artists.ts cannot drift apart — a merge is destructive across six tables
+// and having two implementations of it would be asking for one of them to be wrong.
+
+import { getClient } from './db';
+import {
+  findDuplicateArtistPairs,
+  findReslugCandidates,
+  mergeArtistPair,
+  reslugArtist,
+} from './artist-merge';
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { Sentry } from '../lib/sentry';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body?: string;
+}) {
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+  const json = (statusCode: number, payload: unknown) => ({
+    statusCode,
+    headers: CORS_HEADERS,
+    body: JSON.stringify(payload),
+  });
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const admin = await authenticateAdmin(
+    event.headers['authorization'] || event.headers['Authorization'] || undefined,
+  );
+  if (!admin) return json(401, { error: 'Unauthorized' });
+
+  const client = getClient();
+  if (!client) return json(500, { error: 'Database not configured' });
+
+  // GET: the review list — every pair, its evidence, and anything blocking a merge.
+  if (event.httpMethod === 'GET') {
+    const [pairs, reslugs] = await Promise.all([
+      findDuplicateArtistPairs(client),
+      findReslugCandidates(client),
+    ]);
+    if (!pairs.ok) return json(503, { error: pairs.reason });
+    if (!reslugs.ok) return json(503, { error: reslugs.reason });
+
+    return json(200, {
+      pairs: pairs.pairs,
+      reslugCandidates: reslugs.candidates,
+      // Surfaced so the page can say *why* the list is shorter than it looks: these are slugs an
+      // artist chose, and re-slugging them would break URLs they share.
+      reslugSkippedChosen: reslugs.skippedChosen,
+    });
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method not allowed' });
+  }
+
+  let body: { action?: string; winnerId?: string; loserId?: string; artistId?: string; dryRun?: boolean; force?: boolean };
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return json(400, { error: 'Invalid JSON body' });
+  }
+
+  // Default to a dry run. An admin has to ask for the write explicitly — this deletes artist rows.
+  const dryRun = body.dryRun !== false;
+
+  if (body.action === 'merge') {
+    const { winnerId, loserId } = body;
+    if (!winnerId || !loserId || !UUID_REGEX.test(winnerId) || !UUID_REGEX.test(loserId)) {
+      return json(400, { error: 'winnerId and loserId must be artist UUIDs' });
+    }
+    if (winnerId === loserId) return json(400, { error: 'winnerId and loserId are the same row' });
+
+    // Re-derive the pair server-side rather than trusting the client's idea of the evidence. The
+    // page's list may be stale, and evidence is the whole safety mechanism.
+    const pairs = await findDuplicateArtistPairs(client);
+    if (!pairs.ok) return json(503, { error: pairs.reason });
+
+    const pair = pairs.pairs.find(
+      p => (p.winner.id === winnerId && p.loser.id === loserId)
+        || (p.winner.id === loserId && p.loser.id === winnerId),
+    );
+    if (!pair) {
+      return json(409, {
+        error: 'Those two rows are not a current duplicate pair — the list may be stale. Reload and try again.',
+      });
+    }
+    // Honour the admin's choice of direction if they inverted it, but keep the evidence we derived.
+    const oriented = pair.winner.id === winnerId
+      ? pair
+      : { ...pair, winner: pair.loser, loser: pair.winner };
+
+    const result = await mergeArtistPair(client, oriented, { dryRun, force: body.force === true });
+
+    if (!dryRun && result.ok) {
+      // Worth a breadcrumb: this is irreversible and the evidence class is the thing to audit later.
+      Sentry.captureMessage('[admin] merged duplicate artist rows', {
+        level: 'info',
+        tags: { area: 'artist-merge' },
+        extra: {
+          admin: admin.email,
+          evidence: result.evidence,
+          winner: result.winner.slug,
+          loser: result.loser.slug,
+          forced: body.force === true,
+          steps: result.steps,
+        },
+      });
+    }
+    return json(result.ok ? 200 : 409, result);
+  }
+
+  if (body.action === 'reslug') {
+    const { artistId } = body;
+    if (!artistId || !UUID_REGEX.test(artistId)) {
+      return json(400, { error: 'artistId must be an artist UUID' });
+    }
+    const candidates = await findReslugCandidates(client);
+    if (!candidates.ok) return json(503, { error: candidates.reason });
+
+    const candidate = candidates.candidates.find(c => c.id === artistId);
+    if (!candidate) {
+      return json(409, {
+        error: 'That artist is not a re-slug candidate. Either its slug already matches, or an artist chose it by hand.',
+      });
+    }
+    const result = await reslugArtist(client, candidate, { dryRun });
+    return json(result.ok ? 200 : 409, result);
+  }
+
+  return json(400, { error: "action must be 'merge' or 'reslug'" });
+}

--- a/api/functions/artist-lookup-v1.ts
+++ b/api/functions/artist-lookup-v1.ts
@@ -4,7 +4,7 @@
 
 import { authenticateApiKey, buildCorsHeaders, generateRequestId, v1Response } from './middleware';
 import { checkApiRateLimit, getClientIp } from './ratelimit';
-import { getArtistBySlug } from './db';
+import { getArtistBySlug, resolveArtistSlugAlias } from './db';
 
 interface NetlifyEvent {
   httpMethod: string;
@@ -64,7 +64,14 @@ export async function handler(event: NetlifyEvent) {
   }
 
   try {
-    const artist = await getArtistBySlug(slug);
+    let artist = await getArtistBySlug(slug);
+
+    // A retired slug (merge loser, or an accent re-slug) still resolves. Third-party integrations
+    // hold onto these, so silently 404ing one would break their stored links.
+    if (!artist) {
+      const canonical = await resolveArtistSlugAlias(slug);
+      if (canonical) artist = await getArtistBySlug(canonical);
+    }
 
     if (!artist) {
       return {

--- a/api/functions/artist-lookup.ts
+++ b/api/functions/artist-lookup.ts
@@ -2,7 +2,7 @@
 // Looks up an artist from the Supabase database.
 // Returns the artist with all links, or 404 if not found.
 
-import { getArtistBySlug } from './db';
+import { getArtistBySlug, resolveArtistSlugAlias } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
 export async function handler(event: { queryStringParameters?: Record<string, string>; headers?: Record<string, string> }) {
@@ -22,7 +22,15 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   }
 
   try {
-    const artist = await getArtistBySlug(slug);
+    let artist = await getArtistBySlug(slug);
+
+    // Only on a miss, and only here: a live slug always wins, and getArtistBySlug is on the search
+    // hot path so it must not pay for this. An alias means the artist was merged into another row or
+    // re-slugged when accent folding was fixed — either way the old URL should still work.
+    if (!artist) {
+      const canonical = await resolveArtistSlugAlias(slug);
+      if (canonical) artist = await getArtistBySlug(canonical);
+    }
 
     if (!artist) {
       return {

--- a/api/functions/artist-merge.ts
+++ b/api/functions/artist-merge.ts
@@ -1,0 +1,527 @@
+// Merge duplicate artist rows, and re-slug rows whose slug was mangled before accent folding.
+//
+// ## Why duplicates exist
+//
+// Three separate causes, measured on production 2026-08-03 (27 pairs):
+//
+//   1. **Machine-key names** (9 pairs). Until PR #338, `attachNameOnlyPlatforms` fell back to
+//      `|| normalizedName` when a name-only platform hit had no display name, so the artist was
+//      named after the normalized map key — `kidlightbulbs` alongside `Kid Lightbulbs`. Dead cause.
+//   2. **Spelling disagreement between sources** (13 pairs). MusicBrainz says "Big Thief", another
+//      platform says "Bigthief"; each spelling produces a different `artistSlug`, so each gets a row.
+//      Still live.
+//   3. **Accent mangling** (5 pairs). `artistSlug` used to turn `Björk` into `bj-rk`. Fixed, but the
+//      rows remain.
+//
+// Five pairs shadow a *claimed* profile, which is what makes this user-visible: the artist owns one
+// URL and a stranger's search created a second, thinner one.
+//
+// ## Why a pair being name-similar is NOT enough to merge it
+//
+// `Tiger Cub` and `Tigercub` are different bands — zero shared release titles, measured. So are
+// `Honeycrush` (Brooklyn) and `Honey Crush` (Orlando), which an earlier fix deliberately separated.
+// Merging on name similarity would put one artist's links on another's page, which is the exact
+// failure that fix existed to prevent. So every merge here requires **evidence**, and the evidence
+// is recorded on the result so a human can audit what was trusted.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { artistSlug } from './db';
+import { foldToAscii, normalizeForComparison } from './search-utils';
+
+/** Why we believe two rows are the same artist. */
+export type MergeEvidence =
+  /** The loser's name is exactly the normalized form of the winner's — the #338 bug made it. */
+  | 'provenance'
+  /** The two rows share at least one release title. */
+  | 'release-overlap'
+  /**
+   * The two names are identical once accents are folded — "Björk"/"Bjork",
+   * "Sébastien Tellier"/"Sebastien Tellier". Two sources spelled one artist two ways.
+   *
+   * Mechanical, not a guess, and it excludes the case that looks similar but isn't: `foldToAscii`
+   * maps "Błoto" to "Bloto", which is *not* "Boto", so that pair stays unmerged.
+   */
+  | 'accent-fold'
+  /** Names look alike and nothing else corroborates it. Never merged without an explicit override. */
+  | 'name-only';
+
+/** True when `name` looks like the output of normalizeForComparison rather than a real name. */
+function isMachineKeyName(name: string, other: string): boolean {
+  return name === normalizeForComparison(other) && name !== other;
+}
+
+export interface DuplicateRow {
+  id: string;
+  slug: string;
+  name: string;
+  matchConfidence: string;
+  linkCount: number;
+  releaseCount: number;
+  hasProfile: boolean;
+  analyticsCount: number;
+}
+
+export interface DuplicatePair {
+  /** normalizeForComparison of the shared name. */
+  key: string;
+  winner: DuplicateRow;
+  loser: DuplicateRow;
+  evidence: MergeEvidence;
+  /** Shared normalized release titles, when that's the evidence. */
+  sharedTitles: string[];
+  /**
+   * Reasons this pair must not be merged automatically even if evidence is strong. A merge with any
+   * blocker set is refused unless the caller passes `force`.
+   */
+  blockers: string[];
+}
+
+/**
+ * Pick the surviving row: **claimed wins, else more links.**
+ *
+ * Claimed first because the artist owns that URL and has likely shared it; link count second as a
+ * proxy for which row search has actually populated. This only chooses a winner — it says nothing
+ * about whether the pair is really one artist. That's `evidence`.
+ */
+function pickWinner(a: DuplicateRow, b: DuplicateRow): [DuplicateRow, DuplicateRow] {
+  const aClaimed = a.matchConfidence === 'claimed';
+  const bClaimed = b.matchConfidence === 'claimed';
+  if (aClaimed !== bClaimed) return aClaimed ? [a, b] : [b, a];
+
+  // A machine-key name must never survive. Ahead of link count, because when both rows have one link
+  // the count decides nothing and the id tiebreak was picking rows literally named
+  // "snapinfractionfeatmadeline" and "controlfreakstudio" over the real names. It also has to run
+  // before classify(), which recognises provenance by the *loser* carrying the normalized form.
+  const aIsKey = isMachineKeyName(a.name, b.name);
+  const bIsKey = isMachineKeyName(b.name, a.name);
+  if (aIsKey !== bIsKey) return aIsKey ? [b, a] : [a, b];
+
+  if (a.linkCount !== b.linkCount) return a.linkCount > b.linkCount ? [a, b] : [b, a];
+  // Stable tiebreak so repeated runs agree with each other.
+  return a.id < b.id ? [a, b] : [b, a];
+}
+
+function classify(
+  winner: DuplicateRow,
+  loser: DuplicateRow,
+  winnerTitles: Set<string>,
+  loserTitles: Set<string>,
+): { evidence: MergeEvidence; sharedTitles: string[] } {
+  // The machine-key signature: the loser's name IS the normalized winner name. Nothing else
+  // produces that, so the pair is the same artist by construction.
+  if (isMachineKeyName(loser.name, winner.name)) {
+    return { evidence: 'provenance', sharedTitles: [] };
+  }
+  const shared = [...loserTitles].filter(t => winnerTitles.has(t));
+  if (shared.length > 0) return { evidence: 'release-overlap', sharedTitles: shared };
+
+  // Identical once accents fold: two sources spelled one artist two ways. This is the case fans
+  // actually reported — searching "bjork" landed them on the 1-link `Bjork` stub instead of `Björk`.
+  // Note foldToAscii, not normalizeForComparison: folding keeps "Błoto" as "Bloto" so it does NOT
+  // equal "Boto", which is how that genuinely-different pair stays out of this class.
+  const fold = (s: string) => foldToAscii(s).toLowerCase();
+  if (fold(winner.name) === fold(loser.name) && winner.name !== loser.name) {
+    return { evidence: 'accent-fold', sharedTitles: [] };
+  }
+
+  return { evidence: 'name-only', sharedTitles: [] };
+}
+
+/**
+ * Every pair of artist rows whose names normalize to the same string, with the evidence for merging
+ * and anything that blocks it.
+ *
+ * Reads page by page: `artists` is ~3,400 rows and `artist_links` ~16,800, and PostgREST silently
+ * caps a response at 1,000 whatever limit is asked for.
+ */
+export async function findDuplicateArtistPairs(
+  client: SupabaseClient,
+): Promise<{ ok: true; pairs: DuplicatePair[] } | { ok: false; reason: string }> {
+  const read = async <T>(table: string, columns: string, order: string): Promise<T[] | null> => {
+    const rows: T[] = [];
+    for (let from = 0; from < 50_000; from += 1_000) {
+      const { data, error } = await client
+        .from(table)
+        .select(columns)
+        .order(order)
+        .range(from, from + 999);
+      if (error) {
+        console.error(`[merge] failed reading ${table}:`, error.message);
+        return null;
+      }
+      const batch = (data as T[]) ?? [];
+      rows.push(...batch);
+      if (batch.length < 1_000) return rows;
+    }
+    return rows;
+  };
+
+  const artists = await read<{ id: string; slug: string; name: string; match_confidence: string }>(
+    'artists', 'id, slug, name, match_confidence', 'id');
+  if (!artists) return { ok: false, reason: 'Could not read artists' };
+
+  const links = await read<{ artist_id: string }>('artist_links', 'artist_id', 'id');
+  if (!links) return { ok: false, reason: 'Could not read artist_links' };
+
+  const releases = await read<{ artist_id: string; match_key: string }>(
+    'releases', 'artist_id, match_key', 'id');
+  if (!releases) return { ok: false, reason: 'Could not read releases' };
+
+  const profiles = await read<{ artist_id: string }>('artist_profiles', 'artist_id', 'artist_id');
+  if (!profiles) return { ok: false, reason: 'Could not read artist_profiles' };
+
+  const analytics = await read<{ artist_id: string }>('artist_analytics', 'artist_id', 'artist_id');
+  if (!analytics) return { ok: false, reason: 'Could not read artist_analytics' };
+
+  const count = (rows: { artist_id: string }[]) => {
+    const m = new Map<string, number>();
+    for (const r of rows) m.set(r.artist_id, (m.get(r.artist_id) ?? 0) + 1);
+    return m;
+  };
+  const linkCounts = count(links);
+  const analyticsCounts = count(analytics);
+  const profileIds = new Set(profiles.map(p => p.artist_id));
+  const titles = new Map<string, Set<string>>();
+  for (const r of releases) {
+    if (!titles.has(r.artist_id)) titles.set(r.artist_id, new Set());
+    titles.get(r.artist_id)!.add(r.match_key);
+  }
+
+  const toRow = (a: { id: string; slug: string; name: string; match_confidence: string }): DuplicateRow => ({
+    id: a.id,
+    slug: a.slug,
+    name: a.name,
+    matchConfidence: a.match_confidence,
+    linkCount: linkCounts.get(a.id) ?? 0,
+    releaseCount: titles.get(a.id)?.size ?? 0,
+    hasProfile: profileIds.has(a.id),
+    analyticsCount: analyticsCounts.get(a.id) ?? 0,
+  });
+
+  const groups = new Map<string, DuplicateRow[]>();
+  for (const a of artists) {
+    const key = normalizeForComparison(a.name);
+    if (!key) continue;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(toRow(a));
+  }
+
+  const pairs: DuplicatePair[] = [];
+  for (const [key, rows] of groups) {
+    if (rows.length !== 2) continue; // three-way collisions need a human, not a rule
+    const [winner, loser] = pickWinner(rows[0], rows[1]);
+    const { evidence, sharedTitles } = classify(
+      winner, loser, titles.get(winner.id) ?? new Set(), titles.get(loser.id) ?? new Set());
+
+    const blockers: string[] = [];
+    // Both claimed: two people may each believe they own this artist. Never guess.
+    if (winner.matchConfidence === 'claimed' && loser.matchConfidence === 'claimed') {
+      blockers.push('both rows are claimed');
+    }
+    // artist_profiles is UNIQUE(artist_id), so merging discards one profile's edits outright.
+    if (winner.hasProfile && loser.hasProfile) {
+      blockers.push('both rows have an artist_profiles row — one artist’s edits would be discarded');
+    }
+    // Both sides have releases and none match: positive evidence they are DIFFERENT artists.
+    if (winner.releaseCount > 0 && loser.releaseCount > 0 && sharedTitles.length === 0) {
+      blockers.push('both rows have releases and share none — probably different artists');
+    }
+    pairs.push({ key, winner, loser, evidence, sharedTitles, blockers });
+  }
+
+  // Mergeable first, then by how much is at stake.
+  pairs.sort((a, b) => {
+    const rank = (p: DuplicatePair) =>
+      p.blockers.length > 0 ? 2 : p.evidence === 'name-only' ? 1 : 0;
+    return rank(a) - rank(b) || b.loser.linkCount - a.loser.linkCount;
+  });
+
+  return { ok: true, pairs };
+}
+
+export interface MergeStep {
+  table: string;
+  action: string;
+  count: number;
+}
+
+export interface MergeResult {
+  ok: boolean;
+  dryRun: boolean;
+  winner: { id: string; slug: string; name: string };
+  loser: { id: string; slug: string; name: string };
+  evidence: MergeEvidence;
+  steps: MergeStep[];
+  /** Set when the merge was refused. */
+  refused?: string;
+}
+
+/**
+ * Move everything from `loser` onto `winner`, alias the loser's slug, and delete the loser row.
+ *
+ * Order matters: every reassignment happens before the delete, so a failure part-way leaves the
+ * loser row in place and the merge can simply be re-run. `dryRun` reports the same step list without
+ * writing, and is the default for every caller.
+ *
+ * The seven tables carrying `artist_id`, and what each needs:
+ *   artist_links           UNIQUE(artist_id, platform) — the winner's link wins a platform clash
+ *   artist_analytics       plain reassign; history from both rows should sum
+ *   artist_profiles        UNIQUE(artist_id) — only moves when the winner has none
+ *   release_catalog_state  UNIQUE(artist_id) — derived crawl state, the loser's is dropped
+ *   releases               UNIQUE(artist_id, slug) — only titles the winner lacks move over
+ *   saved_artists          no FK, keyed by (user_id, artist_slug) — the SLUG must be rewritten
+ *   verification_requests  plain reassign
+ */
+export async function mergeArtistPair(
+  client: SupabaseClient,
+  pair: DuplicatePair,
+  opts: { dryRun?: boolean; force?: boolean } = {},
+): Promise<MergeResult> {
+  const dryRun = opts.dryRun !== false;
+  const { winner, loser, evidence } = pair;
+  const base: MergeResult = {
+    ok: false,
+    dryRun,
+    winner: { id: winner.id, slug: winner.slug, name: winner.name },
+    loser: { id: loser.id, slug: loser.slug, name: loser.name },
+    evidence,
+    steps: [],
+  };
+
+  if (winner.id === loser.id) return { ...base, refused: 'winner and loser are the same row' };
+  if (pair.blockers.length > 0 && !opts.force) {
+    return { ...base, refused: `blocked: ${pair.blockers.join('; ')}` };
+  }
+  if (evidence === 'name-only' && !opts.force) {
+    return {
+      ...base,
+      refused:
+        'no evidence beyond name similarity — Tiger Cub/Tigercub and Honeycrush/Honey Crush are ' +
+        'genuinely different artists that look like this',
+    };
+  }
+
+  const steps: MergeStep[] = [];
+  const note = (table: string, action: string, count: number) => {
+    if (count > 0) steps.push({ table, action, count });
+  };
+
+  // --- artist_links: move only platforms the winner doesn't already have.
+  const { data: loserLinks } = await client
+    .from('artist_links').select('id, platform').eq('artist_id', loser.id);
+  const { data: winnerLinks } = await client
+    .from('artist_links').select('platform').eq('artist_id', winner.id);
+  const held = new Set((winnerLinks ?? []).map((l: { platform: string }) => l.platform));
+  const movableLinks = (loserLinks ?? []).filter((l: { platform: string }) => !held.has(l.platform));
+  note('artist_links', 'reassign', movableLinks.length);
+  note('artist_links', 'drop (winner already has the platform)',
+    (loserLinks ?? []).length - movableLinks.length);
+  if (!dryRun && movableLinks.length > 0) {
+    const { error } = await client.from('artist_links')
+      .update({ artist_id: winner.id })
+      .in('id', movableLinks.map((l: { id: string }) => l.id));
+    if (error) return { ...base, steps, refused: `artist_links: ${error.message}` };
+  }
+
+  // --- releases: move only titles the winner lacks, so a shared catalogue isn't duplicated.
+  const { data: loserReleases } = await client
+    .from('releases').select('id, match_key').eq('artist_id', loser.id);
+  const { data: winnerReleases } = await client
+    .from('releases').select('match_key').eq('artist_id', winner.id);
+  const winnerKeys = new Set((winnerReleases ?? []).map((r: { match_key: string }) => r.match_key));
+  const movableReleases = (loserReleases ?? [])
+    .filter((r: { match_key: string }) => !winnerKeys.has(r.match_key));
+  note('releases', 'reassign', movableReleases.length);
+  note('releases', 'drop (winner already has the title)',
+    (loserReleases ?? []).length - movableReleases.length);
+  if (!dryRun && movableReleases.length > 0) {
+    const { error } = await client.from('releases')
+      .update({ artist_id: winner.id })
+      .in('id', movableReleases.map((r: { id: string }) => r.id));
+    if (error) return { ...base, steps, refused: `releases: ${error.message}` };
+  }
+
+  // --- artist_analytics: all of it, so the surviving dashboard keeps both rows' history.
+  //
+  // Counted fresh rather than read off `pair.loser.analyticsCount`. That snapshot is taken when the
+  // pair list is built, which for the admin page is whenever it last loaded — minutes or hours
+  // before the merge is clicked. Gating the write on a stale zero would silently drop history.
+  const { data: loserAnalytics } = await client
+    .from('artist_analytics').select('id').eq('artist_id', loser.id);
+  note('artist_analytics', 'reassign', (loserAnalytics ?? []).length);
+  if (!dryRun && (loserAnalytics ?? []).length > 0) {
+    const { error } = await client.from('artist_analytics')
+      .update({ artist_id: winner.id }).eq('artist_id', loser.id);
+    if (error) return { ...base, steps, refused: `artist_analytics: ${error.message}` };
+  }
+
+  // --- artist_profiles / release_catalog_state: UNIQUE(artist_id), so at most one can survive.
+  for (const table of ['artist_profiles', 'release_catalog_state'] as const) {
+    const { data: onWinner } = await client
+      .from(table).select('artist_id').eq('artist_id', winner.id).maybeSingle();
+    const { data: onLoser } = await client
+      .from(table).select('artist_id').eq('artist_id', loser.id).maybeSingle();
+    if (!onLoser) continue;
+    if (onWinner) {
+      // Dropped rather than merged. For release_catalog_state that's harmless — it's crawl
+      // bookkeeping the next run rebuilds. For artist_profiles it is NOT, which is why two profiles
+      // is a blocker above and this line is only reachable under `force`.
+      note(table, 'delete loser row (winner already has one)', 1);
+      if (!dryRun) await client.from(table).delete().eq('artist_id', loser.id);
+    } else {
+      note(table, 'reassign', 1);
+      if (!dryRun) {
+        const { error } = await client.from(table)
+          .update({ artist_id: winner.id }).eq('artist_id', loser.id);
+        if (error) return { ...base, steps, refused: `${table}: ${error.message}` };
+      }
+    }
+  }
+
+  // --- verification_requests: plain reassign.
+  const { data: vr } = await client
+    .from('verification_requests').select('id').eq('artist_id', loser.id);
+  note('verification_requests', 'reassign', (vr ?? []).length);
+  if (!dryRun && (vr ?? []).length > 0) {
+    await client.from('verification_requests')
+      .update({ artist_id: winner.id }).eq('artist_id', loser.id);
+  }
+
+  // --- saved_artists: keyed by (user_id, artist_slug) with NO foreign key, and artist_id is
+  // ON DELETE SET NULL. So deleting the loser would leave a save pointing at a dead slug rather
+  // than following the merge — the slug has to be rewritten, and a user who saved both rows would
+  // collide on the unique index, so their loser-side save is dropped.
+  const { data: loserSaves } = await client
+    .from('saved_artists').select('id, user_id').eq('artist_slug', loser.slug);
+  const { data: winnerSaves } = await client
+    .from('saved_artists').select('user_id').eq('artist_slug', winner.slug);
+  const savedWinner = new Set((winnerSaves ?? []).map((s: { user_id: string }) => s.user_id));
+  const movableSaves = (loserSaves ?? []).filter((s: { user_id: string }) => !savedWinner.has(s.user_id));
+  const collidingSaves = (loserSaves ?? []).filter((s: { user_id: string }) => savedWinner.has(s.user_id));
+  note('saved_artists', 'repoint slug at the winner', movableSaves.length);
+  note('saved_artists', 'delete (user had already saved the winner)', collidingSaves.length);
+  if (!dryRun) {
+    if (movableSaves.length > 0) {
+      const { error } = await client.from('saved_artists')
+        .update({ artist_slug: winner.slug, artist_id: winner.id })
+        .in('id', movableSaves.map((s: { id: string }) => s.id));
+      if (error) return { ...base, steps, refused: `saved_artists: ${error.message}` };
+    }
+    if (collidingSaves.length > 0) {
+      await client.from('saved_artists').delete()
+        .in('id', collidingSaves.map((s: { id: string }) => s.id));
+    }
+  }
+
+  // --- Alias the loser's slug BEFORE deleting the row, so the URL never has a gap.
+  note('artist_slug_aliases', `alias ${loser.slug} -> ${winner.slug}`, 1);
+  if (!dryRun) {
+    const { error } = await client.from('artist_slug_aliases')
+      .upsert({ alias: loser.slug, artist_id: winner.id, reason: 'merge' }, { onConflict: 'alias' });
+    if (error) return { ...base, steps, refused: `artist_slug_aliases: ${error.message}` };
+  }
+
+  // --- Finally the loser row. Anything still pointing at it cascades away, which is why every
+  // reassignment above happens first.
+  note('artists', 'delete loser row', 1);
+  if (!dryRun) {
+    const { error } = await client.from('artists').delete().eq('id', loser.id);
+    if (error) return { ...base, steps, refused: `artists: ${error.message}` };
+  }
+
+  return { ...base, ok: true, steps };
+}
+
+export interface ReslugCandidate {
+  id: string;
+  name: string;
+  from: string;
+  to: string;
+}
+
+/**
+ * The **old** artistSlug, kept only to tell a machine-generated slug from one a human chose.
+ *
+ * If a row's stored slug equals this, nothing but code produced it and it is safe to replace. If it
+ * differs, somebody picked it — `muz4now`, `boezi`, `courstellation`, `cbertine` — and re-slugging
+ * would break a URL the artist shares. Measured 2026-08-03: 41 rows compute a different slug under
+ * accent folding, but only 17 pass this test; 11 of the other 24 are claimed profiles.
+ */
+function legacyArtistSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+/** Rows whose slug is a mangled artifact of the pre-folding artistSlug, and what it should become. */
+export async function findReslugCandidates(
+  client: SupabaseClient,
+): Promise<{ ok: true; candidates: ReslugCandidate[]; skippedChosen: number } | { ok: false; reason: string }> {
+  const rows: { id: string; slug: string; name: string }[] = [];
+  for (let from = 0; from < 50_000; from += 1_000) {
+    const { data, error } = await client
+      .from('artists').select('id, slug, name').order('id').range(from, from + 999);
+    if (error) return { ok: false, reason: `Could not read artists: ${error.message}` };
+    const batch = data ?? [];
+    rows.push(...batch);
+    if (batch.length < 1_000) break;
+  }
+
+  const candidates: ReslugCandidate[] = [];
+  let skippedChosen = 0;
+  for (const row of rows) {
+    const target = artistSlug(row.name);
+    if (!target || target === row.slug) continue;
+    if (legacyArtistSlug(row.name) !== row.slug) {
+      skippedChosen++; // a human picked this slug
+      continue;
+    }
+    candidates.push({ id: row.id, name: row.name, from: row.slug, to: target });
+  }
+  return { ok: true, candidates, skippedChosen };
+}
+
+/**
+ * Move a row to its folded slug, aliasing the old one.
+ *
+ * Refuses when the target slug is already held by another row — that means the accent duplicate is
+ * still there and must be merged first, which frees the slug.
+ */
+export async function reslugArtist(
+  client: SupabaseClient,
+  candidate: ReslugCandidate,
+  opts: { dryRun?: boolean } = {},
+): Promise<{ ok: boolean; dryRun: boolean; candidate: ReslugCandidate; refused?: string }> {
+  const dryRun = opts.dryRun !== false;
+  const result = { ok: false, dryRun, candidate };
+
+  const { data: holder } = await client
+    .from('artists').select('id, name').eq('slug', candidate.to).maybeSingle();
+  if (holder && (holder as { id: string }).id !== candidate.id) {
+    return { ...result, refused: `slug "${candidate.to}" is held by "${(holder as { name: string }).name}" — merge that pair first` };
+  }
+  if (dryRun) return { ...result, ok: true };
+
+  const { error: aliasError } = await client.from('artist_slug_aliases')
+    .upsert({ alias: candidate.from, artist_id: candidate.id, reason: 'reslug' }, { onConflict: 'alias' });
+  if (aliasError) return { ...result, refused: `alias: ${aliasError.message}` };
+
+  const { error } = await client.from('artists')
+    .update({ slug: candidate.to, updated_at: new Date().toISOString() })
+    .eq('id', candidate.id);
+  if (error) return { ...result, refused: `artists: ${error.message}` };
+
+  // saved_artists keys on the slug and has no FK, so a save would otherwise keep pointing at the
+  // old one. Rows whose user already holds the new slug are left alone rather than colliding.
+  const { data: existing } = await client
+    .from('saved_artists').select('user_id').eq('artist_slug', candidate.to);
+  const taken = new Set((existing ?? []).map((s: { user_id: string }) => s.user_id));
+  const { data: saves } = await client
+    .from('saved_artists').select('id, user_id').eq('artist_slug', candidate.from);
+  const movable = (saves ?? []).filter((s: { user_id: string }) => !taken.has(s.user_id));
+  if (movable.length > 0) {
+    await client.from('saved_artists')
+      .update({ artist_slug: candidate.to })
+      .in('id', movable.map((s: { id: string }) => s.id));
+  }
+
+  return { ...result, ok: true };
+}

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3141,6 +3141,93 @@ export async function findKnownArtistSlugsByName(term: string, limit = 6): Promi
 }
 
 /**
+ * Platforms whose URL identifies the artist's own catalogue, rather than a handle.
+ *
+ * Used as the evidence that an incoming search result is an artist we already have under a different
+ * spelling. Socials and patronage are **deliberately excluded**, and that exclusion is the whole
+ * reason this works. Measured across all 27 duplicate pairs on 2026-08-03:
+ *
+ *   - With socials included, `Honeycrush` and `Honey Crush` share `patreon.com/honeycrush`, and
+ *     `Boto` and `Błoto` share `facebook.com/blotoquartet` — so both pairs look like one artist.
+ *     They are not: those links were mis-attached by the homonym bug fixed in July, and using them
+ *     as evidence would re-fuse exactly what that fix separated.
+ *   - With only these platforms, both drop to "no evidence", `Tigercub`/`Tiger Cub` stays separate,
+ *     and the genuine same-artist pairs still resolve — `Big Thief`/`Bigthief`,
+ *     `Creepy Nuts`/`Creepynuts`, `Cry Wolf`/`Crywolf`, `I.O.I`/`Ioi`, `Rue Oberkampf`/`Rueoberkampf`
+ *     all via a shared Discogs artist id or Bandcamp subdomain.
+ */
+const IDENTITY_PLATFORMS = new Set([
+  'bandcamp', 'mirlo', 'jamcoop', 'faircamp', 'discogs', 'beatport', 'bandwagon', 'subvert', 'even', 'nina',
+]);
+
+/** At most this many URLs are checked per artist, to bound the query. Ordered by trustworthiness. */
+const IDENTITY_LOOKUP_LIMIT = 3;
+
+/**
+ * The slug of an existing artist who already owns one of these platform URLs, or null.
+ *
+ * This is what stops a second row being created for an artist a different source spells differently.
+ * `artistSlug` derives the slug from whichever name won aggregation, and that varies between
+ * searches with which platforms answered — so "Big Thief" and "Bigthief" became two rows, two pages
+ * and two half-populated link sets. Matching on a shared catalogue URL says "this is the artist we
+ * already have" without ever claiming two similarly-named artists are one.
+ *
+ * Returns null when **nothing** matches (a genuinely new artist) and also when **more than one**
+ * artist matches. Two artists sharing an identity URL means the data is already wrong somewhere;
+ * quietly picking one would attach this result to a coin-flip. Falling through creates the row under
+ * its own slug, which is today's behaviour.
+ *
+ * Called only when no row exists at the computed slug — i.e. only when a new row would otherwise be
+ * minted. `persistSearchResults` is awaited before the search response is sent, so an already-known
+ * artist must not pay for this.
+ */
+async function findArtistSlugByIdentityUrl(
+  client: SupabaseClient,
+  platforms: { sourceId: string; url: string }[],
+): Promise<string | null> {
+  const urls = platforms
+    .filter(p => IDENTITY_PLATFORMS.has(p.sourceId))
+    .slice(0, IDENTITY_LOOKUP_LIMIT);
+  if (urls.length === 0) return null;
+
+  // Coarse prefilter on host+path, so a row stored as http://, with a www. prefix, or with a
+  // trailing slash is still a candidate — measured: of 4,782 stored identity links, 2,804 carry
+  // www. and 581 a trailing slash, so exact matching would miss a large share. Same escaping as
+  // deleteStoredLinksForUrl: ilike treats % and _ as wildcards and a URL may contain either.
+  const filters = urls.map(
+    p => `url.ilike.%${urlMatchPrefilter(p.url).replace(/[%_\\]/g, m => `\\${m}`)}%`,
+  );
+
+  try {
+    const { data, error } = await client
+      .from('artist_links')
+      .select('artist_id, url, artists!inner(slug)')
+      .in('platform', [...IDENTITY_PLATFORMS])
+      .or(filters.join(','));
+
+    if (error) {
+      console.error('[DB] identity-url lookup failed:', error.message);
+      return null;
+    }
+
+    // The prefilter is a substring match, so confirm each hit on the normalized URL before trusting
+    // it — otherwise `discogs.com/artist/123` would match `discogs.com/artist/1234`.
+    const wanted = new Set(urls.map(p => normalizeUrlForMatch(p.url)));
+    const slugs = new Set<string>();
+    for (const row of (data ?? []) as { url: string; artists?: { slug?: string } }[]) {
+      if (!wanted.has(normalizeUrlForMatch(row.url))) continue;
+      if (row.artists?.slug) slugs.add(row.artists.slug);
+    }
+
+    if (slugs.size !== 1) return null;
+    return [...slugs][0];
+  } catch (error) {
+    console.error('[DB] findArtistSlugByIdentityUrl error:', error);
+    return null;
+  }
+}
+
+/**
  * Persist artist search results to the database.
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */
@@ -3167,7 +3254,7 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
     // Only persist artists with at least 1 real direct link
     if (validPlatforms.length === 0) return;
 
-    const slug = artistSlug(result.name);
+    let slug = artistSlug(result.name);
 
     try {
       // Check if this artist is already claimed — never overwrite claimed status
@@ -3176,6 +3263,30 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
         .select('id, match_confidence')
         .eq('slug', slug)
         .single();
+
+      // No row at this slug, so a new one is about to be created. Before doing that, check whether
+      // we already hold this artist under a different spelling — different sources spell one artist
+      // differently ("Big Thief" vs "Bigthief"), the slug follows whichever name won aggregation, and
+      // the result was two rows and two half-populated pages. Only reached on the create path, so a
+      // known artist pays nothing for it.
+      if (!existing) {
+        const owned = await findArtistSlugByIdentityUrl(client, validPlatforms);
+        if (owned && owned !== slug) {
+          console.log(`[DB] "${result.name}" already stored as "${owned}" — reusing that row instead of creating ${slug}`);
+          slug = owned;
+          // Re-check the claimed guard against the row we are now writing to: that row may be a
+          // claimed profile, and skipping this would let a stranger's search overwrite it.
+          const { data: owner } = await client
+            .from('artists')
+            .select('match_confidence')
+            .eq('slug', slug)
+            .single();
+          if (owner?.match_confidence === 'claimed') {
+            console.log(`[DB] Skipping persist for claimed artist "${result.name}" (matched via ${slug})`);
+            return;
+          }
+        }
+      }
 
       if (existing?.match_confidence === 'claimed') {
         console.log(`[DB] Skipping persist for claimed artist "${result.name}"`);

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2,7 +2,12 @@
 // All operations are optional — if Supabase is not configured, they no-op gracefully.
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { isBandcampSearchLink, normalizeUrlForMatch, urlMatchPrefilter } from './search-utils';
+import {
+  foldToAscii,
+  isBandcampSearchLink,
+  normalizeUrlForMatch,
+  urlMatchPrefilter,
+} from './search-utils';
 import {
   deriveStatus,
   isFuzzyReleaseMatch,
@@ -30,9 +35,28 @@ export function getClient(): SupabaseClient | null {
   return supabase;
 }
 
-// Generate a URL-safe slug from an artist name
+/**
+ * Generate a URL-safe slug from an artist name.
+ *
+ * Accents are **folded, not stripped**. The old version ran the raw name through
+ * `[^a-z0-9]+ -> '-'`, which mangled every accented artist into something unfindable:
+ *
+ *   Björk             -> bj-rk               (now bjork)
+ *   Sébastien Tellier -> s-bastien-tellier   (now sebastien-tellier)
+ *   Hüsker Dü         -> h-sker-d            (now husker-du)
+ *   Łukasz            -> ukasz               (now lukasz — the Ł used to vanish outright)
+ *
+ * Fans reported being unable to find accented artists, and it was worse than an ugly URL: the
+ * mangled form is what `persistSearchResults` upserts `on conflict (slug)`, so an artist typed with
+ * accents and one typed without produced two rows and two half-populated pages.
+ *
+ * **Changing this changes what an existing artist's slug computes to**, which is why
+ * `artist_slug_aliases` exists — a row whose stored slug is the old mangled form has to be
+ * re-slugged and its old slug aliased, or the next search creates a third row. See
+ * `scripts/merge-duplicate-artists.ts` and migration 20260803180000.
+ */
 export function artistSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return foldToAscii(name).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
 // Determine if a platform URL is a direct link (not a search URL).
@@ -2812,6 +2836,45 @@ export async function putBandcampProbe(
 }
 
 // --- Read Operations ---
+
+/**
+ * Resolve a retired slug to the slug that replaced it, or null if it isn't an alias.
+ *
+ * A **separate** function rather than a fallback inside `getArtistBySlug`, deliberately.
+ * `getArtistBySlug` runs at the front of every search and misses on almost all of them, so folding
+ * an alias read into its miss path would add a round trip to nearly every query. Only the callers
+ * that serve a URL — the artist page and the v1 lookup — should pay for it, and they call this after
+ * `getArtistBySlug` has already returned null.
+ *
+ * Order matters and is the caller's responsibility: a **live** `artists.slug` always wins, so an
+ * alias can never shadow a real artist that later takes that slug.
+ */
+export async function resolveArtistSlugAlias(slug: string): Promise<string | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  // Same guard as getArtistBySlug: stored slugs only ever hold [a-z0-9-], so anything else cannot
+  // match, and rejecting it here keeps the value safe to interpolate into a PostgREST filter.
+  if (!/^[A-Za-z0-9-]+$/.test(slug)) return null;
+
+  try {
+    const { data, error } = await client
+      .from('artist_slug_aliases')
+      .select('artist_id, artists!inner(slug)')
+      .eq('alias', slug.toLowerCase())
+      .maybeSingle();
+
+    if (error) {
+      console.error('[DB] Failed to resolve artist slug alias:', error.message);
+      return null;
+    }
+    const target = (data as { artists?: { slug?: string } } | null)?.artists?.slug;
+    return target ?? null;
+  } catch (error) {
+    console.error('[DB] resolveArtistSlugAlias error:', error);
+    return null;
+  }
+}
 
 /**
  * Look up an artist by slug. Returns null if not found or Supabase is not configured.

--- a/api/functions/search-utils.ts
+++ b/api/functions/search-utils.ts
@@ -379,6 +379,53 @@ export function normalizeAccents(str: string): string {
   return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
+/**
+ * Latin letters Unicode NFD does **not** decompose, and their ASCII equivalents.
+ *
+ * NFD only splits a base letter from a combining mark. A letter with the stroke or slash baked
+ * into the codepoint has nothing to split off, so `normalizeAccents` leaves it untouched and any
+ * `[^a-z0-9]` pass downstream then deletes it or turns it into a separator. Measured 2026-08-03:
+ *
+ *   "Błoto"  -> b-oto     (ł survives NFD, becomes a hyphen)
+ *   "Nørden" -> n-rden
+ *   "Łukasz" -> ukasz     (the first letter disappears entirely)
+ *   "Æther"  -> ther
+ *
+ * Deliberately a short, explicit list of the letters that actually turn up in artist names rather
+ * than a transliteration library — every entry here is one a human can read and check.
+ */
+const NON_DECOMPOSING_LATIN: Record<string, string> = {
+  ø: 'o', Ø: 'O',
+  ł: 'l', Ł: 'L',
+  đ: 'd', Đ: 'D',
+  ð: 'd', Ð: 'D',
+  þ: 'th', Þ: 'Th',
+  æ: 'ae', Æ: 'Ae',
+  œ: 'oe', Œ: 'Oe',
+  ß: 'ss',
+  ħ: 'h', Ħ: 'H',
+  ŋ: 'n', Ŋ: 'N',
+  ı: 'i',
+  ŧ: 't', Ŧ: 'T',
+};
+
+/**
+ * Fold a name to ASCII: decompose what NFD can, transliterate what it can't.
+ *
+ * Use this wherever a name becomes an identifier a human will see or type — a URL slug above all.
+ * `normalizeAccents` alone is not enough there; see NON_DECOMPOSING_LATIN.
+ *
+ * Deliberately NOT used by `normalizeForComparison`, which keys the Bandcamp probe cache
+ * (`query_norm`) and every in-memory match map. Widening that would shift existing cache keys and
+ * silently change which names count as the same artist — a separate, riskier change.
+ */
+export function foldToAscii(str: string): string {
+  return normalizeAccents(str).replace(
+    /[øØłŁđĐðÐþÞæÆœŒßħĦŋŊıŧŦ]/g,
+    c => NON_DECOMPOSING_LATIN[c] ?? c,
+  );
+}
+
 // Normalize a search query for API calls
 // Removes accents but preserves spaces and basic punctuation
 export function normalizeSearchQuery(query: string): string {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -52,6 +52,10 @@
     "functions/__tests__/release-detail-query.test.ts",
     "functions/__tests__/redis-resilience.test.ts",
     "functions/__tests__/recatalog-sweep.test.ts",
-    "functions/__tests__/recatalog-sweep-selection.test.ts"
+    "functions/__tests__/recatalog-sweep-selection.test.ts",
+    "functions/__tests__/artist-slug-accents.test.ts",
+    "functions/artist-merge.ts",
+    "functions/admin-artist-duplicates.ts",
+    "functions/__tests__/artist-merge.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -56,6 +56,7 @@
     "functions/__tests__/artist-slug-accents.test.ts",
     "functions/artist-merge.ts",
     "functions/admin-artist-duplicates.ts",
-    "functions/__tests__/artist-merge.test.ts"
+    "functions/__tests__/artist-merge.test.ts",
+    "functions/__tests__/persist-identity-match.test.ts"
   ]
 }

--- a/apps/web/src/components/AdminDuplicateArtists.tsx
+++ b/apps/web/src/components/AdminDuplicateArtists.tsx
@@ -1,0 +1,300 @@
+// Duplicate artist rows, on the Artist Review page.
+//
+// The same artist can hold two rows with two slugs and two pages — often a near-empty shadow of a
+// claimed profile, which is what artists write in about. Merging is irreversible and touches six
+// tables, so this deliberately makes it a two-step action: Preview runs the merge as a dry run and
+// shows exactly what it would write, and only then does Apply appear.
+//
+// The evidence badge is the safety mechanism, not decoration. A pair that merely *looks* alike is
+// never mergeable here: `Tiger Cub` and `Tigercub` are different bands, and so are `Honeycrush` and
+// `Honey Crush`. The server re-derives the evidence on every request, so a stale page cannot talk it
+// into a merge it wouldn't otherwise allow.
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Session } from '@supabase/supabase-js';
+
+interface DuplicateRow {
+  id: string;
+  slug: string;
+  name: string;
+  matchConfidence: string;
+  linkCount: number;
+  releaseCount: number;
+  hasProfile: boolean;
+}
+
+interface DuplicatePair {
+  key: string;
+  winner: DuplicateRow;
+  loser: DuplicateRow;
+  evidence: 'provenance' | 'release-overlap' | 'accent-fold' | 'name-only';
+  sharedTitles: string[];
+  blockers: string[];
+}
+
+interface ReslugCandidate {
+  id: string;
+  name: string;
+  from: string;
+  to: string;
+}
+
+interface MergeStep {
+  table: string;
+  action: string;
+  count: number;
+}
+
+interface MergeResult {
+  ok: boolean;
+  dryRun: boolean;
+  steps: MergeStep[];
+  refused?: string;
+}
+
+const EVIDENCE_LABEL: Record<DuplicatePair['evidence'], string> = {
+  provenance: 'same artist by construction — the loser’s name is the normalised winner name',
+  'release-overlap': 'shares release titles',
+  'accent-fold': 'identical once accents are folded',
+  'name-only': 'names look alike and nothing corroborates it',
+};
+
+const EVIDENCE_STYLE: Record<DuplicatePair['evidence'], string> = {
+  provenance: 'bg-green-500/10 text-green-400 border-green-500/30',
+  'release-overlap': 'bg-green-500/10 text-green-400 border-green-500/30',
+  'accent-fold': 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+  'name-only': 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
+};
+
+function RowSummary({ row, keep }: { row: DuplicateRow; keep: boolean }) {
+  return (
+    <div className="flex items-baseline gap-2 text-sm">
+      <span className={`text-xs font-mono uppercase ${keep ? 'text-green-400' : 'text-red-400'}`}>
+        {keep ? 'keep' : 'drop'}
+      </span>
+      <span className="text-text-primary font-medium">{row.name}</span>
+      <span className="text-text-muted">/{row.slug}</span>
+      <span className="text-text-muted text-xs">
+        {row.linkCount} links · {row.releaseCount} releases
+        {row.matchConfidence === 'claimed' && ' · CLAIMED'}
+        {row.hasProfile && ' · profile'}
+      </span>
+    </div>
+  );
+}
+
+export function AdminDuplicateArtists({ session }: { session: Session | null }) {
+  const [pairs, setPairs] = useState<DuplicatePair[]>([]);
+  const [reslugs, setReslugs] = useState<ReslugCandidate[]>([]);
+  const [skippedChosen, setSkippedChosen] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [previews, setPreviews] = useState<Record<string, MergeResult>>({});
+
+  const token = session?.access_token;
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/artist-duplicates', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load duplicates');
+      setPairs(data.pairs || []);
+      setReslugs(data.reslugCandidates || []);
+      setSkippedChosen(data.reslugSkippedChosen || 0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load duplicates');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function post(body: Record<string, unknown>): Promise<MergeResult | null> {
+    if (!token) return null;
+    const res = await fetch('/api/admin/artist-duplicates', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok && !data.steps) {
+      setError(data.error || data.refused || 'Request failed');
+      return null;
+    }
+    return data as MergeResult;
+  }
+
+  async function preview(pair: DuplicatePair) {
+    setBusy(pair.key);
+    setError(null);
+    const result = await post({
+      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: true,
+    });
+    if (result) setPreviews(prev => ({ ...prev, [pair.key]: result }));
+    setBusy(null);
+  }
+
+  async function apply(pair: DuplicatePair) {
+    setBusy(pair.key);
+    setError(null);
+    const result = await post({
+      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: false,
+    });
+    setBusy(null);
+    if (result?.ok) {
+      setPreviews(prev => {
+        const next = { ...prev };
+        delete next[pair.key];
+        return next;
+      });
+      await load();
+    } else if (result?.refused) {
+      setError(result.refused);
+    }
+  }
+
+  async function doReslug(candidate: ReslugCandidate) {
+    setBusy(candidate.id);
+    setError(null);
+    await post({ action: 'reslug', artistId: candidate.id, dryRun: false });
+    setBusy(null);
+    await load();
+  }
+
+  const mergeable = pairs.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
+  const review = pairs.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
+
+  if (loading) return <p className="text-text-muted text-sm">Loading duplicate artists…</p>;
+
+  return (
+    <section className="space-y-4">
+      <h2 className="font-display text-lg font-semibold text-text-primary">
+        Duplicate artist rows ({pairs.length})
+      </h2>
+
+      {error && (
+        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      <p className="text-text-muted text-sm">
+        Mergeable pairs have evidence beyond their names. The rest need a look — two artists can share
+        a name, so merging on the name alone would put one artist’s links on another’s page.
+      </p>
+
+      <h3 className="text-text-secondary text-sm font-semibold">
+        Mergeable ({mergeable.length})
+      </h3>
+      {mergeable.length === 0 ? (
+        <p className="text-text-muted text-sm">Nothing to merge.</p>
+      ) : (
+        mergeable.map(pair => {
+          const p = previews[pair.key];
+          return (
+            <div key={pair.key} className="p-4 rounded-xl bg-surface border border-border space-y-3">
+              <span className={`inline-block px-2 py-0.5 rounded border text-xs ${EVIDENCE_STYLE[pair.evidence]}`}>
+                {pair.evidence} — {EVIDENCE_LABEL[pair.evidence]}
+              </span>
+              <div className="space-y-1">
+                <RowSummary row={pair.winner} keep />
+                <RowSummary row={pair.loser} keep={false} />
+              </div>
+              {pair.sharedTitles.length > 0 && (
+                <p className="text-text-muted text-xs">
+                  shared titles: {pair.sharedTitles.slice(0, 5).join(', ')}
+                </p>
+              )}
+
+              {p && (
+                <div className="p-3 rounded-lg bg-bg-secondary text-xs space-y-1">
+                  <span className="text-text-muted block">
+                    This merge would write, then delete /{pair.loser.slug} and alias it to /{pair.winner.slug}:
+                  </span>
+                  {p.steps.map((s, i) => (
+                    <span key={i} className="block text-text-secondary font-mono">
+                      {s.table}: {s.action} ×{s.count}
+                    </span>
+                  ))}
+                  {p.refused && <span className="block text-red-400">{p.refused}</span>}
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <button
+                  onClick={() => void preview(pair)}
+                  disabled={busy === pair.key}
+                  className="px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-sm hover:bg-border disabled:opacity-50"
+                >
+                  {busy === pair.key ? 'Working…' : 'Preview'}
+                </button>
+                {/* Apply only appears after a preview — this deletes an artist row. */}
+                {p?.ok && (
+                  <button
+                    onClick={() => void apply(pair)}
+                    disabled={busy === pair.key}
+                    className="px-3 py-1.5 rounded-lg bg-red-500/15 border border-red-500/30 text-red-400 text-sm hover:bg-red-500/25 disabled:opacity-50"
+                  >
+                    Apply merge
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })
+      )}
+
+      <h3 className="text-text-secondary text-sm font-semibold pt-2">
+        Needs a look ({review.length})
+      </h3>
+      {review.map(pair => (
+        <div key={pair.key} className="p-4 rounded-xl bg-surface border border-border space-y-2">
+          <span className={`inline-block px-2 py-0.5 rounded border text-xs ${EVIDENCE_STYLE[pair.evidence]}`}>
+            {pair.evidence}
+          </span>
+          <div className="space-y-1">
+            <RowSummary row={pair.winner} keep />
+            <RowSummary row={pair.loser} keep={false} />
+          </div>
+          {pair.blockers.map((b, i) => (
+            <p key={i} className="text-yellow-400 text-xs">⚠ {b}</p>
+          ))}
+        </div>
+      ))}
+
+      {reslugs.length > 0 && (
+        <>
+          <h3 className="text-text-secondary text-sm font-semibold pt-2">
+            Slugs to fix ({reslugs.length})
+          </h3>
+          <p className="text-text-muted text-sm">
+            These slugs were mangled before accent folding. {skippedChosen} other rows are left alone
+            because an artist chose their slug by hand. The old slug keeps working after the change.
+          </p>
+          {reslugs.map(c => (
+            <div key={c.id} className="p-3 rounded-xl bg-surface border border-border flex items-center justify-between gap-3">
+              <span className="text-sm">
+                <span className="text-text-primary">{c.name}</span>{' '}
+                <span className="text-text-muted font-mono text-xs">/{c.from} → /{c.to}</span>
+              </span>
+              <button
+                onClick={() => void doReslug(c)}
+                disabled={busy === c.id}
+                className="px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-sm hover:bg-border disabled:opacity-50 whitespace-nowrap"
+              >
+                {busy === c.id ? 'Working…' : 'Fix slug'}
+              </button>
+            </div>
+          ))}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pages/AdminVerifyPage.tsx
+++ b/apps/web/src/pages/AdminVerifyPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Header } from '../components/Header';
 import { SkeletonScreen } from '../components/Skeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
+import { AdminDuplicateArtists } from '../components/AdminDuplicateArtists';
 
 interface VerificationRequest {
   id: string;
@@ -273,6 +274,9 @@ export function AdminVerifyPage() {
                   ))}
                 </section>
               )}
+
+              {/* Duplicate artist rows — the other half of reviewing an artist's identity. */}
+              <AdminDuplicateArtists session={session} />
             </>
           )}
         </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -210,6 +210,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/admin/artist-duplicates"
+  to = "/.netlify/functions/admin-artist-duplicates"
+  status = 200
+
+[[redirects]]
   from = "/api/discord/interaction"
   to = "/.netlify/functions/discord-interaction"
   status = 200

--- a/scripts/merge-duplicate-artists.ts
+++ b/scripts/merge-duplicate-artists.ts
@@ -1,0 +1,134 @@
+/**
+ * Review and merge duplicate artist rows.
+ *
+ * The same artist can hold two rows with two slugs and two pages — one of them often a near-empty
+ * shadow of a claimed profile. See api/functions/artist-merge.ts for how they arise.
+ *
+ * Usage:
+ *   npx tsx scripts/merge-duplicate-artists.ts list
+ *   npx tsx scripts/merge-duplicate-artists.ts merge --all           # dry run
+ *   npx tsx scripts/merge-duplicate-artists.ts merge --all --apply
+ *   npx tsx scripts/merge-duplicate-artists.ts merge <winnerSlug> <loserSlug> [--apply] [--force]
+ *   npx tsx scripts/merge-duplicate-artists.ts reslug [--apply]
+ *
+ * Dry run is the default everywhere; `--apply` is the only thing that writes. `--all` merges only
+ * pairs that have evidence and no blockers — never a name-only lookalike, because `Tiger Cub` and
+ * `Tigercub` are different bands and so are `Honeycrush` and `Honey Crush`. Merging one of those
+ * puts an artist's links on someone else's page.
+ *
+ * Requires SUPABASE_URL and SUPABASE_SERVICE_KEY (or a .env at the repo root).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import {
+  findDuplicateArtistPairs,
+  findReslugCandidates,
+  mergeArtistPair,
+  reslugArtist,
+  type DuplicatePair,
+} from '../api/functions/artist-merge';
+
+config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_KEY;
+if (!url || !key) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_KEY. Set them in .env or environment.');
+  process.exit(1);
+}
+const client = createClient(url, key);
+
+const argv = process.argv.slice(2);
+const command = argv[0];
+const apply = argv.includes('--apply');
+const force = argv.includes('--force');
+const positional = argv.slice(1).filter(a => !a.startsWith('--'));
+
+function describe(pair: DuplicatePair): string {
+  const row = (r: DuplicatePair['winner']) =>
+    `"${r.name}" (${r.slug}, ${r.linkCount}L/${r.releaseCount}R${r.matchConfidence === 'claimed' ? ', CLAIMED' : ''}${r.hasProfile ? ', profile' : ''})`;
+  const blockers = pair.blockers.length ? `\n      BLOCKED: ${pair.blockers.join('; ')}` : '';
+  const shared = pair.sharedTitles.length
+    ? `\n      shared titles: ${pair.sharedTitles.slice(0, 4).join(', ')}`
+    : '';
+  return `  [${pair.evidence}]\n      keep ${row(pair.winner)}\n      drop ${row(pair.loser)}${shared}${blockers}`;
+}
+
+async function list() {
+  const result = await findDuplicateArtistPairs(client);
+  if (!result.ok) { console.error(result.reason); process.exit(1); }
+
+  const mergeable = result.pairs.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
+  const needsReview = result.pairs.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
+
+  console.log(`${result.pairs.length} duplicate pairs\n`);
+  console.log(`MERGEABLE — evidence, no blockers (${mergeable.length}):`);
+  for (const p of mergeable) console.log(describe(p));
+  console.log(`\nNEEDS A HUMAN (${needsReview.length}):`);
+  for (const p of needsReview) console.log(describe(p));
+
+  const reslugs = await findReslugCandidates(client);
+  if (reslugs.ok) {
+    console.log(`\nRE-SLUG candidates (${reslugs.candidates.length}); ${reslugs.skippedChosen} slugs left alone because an artist chose them:`);
+    for (const c of reslugs.candidates) console.log(`  "${c.name}"  ${c.from} -> ${c.to}`);
+  }
+}
+
+async function merge() {
+  const result = await findDuplicateArtistPairs(client);
+  if (!result.ok) { console.error(result.reason); process.exit(1); }
+
+  let targets: DuplicatePair[];
+  if (argv.includes('--all')) {
+    targets = result.pairs.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
+  } else {
+    const [winnerSlug, loserSlug] = positional;
+    if (!winnerSlug || !loserSlug) {
+      console.error('Usage: merge <winnerSlug> <loserSlug> [--apply] [--force]   (or merge --all)');
+      process.exit(1);
+    }
+    const found = result.pairs.find(
+      p => (p.winner.slug === winnerSlug && p.loser.slug === loserSlug)
+        || (p.winner.slug === loserSlug && p.loser.slug === winnerSlug),
+    );
+    if (!found) { console.error(`No current duplicate pair for ${winnerSlug} / ${loserSlug}`); process.exit(1); }
+    // Respect the direction the caller asked for.
+    targets = [found.winner.slug === winnerSlug ? found : { ...found, winner: found.loser, loser: found.winner }];
+  }
+
+  console.log(apply ? `APPLYING ${targets.length} merge(s)\n` : `DRY RUN — ${targets.length} merge(s), pass --apply to write\n`);
+  let merged = 0;
+  for (const pair of targets) {
+    const r = await mergeArtistPair(client, pair, { dryRun: !apply, force });
+    const label = `${pair.loser.slug} -> ${pair.winner.slug}`;
+    if (!r.ok) { console.log(`  SKIP  ${label}\n        ${r.refused}`); continue; }
+    merged++;
+    console.log(`  ${apply ? 'OK  ' : 'WOULD'}  ${label}  [${r.evidence}]`);
+    for (const s of r.steps) console.log(`           ${s.table}: ${s.action} x${s.count}`);
+  }
+  console.log(`\n${apply ? 'merged' : 'would merge'} ${merged} of ${targets.length}`);
+}
+
+async function reslug() {
+  const result = await findReslugCandidates(client);
+  if (!result.ok) { console.error(result.reason); process.exit(1); }
+
+  console.log(apply ? `APPLYING ${result.candidates.length} re-slug(s)\n` : `DRY RUN — ${result.candidates.length} re-slug(s), pass --apply to write\n`);
+  console.log(`(${result.skippedChosen} rows skipped: an artist chose that slug, so changing it would break a URL they share)\n`);
+  for (const c of result.candidates) {
+    const r = await reslugArtist(client, c, { dryRun: !apply });
+    if (!r.ok) { console.log(`  SKIP  ${c.from} -> ${c.to}\n        ${r.refused}`); continue; }
+    console.log(`  ${apply ? 'OK  ' : 'WOULD'}  "${c.name}"  ${c.from} -> ${c.to}`);
+  }
+}
+
+switch (command) {
+  case 'list': await list(); break;
+  case 'merge': await merge(); break;
+  case 'reslug': await reslug(); break;
+  default:
+    console.error('Usage: list | merge [--all | <winnerSlug> <loserSlug>] [--apply] [--force] | reslug [--apply]');
+    process.exit(1);
+}

--- a/supabase/migrations/20260803180000_artist-slug-aliases.sql
+++ b/supabase/migrations/20260803180000_artist-slug-aliases.sql
@@ -1,0 +1,49 @@
+-- Migration: artist_slug_aliases — keep an artist reachable at a slug they used to have.
+--
+-- ## Why
+--
+-- Two things need this, both of which otherwise break URLs that already exist.
+--
+-- 1. **Merging duplicate artist rows.** The same artist can hold two rows with two slugs, so a
+--    merge deletes one of them. Without an alias the loser's URL starts 404ing, and those URLs are
+--    real: `/a/honeycrush` and `/a/kidlightbulbs` are as linkable as any other page.
+--
+-- 2. **Fixing accented slugs.** `artistSlug()` mapped every non-`[a-z0-9]` character to `-`, so
+--    `Björk` became `bj-rk`, `Sébastien Tellier` became `sebastien-tellier`'s ugly cousin
+--    `s-bastien-tellier`, and `Choan Gálvez` became `choan-g-lvez`. Folding accents instead
+--    (`bjork`) is the fix, but it changes what the slug *computes to* — and `persistSearchResults`
+--    upserts `on conflict (slug)`. So the next search for an accented artist would no longer match
+--    their stored row and would create a third one. Re-slugging the row to the folded form and
+--    aliasing the old slug is what makes that fix safe.
+--
+-- ## Lookup order matters
+--
+-- Callers resolve the real `artists.slug` FIRST and only consult this table on a miss. A live slug
+-- must always win, so an alias can never shadow a real artist that later takes that slug — and it
+-- also means the alias lookup costs nothing on the hot path (`getArtistBySlug` runs at the front of
+-- every search; only the artist-page callers ask about aliases).
+
+create table if not exists public.artist_slug_aliases (
+  -- The retired slug. Primary key, so one alias resolves to exactly one artist and the same slug
+  -- can't be claimed twice.
+  alias      text primary key,
+  artist_id  uuid not null references public.artists(id) on delete cascade,
+  -- Why the alias exists: 'merge' (loser of a duplicate merge) or 'reslug' (accent fix).
+  reason     text not null check (reason in ('merge', 'reslug')),
+  created_at timestamptz not null default now()
+);
+
+-- Every lookup is "find the artist for this alias", which the primary key already serves. This
+-- index is for the reverse direction — listing an artist's old slugs when reviewing a merge.
+create index if not exists idx_artist_slug_aliases_artist
+  on public.artist_slug_aliases (artist_id);
+
+alter table public.artist_slug_aliases enable row level security;
+
+-- Intentionally no policies: every reader is server-side and uses the service-role client, which
+-- bypasses RLS. The artist page is rendered by an edge function and the SPA gets its data from a
+-- serverless function, so no anon client ever needs this table. Same pattern as
+-- bandcamp_slug_probes — the missing policies are deliberate, not an oversight.
+
+comment on table public.artist_slug_aliases is
+  'Retired artist slugs (merge losers, accent re-slugs) so old URLs keep resolving. Server-only; resolved after artists.slug misses, never before.';


### PR DESCRIPTION
Artists have been writing in about duplicate profiles. There are **27 duplicate artist row pairs** on production and **5 shadow a claimed profile** — Kid Lightbulbs, Snap Infraction, Shannon Curtis, Loki P-A-W.net and Stan Stewart each have a second, near-empty page at a different URL.

Separately, fans reported being unable to find artists whose name has an accent. That turned out to be the *same* problem: `Björk` and `Bjork` are two rows, and a search for "bjork" lands on the one with 1 link instead of the one with 10.

## What causes it

Three mechanisms, measured:

| Cause | Pairs | Status |
|---|---|---|
| Machine-key names — `kidlightbulbs` beside `Kid Lightbulbs` | 9 | Dead since #338, which added `displayName` to every name-only source |
| Sources spelling one artist differently — `Big Thief` / `Bigthief` | 13 | Still live; not addressed here (see below) |
| Accent mangling — `Björk` → slug `bj-rk` | 5 | Generator fixed in this PR |

## Commit 1 — fold accents in slugs

`artistSlug` ran the raw name through `/[^a-z0-9]+/ -> '-'`, so `Sébastien Tellier` became `s-bastien-tellier` and `Łukasz` lost its first letter entirely. Unicode NFD alone doesn't fix it: a letter carrying its stroke in the codepoint (ł, ø, đ, æ) has no combining mark to strip. `foldToAscii` adds a short, explicit transliteration map for those — deliberately not a library, so every entry is readable.

Deliberately **not** wired into `normalizeForComparison`, which keys the Bandcamp probe cache and every match map — widening that would shift existing cache keys and silently change which names count as the same artist.

Changing `artistSlug` changes what an existing row's slug computes to, so this adds **`artist_slug_aliases`**. Three rules matter:

- Resolved only *after* `artists.slug` misses, so a live slug always wins.
- Via a separate `resolveArtistSlugAlias`, not a fallback inside `getArtistBySlug` — that runs at the front of every search and misses on nearly all of them, so it must not pay a round trip.
- The edge renderer **301s** rather than serving one page at two URLs; it only ever sees crawlers, and humans fall through to the SPA.

Migration validated against a throwaway `postgres:16`: applies clean, idempotent, PK prevents double-claiming an alias, CHECK constrains `reason`, cascade works, RLS on with no policies (server-only, matching `bandcamp_slug_probes`).

## Commit 2 — merge the duplicates that exist

Evidence-gated, because **name similarity is not evidence**: `Tiger Cub` and `Tigercub` are different bands (zero shared release titles), and so are `Honeycrush` and `Honey Crush`, which an earlier fix deliberately separated.

| Evidence | Meaning |
|---|---|
| `provenance` | loser's name **is** `normalizeForComparison(winner's name)` — only the old bug produced that |
| `release-overlap` | the rows share a release title |
| `accent-fold` | identical once folded. Uses `foldToAscii`, so `Błoto` → `Bloto` ≠ `Boto` and that pair stays unmerged |
| `name-only` | refused without an explicit override |

Blockers refuse a merge even with evidence: both rows claimed, both holding an `artist_profiles` row (UNIQUE on `artist_id`, so one artist's edits would be discarded), or both having releases with none shared.

The merge covers all seven tables carrying `artist_id`. Two are subtle:

- `artist_analytics` is counted fresh, not read off the pair snapshot — the admin list can be hours old and a stale zero would silently drop an artist's history.
- `saved_artists` has **no foreign key**, is keyed by `(user_id, artist_slug)`, and nulls `artist_id` on delete. The **slug** has to be rewritten or a fan's save survives pointing at a dead page. A test fails if that's reduced to reassigning `artist_id`.

The loser's slug is aliased **before** the row is deleted, so the URL never has a gap.

Re-slugging is included and only moves rows whose stored slug equals what the *old* `artistSlug` produced. **24 rows fail that test** because an artist picked their slug by hand — `muz4now`, `boezi`, `courstellation`, `cbertine` — 11 of them claimed. Re-slugging those would break URLs artists share.

## How to run it

One module behind both surfaces so they can't drift:

```bash
npx tsx scripts/merge-duplicate-artists.ts list
```

…or the **Duplicate artist rows** section now on `/admin/verify`. Dry run is the default everywhere, Apply only appears after a Preview showing every write, and the server re-derives the evidence per request so a stale page can't talk it into a merge.

## Result

**13 of 27 pairs mergeable** (9 provenance, 3 accent-fold, 1 release-overlap), 14 held for review, 17 slugs to fix. **Nothing is merged or re-slugged by this PR** — that's a separate, reviewed action in the admin UI.

Held back and needing a human: `Stan Stewart` (both rows claimed), `Choan Gálvez` (both hold a profile), `Tigercub`/`Tiger Cub` (probably wants a merge *override* rather than a merge, since search currently conflates two real bands).

## Not in scope

The 13 casing pairs are still arriving, and the mechanism is harder than it looks — it needs choosing a canonical name across sources that disagree, and the same machinery would wrongly merge Tiger Cub with Tigercub. Worth its own change.

## Verification

- 877 API tests pass; 32 new for the merge, 19 for accent folding
- Two bugs were caught by tests written to fail first (the stale analytics count, the `saved_artists` slug rewrite)
- Two more were caught only by running the CLI over production read-only: the winner rule was electing rows named `snapinfractionfeatmadeline`, and `Björk`/`Bjork` was landing in "needs a human"
- `typecheck:api` clean, with all three new files added to the narrow `include` and coverage proven by a deliberate type error
- Full build green; lint unchanged from the baseline on `main` (71 problems before and after)
- An existing test pinned `sigur-r-s`; updated, and strengthened to assert agreement with `artistSlug` rather than a hand-maintained string

🤖 Generated with [Claude Code](https://claude.com/claude-code)