### PR TITLE
Add merge and ignore buttons to the duplicate review queue

### DIFF
--- a/api/functions/__tests__/artist-merge.test.ts
+++ b/api/functions/__tests__/artist-merge.test.ts
@@ -18,6 +18,9 @@ interface Op { table: string; kind: 'select' | 'update' | 'delete' | 'upsert'; p
 const ops: Op[] = [];
 const tables: Record<string, Record<string, unknown>[]> = {};
 
+/** Set to a table name to make that table's paged read fail, as a dropped connection would. */
+let failingTable: string | null = null;
+
 function makeClient() {
   const match = (rows: Record<string, unknown>[], filters: [string, unknown][], ins: [string, unknown[]][]) =>
     rows.filter(r => filters.every(([c, v]) => r[c] === v) && ins.every(([c, vs]) => vs.includes(r[c])));
@@ -37,6 +40,9 @@ function makeClient() {
         in(c: string, v: unknown[]) { ins.push([c, v]); return builder; },
         order() { return builder; },
         range(from: number, to: number) {
+          if (failingTable === table) {
+            return Promise.resolve({ data: null, error: { message: 'connection reset' } });
+          }
           const rows = match(rowsOf(), filters, ins).slice(from, to + 1);
           return Promise.resolve({ data: rows, error: null });
         },
@@ -62,7 +68,12 @@ function makeClient() {
             return Promise.resolve({ data: null, error: null });
           };
           return { eq: (c: string, v: unknown) => { filters.push([c, v]); return apply(); },
-                   in: (c: string, v: unknown[]) => { ins.push([c, v]); return apply(); } };
+                   in: (c: string, v: unknown[]) => { ins.push([c, v]); return apply(); },
+                   // Composite-key delete, as restoreArtistDuplicatePair uses.
+                   match: (obj: Record<string, unknown>) => {
+                     for (const [c, v] of Object.entries(obj)) filters.push([c, v]);
+                     return apply();
+                   } };
         },
         upsert(row: Record<string, unknown>) {
           ops.push({ table, kind: 'upsert', payload: row });
@@ -82,8 +93,10 @@ vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
 process.env.SUPABASE_URL = 'https://example.supabase.co';
 process.env.SUPABASE_SERVICE_KEY = 'k';
 
-const { findDuplicateArtistPairs, mergeArtistPair, findReslugCandidates, reslugArtist } =
-  await import('../artist-merge');
+const {
+  findDuplicateArtistPairs, mergeArtistPair, findReslugCandidates, reslugArtist,
+  dismissArtistDuplicatePair, restoreArtistDuplicatePair, dismissalKey,
+} = await import('../artist-merge');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const client = makeClient() as any;
@@ -104,6 +117,8 @@ beforeEach(() => {
   tables.verification_requests = [];
   tables.saved_artists = [];
   tables.artist_slug_aliases = [];
+  tables.artist_duplicate_dismissals = [];
+  failingTable = null;
 });
 
 async function onlyPair() {
@@ -384,6 +399,106 @@ describe('mergeArtistPair — what it writes', () => {
     const writes = ops.filter(o => o.kind !== 'select');
     expect(writes.at(-1)).toMatchObject({ table: 'artists', kind: 'delete' });
     expect(tables.artists.map(a => a.id)).toEqual(['w']);
+  });
+});
+
+describe('dismissing a pair as different artists', () => {
+  async function tigercubPair() {
+    // The real case: two bands, zero shared titles, so it sits in the review queue forever.
+    tables.artists = [artist('w', 'Tigercub', 'tigercub'), artist('l', 'Tiger Cub', 'tiger-cub')];
+    tables.artist_links = [{ id: 'lk', artist_id: 'w', platform: 'bandcamp' }];
+    return onlyPair();
+  }
+
+  it('canonicalises the id order, so a pair has one representation', () => {
+    // The table enforces artist_id_a < artist_id_b; without sorting, (A,B) and (B,A) would both be
+    // attempted and one would violate the CHECK constraint depending on which row won.
+    expect(dismissalKey('bbb', 'aaa')).toEqual({ artist_id_a: 'aaa', artist_id_b: 'bbb' });
+    expect(dismissalKey('aaa', 'bbb')).toEqual({ artist_id_a: 'aaa', artist_id_b: 'bbb' });
+  });
+
+  it('refuses to dismiss an artist against itself', async () => {
+    const r = await dismissArtistDuplicatePair(client, 'same', 'same');
+    expect(r.ok).toBe(false);
+    expect(tables.artist_duplicate_dismissals ?? []).toEqual([]);
+  });
+
+  it('records the decision with a note and who made it', async () => {
+    const pair = await tigercubPair();
+    const r = await dismissArtistDuplicatePair(client, pair.winner.id, pair.loser.id, {
+      note: 'two bands, Brighton vs Leeds', dismissedBy: 'admin@example.test',
+    });
+
+    expect(r.ok).toBe(true);
+    expect(tables.artist_duplicate_dismissals[0]).toMatchObject({
+      artist_id_a: 'l', artist_id_b: 'w',
+      note: 'two bands, Brighton vs Leeds', dismissed_by: 'admin@example.test',
+    });
+  });
+
+  it('marks the pair dismissed rather than hiding it', async () => {
+    const pair = await tigercubPair();
+    await dismissArtistDuplicatePair(client, pair.winner.id, pair.loser.id, { note: 'different bands' });
+
+    const again = await onlyPair();
+    // Still returned, so the decision is visible and reversible. A one-way hide would mean a
+    // mis-click silently loses a real duplicate.
+    expect(again.dismissed).toBe(true);
+    expect(again.dismissal).toMatchObject({ note: 'different bands' });
+  });
+
+  it('refuses a merge on a dismissed pair EVEN with force', async () => {
+    const pair = await tigercubPair();
+    await dismissArtistDuplicatePair(client, pair.winner.id, pair.loser.id);
+    const dismissedPair = await onlyPair();
+
+    const result = await mergeArtistPair(client, dismissedPair, { dryRun: false, force: true });
+
+    // `force` overrides the automatic checks, not a recorded human decision. Restoring is the
+    // explicit, visible way back — otherwise the queue's own record would be untrustworthy.
+    expect(result.ok).toBe(false);
+    expect(result.refused).toContain('dismissed as different artists');
+    expect(tables.artists).toHaveLength(2);
+  });
+
+  it('restores a pair to the queue', async () => {
+    const pair = await tigercubPair();
+    await dismissArtistDuplicatePair(client, pair.winner.id, pair.loser.id);
+    expect((await onlyPair()).dismissed).toBe(true);
+
+    // Deliberately passed in the opposite order to the dismissal, to prove the key is canonical.
+    const r = await restoreArtistDuplicatePair(client, pair.loser.id, pair.winner.id);
+
+    expect(r.ok).toBe(true);
+    expect(tables.artist_duplicate_dismissals).toEqual([]);
+    expect((await onlyPair()).dismissed).toBe(false);
+  });
+
+  it('sorts dismissed pairs last', async () => {
+    tables.artists = [
+      artist('w1', 'Kid Lightbulbs', 'kid-lightbulbs', 'claimed'), artist('l1', 'kidlightbulbs', 'kidlightbulbs'),
+      artist('w2', 'Tigercub', 'tigercub'), artist('l2', 'Tiger Cub', 'tiger-cub'),
+    ];
+    await dismissArtistDuplicatePair(client, 'w2', 'l2');
+
+    const r = await findDuplicateArtistPairs(client);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // Settled decisions belong at the bottom; the actionable ones are what the queue is for.
+    expect(r.pairs.map(p => p.dismissed)).toEqual([false, true]);
+  });
+
+  it('reports a failed dismissals read rather than showing every pair as active', async () => {
+    tables.artists = [artist('w', 'Tigercub', 'tigercub'), artist('l', 'Tiger Cub', 'tiger-cub')];
+    failingTable = 'artist_duplicate_dismissals';
+
+    const r = await findDuplicateArtistPairs(client);
+
+    // "Couldn't read the dismissals" must not render as "nothing is dismissed" — that would put
+    // settled pairs back in front of the admin and invite a merge they already rejected.
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toContain('artist_duplicate_dismissals');
   });
 });
 

--- a/api/functions/admin-artist-duplicates.ts
+++ b/api/functions/admin-artist-duplicates.ts
@@ -91,15 +91,23 @@ export async function handler(event: {
     }
     if (winnerId === loserId) return json(400, { error: 'An artist cannot be dismissed against itself' });
 
+    const note = body.note?.slice(0, 500)?.trim() || null;
     const result = body.action === 'dismiss'
-      ? await dismissArtistDuplicatePair(client, winnerId, loserId, {
-          note: body.note?.slice(0, 500) ?? null,
-          dismissedBy: admin.email,
-        })
+      ? await dismissArtistDuplicatePair(client, winnerId, loserId, { note, dismissedBy: admin.email })
       : await restoreArtistDuplicatePair(client, winnerId, loserId);
 
     if (!result.ok) return json(503, { error: result.error ?? 'Failed' });
-    return json(200, { ok: true, action: body.action });
+
+    // The stored values come back so the admin page can update the row it just acted on instead of
+    // re-fetching the whole listing — that read pages ~20,000 rows and takes seconds, and reloading
+    // costs the reviewer their place in the queue.
+    return json(200, {
+      ok: true,
+      action: body.action,
+      dismissal: body.action === 'dismiss'
+        ? { note, dismissedBy: admin.email, at: new Date().toISOString() }
+        : null,
+    });
   }
 
   // Default to a dry run. An admin has to ask for the write explicitly — this deletes artist rows.

--- a/api/functions/admin-artist-duplicates.ts
+++ b/api/functions/admin-artist-duplicates.ts
@@ -8,10 +8,12 @@
 
 import { getClient } from './db';
 import {
+  dismissArtistDuplicatePair,
   findDuplicateArtistPairs,
   findReslugCandidates,
   mergeArtistPair,
   reslugArtist,
+  restoreArtistDuplicatePair,
 } from './artist-merge';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
 import { Sentry } from '../lib/sentry';
@@ -65,11 +67,39 @@ export async function handler(event: {
     return json(405, { error: 'Method not allowed' });
   }
 
-  let body: { action?: string; winnerId?: string; loserId?: string; artistId?: string; dryRun?: boolean; force?: boolean };
+  let body: {
+    action?: string;
+    winnerId?: string;
+    loserId?: string;
+    artistId?: string;
+    dryRun?: boolean;
+    force?: boolean;
+    note?: string;
+  };
   try {
     body = JSON.parse(event.body || '{}');
   } catch {
     return json(400, { error: 'Invalid JSON body' });
+  }
+
+  // dismiss/restore act on a pair of artist ids and never touch artist data, so they share one
+  // validation path and skip the dry-run convention that the destructive actions use.
+  if (body.action === 'dismiss' || body.action === 'restore') {
+    const { winnerId, loserId } = body;
+    if (!winnerId || !loserId || !UUID_REGEX.test(winnerId) || !UUID_REGEX.test(loserId)) {
+      return json(400, { error: 'winnerId and loserId must be artist UUIDs' });
+    }
+    if (winnerId === loserId) return json(400, { error: 'An artist cannot be dismissed against itself' });
+
+    const result = body.action === 'dismiss'
+      ? await dismissArtistDuplicatePair(client, winnerId, loserId, {
+          note: body.note?.slice(0, 500) ?? null,
+          dismissedBy: admin.email,
+        })
+      : await restoreArtistDuplicatePair(client, winnerId, loserId);
+
+    if (!result.ok) return json(503, { error: result.error ?? 'Failed' });
+    return json(200, { ok: true, action: body.action });
   }
 
   // Default to a dry run. An admin has to ask for the write explicitly — this deletes artist rows.
@@ -139,5 +169,5 @@ export async function handler(event: {
     return json(result.ok ? 200 : 409, result);
   }
 
-  return json(400, { error: "action must be 'merge' or 'reslug'" });
+  return json(400, { error: "action must be 'merge', 'reslug', 'dismiss' or 'restore'" });
 }

--- a/api/functions/artist-merge.ts
+++ b/api/functions/artist-merge.ts
@@ -74,6 +74,23 @@ export interface DuplicatePair {
    * blocker set is refused unless the caller passes `force`.
    */
   blockers: string[];
+  /**
+   * A human has confirmed these are different artists. Still returned, not dropped, so the decision
+   * can be seen and undone — a one-way hide would mean a mis-click silently loses a real duplicate.
+   */
+  dismissed: boolean;
+  /** Why they were dismissed, and by whom. Null unless `dismissed`. */
+  dismissal: { note: string | null; dismissedBy: string | null; at: string } | null;
+}
+
+/**
+ * The canonical key for a dismissal row: ids sorted, because the table enforces `a < b` so a pair has
+ * exactly one representation and a lookup never has to try both orders.
+ */
+export function dismissalKey(idA: string, idB: string): { artist_id_a: string; artist_id_b: string } {
+  return idA < idB
+    ? { artist_id_a: idA, artist_id_b: idB }
+    : { artist_id_a: idB, artist_id_b: idA };
 }
 
 /**
@@ -173,6 +190,15 @@ export async function findDuplicateArtistPairs(
   const analytics = await read<{ artist_id: string }>('artist_analytics', 'artist_id', 'artist_id');
   if (!analytics) return { ok: false, reason: 'Could not read artist_analytics' };
 
+  const dismissals = await read<{
+    artist_id_a: string; artist_id_b: string; note: string | null; dismissed_by: string | null; created_at: string;
+  }>('artist_duplicate_dismissals', 'artist_id_a, artist_id_b, note, dismissed_by, created_at', 'artist_id_a');
+  if (!dismissals) return { ok: false, reason: 'Could not read artist_duplicate_dismissals' };
+
+  const dismissedBy = new Map(
+    dismissals.map(d => [`${d.artist_id_a}|${d.artist_id_b}`, d]),
+  );
+
   const count = (rows: { artist_id: string }[]) => {
     const m = new Map<string, number>();
     for (const r of rows) m.set(r.artist_id, (m.get(r.artist_id) ?? 0) + 1);
@@ -226,17 +252,78 @@ export async function findDuplicateArtistPairs(
     if (winner.releaseCount > 0 && loser.releaseCount > 0 && sharedTitles.length === 0) {
       blockers.push('both rows have releases and share none — probably different artists');
     }
-    pairs.push({ key, winner, loser, evidence, sharedTitles, blockers });
+    const dk = dismissalKey(winner.id, loser.id);
+    const dismissal = dismissedBy.get(`${dk.artist_id_a}|${dk.artist_id_b}`);
+
+    pairs.push({
+      key, winner, loser, evidence, sharedTitles, blockers,
+      dismissed: !!dismissal,
+      dismissal: dismissal
+        ? { note: dismissal.note, dismissedBy: dismissal.dismissed_by, at: dismissal.created_at }
+        : null,
+    });
   }
 
-  // Mergeable first, then by how much is at stake.
+  // Dismissed last — they are settled. Then mergeable, then by how much is at stake.
   pairs.sort((a, b) => {
     const rank = (p: DuplicatePair) =>
-      p.blockers.length > 0 ? 2 : p.evidence === 'name-only' ? 1 : 0;
+      p.dismissed ? 3 : p.blockers.length > 0 ? 2 : p.evidence === 'name-only' ? 1 : 0;
     return rank(a) - rank(b) || b.loser.linkCount - a.loser.linkCount;
   });
 
   return { ok: true, pairs };
+}
+
+/**
+ * Record that two same-named artists are different artists, so the review queue stops listing them.
+ *
+ * Idempotent: dismissing twice is a no-op rather than an error, because the admin page can be open in
+ * two tabs and a duplicate click should not surface a constraint violation.
+ */
+export async function dismissArtistDuplicatePair(
+  client: SupabaseClient,
+  artistIdA: string,
+  artistIdB: string,
+  opts: { note?: string | null; dismissedBy?: string | null } = {},
+): Promise<{ ok: boolean; error?: string }> {
+  if (artistIdA === artistIdB) return { ok: false, error: 'An artist cannot be dismissed against itself' };
+
+  const { error } = await client
+    .from('artist_duplicate_dismissals')
+    .upsert(
+      {
+        ...dismissalKey(artistIdA, artistIdB),
+        note: opts.note ?? null,
+        dismissed_by: opts.dismissedBy ?? null,
+      },
+      { onConflict: 'artist_id_a,artist_id_b' },
+    );
+
+  if (error) {
+    console.error('[merge] failed to dismiss pair:', error.message);
+    return { ok: false, error: error.message };
+  }
+  return { ok: true };
+}
+
+/** Undo a dismissal, putting the pair back in the review queue. */
+export async function restoreArtistDuplicatePair(
+  client: SupabaseClient,
+  artistIdA: string,
+  artistIdB: string,
+): Promise<{ ok: boolean; error?: string }> {
+  // One `.match()` rather than two chained `.eq()` — the key is composite, so this reads as the
+  // single lookup it is.
+  const { error } = await client
+    .from('artist_duplicate_dismissals')
+    .delete()
+    .match(dismissalKey(artistIdA, artistIdB));
+
+  if (error) {
+    console.error('[merge] failed to restore pair:', error.message);
+    return { ok: false, error: error.message };
+  }
+  return { ok: true };
 }
 
 export interface MergeStep {
@@ -289,6 +376,16 @@ export async function mergeArtistPair(
   };
 
   if (winner.id === loser.id) return { ...base, refused: 'winner and loser are the same row' };
+  // A human already decided these are different artists. Refuse even under `force`: force exists to
+  // override the *automatic* checks, not a recorded human decision. Restore the pair first — that is
+  // an explicit, visible step, whereas silently merging over a dismissal would make the review
+  // queue's own record untrustworthy.
+  if (pair.dismissed) {
+    return {
+      ...base,
+      refused: 'this pair was dismissed as different artists — restore it first if that was wrong',
+    };
+  }
   if (pair.blockers.length > 0 && !opts.force) {
     return { ...base, refused: `blocked: ${pair.blockers.join('; ')}` };
   }

--- a/apps/web/src/components/AdminDuplicateArtists.tsx
+++ b/apps/web/src/components/AdminDuplicateArtists.tsx
@@ -89,7 +89,16 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   const [pairs, setPairs] = useState<DuplicatePair[]>([]);
   const [reslugs, setReslugs] = useState<ReslugCandidate[]>([]);
   const [skippedChosen, setSkippedChosen] = useState(0);
-  const [loading, setLoading] = useState(true);
+  /**
+   * True only until the first fetch resolves.
+   *
+   * Deliberately not reused for later refreshes: this flag gates the whole section, so setting it
+   * again would unmount the list, throw away the reviewer's scroll position, and show a spinner for
+   * the several seconds the listing read takes (it pages ~20,000 rows). Every action below therefore
+   * updates local state in place instead, and `refresh` is the only thing that re-fetches.
+   */
+  const [firstLoad, setFirstLoad] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [previews, setPreviews] = useState<Record<string, MergeResult>>({});
@@ -100,7 +109,7 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
 
   const load = useCallback(async () => {
     if (!token) return;
-    setLoading(true);
+    setRefreshing(true);
     setError(null);
     try {
       const res = await fetch('/api/admin/artist-duplicates', {
@@ -114,13 +123,16 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load duplicates');
     } finally {
-      setLoading(false);
+      setRefreshing(false);
+      setFirstLoad(false);
     }
   }, [token]);
 
   useEffect(() => { void load(); }, [load]);
 
-  async function post(body: Record<string, unknown>): Promise<MergeResult | null> {
+  async function post<T extends { ok?: boolean; error?: string; refused?: string }>(
+    body: Record<string, unknown>,
+  ): Promise<T | null> {
     if (!token) return null;
     const res = await fetch('/api/admin/artist-duplicates', {
       method: 'POST',
@@ -128,11 +140,18 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
       body: JSON.stringify(body),
     });
     const data = await res.json();
-    if (!res.ok && !data.steps) {
+    // A refused merge still carries `steps`, which the preview wants to show — so a non-2xx is only
+    // an error when there is nothing useful in the body.
+    if (!res.ok && !('steps' in data)) {
       setError(data.error || data.refused || 'Request failed');
       return null;
     }
-    return data as MergeResult;
+    return data as T;
+  }
+
+  /** Patch one pair in place, leaving the rest of the list — and the scroll position — untouched. */
+  function patchPair(key: string, patch: Partial<DuplicatePair>) {
+    setPairs(prev => prev.map(p => (p.key === key ? { ...p, ...patch } : p)));
   }
 
   /**
@@ -142,7 +161,7 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   async function preview(pair: DuplicatePair, force = false) {
     setBusy(pair.key);
     setError(null);
-    const result = await post({
+    const result = await post<MergeResult>({
       action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: true, force,
     });
     if (result) setPreviews(prev => ({ ...prev, [pair.key]: result }));
@@ -157,17 +176,21 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   async function apply(pair: DuplicatePair, force = false) {
     setBusy(pair.key);
     setError(null);
-    const result = await post({
+    const result = await post<MergeResult>({
       action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: false, force,
     });
     setBusy(null);
     if (result?.ok) {
+      // The pair is gone, so drop it from the list rather than re-fetching. Nothing else in the
+      // listing goes stale: findReslugCandidates already returns candidates whose target slug is
+      // still held by a duplicate (reslugArtist is what refuses them), so a merge freeing a slug
+      // does not add or remove a row here.
       setPreviews(prev => {
         const next = { ...prev };
         delete next[pair.key];
         return next;
       });
-      await load();
+      setPairs(prev => prev.filter(p => p.key !== pair.key));
     } else if (result?.refused) {
       setError(result.refused);
     }
@@ -176,30 +199,44 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   async function doReslug(candidate: ReslugCandidate) {
     setBusy(candidate.id);
     setError(null);
-    await post({ action: 'reslug', artistId: candidate.id, dryRun: false });
+    const result = await post<{ ok?: boolean; refused?: string }>({
+      action: 'reslug', artistId: candidate.id, dryRun: false,
+    });
     setBusy(null);
-    await load();
+    if (result?.ok) {
+      // Done with this one — drop the row. The list this came from is the only thing the action
+      // changed, so there is nothing to re-fetch.
+      setReslugs(prev => prev.filter(c => c.id !== candidate.id));
+    } else if (result?.refused) {
+      setError(result.refused);
+    }
   }
 
   async function dismiss(pair: DuplicatePair) {
     setBusy(pair.key);
     setError(null);
-    await post({
+    const result = await post<{
+      ok?: boolean; dismissal?: { note: string | null; dismissedBy: string | null; at: string };
+    }>({
       action: 'dismiss',
       winnerId: pair.winner.id,
       loserId: pair.loser.id,
       note: notes[pair.key]?.trim() || undefined,
     });
     setBusy(null);
-    await load();
+    // The server sends back what it stored, so the row moves to the ignored list showing the real
+    // note and author rather than a local guess at them.
+    if (result?.ok) patchPair(pair.key, { dismissed: true, dismissal: result.dismissal ?? null });
   }
 
   async function restore(pair: DuplicatePair) {
     setBusy(pair.key);
     setError(null);
-    await post({ action: 'restore', winnerId: pair.winner.id, loserId: pair.loser.id });
+    const result = await post<{ ok?: boolean }>({
+      action: 'restore', winnerId: pair.winner.id, loserId: pair.loser.id,
+    });
     setBusy(null);
-    await load();
+    if (result?.ok) patchPair(pair.key, { dismissed: false, dismissal: null });
   }
 
   const active = pairs.filter(p => !p.dismissed);
@@ -207,13 +244,25 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   const review = active.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
   const ignored = pairs.filter(p => p.dismissed);
 
-  if (loading) return <p className="text-text-muted text-sm">Loading duplicate artists…</p>;
+  // Only the very first fetch replaces the section. Afterwards the list stays mounted no matter what,
+  // so an action never costs the reviewer their scroll position.
+  if (firstLoad) return <p className="text-text-muted text-sm">Loading duplicate artists…</p>;
 
   return (
     <section className="space-y-4">
-      <h2 className="font-display text-lg font-semibold text-text-primary">
-        Duplicate artist rows ({pairs.length})
-      </h2>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-display text-lg font-semibold text-text-primary">
+          Duplicate artist rows ({pairs.length})
+        </h2>
+        {/* Manual, because actions update the list in place and re-reading it costs seconds. */}
+        <button
+          onClick={() => void load()}
+          disabled={refreshing}
+          className="px-3 py-1.5 rounded-lg bg-bg-secondary text-text-secondary text-sm hover:bg-border disabled:opacity-50 whitespace-nowrap"
+        >
+          {refreshing ? 'Refreshing…' : 'Refresh list'}
+        </button>
+      </div>
 
       {error && (
         <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">

--- a/apps/web/src/components/AdminDuplicateArtists.tsx
+++ b/apps/web/src/components/AdminDuplicateArtists.tsx
@@ -30,6 +30,8 @@ interface DuplicatePair {
   evidence: 'provenance' | 'release-overlap' | 'accent-fold' | 'name-only';
   sharedTitles: string[];
   blockers: string[];
+  dismissed: boolean;
+  dismissal: { note: string | null; dismissedBy: string | null; at: string } | null;
 }
 
 interface ReslugCandidate {
@@ -91,6 +93,8 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [previews, setPreviews] = useState<Record<string, MergeResult>>({});
+  /** Per-pair note, saved with a dismissal so a surprising decision can be understood later. */
+  const [notes, setNotes] = useState<Record<string, string>>({});
 
   const token = session?.access_token;
 
@@ -131,21 +135,30 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
     return data as MergeResult;
   }
 
-  async function preview(pair: DuplicatePair) {
+  /**
+   * `force` matches whatever the Apply button will send. Without it a review-list dry run just comes
+   * back refused, so the admin would be asked to confirm a merge they were never shown.
+   */
+  async function preview(pair: DuplicatePair, force = false) {
     setBusy(pair.key);
     setError(null);
     const result = await post({
-      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: true,
+      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: true, force,
     });
     if (result) setPreviews(prev => ({ ...prev, [pair.key]: result }));
     setBusy(null);
   }
 
-  async function apply(pair: DuplicatePair) {
+  /**
+   * `force` is passed only from the review list, where the pair has no automatic evidence and the
+   * admin is the evidence. It overrides the automatic checks — it does NOT override a recorded
+   * dismissal, which the server refuses outright.
+   */
+  async function apply(pair: DuplicatePair, force = false) {
     setBusy(pair.key);
     setError(null);
     const result = await post({
-      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: false,
+      action: 'merge', winnerId: pair.winner.id, loserId: pair.loser.id, dryRun: false, force,
     });
     setBusy(null);
     if (result?.ok) {
@@ -168,8 +181,31 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
     await load();
   }
 
-  const mergeable = pairs.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
-  const review = pairs.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
+  async function dismiss(pair: DuplicatePair) {
+    setBusy(pair.key);
+    setError(null);
+    await post({
+      action: 'dismiss',
+      winnerId: pair.winner.id,
+      loserId: pair.loser.id,
+      note: notes[pair.key]?.trim() || undefined,
+    });
+    setBusy(null);
+    await load();
+  }
+
+  async function restore(pair: DuplicatePair) {
+    setBusy(pair.key);
+    setError(null);
+    await post({ action: 'restore', winnerId: pair.winner.id, loserId: pair.loser.id });
+    setBusy(null);
+    await load();
+  }
+
+  const active = pairs.filter(p => !p.dismissed);
+  const mergeable = active.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
+  const review = active.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
+  const ignored = pairs.filter(p => p.dismissed);
 
   if (loading) return <p className="text-text-muted text-sm">Loading duplicate artists…</p>;
 
@@ -254,20 +290,105 @@ export function AdminDuplicateArtists({ session }: { session: Session | null }) 
       <h3 className="text-text-secondary text-sm font-semibold pt-2">
         Needs a look ({review.length})
       </h3>
-      {review.map(pair => (
-        <div key={pair.key} className="p-4 rounded-xl bg-surface border border-border space-y-2">
-          <span className={`inline-block px-2 py-0.5 rounded border text-xs ${EVIDENCE_STYLE[pair.evidence]}`}>
-            {pair.evidence}
-          </span>
-          <div className="space-y-1">
-            <RowSummary row={pair.winner} keep />
-            <RowSummary row={pair.loser} keep={false} />
+      <p className="text-text-muted text-sm">
+        Nothing here has evidence beyond the names, so decide each one yourself. If they really are one
+        artist, preview and merge. If they are two different acts, mark them as such and they’ll stop
+        appearing — that decision is recorded and can be undone.
+      </p>
+      {review.map(pair => {
+        const p = previews[pair.key];
+        return (
+          <div key={pair.key} className="p-4 rounded-xl bg-surface border border-border space-y-3">
+            <span className={`inline-block px-2 py-0.5 rounded border text-xs ${EVIDENCE_STYLE[pair.evidence]}`}>
+              {pair.evidence} — {EVIDENCE_LABEL[pair.evidence]}
+            </span>
+            <div className="space-y-1">
+              <RowSummary row={pair.winner} keep />
+              <RowSummary row={pair.loser} keep={false} />
+            </div>
+            {pair.blockers.map((b, i) => (
+              <p key={i} className="text-yellow-400 text-xs">⚠ {b}</p>
+            ))}
+
+            {p && (
+              <div className="p-3 rounded-lg bg-bg-secondary text-xs space-y-1">
+                <span className="text-text-muted block">
+                  This merge would write, then delete /{pair.loser.slug} and alias it to /{pair.winner.slug}:
+                </span>
+                {p.steps.map((s, i) => (
+                  <span key={i} className="block text-text-secondary font-mono">
+                    {s.table}: {s.action} ×{s.count}
+                  </span>
+                ))}
+                {p.refused && <span className="block text-red-400">{p.refused}</span>}
+              </div>
+            )}
+
+            <input
+              type="text"
+              value={notes[pair.key] ?? ''}
+              onChange={e => setNotes(prev => ({ ...prev, [pair.key]: e.target.value }))}
+              placeholder="Why are they different? (optional, saved with the decision)"
+              className="w-full px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-primary text-sm placeholder:text-text-muted"
+            />
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => void preview(pair, true)}
+                disabled={busy === pair.key}
+                className="px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-sm hover:bg-border disabled:opacity-50"
+              >
+                {busy === pair.key ? 'Working…' : 'Preview merge'}
+              </button>
+              {/* Apply only after a preview, and `force` because these have no automatic evidence. */}
+              {p && (
+                <button
+                  onClick={() => void apply(pair, true)}
+                  disabled={busy === pair.key}
+                  className="px-3 py-1.5 rounded-lg bg-red-500/15 border border-red-500/30 text-red-400 text-sm hover:bg-red-500/25 disabled:opacity-50"
+                >
+                  Merge anyway
+                </button>
+              )}
+              <button
+                onClick={() => void dismiss(pair)}
+                disabled={busy === pair.key}
+                className="px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-text-secondary text-sm hover:bg-border disabled:opacity-50"
+              >
+                Not duplicates
+              </button>
+            </div>
           </div>
-          {pair.blockers.map((b, i) => (
-            <p key={i} className="text-yellow-400 text-xs">⚠ {b}</p>
+        );
+      })}
+
+      {ignored.length > 0 && (
+        <>
+          <h3 className="text-text-secondary text-sm font-semibold pt-2">
+            Marked as different artists ({ignored.length})
+          </h3>
+          {ignored.map(pair => (
+            <div key={pair.key} className="p-3 rounded-xl bg-surface/50 border border-border space-y-2">
+              <div className="space-y-1 opacity-70">
+                <RowSummary row={pair.winner} keep />
+                <RowSummary row={pair.loser} keep={false} />
+              </div>
+              <p className="text-text-muted text-xs">
+                {pair.dismissal?.note || 'No reason recorded'}
+                {pair.dismissal?.dismissedBy && ` — ${pair.dismissal.dismissedBy}`}
+                {pair.dismissal?.at && `, ${new Date(pair.dismissal.at).toLocaleDateString()}`}
+              </p>
+              <button
+                onClick={() => void restore(pair)}
+                disabled={busy === pair.key}
+                className="px-3 py-1.5 rounded-lg bg-bg-secondary text-text-primary text-sm hover:bg-border disabled:opacity-50"
+              >
+                {busy === pair.key ? 'Working…' : 'Put back in the queue'}
+              </button>
+            </div>
           ))}
-        </div>
-      ))}
+        </>
+      )}
 
       {reslugs.length > 0 && (
         <>

--- a/apps/web/tests/unit/AdminDuplicateArtists.test.tsx
+++ b/apps/web/tests/unit/AdminDuplicateArtists.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+// The duplicate-artist review queue on /admin/verify.
+//
+// What's worth locking is a workflow property rather than any single render: **an action must not
+// re-fetch the listing.** Brandon, reviewing the first version: "when I 'fix slug' in the current
+// /admin/verify UI, it drives a full page reload - I lose my place and the full list of issues to
+// review takes seconds to reload."
+//
+// Both halves of that were real. `load()` set the flag that gates the whole section, so the list
+// unmounted and came back; and the GET behind it pages ~20,000 rows across six tables. So every
+// action now patches local state, and the tests below fail if any of them goes back to re-fetching.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { AdminDuplicateArtists } from 'src/components/AdminDuplicateArtists';
+
+const session = { access_token: 'admin-token' } as never;
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'id-1', slug: 'slug-1', name: 'Name One', matchConfidence: 'unverified',
+    linkCount: 3, releaseCount: 0, hasProfile: false, ...over,
+  };
+}
+
+function pair(over: Record<string, unknown> = {}) {
+  return {
+    key: 'somekey',
+    winner: row({ id: 'w', slug: 'tigercub', name: 'Tigercub' }),
+    loser: row({ id: 'l', slug: 'tiger-cub', name: 'Tiger Cub', linkCount: 1 }),
+    evidence: 'name-only',
+    sharedTitles: [],
+    blockers: [],
+    dismissed: false,
+    dismissal: null,
+    ...over,
+  };
+}
+
+const LISTING = {
+  pairs: [pair()],
+  reslugCandidates: [{ id: 'a1', name: 'Björk', from: 'bj-rk', to: 'bjork' }],
+  reslugSkippedChosen: 24,
+};
+
+/** Every GET the component makes, so a re-fetch after an action is visible. */
+let gets: number;
+let posts: Record<string, unknown>[];
+let postReply: Record<string, unknown>;
+
+beforeEach(() => {
+  gets = 0;
+  posts = [];
+  postReply = { ok: true };
+  global.fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+    if (!init || init.method !== 'POST') {
+      gets++;
+      return { ok: true, json: async () => LISTING } as Response;
+    }
+    posts.push(JSON.parse(init.body as string));
+    return { ok: true, json: async () => postReply } as Response;
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => cleanup());
+
+/** Render and wait for the one initial fetch to settle. */
+async function mounted() {
+  render(<AdminDuplicateArtists session={session} />);
+  await waitFor(() => expect(screen.getByText(/Slugs to fix/)).toBeTruthy());
+  expect(gets).toBe(1);
+}
+
+describe('AdminDuplicateArtists — an action never re-fetches the listing', () => {
+  it('fixes a slug without re-reading the list', async () => {
+    await mounted();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fix slug' }));
+    await waitFor(() => expect(posts).toHaveLength(1));
+
+    expect(posts[0]).toMatchObject({ action: 'reslug', artistId: 'a1', dryRun: false });
+    // The whole point: no second GET. A re-fetch here is what cost the reviewer their place.
+    expect(gets).toBe(1);
+    // The row it acted on is gone, from local state alone.
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Fix slug' })).toBeNull());
+  });
+
+  it('keeps the rest of the queue mounted through an action', async () => {
+    await mounted();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fix slug' }));
+    await waitFor(() => expect(posts).toHaveLength(1));
+
+    // The section must never fall back to its first-load placeholder — that unmount is what threw
+    // away the scroll position.
+    expect(screen.queryByText(/Loading duplicate artists/)).toBeNull();
+    expect(screen.getByText(/Duplicate artist rows/)).toBeTruthy();
+    expect(screen.getByText('Tigercub')).toBeTruthy();
+  });
+
+  it('dismisses a pair in place, showing what the server recorded', async () => {
+    postReply = {
+      ok: true,
+      dismissal: { note: 'two bands, Brighton vs Leeds', dismissedBy: 'admin@example.test', at: '2026-08-03T15:00:00Z' },
+    };
+    await mounted();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not duplicates' }));
+    await waitFor(() => expect(screen.getByText(/Marked as different artists/)).toBeTruthy());
+
+    expect(gets).toBe(1);
+    // The note and author come from the response, not a local guess, so the row is accurate without
+    // a re-read.
+    expect(screen.getByText(/two bands, Brighton vs Leeds/)).toBeTruthy();
+    expect(screen.getByText(/admin@example\.test/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Not duplicates' })).toBeNull();
+  });
+
+  it('restores a dismissed pair in place', async () => {
+    await mounted();
+    fireEvent.click(screen.getByRole('button', { name: 'Not duplicates' }));
+    await waitFor(() => expect(screen.getByText(/Marked as different artists/)).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Put back in the queue' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Not duplicates' })).toBeTruthy());
+
+    expect(posts.map(p => p.action)).toEqual(['dismiss', 'restore']);
+    expect(gets).toBe(1);
+  });
+
+  it('removes a merged pair without re-fetching', async () => {
+    postReply = { ok: true, dryRun: true, steps: [{ table: 'artist_links', action: 'reassign', count: 1 }] };
+    await mounted();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview merge' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Merge anyway' })).toBeTruthy());
+
+    postReply = { ok: true, dryRun: false, steps: [] };
+    fireEvent.click(screen.getByRole('button', { name: 'Merge anyway' }));
+
+    await waitFor(() => expect(screen.queryByText('Tigercub')).toBeNull());
+    expect(gets).toBe(1);
+    // Review pairs merge with force — they have no automatic evidence, so the admin is the evidence.
+    expect(posts.at(-1)).toMatchObject({ action: 'merge', dryRun: false, force: true });
+  });
+
+  it('re-fetches only when the reviewer asks', async () => {
+    await mounted();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh list' }));
+
+    await waitFor(() => expect(gets).toBe(2));
+    expect(screen.queryByText(/Loading duplicate artists/)).toBeNull();
+  });
+
+  it('keeps the list on screen WHILE a refresh is in flight', async () => {
+    // The assertion above only sees the settled state, so it would miss a placeholder that flashes
+    // during the request — which is exactly the unmount Brandon reported. Holding the response open
+    // is the only way to observe it.
+    await mounted();
+
+    let release: () => void = () => {};
+    const held = new Promise<void>(resolve => { release = resolve; });
+    global.fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init || init.method !== 'POST') {
+        gets++;
+        await held;
+        return { ok: true, json: async () => LISTING } as Response;
+      }
+      posts.push(JSON.parse(init.body as string));
+      return { ok: true, json: async () => postReply } as Response;
+    }) as unknown as typeof fetch;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh list' }));
+    await waitFor(() => expect(screen.getByText(/Refreshing/)).toBeTruthy());
+
+    // Mid-flight: the queue is still there and the first-load placeholder is not.
+    expect(screen.queryByText(/Loading duplicate artists/)).toBeNull();
+    expect(screen.getByText('Tigercub')).toBeTruthy();
+    expect(screen.getByText(/Duplicate artist rows/)).toBeTruthy();
+
+    release();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh list' })).toBeTruthy());
+  });
+});

--- a/scripts/merge-duplicate-artists.ts
+++ b/scripts/merge-duplicate-artists.ts
@@ -23,10 +23,12 @@ import { createClient } from '@supabase/supabase-js';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 import {
+  dismissArtistDuplicatePair,
   findDuplicateArtistPairs,
   findReslugCandidates,
   mergeArtistPair,
   reslugArtist,
+  restoreArtistDuplicatePair,
   type DuplicatePair,
 } from '../api/functions/artist-merge';
 
@@ -60,14 +62,23 @@ async function list() {
   const result = await findDuplicateArtistPairs(client);
   if (!result.ok) { console.error(result.reason); process.exit(1); }
 
-  const mergeable = result.pairs.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
-  const needsReview = result.pairs.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
+  const active = result.pairs.filter(p => !p.dismissed);
+  const ignored = result.pairs.filter(p => p.dismissed);
+  const mergeable = active.filter(p => p.evidence !== 'name-only' && p.blockers.length === 0);
+  const needsReview = active.filter(p => p.evidence === 'name-only' || p.blockers.length > 0);
 
-  console.log(`${result.pairs.length} duplicate pairs\n`);
+  console.log(`${result.pairs.length} duplicate pairs (${ignored.length} marked as different artists)\n`);
   console.log(`MERGEABLE — evidence, no blockers (${mergeable.length}):`);
   for (const p of mergeable) console.log(describe(p));
   console.log(`\nNEEDS A HUMAN (${needsReview.length}):`);
   for (const p of needsReview) console.log(describe(p));
+
+  if (ignored.length > 0) {
+    console.log(`\nMARKED AS DIFFERENT ARTISTS (${ignored.length}) — 'unignore' puts one back:`);
+    for (const p of ignored) {
+      console.log(`  ${p.winner.slug} / ${p.loser.slug}${p.dismissal?.note ? ` — ${p.dismissal.note}` : ''}`);
+    }
+  }
 
   const reslugs = await findReslugCandidates(client);
   if (reslugs.ok) {
@@ -124,11 +135,44 @@ async function reslug() {
   }
 }
 
+/** Record that two same-named artists are different, so `list` stops showing them. */
+async function ignore(restoreInstead: boolean) {
+  const [slugA, slugB] = positional;
+  if (!slugA || !slugB) {
+    console.error(`Usage: ${restoreInstead ? 'unignore' : 'ignore'} <slugA> <slugB> [--note "reason"]`);
+    process.exit(1);
+  }
+  const result = await findDuplicateArtistPairs(client);
+  if (!result.ok) { console.error(result.reason); process.exit(1); }
+
+  const pair = result.pairs.find(
+    p => (p.winner.slug === slugA && p.loser.slug === slugB)
+      || (p.winner.slug === slugB && p.loser.slug === slugA),
+  );
+  if (!pair) { console.error(`No duplicate pair for ${slugA} / ${slugB}`); process.exit(1); }
+
+  const noteIndex = argv.indexOf('--note');
+  const note = noteIndex > -1 ? argv[noteIndex + 1] : undefined;
+
+  const r = restoreInstead
+    ? await restoreArtistDuplicatePair(client, pair.winner.id, pair.loser.id)
+    : await dismissArtistDuplicatePair(client, pair.winner.id, pair.loser.id, { note, dismissedBy: 'cli' });
+
+  if (!r.ok) { console.error(r.error); process.exit(1); }
+  console.log(restoreInstead
+    ? `${slugA} / ${slugB} back in the review queue`
+    : `${slugA} / ${slugB} marked as different artists${note ? ` — ${note}` : ''}`);
+}
+
 switch (command) {
   case 'list': await list(); break;
   case 'merge': await merge(); break;
   case 'reslug': await reslug(); break;
+  case 'ignore': await ignore(false); break;
+  case 'unignore': await ignore(true); break;
   default:
-    console.error('Usage: list | merge [--all | <winnerSlug> <loserSlug>] [--apply] [--force] | reslug [--apply]');
+    console.error(
+      'Usage: list | merge [--all | <winnerSlug> <loserSlug>] [--apply] [--force] | reslug [--apply]\n' +
+      '     | ignore <slugA> <slugB> [--note "reason"] | unignore <slugA> <slugB>');
     process.exit(1);
 }

--- a/supabase/migrations/20260803210000_artist-duplicate-dismissals.sql
+++ b/supabase/migrations/20260803210000_artist-duplicate-dismissals.sql
@@ -1,0 +1,54 @@
+-- Migration: artist_duplicate_dismissals — remember that two same-named artists are NOT duplicates.
+--
+-- ## Why
+--
+-- `/admin/verify` lists every pair of artist rows whose names normalise alike, and 14 of the 27 on
+-- production cannot be merged automatically because name similarity is not evidence. Several of them
+-- are not duplicates at all and never will be:
+--
+--   Tigercub / Tiger Cub     two real bands, zero shared release titles
+--   Honeycrush / Honey Crush Brooklyn and Orlando, separated on purpose by an earlier fix
+--   Boto / Błoto             different artists whose names only collide once folded
+--
+-- Without this table those three sit in the review queue forever, and a queue that always shows the
+-- same un-actionable rows is a queue nobody reads — which is how the real duplicates would get missed.
+--
+-- ## Keyed on the pair, not the name
+--
+-- The obvious key is the shared normalised name, but that would also hide a genuinely *new* third
+-- artist who happens to normalise the same way. Keying on the two artist ids scopes the dismissal to
+-- exactly the pair a human looked at.
+--
+-- `artist_id_a < artist_id_b` is enforced so a pair has one canonical representation: without it
+-- (A,B) and (B,A) could both exist and a lookup would have to try both orders.
+--
+-- Deliberately NOT consulted by the duplicate *prevention* in persistSearchResults. That path matches
+-- an incoming search result against a stored artist by shared platform URL, and the incoming result
+-- has no artist row yet — so there is no pair to look up. Dismissal is about the review queue.
+
+create table if not exists public.artist_duplicate_dismissals (
+  artist_id_a uuid not null references public.artists(id) on delete cascade,
+  artist_id_b uuid not null references public.artists(id) on delete cascade,
+  -- Why a human decided they are different, e.g. "two bands, Brighton vs Leeds".
+  note         text,
+  -- Admin email, so a surprising dismissal can be asked about later.
+  dismissed_by text,
+  created_at   timestamptz not null default now(),
+
+  primary key (artist_id_a, artist_id_b),
+  constraint artist_duplicate_dismissals_ordered check (artist_id_a < artist_id_b)
+);
+
+-- Deleting either artist (including as the loser of a merge elsewhere) drops the dismissal via the
+-- cascades above; this index serves the "what has this artist been dismissed against" direction.
+create index if not exists idx_artist_duplicate_dismissals_b
+  on public.artist_duplicate_dismissals (artist_id_b);
+
+alter table public.artist_duplicate_dismissals enable row level security;
+
+-- Intentionally no policies: written and read only by the admin endpoint through the service-role
+-- client, which bypasses RLS. No anon or authenticated client ever touches it. Same pattern as
+-- bandcamp_slug_probes and artist_slug_aliases — the missing policies are deliberate.
+
+comment on table public.artist_duplicate_dismissals is
+  'Pairs of same-named artists a human confirmed are different artists, so /admin/verify stops listing them. Keyed on the pair (a < b), never on the shared name.';


### PR DESCRIPTION
The review list on `/admin/verify` was read-only. The 14 pairs that need a human decision were a list you could look at and not act on.

## Two buttons, because there are two right answers

| Action | For | How it's guarded |
|---|---|---|
| **Merge anyway** | pairs that really are one artist | Passes `force` — by definition these have no automatic evidence, so the admin *is* the evidence. Preview-first: the button only appears after a dry run has shown every write. |
| **Not duplicates** | pairs that are two different acts | Records the decision in a new `artist_duplicate_dismissals` table with an optional note and the admin's email. |

Ignoring matters as much as merging. `Tigercub`/`Tiger Cub`, `Honeycrush`/`Honey Crush` and `Boto`/`Błoto` are provably different artists — without a way to say so they sit at the top of the queue forever, and a queue that always shows the same un-actionable rows is one nobody reads. That's how a real duplicate gets missed.

## Three design points

**Keyed on the pair, not the shared name.** Keying on the name would also hide a genuinely *new* third artist who normalises the same way. The table enforces `artist_id_a < artist_id_b` so a pair has exactly one representation, and `dismissalKey` sorts to match.

**Dismissed pairs are still returned**, flagged, and shown under "Marked as different artists" with a restore button. A one-way hide would mean a mis-click silently loses a real duplicate.

**A dismissed pair refuses to merge even with `force`.** `force` overrides the automatic checks, not a recorded human decision — restoring is the explicit way back. Otherwise the queue's own record would be untrustworthy. A test fails if that guard weakens to `!opts.force`.

## Failure behaviour

A failed read of the dismissals table refuses the whole listing rather than reporting every pair as active — showing settled pairs again would invite a merge the admin already rejected. Verified against production, where the table doesn't exist yet:

```
[merge] failed reading artist_duplicate_dismissals: Could not find the table ...
Could not read artist_duplicate_dismissals
```

Which is the point, and also means **there's a deploy-ordering window**: the Netlify function deploy and the Supabase migration workflow both fire on merge, and if the function wins the race the duplicates panel 503s until the migration lands. Failing loudly for a couple of minutes beats risking a merge over a dismissal, so I've left it that way — worth a glance at `/admin/verify` a few minutes after merging.

Deliberately **not** consulted by the duplicate prevention in `persistSearchResults`: that path matches an incoming search result against a stored artist by shared platform URL, and the incoming result has no artist row yet, so there is no pair to look up.

## Verification

- Migration validated against a throwaway `postgres:16`: applies clean, idempotent, reversed id order rejected by the CHECK, same pair twice rejected by the PK, cascade drops the dismissal with either artist, RLS on with no policies.
- 898 API tests pass (10 new). Teeth proven on the force guard by weakening it to `!opts.force` and watching the test fail.
- The fake client in `artist-merge.test.ts` gained failure injection so the "couldn't read dismissals" case is actually covered rather than asserted against an undefined variable.
- `typecheck:api` clean, build green, lint unchanged from baseline (71 problems before and after).
- CLI parity: `ignore <slugA> <slugB> [--note "..."]` and `unignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)