### PR TITLE
Page the artist-directory reads so the index can't silently truncate

### DIFF
--- a/api/functions/__tests__/artist-directory.test.ts
+++ b/api/functions/__tests__/artist-directory.test.ts
@@ -11,6 +11,36 @@ vi.mock('@supabase/supabase-js', () => ({
 
 import { handler } from '../artist-directory';
 
+/** PostgREST's `max-rows` on this project. Reads above it are truncated silently. */
+const CAP = 1000;
+
+/**
+ * A filtered query that behaves the way PostgREST really does.
+ *
+ * Awaiting it directly — the bare `.select().eq()` this endpoint used to do — resolves to the
+ * *first `CAP` rows only*, with `error: null`, exactly as production would. `.range(from, to)`
+ * returns that window instead. So a handler that forgets to page still gets a successful-looking
+ * response here and fails on the row count, which is the failure that matters.
+ */
+function cappedQuery<T>(rows: T[]) {
+  const respond = (data: T[]) => Promise.resolve({ data, error: null });
+  return {
+    range: vi.fn((from: number, to: number) => respond(rows.slice(from, to + 1))),
+    then: (
+      onFulfilled: (value: { data: T[]; error: null }) => unknown,
+      onRejected?: (reason: unknown) => unknown
+    ) => respond(rows.slice(0, CAP)).then(onFulfilled, onRejected),
+  };
+}
+
+function verifiedArtists(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    slug: `artist-${String(i).padStart(4, '0')}`,
+    name: `Artist ${String(i).padStart(4, '0')}`,
+    image_url: null,
+  }));
+}
+
 describe('artist-directory handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -25,13 +55,10 @@ describe('artist-directory handler', () => {
         eq: vi.fn((column: string, value: string) => {
           expect(column).toBe('match_confidence');
           expect(value).toBe('verified');
-          return Promise.resolve({
-            data: [
-              { slug: 'zzz-artist', name: 'ZZZ Artist', image_url: null },
-              { slug: 'patrick-hardy', name: 'Patrick Hardy', image_url: 'https://img/p.jpg' },
-            ],
-            error: null,
-          });
+          return cappedQuery([
+            { slug: 'zzz-artist', name: 'ZZZ Artist', image_url: null },
+            { slug: 'patrick-hardy', name: 'Patrick Hardy', image_url: 'https://img/p.jpg' },
+          ]);
         }),
       })),
     });
@@ -43,15 +70,38 @@ describe('artist-directory handler', () => {
       { slug: 'patrick-hardy', name: 'Patrick Hardy', imageUrl: 'https://img/p.jpg' },
       { slug: 'zzz-artist', name: 'ZZZ Artist', imageUrl: null },
     ]);
-    // Only one query — no artist_profiles join for the known scope.
-    expect(mocks.mockFrom).toHaveBeenCalledTimes(1);
+    // Only one table touched — no artist_profiles join for the known scope.
     expect(mocks.mockFrom).toHaveBeenCalledWith('artists');
+    expect(mocks.mockFrom).not.toHaveBeenCalledWith('artist_profiles');
+  });
+
+  // The regression this endpoint was one page away from: 958 verified artists in production on
+  // 2026-08-04, and a bare .select() drops everything past 1,000 with no error to notice.
+  it('scope=known pages past the 1,000-row PostgREST cap instead of truncating', async () => {
+    const rows = verifiedArtists(1042);
+    const eq = vi.fn(() => cappedQuery(rows));
+    mocks.mockFrom.mockReturnValue({ select: vi.fn(() => ({ eq })) });
+
+    const res = await handler({ queryStringParameters: { scope: 'known' } });
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(res.body);
+    expect(body.artists).toHaveLength(1042);
+    // The tail is the part a truncated read loses.
+    expect(body.artists[1041]).toEqual({ slug: 'artist-1041', name: 'Artist 1041', imageUrl: null });
+    expect(new Set(body.artists.map((a: { slug: string }) => a.slug)).size).toBe(1042);
+
+    // Two ranged pages: rows 0–999 (full, so keep going) then 1000–1999 (short, so stop).
+    const ranges = eq.mock.results.flatMap(r => (r.value as { range: { mock: { calls: number[][] } } }).range.mock.calls);
+    expect(ranges).toEqual([[0, 999], [1000, 1999]]);
   });
 
   it('scope=known returns 500 on a query error', async () => {
     mocks.mockFrom.mockReturnValue({
       select: vi.fn(() => ({
-        eq: vi.fn(() => Promise.resolve({ data: null, error: { message: 'boom' } })),
+        eq: vi.fn(() => ({
+          range: vi.fn(() => Promise.resolve({ data: null, error: { message: 'boom' } })),
+        })),
       })),
     });
 
@@ -63,10 +113,7 @@ describe('artist-directory handler', () => {
     mocks.mockFrom
       .mockReturnValueOnce({
         select: vi.fn(() => ({
-          not: vi.fn(() => Promise.resolve({
-            data: [{ artist_id: 'a1', custom_image_url: null }],
-            error: null,
-          })),
+          not: vi.fn(() => cappedQuery([{ artist_id: 'a1', custom_image_url: null }])),
         })),
       })
       .mockReturnValueOnce({
@@ -88,10 +135,67 @@ describe('artist-directory handler', () => {
     expect(mocks.mockFrom).toHaveBeenCalledWith('artists');
   });
 
+  // Same cap on artist_profiles, plus the id list going into a query string: 1,150 claimed
+  // profiles must come back as 1,150 artists, fetched in bounded .in() chunks.
+  it('default scope pages the profile read and chunks the id lookup', async () => {
+    const profiles = Array.from({ length: 1150 }, (_, i) => ({
+      artist_id: `id-${String(i).padStart(4, '0')}`,
+      custom_image_url: null,
+    }));
+
+    const inCalls: string[][] = [];
+    mocks.mockFrom.mockImplementation((table: string) => {
+      if (table === 'artist_profiles') {
+        return { select: vi.fn(() => ({ not: vi.fn(() => cappedQuery(profiles)) })) };
+      }
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn((column: string, ids: string[]) => {
+            expect(column).toBe('id');
+            inCalls.push(ids);
+            return Promise.resolve({
+              // Capped like the real thing, so an unchunked .in() over every id loses the tail.
+              data: ids.slice(0, CAP).map(id => ({
+                id,
+                name: `Artist ${id.slice(3)}`,
+                slug: `artist-${id.slice(3)}`,
+                image_url: null,
+              })),
+              error: null,
+            });
+          }),
+        })),
+      };
+    });
+
+    const res = await handler({});
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).artists).toHaveLength(1150);
+
+    // Every id asked about exactly once, and no chunk large enough to hit the cap or a 414.
+    expect(inCalls.flat()).toEqual(profiles.map(p => p.artist_id));
+    expect(Math.max(...inCalls.map(c => c.length))).toBeLessThanOrEqual(200);
+  });
+
+  it('default scope returns an uncacheable 500 when the profile read fails, not an empty list', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        not: vi.fn(() => ({
+          range: vi.fn(() => Promise.resolve({ data: null, error: { message: 'boom' } })),
+        })),
+      })),
+    });
+
+    const res = await handler({});
+    expect(res.statusCode).toBe(500);
+    // A 200 here would be cached for five minutes as "there are no claimed artists".
+    expect(res.headers).toBeUndefined();
+  });
+
   it('an unrecognized scope value falls back to the claimed (default) path', async () => {
     mocks.mockFrom.mockReturnValue({
       select: vi.fn(() => ({
-        not: vi.fn(() => Promise.resolve({ data: [], error: null })),
+        not: vi.fn(() => cappedQuery([])),
       })),
     });
 

--- a/api/functions/artist-directory.ts
+++ b/api/functions/artist-directory.ts
@@ -1,4 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
+import { readAllPages } from './db';
+
+/**
+ * `.in()` on a list of primary keys, chunked.
+ *
+ * Two hazards in one call: PostgREST caps any response at 1,000 rows, and the id list travels in
+ * the query string, so a few thousand ids is a 414 rather than a slow query. 200 keeps both away —
+ * `id` is unique, so a 200-id chunk can match at most 200 rows and can never reach the row cap,
+ * which is why the chunks below don't need paging on top of this.
+ */
+const ID_CHUNK = 200;
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'public, max-age=300, s-maxage=300',
+};
 
 export async function handler(event: { queryStringParameters?: Record<string, string> }) {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -14,60 +30,75 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   // /artist/ pages backfilled from data/artists-manifest.json (#384/#385).
   // match_confidence is a single, mutually-exclusive column, so this needs
   // no join against artist_profiles the way the claimed path below does.
+  //
+  // Paged, not a bare .select(): 958 verified artists as of 2026-08-04, and at 1,000 PostgREST
+  // starts dropping the rest silently — no error, just a shorter index than the real one.
   if (event.queryStringParameters?.scope === 'known') {
-    const { data: artistRows, error } = await supabase
+    const known = await readAllPages<{ slug: string; name: string; image_url: string | null }>(
+      (from, to) =>
+        supabase
+          .from('artists')
+          .select('slug, name, image_url')
+          .eq('match_confidence', 'verified')
+          .range(from, to),
+      'verified artists'
+    );
+
+    if (!known.ok) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
+    }
+
+    const artists = known.rows
+      .map(a => ({ slug: a.slug, name: a.name, imageUrl: a.image_url || null }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ artists }) };
+  }
+
+  // Fetch all verified (claimed) artist profiles — 128 today, so the paging is headroom rather
+  // than a live fix, but the failure mode is identical and invisible.
+  const profiles = await readAllPages<{ artist_id: string; custom_image_url: string | null }>(
+    (from, to) =>
+      supabase
+        .from('artist_profiles')
+        .select('artist_id, custom_image_url')
+        .not('verified_at', 'is', null)
+        .range(from, to),
+    'verified artist profiles'
+  );
+
+  // A read failure is not "there are no claimed artists". This used to answer 200 with an empty
+  // list, which the Cache-Control above then pinned for five minutes — a blank directory served
+  // long after the transient error cleared. 5xx isn't cached, and ArtistIndexPage retries it.
+  if (!profiles.ok) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
+  }
+
+  if (profiles.rows.length === 0) {
+    return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ artists: [] }) };
+  }
+
+  // Fetch artist details
+  const artistIds = profiles.rows.map(p => p.artist_id);
+  const artistRows: { id: string; name: string; slug: string; image_url: string | null }[] = [];
+
+  for (let i = 0; i < artistIds.length; i += ID_CHUNK) {
+    const { data, error } = await supabase
       .from('artists')
-      .select('slug, name, image_url')
-      .eq('match_confidence', 'verified');
+      .select('id, name, slug, image_url')
+      .in('id', artistIds.slice(i, i + ID_CHUNK));
 
     if (error) {
       return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
     }
-
-    const artists = (artistRows || [])
-      .map(a => ({ slug: a.slug, name: a.name, imageUrl: a.image_url || null }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300, s-maxage=300',
-      },
-      body: JSON.stringify({ artists }),
-    };
-  }
-
-  // Fetch all verified (claimed) artist profiles
-  const { data: profiles, error: profileError } = await supabase
-    .from('artist_profiles')
-    .select('artist_id, custom_image_url')
-    .not('verified_at', 'is', null);
-
-  if (profileError || !profiles || profiles.length === 0) {
-    return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300, s-maxage=300' },
-      body: JSON.stringify({ artists: [] }),
-    };
-  }
-
-  // Fetch artist details
-  const artistIds = profiles.map(p => p.artist_id);
-  const { data: artistRows, error: artistError } = await supabase
-    .from('artists')
-    .select('id, name, slug, image_url')
-    .in('id', artistIds);
-
-  if (artistError) {
-    return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
+    artistRows.push(...(data || []));
   }
 
   const customImageMap = new Map(
-    profiles.filter(p => p.custom_image_url).map(p => [p.artist_id, p.custom_image_url])
+    profiles.rows.filter(p => p.custom_image_url).map(p => [p.artist_id, p.custom_image_url])
   );
 
-  const artists = (artistRows || [])
+  const artists = artistRows
     .map(a => ({
       slug: a.slug,
       name: a.name,
@@ -75,12 +106,5 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=300, s-maxage=300',
-    },
-    body: JSON.stringify({ artists }),
-  };
+  return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ artists }) };
 }

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -711,8 +711,11 @@ function isCatalogueableLink(platform: string, url: string): boolean {
  * rows simply aren't there. A single `.select()` over `artist_links` returns 1,000 of ~3,900
  * rows and looks perfectly successful, which would quietly hide three quarters of the sweep's
  * pool. Measured on production 2026-08-02.
+ *
+ * Exported because the cap is not the sweep's problem, it's every read's problem: use this for
+ * any query whose table can exceed 1,000 rows, and pass the caller's own `.range(from, to)`.
  */
-async function readAllPages<T>(
+export async function readAllPages<T>(
   run: (from: number, to: number) => PromiseLike<{ data: unknown; error: { message: string } | null }>,
   label: string
 ): Promise<{ ok: true; rows: T[] } | { ok: false; reason: string }> {
@@ -736,7 +739,7 @@ async function readAllPages<T>(
   // Hitting this means the table outgrew the backstop. Say so rather than returning a truncated
   // pool that reads as complete — the whole point of this helper.
   console.error(`[DB] ${label} exceeded ${MAX_PAGES * PAGE} rows; refusing a truncated read`);
-  return { ok: false, reason: `${label} is larger than the sweep can page through` };
+  return { ok: false, reason: `${label} is larger than this read can page through` };
 }
 
 /**

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -54,6 +54,8 @@
     "functions/__tests__/recatalog-sweep.test.ts",
     "functions/__tests__/recatalog-sweep-selection.test.ts",
     "functions/__tests__/artist-slug-accents.test.ts",
+    "functions/artist-directory.ts",
+    "functions/__tests__/artist-directory.test.ts",
     "functions/artist-merge.ts",
     "functions/admin-artist-duplicates.ts",
     "functions/__tests__/artist-merge.test.ts",


### PR DESCRIPTION
## Why

`/api/artist-directory?scope=known` — the "Artists You Know" set behind [/known-artists](https://unstream.stream/known-artists) — read the whole table with a bare `.select()`:

```ts
const { data: artistRows, error } = await supabase
  .from('artists')
  .select('slug, name, image_url')
  .eq('match_confidence', 'verified');
```

PostgREST caps every response at 1,000 rows and truncates **silently** — no error, no flag, the rows simply aren't in `data`. There are **958 verified artists** today, so this endpoint was ~42 artists away from quietly dropping people off the page with nothing to notice it by. This is the same class of bug as the one that gave the recatalog sweep a pool of 697 instead of 2,564 (#404), and CLAUDE.md's "Paging, not `.limit()`" section exists because of it.

Nothing alerts on this. The only defence is reading every `.select()` and asking how big the table gets.

## What changed

**Both reads now page.** `readAllPages` in `db.ts` — already doing this for the sweep — is exported for the purpose, and takes the caller's own `.range(from, to)`, so `artist-directory.ts` keeps its own client.

- `scope=known` (958 rows): the live fix.
- The claimed path's `artist_profiles` read (128 rows): headroom rather than a live fix, but the failure mode is identical and just as invisible. Commented as such so the number doesn't read as urgent.

**The `.in('id', artistIds)` lookup is chunked at 200.** Two hazards in one call, not one: the row cap, *and* the id list travelling in the query string, where a few thousand UUIDs is a 414 rather than a slow query. Because `id` is unique, a 200-id chunk can match at most 200 rows and can never reach the cap — so the chunks need no `.range()` paging on top of the chunking, which the comment says explicitly so it doesn't read as a half-done fix.

## One behaviour change worth a look

A **failed** `artist_profiles` read used to return `200 {artists: []}` *with* `Cache-Control: public, max-age=300` — a transient error pinned as "there are no claimed artists" for five minutes after it had cleared. That's caching uncertainty on an error path. It now returns 500, matching what the `scope=known` branch already did: uncached, and `ArtistIndexPage` already retries 5xx once before giving up. Either way the user sees an empty list in the worst case; the difference is whether the CDN keeps serving it.

## Test approach

The new tests mock what PostgREST actually does rather than just offering a `.range()` method. A mock whose chain *only* has `.range()` makes unpaged code fail with `range is not a function` — a shape error, not the bug. So `cappedQuery` gives the query object both a `.range(from, to)` **and** a `then` that resolves to `rows.slice(0, 1000)` with `error: null`, exactly as production would.

The unpaged handler therefore still gets a successful-looking response and fails on the row count. Confirmed by reverting the fix and running the suite:

```
× scope=known pages past the 1,000-row PostgREST cap instead of truncating
  AssertionError: expected [ …(1000) ] to have a length of 1042 but got 1000
× default scope pages the profile read and chunks the id lookup
  AssertionError: expected [ …(1000) ] to have a length of 1150 but got 1000
```

4 tests → 7, covering: paging past the cap with the tail intact and the exact ranges requested (`[[0, 999], [1000, 1999]]`), chunked `.in()` with every id asked about exactly once and no chunk over 200, and the uncacheable 500 on a failed profile read.

`artist-directory.ts` and its test are added to `api/tsconfig.json`'s typecheck include, per CLAUDE.md's note about that list's narrow coverage. I confirmed the include actually bites by planting a deliberate type error and watching it fail.

## Verification

- `npm run test:api` — 901 passed (49 files)
- `npm run test:unit` — 636 passed (47 files)
- `npx tsc -b` and `npm run typecheck:api` — clean
- `npm run lint` — 71 problems, unchanged from the pre-existing baseline on `main` (it only covers `apps/web`; nothing here is in scope)
- No generated files dirtied (`sitemap.xml` / `dispatch.xml` untouched)

No migration, no schema change, no new env var. `/known-artists` and `/artists` are the only consumers, plus `scripts/generate-social-posts.ts`, which reads the default scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)