### PR TITLE
Add Mirlo as a release source via its REST API

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PLATFORMS } from "../shared/platform-registry.ts";
 import { isBandcampFriday } from "../shared/bandcamp-friday.ts";
 import { mainLinkDividerIndexes } from "../shared/link-dividers.ts";
-import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate } from "../shared/release-display.ts";
+import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate, releaseTypeLabel } from "../shared/release-display.ts";
 import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.ts";
 
 /**
@@ -77,13 +77,11 @@ function renderReleaseRow(release: ReleaseRow, artistSlug: string): string {
   const title = escapeHtml(release.title);
   const date = formatReleaseDate(release.release_date, release.date_precision);
 
-  // Capitalized here rather than with `text-transform: capitalize`, which applies to the whole
-  // line and would turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
-  const type = release.release_type === 'other'
-    ? ''
-    : release.release_type.charAt(0).toUpperCase() + release.release_type.slice(1);
-
   const sources = (release.release_sources || []).map(s => ({ platform: s.platform, offers: s.release_offers || [] }));
+
+  // Capitalized in the helper rather than with `text-transform: capitalize`, which applies to the
+  // whole line and would turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
+  const type = releaseTypeLabel(release.release_type, sources.map(s => s.platform));
   // leadingOfferSummary, not the globally cheapest price across every source — see the
   // function's own doc for why picking the absolute cheapest could rank a Discogs secondhand
   // listing above a Bandcamp direct purchase.

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -28,6 +28,7 @@ import {
   payoutEstimate,
   payoutRank,
   relativeDays,
+  releaseTypeLabel,
 } from "../shared/release-display.ts";
 
 function escapeHtml(str: string): string {
@@ -220,7 +221,13 @@ export default async function handler(request: Request, context: Context) {
     const bcFriday = isBandcampFriday();
 
     const dateText = formatReleaseDate(release.release_date, release.date_precision);
-    const typeLabel = release.release_type === 'other' ? '' : release.release_type.toUpperCase();
+    // Upper-cased here, not in the helper: this page shouts the label where the lists sentence-case
+    // it. Platforms come from the release's own sources, so a download-only release reads DIGITAL
+    // rather than showing nothing where its kind is unknown.
+    const typeLabel = releaseTypeLabel(
+      release.release_type,
+      (release.release_sources || []).map(s => s.platform)
+    ).toUpperCase();
     const statusText = release.status === 'announced'
       ? (dateText ? `Coming ${dateText}` : 'Announced')
       : dateText;

--- a/api/functions/__tests__/mirlo-rest-ingest.test.ts
+++ b/api/functions/__tests__/mirlo-rest-ingest.test.ts
@@ -1,0 +1,459 @@
+// Mirlo's REST API as a release source.
+//
+// **Every fixture here is real.** Each `trackGroups[]` entry below was captured from a live
+// `GET https://api.mirlo.space/v1/artists/{slug}` on 2026-08-05 (209 releases across 31 artists,
+// trimmed to the fields the ingest reads). That matters: the previous attempt at this integration
+// built its fixtures from pasted documentation and therefore only ever pinned our own
+// assumptions. These pin Mirlo's actual field names and actual data hygiene.
+//
+// The cases that would fail silently in production, and so are the point of this file:
+//   - `null` minPrice read as free, which would advertise terms an artist never set
+//   - cents read as currency units, publishing a $4.00 record as $400
+//   - 'gbp' and 'GBP' stored as two different currencies
+//   - drafts ingested as untitled releases, because they report isPublic: true
+//   - an error body reduced to "this artist has released nothing"
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildMirloRelease,
+  ingestMirloArtist,
+  mirloArtistSlug,
+  type MirloTrackGroupRaw,
+} from '../release-ingest';
+
+/** A fixed "now" so status and date-bounding assertions don't drift with the wall clock. */
+const NOW = new Date('2026-08-05T12:00:00.000Z');
+
+// --- Real captured releases ----------------------------------------------------
+
+/** timerival — name-your-price: minPrice 0 with a suggestion, and a genuine future date. */
+const NAME_YOUR_PRICE: MirloTrackGroupRaw = {
+  title: 'Below the Apex of the Sky',
+  urlSlug: 'below-the-apex-of-the-sky',
+  type: null,
+  releaseDate: '2026-09-04T00:00:00.000Z',
+  minPrice: 0,
+  currency: 'usd',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: {
+    sizes: {
+      '600': 'https://cdn.mirlo.space/file/trackgroup-covers/1806e57e-11d5-4015-85c0-0cc6abaf96e7-x600.webp',
+    },
+  },
+};
+
+/** timerival — the one release in the whole sample with isPreorder: true. */
+const PREORDER: MirloTrackGroupRaw = {
+  title: 'Cooked',
+  urlSlug: 'cooked',
+  type: null,
+  releaseDate: '2026-08-07T00:00:00.000Z',
+  minPrice: 400,
+  currency: 'usd',
+  isPreorder: true,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: {
+    sizes: {
+      '600': 'https://cdn.mirlo.space/file/trackgroup-covers/13022cc3-f02b-4ce8-a5d6-8f774b6165eb-x600.webp',
+    },
+  },
+};
+
+/** timerival — an ordinary priced, already-released record. */
+const PLAIN_PRICED: MirloTrackGroupRaw = {
+  title: 'stay safe out there',
+  urlSlug: 'stay-safe-out-there',
+  type: null,
+  releaseDate: '2026-07-28T00:00:00.000Z',
+  minPrice: 100,
+  currency: 'usd',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: { sizes: { '600': 'https://cdn.mirlo.space/file/trackgroup-covers/09f5c9d7-x600.webp' } },
+};
+
+/**
+ * timerival — a draft. Note `isPublic: true`, `hideFromSearch: false`, `isGettable: true`: the
+ * visibility flags do NOT mark it, which is exactly why the slug prefix is what's matched.
+ */
+const DRAFT_UUID_SLUG: MirloTrackGroupRaw = {
+  title: '',
+  urlSlug: 'mi-temp-slug-new-album-1a734faf-94c2-4a8e-9491-17906d3a0b3a',
+  type: null,
+  releaseDate: '2024-05-20T14:58:43.070Z',
+  minPrice: null,
+  currency: 'usd',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: null,
+};
+
+/** botflymother — the other real draft shape: no uuid, just a counter. */
+const DRAFT_COUNTER_SLUG: MirloTrackGroupRaw = {
+  ...DRAFT_UUID_SLUG,
+  urlSlug: 'mi-temp-slug-new-album-0',
+  releaseDate: '2024-03-30T18:41:14.082Z',
+};
+
+/** mumbleandsigh — minPrice null alongside suggestedPrice null: no price configured. */
+const NO_PRICE_SET: MirloTrackGroupRaw = {
+  title: 'looptober 2025',
+  urlSlug: 'looptober-2025',
+  type: null,
+  releaseDate: '2025-11-01T00:00:00.000Z',
+  minPrice: null,
+  currency: 'usd',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: null,
+};
+
+/** dreamofomni — not purchasable, despite minPrice 0. A CD comp with no digital offer. */
+const NOT_GETTABLE: MirloTrackGroupRaw = {
+  title: ' [CD compilation] The Chosen Game Ones',
+  urlSlug: 'cd-compilation-the-chosen-hardcore-ones',
+  type: null,
+  releaseDate: '2025-10-01T00:00:00.000Z',
+  minPrice: 0,
+  currency: 'cad',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: false,
+  deletedAt: null,
+  cover: null,
+};
+
+/** clive-murray — one of only 5 releases in 209 with `type` populated. */
+const TYPED_LP: MirloTrackGroupRaw = {
+  title: 'Earthman',
+  urlSlug: 'earthman',
+  type: 'lp',
+  releaseDate: '2002-01-01T00:00:00.000Z',
+  minPrice: 300,
+  currency: 'GBP',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: null,
+};
+
+/** jetjaguar — the other populated type value seen, plus a third currency casing. */
+const TYPED_EP: MirloTrackGroupRaw = {
+  title: 'Hoops',
+  urlSlug: 'hoops',
+  type: 'ep',
+  releaseDate: '2023-05-05T00:00:00.000Z',
+  minPrice: 100,
+  currency: 'NZD',
+  isPreorder: false,
+  isPublic: true,
+  hideFromSearch: false,
+  isGettable: true,
+  deletedAt: null,
+  cover: null,
+};
+
+/** Wrap releases in the real `{ result: { urlSlug, trackGroups } }` envelope. */
+function artistDoc(slug: string, trackGroups: MirloTrackGroupRaw[]): unknown {
+  return { result: { urlSlug: slug, name: 'Test Artist', trackGroups } };
+}
+
+// --- Envelope and failure modes ------------------------------------------------
+
+describe('ingestMirloArtist — what counts as an answer', () => {
+  it('reads a real artist document', () => {
+    const rows = ingestMirloArtist(artistDoc('timerival', [PLAIN_PRICED]), 'timerival', NOW);
+    expect(rows).toHaveLength(1);
+    expect(rows?.[0].title).toBe('stay safe out there');
+  });
+
+  it('distinguishes "no releases" from "not an answer" — the whole point', () => {
+    // An artist who has genuinely released nothing: an empty list, which is a cacheable fact.
+    expect(ingestMirloArtist(artistDoc('timerival', []), 'timerival', NOW)).toEqual([]);
+
+    // Everything that is NOT an answer must be null, never []. An empty list here would be
+    // recorded as an ordinary successful zero and reset the artist's cooldown for a week.
+    expect(ingestMirloArtist(null, 'timerival', NOW)).toBeNull();
+    expect(ingestMirloArtist('<html>challenge</html>', 'timerival', NOW)).toBeNull();
+    expect(ingestMirloArtist({ error: 'Not found' }, 'timerival', NOW)).toBeNull();
+    expect(ingestMirloArtist({ result: null }, 'timerival', NOW)).toBeNull();
+    expect(ingestMirloArtist({ result: { urlSlug: 'timerival' } }, 'timerival', NOW)).toBeNull();
+  });
+
+  it('rejects the search endpoint’s plural `results` envelope', () => {
+    // `/v1/artists?name=` returns { results: [...] } and embeds full artists. Accepting it here
+    // would file a search hit's discography under whichever artist we were asking about.
+    const searchShape = { results: [{ urlSlug: 'timerival', trackGroups: [PLAIN_PRICED] }] };
+    expect(ingestMirloArtist(searchShape, 'timerival', NOW)).toBeNull();
+  });
+
+  it('rejects a document for a different artist', () => {
+    // A redirect landing on someone else's profile would otherwise attribute their records here.
+    const rows = ingestMirloArtist(artistDoc('someoneelse', [PLAIN_PRICED]), 'timerival', NOW);
+    expect(rows).toBeNull();
+  });
+
+  it('matches the artist slug case-insensitively', () => {
+    expect(ingestMirloArtist(artistDoc('TimeRival', [PLAIN_PRICED]), 'timerival', NOW)).toHaveLength(1);
+  });
+});
+
+// --- Drafts and artist-set visibility ------------------------------------------
+
+describe('ingestMirloArtist — what the artist has not published', () => {
+  it('drops both real draft shapes, despite isPublic: true', () => {
+    // Both real drafts in the 209-release sample. Note what they do NOT say: isPublic is true,
+    // hideFromSearch is false, isGettable is true — the visibility flags mark neither of them.
+    expect(DRAFT_UUID_SLUG.isPublic).toBe(true);
+    expect(DRAFT_COUNTER_SLUG.hideFromSearch).toBe(false);
+
+    const rows = ingestMirloArtist(
+      artistDoc('timerival', [DRAFT_UUID_SLUG, DRAFT_COUNTER_SLUG, PLAIN_PRICED]),
+      'timerival',
+      NOW
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows?.[0].title).toBe('stay safe out there');
+  });
+
+  it('drops a titled draft on its temp slug alone', () => {
+    // In the sample the two draft signals were perfectly correlated: all 2 temp-slug releases had
+    // an empty title and all 2 empty-title releases had a temp slug, so the test above would pass
+    // on the title check by itself. This case is therefore **constructed, not observed** — a
+    // draft the artist has begun titling but not published. It exists because the temp slug is
+    // the durable "never published" marker of the two, and without this assertion the slug filter
+    // would be untested code.
+    const titledDraft: MirloTrackGroupRaw = {
+      ...DRAFT_UUID_SLUG,
+      title: 'Work In Progress',
+    };
+    expect(ingestMirloArtist(artistDoc('timerival', [titledDraft]), 'timerival', NOW)).toEqual([]);
+  });
+
+  it('respects isPublic, hideFromSearch and deletedAt', () => {
+    // Uniform in the live sample, so these are guarded by construction rather than observation —
+    // but the artist sets them deliberately and ingesting past them is a trust violation.
+    const hidden: MirloTrackGroupRaw[] = [
+      { ...PLAIN_PRICED, urlSlug: 'a', title: 'Private', isPublic: false },
+      { ...PLAIN_PRICED, urlSlug: 'b', title: 'Unlisted', hideFromSearch: true },
+      { ...PLAIN_PRICED, urlSlug: 'c', title: 'Deleted', deletedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    expect(ingestMirloArtist(artistDoc('timerival', hidden), 'timerival', NOW)).toEqual([]);
+  });
+});
+
+// --- Prices: the three states --------------------------------------------------
+
+describe('mirlo offers — cents, and null is not zero', () => {
+  it('converts integer cents to currency units', () => {
+    const [row] = ingestMirloArtist(artistDoc('timerival', [PREORDER]), 'timerival', NOW)!;
+    // 400 cents is $4.00. Read as currency units it would publish this record at $400.
+    expect(row.offers).toEqual([
+      { format: 'digital', price: 4, currency: 'USD', availability: 'preorder' },
+    ]);
+  });
+
+  it('treats minPrice 0 as name-your-price', () => {
+    const [row] = ingestMirloArtist(artistDoc('timerival', [NAME_YOUR_PRICE]), 'timerival', NOW)!;
+    expect(row.offers[0].price).toBe(0);
+  });
+
+  it('yields NO offer when no price is configured', () => {
+    // 56 of 209 live releases. `price: 0` renders as "Name your price" — publishing that here
+    // would advertise terms the artist never set.
+    const [row] = ingestMirloArtist(artistDoc('mumbleandsigh', [NO_PRICE_SET]), 'mumbleandsigh', NOW)!;
+    expect(row.offers).toEqual([]);
+    expect(row.title).toBe('looptober 2025');
+  });
+
+  it('yields no offer when the release is not gettable, whatever the price says', () => {
+    const [row] = ingestMirloArtist(artistDoc('dreamofomni', [NOT_GETTABLE]), 'dreamofomni', NOW)!;
+    expect(NOT_GETTABLE.minPrice).toBe(0);
+    expect(row.offers).toEqual([]);
+  });
+
+  it('normalizes inconsistent currency casing', () => {
+    // Live sample carried 'usd' (100), 'GBP' (40), 'cad' (39), 'eur' (10), 'gbp' (8), 'NZD' (7),
+    // 'USD' (5). Stored raw, GBP and gbp become two currencies for the same money.
+    const lower = buildMirloRelease({ ...TYPED_LP, currency: 'gbp' }, 'a', new Set(), NOW);
+    const upper = buildMirloRelease({ ...TYPED_LP, currency: 'GBP' }, 'a', new Set(), NOW);
+    expect(lower?.offers[0].currency).toBe('GBP');
+    expect(upper?.offers[0].currency).toBe('GBP');
+    expect(lower?.offers[0].currency).toBe(upper?.offers[0].currency);
+  });
+
+  it('leaves currency null rather than guessing when it is absent', () => {
+    // Not defaulted to USD: `formatMoney` renders a null currency as USD, so guessing here would
+    // publish "£3.00" as "$3.00" — a wrong number about someone's money. A null currency is the
+    // display layer's problem to handle, not the parser's to invent.
+    const row = buildMirloRelease({ ...TYPED_LP, currency: null }, 'a', new Set(), NOW);
+    expect(row?.offers[0].currency).toBeNull();
+  });
+
+  it('never emits a payout figure derived from platformPercent', () => {
+    // platformPercent ran 7, 10, 15, 20, 25, 50 and 100 across the sample, contradicted the
+    // artist-level defaultPlatformFee, and was 100 on a free release. Payout comes from the
+    // platform registry; nothing here may smuggle this field into an offer.
+    const withPercent = { ...PREORDER, platformPercent: 100 } as MirloTrackGroupRaw;
+    const row = buildMirloRelease(withPercent, 'timerival', new Set(), NOW);
+    expect(Object.keys(row!.offers[0]).sort()).toEqual(
+      ['availability', 'currency', 'format', 'price'].sort()
+    );
+  });
+});
+
+// --- Type, status, dates, URLs -------------------------------------------------
+
+describe('mirlo release mapping', () => {
+  it('uses `type` when Mirlo populates it', () => {
+    const lp = buildMirloRelease(TYPED_LP, 'clive-murray', new Set(), NOW);
+    const ep = buildMirloRelease(TYPED_EP, 'jetjaguar', new Set(), NOW);
+    expect(lp?.releaseType).toBe('album');
+    expect(ep?.releaseType).toBe('ep');
+  });
+
+  it('infers type from the title when `type` is null', () => {
+    // 204 of 209 live releases had type null, and Mirlo artists commonly bracket-prefix titles.
+    const cases: [string, string][] = [
+      ['[Single] The Trifecta', 'single'],
+      ['[EP] Unclouded Future', 'ep'],
+      ['[Compilation] 32-Bit Rekt', 'compilation'],
+      ['Hometown Tour (Live at KW)', 'live'],
+    ];
+    for (const [title, expected] of cases) {
+      const row = buildMirloRelease({ ...PLAIN_PRICED, title, type: null }, 'a', new Set(), NOW);
+      expect(row?.releaseType, title).toBe(expected);
+    }
+  });
+
+  it('marks a pre-order announced, and trusts the flag over the date', () => {
+    const row = buildMirloRelease(PREORDER, 'timerival', new Set(), NOW);
+    expect(row?.status).toBe('announced');
+    expect(row?.offers[0].availability).toBe('preorder');
+
+    // Flag wins even for a release whose date has already passed.
+    const past = buildMirloRelease(
+      { ...PREORDER, releaseDate: '2024-01-01T00:00:00.000Z' },
+      'timerival',
+      new Set(),
+      NOW
+    );
+    expect(past?.status).toBe('announced');
+  });
+
+  it('marks a genuine future date announced without a pre-order flag', () => {
+    // 2026-09-04 against a 2026-08-05 now. Mirlo really does carry dates this far out.
+    const row = buildMirloRelease(NAME_YOUR_PRICE, 'timerival', new Set(), NOW);
+    expect(row?.isPreorder).toBeUndefined();
+    expect(row?.status).toBe('announced');
+  });
+
+  it('parses full ISO timestamps to a day-precision date', () => {
+    const row = buildMirloRelease(PLAIN_PRICED, 'timerival', new Set(), NOW);
+    expect(row?.releaseDate).toBe('2026-07-28');
+    expect(row?.datePrecision).toBe('day');
+  });
+
+  it('bounds an implausible date instead of storing it', () => {
+    // Mirlo has carried a release dated 2925-11-02. Unbounded, one typo sorts to the top of
+    // every chronology and lands in every calendar feed forever.
+    const row = buildMirloRelease(
+      { ...PLAIN_PRICED, releaseDate: '2925-11-02T00:00:00.000Z' },
+      'timerival',
+      new Set(),
+      NOW
+    );
+    expect(row?.releaseDate).toBeNull();
+    expect(row?.datePrecision).toBe('unknown');
+    // Undated still counts as released — promising a fan something is "coming" when we don't
+    // know is the worse error.
+    expect(row?.status).toBe('released');
+  });
+
+  it('builds the verified release URL shape', () => {
+    const row = buildMirloRelease(PLAIN_PRICED, 'timerival', new Set(), NOW);
+    // Verified live 2026-08-05: this URL returns 200.
+    expect(row?.externalUrl).toBe('https://mirlo.space/timerival/release/stay-safe-out-there');
+  });
+
+  it('takes artwork from cover.sizes, not the opaque cover.url ids', () => {
+    const row = buildMirloRelease(PREORDER, 'timerival', new Set(), NOW);
+    expect(row?.artworkUrl).toBe(
+      'https://cdn.mirlo.space/file/trackgroup-covers/13022cc3-f02b-4ce8-a5d6-8f774b6165eb-x600.webp'
+    );
+
+    // `cover.url` is an array of size-suffixed ids like "<uuid>-x600" — not URLs. Present but
+    // without `sizes`, there is no usable artwork.
+    const idsOnly = {
+      ...PREORDER,
+      cover: { url: ['13022cc3-original', '13022cc3-x600'] },
+    } as MirloTrackGroupRaw;
+    expect(buildMirloRelease(idsOnly, 'timerival', new Set(), NOW)?.artworkUrl).toBeNull();
+  });
+
+  it('gives two same-titled releases distinct slugs', () => {
+    const rows = ingestMirloArtist(
+      artistDoc('timerival', [
+        { ...PLAIN_PRICED, urlSlug: 'one', title: 'Repeat' },
+        { ...PLAIN_PRICED, urlSlug: 'two', title: 'Repeat' },
+      ]),
+      'timerival',
+      NOW
+    )!;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].slug).not.toBe(rows[1].slug);
+  });
+
+  it('skips a release with no usable title or slug', () => {
+    expect(buildMirloRelease({ ...PLAIN_PRICED, title: '   ' }, 'a', new Set(), NOW)).toBeNull();
+    expect(buildMirloRelease({ ...PLAIN_PRICED, urlSlug: '' }, 'a', new Set(), NOW)).toBeNull();
+  });
+});
+
+// --- Stored-link handling ------------------------------------------------------
+
+describe('mirloArtistSlug', () => {
+  it('handles every URL shape live artist_links actually holds', () => {
+    // Measured 2026-08-02: 50 bare /{slug}, 15 with a second segment, 1 with three, trailing
+    // slashes throughout.
+    expect(mirloArtistSlug('https://mirlo.space/timerival')).toBe('timerival');
+    expect(mirloArtistSlug('https://mirlo.space/timerival/')).toBe('timerival');
+    expect(mirloArtistSlug('https://mirlo.space/timerival/releases')).toBe('timerival');
+    expect(mirloArtistSlug('https://mirlo.space/timerival/release/cooked')).toBe('timerival');
+    expect(mirloArtistSlug('https://www.mirlo.space/TimeRival')).toBe('timerival');
+  });
+
+  it('refuses anything that is not a Mirlo artist page', () => {
+    // A claimed artist can save any URL against the platform, so the host is never assumed.
+    expect(mirloArtistSlug('https://evil.example.com/timerival')).toBeNull();
+    expect(mirloArtistSlug('https://mirlo.space.evil.com/timerival')).toBeNull();
+    expect(mirloArtistSlug('javascript:alert(1)')).toBeNull();
+    expect(mirloArtistSlug('https://mirlo.space/')).toBeNull();
+    expect(mirloArtistSlug('not a url')).toBeNull();
+  });
+
+  it('refuses Mirlo’s own routes, which sit at artist depth', () => {
+    for (const path of ['login', 'signup', 'pages', 'v1', 'admin', 'settings', 'checkout']) {
+      expect(mirloArtistSlug(`https://mirlo.space/${path}`), path).toBeNull();
+    }
+  });
+});

--- a/api/functions/__tests__/recatalog-sweep-selection.test.ts
+++ b/api/functions/__tests__/recatalog-sweep-selection.test.ts
@@ -170,7 +170,7 @@ describe('getStaleCatalogCandidates — who is in the pool', () => {
   });
 
   it('excludes artists with nothing crawlable', async () => {
-    // catalogArtist records an artist with no bandcamp/discogs/faircamp/jamcoop link as an
+    // catalogArtist records an artist with no bandcamp/discogs/faircamp/jamcoop/mirlo link as an
     // *error*, which bumps consecutive_failures and writes last_error. Sweeping them would
     // spend the batch on artists with nothing to fetch and turn the failure counters to noise.
     tables.artist_links = [link('real', 'bandcamp'), link('site-only', 'officialsite')];
@@ -180,7 +180,11 @@ describe('getStaleCatalogCandidates — who is in the pool', () => {
     expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['real']);
   });
 
-  it.each(['bandcamp', 'discogs', 'faircamp', 'jamcoop'])(
+  // This list must stay identical to catalogArtist's "is there anything to fetch" condition in
+  // catalog-artist-background.ts. The two disagreeing is the specific failure this pins: a
+  // platform the sweep considers crawlable but catalogArtist doesn't gets swept, rejected, and
+  // recorded as a failure, poisoning consecutive_failures for an artist who was never at fault.
+  it.each(['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'mirlo'])(
     'treats a %s link as crawlable',
     async platform => {
       tables.artist_links = [link('a', platform)];
@@ -190,6 +194,16 @@ describe('getStaleCatalogCandidates — who is in the pool', () => {
       expect(result.ok && result.candidates.map(c => c.artistId)).toEqual(['a']);
     }
   );
+
+  it('treats a platform outside the catalogueable list as not crawlable', async () => {
+    // The negative half of the case above: without it, the it.each only proves the listed
+    // platforms are *included*, so a stray addition to CATALOGUEABLE_PLATFORMS would go unnoticed.
+    tables.artist_links = [link('a', 'spotify'), link('b', 'ampwall'), link('c', 'subvert')];
+
+    const result = await getStaleCatalogCandidates(10);
+
+    expect(result.ok && result.candidates).toEqual([]);
+  });
 
   it('excludes an artist whose only Bandcamp link is a search placeholder', async () => {
     // `https://bandcamp.com/search?q=X` is a UI affordance, not an artist page. bandcampMusicUrl

--- a/api/functions/__tests__/release-display.test.ts
+++ b/api/functions/__tests__/release-display.test.ts
@@ -15,6 +15,7 @@ import {
   payoutEstimate,
   payoutRank,
   relativeDays,
+  releaseTypeLabel,
 } from '../../shared/release-display';
 
 describe('formatMoney', () => {
@@ -179,5 +180,47 @@ describe('leadingOfferSummary', () => {
     expect(leadingOfferSummary([])).toBe('');
     expect(leadingOfferSummary([source('bandcamp', [])])).toBe('');
     expect(leadingOfferSummary([source('bandcamp', [offer(null)])])).toBe('');
+  });
+});
+
+describe('releaseTypeLabel', () => {
+  it('uses the upstream type when there is one', () => {
+    expect(releaseTypeLabel('album', ['bandcamp'])).toBe('Album');
+    expect(releaseTypeLabel('ep', ['mirlo'])).toBe('Ep');
+    expect(releaseTypeLabel('compilation', ['discogs'])).toBe('Compilation');
+  });
+
+  it('says Digital for an unknown type sold only on download-only platforms', () => {
+    // The normal case on Mirlo, Faircamp and Jam.coop: none of them expose a type field, so
+    // without this every one of their releases shows no label at all.
+    expect(releaseTypeLabel('other', ['mirlo'])).toBe('Digital');
+    expect(releaseTypeLabel('other', ['faircamp'])).toBe('Digital');
+    expect(releaseTypeLabel('other', ['jamcoop'])).toBe('Digital');
+    expect(releaseTypeLabel('other', ['mirlo', 'jamcoop'])).toBe('Digital');
+  });
+
+  it('refuses Digital when ANY platform might sell something physical', () => {
+    // The failure this prevents: a release on Mirlo *and* Bandcamp may well exist as a vinyl
+    // pressing, and "Digital" would then be a wrong claim about a physical product. One
+    // unflagged platform is enough to fall back to no label.
+    expect(releaseTypeLabel('other', ['mirlo', 'bandcamp'])).toBe('');
+    expect(releaseTypeLabel('other', ['bandcamp'])).toBe('');
+    expect(releaseTypeLabel('other', ['discogs'])).toBe('');
+    // An unrecognized platform is unknown, not digital.
+    expect(releaseTypeLabel('other', ['mirlo', 'somethingnew'])).toBe('');
+  });
+
+  it('says nothing when there are no platforms at all', () => {
+    // No sources is an absence of evidence, not evidence of digital — the same distinction the
+    // ingest layer draws between "no price configured" and "free".
+    expect(releaseTypeLabel('other', [])).toBe('');
+    expect(releaseTypeLabel(null, [])).toBe('');
+  });
+
+  it('never renders the literal word "Other"', () => {
+    // It never has, on any surface. "Other · 4 July 2026 · $4" tells a fan nothing.
+    for (const platforms of [[], ['bandcamp'], ['mirlo'], ['discogs', 'mirlo']]) {
+      expect(releaseTypeLabel('other', platforms)).not.toBe('Other');
+    }
   });
 });

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -16,6 +16,7 @@ import {
   persistDiscogsReleases,
   persistFaircampReleases,
   persistJamcoopReleases,
+  persistMirloReleases,
   persistMusicBrainzEnrichment,
   persistReleaseDetail,
   persistReleases,
@@ -40,8 +41,10 @@ import {
   ingestFaircampReleasePage,
   ingestJamcoopAlbumPage,
   ingestJamcoopArtistPage,
+  ingestMirloArtist,
   ingestMusicBrainzReleaseGroups,
   jamcoopArtistUrl,
+  mirloArtistSlug,
   type DiscogsArtistReleaseEntry,
   type DiscogsReleaseDetailRaw,
   type IngestedOffer,
@@ -186,6 +189,42 @@ interface JamcoopBudget {
   deadline: number;
 }
 
+// --- Mirlo budgets -------------------------------------------------------------
+//
+// The cheapest source in the codebase: `/v1/artists/{slug}` returns the whole discography **and
+// its prices** in one request, so an artist costs exactly one fetch and there is no detail pass.
+// Compare Bandcamp (grid + one page per release) and Jam.coop (artist page + one per album).
+//
+// Mirlo granted Unstream permission to use this endpoint and issued an API key (2026-08-05), so
+// the `Disallow: /v1/` in their robots.txt is superseded by direct consent rather than ignored.
+// The pacing below is still deliberately gentle: a small co-op's own servers, and the recatalog
+// sweep runs four times a day.
+
+const DELAY_BETWEEN_MIRLO_FETCHES_MS = 1_000;
+
+/**
+ * Invocation-wide. One request per artist, so this is effectively "how many Mirlo artists can one
+ * batch cover" — set to the batch ceiling (`MAX_ARTISTS_PER_RUN`) since no artist needs a second.
+ */
+const MAX_MIRLO_FETCHES_PER_RUN = 25;
+
+interface MirloBudget {
+  fetchesLeft: number;
+  deadline: number;
+}
+
+/**
+ * Sent as `mirlo-api-key` when set.
+ *
+ * Verified live 2026-08-05: this endpoint returns byte-identical responses with the key, with a
+ * bearer token, and with no auth at all — so the key is **not** what grants access, and an absent
+ * key must not disable the pass. It is sent because Mirlo issued it for this use and it lets them
+ * attribute our traffic; if they later gate or rate-limit by key, we are already correct.
+ */
+const MIRLO_API_KEY = process.env.MIRLO_API_KEY;
+
+const MIRLO_USER_AGENT = 'Unstream/1.0 (https://unstream.stream - ethical music finder)';
+
 export async function handler(event: {
   httpMethod?: string;
   headers?: Record<string, string | undefined>;
@@ -244,6 +283,10 @@ export async function handler(event: {
     fetchesLeft: MAX_JAMCOOP_FETCHES_PER_RUN,
     deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
   };
+  const mirloBudget: MirloBudget = {
+    fetchesLeft: MAX_MIRLO_FETCHES_PER_RUN,
+    deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
+  };
   const enrichmentDeadline = Date.now() + ENRICHMENT_CUTOFF_MS;
 
   for (const [index, artistId] of artistIds.entries()) {
@@ -263,6 +306,7 @@ export async function handler(event: {
         discogsBudget,
         faircampBudget,
         jamcoopBudget,
+        mirloBudget,
         enrichmentDeadline
       );
       if (found === null) {
@@ -297,6 +341,7 @@ async function catalogArtist(
   discogsBudget: DiscogsBudget,
   faircampBudget: FaircampBudget,
   jamcoopBudget: JamcoopBudget,
+  mirloBudget: MirloBudget,
   enrichmentDeadline: number
 ): Promise<number | null> {
   const artist = await getArtistForCatalog(artistId);
@@ -304,8 +349,18 @@ async function catalogArtist(
     await recordCatalogOutcome(artistId, { error: 'artist not found' });
     return null;
   }
-  if (!artist.bandcampUrl && !artist.discogsUrl && !artist.faircampUrl && !artist.jamcoopUrl) {
-    await recordCatalogOutcome(artistId, { error: 'no bandcamp, discogs, faircamp, or jam.coop link stored' });
+  // Keep this list identical to CATALOGUEABLE_PLATFORMS in db.ts — the sweep picks its pool from
+  // that constant, and an artist it sweeps but this rejects is recorded as a failure.
+  if (
+    !artist.bandcampUrl &&
+    !artist.discogsUrl &&
+    !artist.faircampUrl &&
+    !artist.jamcoopUrl &&
+    !artist.mirloUrl
+  ) {
+    await recordCatalogOutcome(artistId, {
+      error: 'no bandcamp, discogs, faircamp, jam.coop, or mirlo link stored',
+    });
     return null;
   }
 
@@ -339,6 +394,12 @@ async function catalogArtist(
       const { found, detailed } = await catalogJamcoop(artistId, artist.jamcoopUrl, jamcoopBudget);
       totalFound += found;
       totalDetailed += detailed;
+    }
+    if (artist.mirloUrl) {
+      // Not counted in totalDetailed: Mirlo has no detail pass to run, so every release it
+      // writes arrives complete. Counting them as "detailed" would inflate a figure whose whole
+      // meaning is "how many second fetches did we spend".
+      totalFound += await catalogMirlo(artistId, artist.mirloUrl, mirloBudget);
     }
     if (artist.officialSiteUrl) {
       await catalogOfficialSite(artistId, artist.officialSiteUrl);
@@ -787,6 +848,97 @@ async function catalogJamcoop(
   } catch (error) {
     console.warn('[catalog] jam.coop ingest failed:', error instanceof Error ? error.message : String(error));
     return { found: 0, detailed: 0 };
+  }
+}
+
+/**
+ * The Mirlo pass: one request, the whole discography, prices included.
+ *
+ * There is no detail pass and no per-release loop, because there is nothing left to fetch — the
+ * offers written below came out of the same response as the release rows.
+ *
+ * Fetched with `globalThis.fetch` rather than `safeFetch`, matching the Discogs and MusicBrainz
+ * passes and for the same reason: the URL is **ours**, built against a hardcoded
+ * `api.mirlo.space` host. The only external input is a single path segment derived by
+ * `mirloArtistSlug()` (which itself refuses any URL that isn't on mirlo.space) and URL-encoded
+ * here. `safeFetch` exists to vet attacker-influenced *hosts*, and there isn't one; it also
+ * cannot send the API key, since it hardcodes its headers.
+ *
+ * A non-200, an unparseable body, or a document for the wrong artist all yield 0 rather than a
+ * thrown error — one source declining to answer is not the artist's whole run failing. But they
+ * are logged distinctly from "this artist has no releases", which is the case `ingestMirloArtist`
+ * returning `null` versus `[]` exists to keep apart.
+ */
+async function catalogMirlo(
+  artistId: string,
+  storedUrl: string,
+  budget: MirloBudget
+): Promise<number> {
+  try {
+    const slug = mirloArtistSlug(storedUrl);
+    if (!slug) {
+      console.warn(`[catalog] could not derive mirlo slug for artist ${artistId}`);
+      return 0;
+    }
+
+    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) return 0;
+    budget.fetchesLeft--;
+
+    const apiUrl = `https://api.mirlo.space/v1/artists/${encodeURIComponent(slug)}`;
+    const headers: Record<string, string> = { 'User-Agent': MIRLO_USER_AGENT };
+    if (MIRLO_API_KEY) headers['mirlo-api-key'] = MIRLO_API_KEY;
+
+    const response = await globalThis.fetch(apiUrl, { headers });
+    if (!response.ok) {
+      console.warn(`[catalog] mirlo responded ${response.status} for artist ${artistId}`);
+      return 0;
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      // A 200 whose body isn't JSON is the upstream not answering — a challenge page, an HTML
+      // error. Reported rather than swallowed, because it is indistinguishable from success by
+      // status code alone.
+      console.error(`[catalog] mirlo returned a 200 with a non-JSON body for artist ${artistId}`);
+      return 0;
+    }
+
+    const releases = ingestMirloArtist(body, slug);
+    if (releases === null) {
+      console.error(`[catalog] mirlo 200 was not an artist document for ${slug} (artist ${artistId})`);
+      return 0;
+    }
+    if (releases.length === 0) return 0;
+
+    const written = await persistMirloReleases(artistId, releases);
+
+    // Offers hang off a `release_sources.id` that only exists after the rows are written, so the
+    // prices from the one response are attached here rather than in the same call.
+    const offersByUrl = new Map(
+      releases.filter(r => r.offers.length > 0).map(r => [r.externalUrl, r.offers])
+    );
+    for (const release of written) {
+      const offers = offersByUrl.get(release.url);
+      if (!offers) continue;
+
+      // status null: the date and status were already written by persistMirloReleases from this
+      // same response, so restating them would be a second write of the same fact — and could
+      // overwrite a date another source got more precisely.
+      await persistReleaseDetail(release, {
+        releaseDate: null,
+        datePrecision: 'unknown',
+        status: null,
+        offers,
+      });
+    }
+
+    await sleep(DELAY_BETWEEN_MIRLO_FETCHES_MS);
+    return written.length;
+  } catch (error) {
+    console.warn('[catalog] mirlo ingest failed:', error instanceof Error ? error.message : String(error));
+    return 0;
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -686,12 +686,12 @@ export type StaleCatalogResult =
  *
  * Deliberately **not** including `officialsite`: that link is only followed to *discover* other
  * platforms, and `catalogArtist` treats an artist with nothing but an official site as having
- * "no bandcamp, discogs, faircamp, or jam.coop link stored" — which it records as an **error**,
- * incrementing `consecutive_failures` and writing `last_error`. Keep this list identical to that
- * condition or the sweep will spend its batch on artists with nothing to fetch and turn the
- * failure counters into noise.
+ * "no bandcamp, discogs, faircamp, jam.coop, or mirlo link stored" — which it records as an
+ * **error**, incrementing `consecutive_failures` and writing `last_error`. Keep this list
+ * identical to that condition or the sweep will spend its batch on artists with nothing to fetch
+ * and turn the failure counters into noise.
  */
-const CATALOGUEABLE_PLATFORMS = ['bandcamp', 'discogs', 'faircamp', 'jamcoop'] as const;
+const CATALOGUEABLE_PLATFORMS = ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'mirlo'] as const;
 
 /**
  * Whether a stored link is something the catalog pass can actually crawl.
@@ -1305,6 +1305,7 @@ export interface ArtistForCatalog {
   discogsUrl: string | null;
   faircampUrl: string | null;
   jamcoopUrl: string | null;
+  mirloUrl: string | null;
   officialSiteUrl: string | null;
 }
 
@@ -1326,7 +1327,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
         .from('artist_links')
         .select('platform, url')
         .eq('artist_id', artistId)
-        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'officialsite']),
+        .in('platform', ['bandcamp', 'discogs', 'faircamp', 'jamcoop', 'mirlo', 'officialsite']),
     ]);
 
     if (artistError || !artistRow) {
@@ -1348,6 +1349,7 @@ export async function getArtistForCatalog(artistId: string): Promise<ArtistForCa
       discogsUrl: links.find(l => l.platform === 'discogs')?.url ?? null,
       faircampUrl: links.find(l => l.platform === 'faircamp')?.url ?? null,
       jamcoopUrl: links.find(l => l.platform === 'jamcoop')?.url ?? null,
+      mirloUrl: links.find(l => l.platform === 'mirlo')?.url ?? null,
       officialSiteUrl: links.find(l => l.platform === 'officialsite')?.url ?? null,
     };
   } catch (error) {
@@ -1974,6 +1976,181 @@ export async function persistJamcoopReleases(
     return written;
   } catch (error) {
     console.error('[DB] persistJamcoopReleases error:', error);
+    return [];
+  }
+}
+
+/**
+ * Write a Mirlo catalog pass.
+ *
+ * Matches on `match_key` alone, for the same reason `persistJamcoopReleases` does: Mirlo
+ * populates `type` on only a small minority of releases (5 of 209 measured live), so the stored
+ * type is usually title-inferred and too weak to partition identity by. Partitioning on it would
+ * mint a duplicate row every time Bandcamp had already typed the same record correctly.
+ *
+ * Dedup behaviour is unchanged from every other source: an exact `match_key` merges into the
+ * existing row, `isFuzzyReleaseMatch` flags a pair for human review, and nothing new
+ * auto-merges. Under-merge is preserved deliberately.
+ *
+ * Like Jam.coop, Mirlo publishes a date, so this fills `release_date`/`date_precision` on a row
+ * that lacks them — under the usual never-overwrite rules: a stored date wins over a new one,
+ * and a date the artist curated is never touched.
+ */
+interface MirloReleaseToPersistRow {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: string;
+  releaseDate: string | null;
+  datePrecision: string;
+  status: string;
+  artworkUrl: string | null;
+  externalUrl: string;
+}
+
+export async function persistMirloReleases(
+  artistId: string,
+  releases: MirloReleaseToPersistRow[]
+): Promise<PersistedRelease[]> {
+  const client = getClient();
+  if (!client || releases.length === 0) return [];
+
+  try {
+    const { data: existingRows, error: readError } = await client
+      .from('releases')
+      .select('id, slug, match_key, release_type, release_date, artwork_url, curated_fields')
+      .eq('artist_id', artistId);
+
+    if (readError) {
+      console.error('[DB] persistMirloReleases read failed:', readError.message);
+      return [];
+    }
+
+    type ExistingRow = {
+      id: string;
+      slug: string;
+      match_key: string;
+      release_type: string;
+      release_date: string | null;
+      artwork_url: string | null;
+      curated_fields: string[] | null;
+    };
+    const existing = (existingRows as ExistingRow[]) || [];
+    const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
+    const takenSlugs = new Set(existing.map(r => r.slug));
+    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+
+    const written: PersistedRelease[] = [];
+
+    for (const release of releases) {
+      const prior = byMatchKey.get(release.matchKey);
+
+      let releaseId: string;
+      let curatedFields: string[];
+
+      if (prior) {
+        const curated = new Set(prior.curated_fields ?? []);
+        curatedFields = [...curated];
+        const patch: Record<string, unknown> = {};
+
+        if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
+          patch.artwork_url = release.artworkUrl;
+        }
+        if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
+          patch.release_date = release.releaseDate;
+          patch.date_precision = release.datePrecision;
+          // Status moves with the date, but only when this pass is the one supplying it. A row
+          // that already had a date keeps whatever status its own source derived — including an
+          // 'announced' from a real pre-order flag.
+          patch.status = release.status;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          const { error } = await client.from('releases').update(patch).eq('id', prior.id);
+          if (error) {
+            console.error('[DB] persistMirloReleases update failed:', error.message);
+            continue;
+          }
+        }
+        releaseId = prior.id;
+      } else {
+        const fuzzy = existing.find(c => isFuzzyReleaseMatch(c.match_key, release.matchKey));
+
+        let slug = release.slug;
+        if (takenSlugs.has(slug)) slug = `${slug}-${release.matchKey.slice(0, 6)}`;
+        takenSlugs.add(slug);
+
+        const { data: inserted, error } = await client
+          .from('releases')
+          .insert({
+            artist_id: artistId,
+            title: release.title,
+            slug,
+            match_key: release.matchKey,
+            release_type: release.releaseType,
+            release_date: release.releaseDate,
+            date_precision: release.datePrecision,
+            status: release.status,
+            artwork_url: release.artworkUrl,
+            source: 'auto',
+            ...(fuzzy && { needs_review: true, flagged_against_release_id: fuzzy.id }),
+          })
+          .select('id')
+          .single();
+
+        if (error || !inserted) {
+          console.error('[DB] persistMirloReleases insert failed:', error?.message);
+          continue;
+        }
+        releaseId = (inserted as { id: string }).id;
+        curatedFields = [];
+
+        const createdRow: ExistingRow = {
+          id: releaseId,
+          slug,
+          match_key: release.matchKey,
+          release_type: release.releaseType,
+          release_date: release.releaseDate,
+          artwork_url: release.artworkUrl,
+          curated_fields: [],
+        };
+        byMatchKey.set(release.matchKey, createdRow);
+        existing.push(createdRow);
+
+        if (fuzzy) {
+          const { error: flagError } = await client
+            .from('releases')
+            .update({ needs_review: true, flagged_against_release_id: releaseId })
+            .eq('id', fuzzy.id);
+          if (flagError) console.error('[DB] persistMirloReleases fuzzy-flag failed:', flagError.message);
+        }
+      }
+
+      const source = await upsertReleaseSource(
+        client,
+        releaseId,
+        'mirlo',
+        release.externalUrl,
+        release.externalUrl,
+        claimedKeys
+      );
+      if (!source) {
+        console.error('[DB] persistMirloReleases source write failed for release', releaseId);
+        continue;
+      }
+
+      written.push({
+        releaseId,
+        sourceId: source.id,
+        url: source.url,
+        detailCheckedAt: source.detail_checked_at,
+        curatedFields,
+      });
+    }
+
+    return written;
+  } catch (error) {
+    console.error('[DB] persistMirloReleases error:', error);
     return [];
   }
 }

--- a/api/functions/release-ingest.ts
+++ b/api/functions/release-ingest.ts
@@ -1041,6 +1041,241 @@ export function jamcoopArtistUrl(storedUrl: string): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Mirlo — the REST API: one request per artist for the whole discography *and* its prices
+// ---------------------------------------------------------------------------
+//
+// `GET https://api.mirlo.space/v1/artists/{slug}` returns the artist with `trackGroups[]`
+// embedded, so a Mirlo artist costs **one** request — no detail pass at all, where Bandcamp and
+// Jam.coop each need 1+N. It is the cheapest and richest release source in the codebase.
+//
+// Mirlo's robots.txt carries `Disallow: /v1/` under a hand-written "# Disallow crawling the API"
+// comment. We poll it anyway because Mirlo granted Unstream permission directly (2026-08-05) and
+// issued an API key. That permission, not the key, is what makes this allowed: verified live the
+// same day, the endpoint returns byte-identical responses with the key, with a bearer token, and
+// with no auth at all. The key is still sent — it identifies us, and it is what they asked us to
+// use — but it gates nothing, so nothing here may assume an authenticated response differs.
+//
+// Everything below was verified against 209 real releases across 31 artists on 2026-08-05. The
+// field-level surprises are commented where they bite; three are worth reading before editing:
+// prices are integer cents with `null` distinct from `0`, `currency` casing is inconsistent, and
+// `platformPercent` is deliberately ignored.
+
+/** One `trackGroups[]` entry, as `/v1/artists/{slug}` actually returns it. */
+export interface MirloTrackGroupRaw {
+  title?: string | null;
+  urlSlug?: string | null;
+  type?: string | null;
+  releaseDate?: string | null;
+  minPrice?: number | null;
+  currency?: string | null;
+  isPreorder?: boolean | null;
+  isPublic?: boolean | null;
+  hideFromSearch?: boolean | null;
+  isGettable?: boolean | null;
+  deletedAt?: string | null;
+  cover?: { sizes?: Record<string, string> | null } | null;
+}
+
+export interface MirloReleaseToPersist {
+  title: string;
+  slug: string;
+  matchKey: string;
+  releaseType: ReleaseType;
+  releaseDate: string | null;
+  datePrecision: DatePrecision;
+  status: ReleaseStatus;
+  artworkUrl: string | null;
+  externalUrl: string;
+  offers: IngestedOffer[];
+}
+
+/**
+ * Which `cover.sizes` key to store.
+ *
+ * `cover.url` is an array of opaque size-suffixed **ids**, not URLs — using it would store
+ * `"<uuid>-x600"` as an image src. `cover.sizes` is the parallel map of real CDN URLs.
+ */
+const MIRLO_COVER_SIZE = '600';
+
+/** The `mi-temp-slug-` prefix Mirlo gives an unpublished draft's auto-generated slug. */
+const MIRLO_DRAFT_SLUG_PREFIX = 'mi-temp-slug-';
+
+/**
+ * Read one artist's `/v1/artists/{slug}` response into rows ready to persist.
+ *
+ * Returns **null** when the body isn't a Mirlo artist document at all — an error envelope, a
+ * challenge page, a redirect's HTML. That is the "never cache uncertainty" rule applied at the
+ * parse boundary: an unrecognized body must not reduce to an empty list, because an empty list
+ * is indistinguishable from "this artist has released nothing" and would be recorded as a
+ * perfectly ordinary success. An artist who genuinely has no releases still returns `[]`.
+ */
+export function ingestMirloArtist(
+  body: unknown,
+  artistSlug: string,
+  now: Date = new Date()
+): MirloReleaseToPersist[] | null {
+  if (!body || typeof body !== 'object') return null;
+
+  // `/v1/artists/{slug}` wraps in `result` (singular). The search endpoint uses `results`
+  // (plural) and is a different shape entirely — don't accept it here by accident.
+  const result = (body as { result?: unknown }).result;
+  if (!result || typeof result !== 'object') return null;
+
+  const artist = result as { urlSlug?: unknown; trackGroups?: unknown };
+
+  // The document must be the artist we asked for. A redirect that landed on someone else's
+  // profile would otherwise file their records under this artist.
+  if (typeof artist.urlSlug !== 'string' || artist.urlSlug.toLowerCase() !== artistSlug.toLowerCase()) {
+    return null;
+  }
+  if (!Array.isArray(artist.trackGroups)) return null;
+
+  const out: MirloReleaseToPersist[] = [];
+  const takenSlugs = new Set<string>();
+
+  for (const node of artist.trackGroups) {
+    const release = buildMirloRelease(node as MirloTrackGroupRaw, artistSlug, takenSlugs, now);
+    if (!release) continue;
+    takenSlugs.add(release.slug);
+    out.push(release);
+  }
+
+  return out;
+}
+
+/**
+ * Turn one `trackGroups[]` entry into a persistable row, or null to skip it.
+ *
+ * Skipped: anything the artist has hidden (`isPublic: false`, `hideFromSearch: true`,
+ * `deletedAt` set) — those are deliberate settings and ingesting past them is a trust violation
+ * — and **drafts**, which need their own rule. A draft carries an empty `title` and a
+ * `mi-temp-slug-…` slug while still reporting `isPublic: true`, `hideFromSearch: false` and
+ * `isGettable: true`, so the visibility flags do not catch it. Both draft shapes were live on
+ * 2026-08-05 (`mi-temp-slug-new-album-0` and `mi-temp-slug-new-album-<uuid>`), so the prefix is
+ * matched rather than the uuid suffix.
+ */
+export function buildMirloRelease(
+  raw: MirloTrackGroupRaw,
+  artistSlug: string,
+  takenSlugs: ReadonlySet<string>,
+  now: Date = new Date()
+): MirloReleaseToPersist | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if (raw.isPublic === false || raw.hideFromSearch === true || raw.deletedAt) return null;
+
+  const urlSlug = typeof raw.urlSlug === 'string' ? raw.urlSlug.trim() : '';
+  if (!urlSlug || urlSlug.startsWith(MIRLO_DRAFT_SLUG_PREFIX)) return null;
+
+  const title = typeof raw.title === 'string' ? raw.title.trim() : '';
+  if (!title) return null;
+
+  const matchKey = releaseMatchKey(title);
+  if (!matchKey) return null;
+
+  const { date, precision } = parseReleaseDate(raw.releaseDate, now);
+  const isPreorder = raw.isPreorder === true;
+
+  return {
+    title,
+    slug: uniqueReleaseSlug(title, takenSlugs),
+    matchKey,
+    // `type` is populated on only a small minority of releases (5 of 209 live), so the title is
+    // the usual signal — and an effective one here, since Mirlo artists often prefix titles
+    // "[Single]" / "[EP]" / "[Compilation]". `mapReleaseType` already folds 'lp' into 'album'.
+    releaseType: raw.type ? mapReleaseType(raw.type) : mapDiscogsFormatToReleaseType(null, title),
+    releaseDate: date,
+    datePrecision: precision,
+    // Mirlo publishes a real pre-order flag, so status has a true signal rather than an
+    // inference from the date.
+    status: deriveStatus(date, isPreorder, now),
+    artworkUrl: raw.cover?.sizes?.[MIRLO_COVER_SIZE]?.trim() || null,
+    externalUrl: mirloReleaseUrl(artistSlug, urlSlug),
+    offers: mirloOffers(raw),
+  };
+}
+
+/**
+ * The single digital offer for a Mirlo release, or none.
+ *
+ * Three price states, and conflating any two of them would misstate an artist's own terms:
+ *
+ * - `minPrice: null` (56 of 209 live, always alongside `suggestedPrice: null`) — **no price
+ *   configured**. Yields no offer. Not zero: `price: 0` renders as "Name your price", which
+ *   would advertise terms the artist never set.
+ * - `minPrice: 0` — genuinely name-your-price. Yields `price: 0`, which the display layer
+ *   already renders correctly.
+ * - `minPrice: N` — a real floor, in **integer cents**. `400` is $4.00.
+ *
+ * `isGettable: false` (3 of 209) means it isn't purchasable at all, whatever the price says, so
+ * it yields no offer either.
+ *
+ * `platformPercent` is **deliberately unused.** It looks like a payout share and is not
+ * trustworthy as one: it contradicts the artist's own `defaultPlatformFee` (one artist had
+ * `defaultPlatformFee: 7` with every release at `50`), and one free release carried
+ * `platformPercent: 100`, which is meaningless as a fee. None of the outliers correlated with
+ * `fundraiser` or `isAllOrNothing`. Payout comes from the platform registry until Mirlo tells us
+ * what this field means — a wrong number about someone's money is worse than a coarse one.
+ */
+function mirloOffers(raw: MirloTrackGroupRaw): IngestedOffer[] {
+  if (raw.isGettable === false) return [];
+
+  const cents = raw.minPrice;
+  if (typeof cents !== 'number' || !Number.isFinite(cents) || cents < 0) return [];
+
+  return [
+    {
+      format: 'digital',
+      price: cents / 100,
+      // Casing is inconsistent upstream — 'GBP' and 'gbp' both occur for the same currency, as
+      // do 'usd' and 'USD'. Left raw, one currency would be stored as two.
+      currency: typeof raw.currency === 'string' && raw.currency.trim()
+        ? raw.currency.trim().toUpperCase()
+        : null,
+      availability: raw.isPreorder === true ? 'preorder' : 'available',
+    },
+  ];
+}
+
+/** Verified live 2026-08-05: `https://mirlo.space/{artistSlug}/release/{urlSlug}` returns 200. */
+function mirloReleaseUrl(artistSlug: string, releaseSlug: string): string {
+  return `https://mirlo.space/${encodeURIComponent(artistSlug)}/release/${encodeURIComponent(releaseSlug)}`;
+}
+
+/**
+ * The Mirlo artist slug for a stored `mirlo` link, for building the API URL.
+ *
+ * Stored links come from search's own Mirlo lookup, but a claimed artist can save any URL to
+ * their profile, so the shape is not assumed. Live `artist_links` (measured 2026-08-02) held 50
+ * bare `/{slug}`, 15 with a second segment (mostly `/releases`), 1 with three, and trailing
+ * slashes throughout — the first path segment is the slug in every case.
+ */
+export function mirloArtistSlug(storedUrl: string): string | null {
+  try {
+    const u = new URL(storedUrl);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+
+    const host = u.hostname.toLowerCase();
+    if (host !== 'mirlo.space' && !host.endsWith('.mirlo.space')) return null;
+
+    const slug = u.pathname.split('/').filter(Boolean)[0]?.toLowerCase();
+    if (!slug) return null;
+    // Mirlo's own routes live at the same depth as artist profiles, so a link to one of these
+    // would otherwise be requested as though it were an artist.
+    if (MIRLO_RESERVED_SEGMENTS.has(slug)) return null;
+
+    return slug;
+  } catch {
+    return null;
+  }
+}
+
+const MIRLO_RESERVED_SEGMENTS: ReadonlySet<string> = new Set([
+  'login', 'signup', 'password-reset', 'profile', 'widget', 'pages', 'post', 'posts',
+  'releases', 'artists', 'about', 'faq', 'terms', 'privacy', 'support', 'admin', 'api',
+  'v1', 'search', 'settings', 'checkout', 'cart', 'label', 'labels',
+]);
+
+// ---------------------------------------------------------------------------
 // Discovered links — a specific release, spotted on a page we fetched for another reason
 // ---------------------------------------------------------------------------
 //

--- a/api/shared/platform-registry.ts
+++ b/api/shared/platform-registry.ts
@@ -19,6 +19,18 @@ export interface PlatformMeta {
   homepageUrl?: string;
   aiPolicy?: 'formal' | 'discouraged';
   aiPolicyUrl?: string;
+  /**
+   * The platform sells downloads and nothing physical.
+   *
+   * Read by `releaseTypeLabel` to say "Digital" about a release whose *kind* (album/EP/single)
+   * the upstream never told us — which is the normal case on exactly these platforms, since none
+   * of them expose a type field. Absent means "not established", not "sells physical": Bandcamp
+   * and Discogs are deliberately unflagged because they genuinely sell vinyl, cassettes and CDs,
+   * and so is anything we haven't verified. An unflagged platform simply produces no label, which
+   * is the honest outcome — this field exists to state a fact about a shop, so a guess here would
+   * put a wrong claim about a physical product on a release page.
+   */
+  digitalOnly?: true;
 }
 
 export const PLATFORMS: Record<string, PlatformMeta> = {
@@ -40,6 +52,9 @@ export const PLATFORMS: Record<string, PlatformMeta> = {
     icon: '🪺',
     category: 'marketplace',
     payoutPercent: '86-90%',
+    // Verified live 2026-08-05: every trackGroup is a download. Artists can link a merch store
+    // (`merchStoreURL`), but that is off-platform and never a release row.
+    digitalOnly: true,
     homepageUrl: 'https://mirlo.space',
     aiPolicy: 'formal',
     aiPolicyUrl: 'https://mirlo.space/pages/content-policy',
@@ -104,6 +119,9 @@ export const PLATFORMS: Record<string, PlatformMeta> = {
     // on a £1.00 sale the fee is 20p (20%), not 15p — and plenty of Jam.coop releases
     // sell for £0.75–£3.00, so the effective payout at the low end is under 85%.
     payoutPercent: '82-85%',
+    // Every album page states "Digital download. MP3 and FLAC"; there is no physical stock,
+    // which is also why `ingestJamcoopAlbumPage` types every offer 'digital'.
+    digitalOnly: true,
     homepageUrl: 'https://jam.coop',
   },
   discogs: {
@@ -130,6 +148,8 @@ export const PLATFORMS: Record<string, PlatformMeta> = {
     icon: '🏕️',
     category: 'decentralized',
     payoutPercent: '90-97%',
+    // A static-site generator for selling downloads. No cart, no stock, no shipping.
+    digitalOnly: true,
     homepageUrl: 'https://simonrepp.com/faircamp',
   },
 

--- a/api/shared/release-display.ts
+++ b/api/shared/release-display.ts
@@ -165,6 +165,41 @@ export function payoutRank(platform: string): number {
   return first ? Number(first) : -1;
 }
 
+/**
+ * The type label for a release list row — "Album", "EP", "Digital", or nothing.
+ *
+ * Two jobs in one function so every surface agrees, which matters more than it sounds: the same
+ * release appears on the public artist page, in the artist's own management list, and in the
+ * admin review queue, and a label that showed up in one but not another would read as a bug in
+ * whichever view the person happened to be looking at.
+ *
+ * When the upstream told us the kind of release, that wins. When it didn't — `'other'`, our
+ * honest "we don't know" — a release sold only on download-only platforms is labelled **Digital**.
+ * That is the normal case on Mirlo, Faircamp and Jam.coop: none of them expose a type field, so
+ * every release from them would otherwise show no label at all.
+ *
+ * `'other'` deliberately does not become "Other" — it never has. A row reading "Other · 4 July
+ * 2026 · $4" tells a fan nothing; omitting it and showing "4 July 2026 · $4" is cleaner, and
+ * "Digital · 4 July 2026 · $4" is better still where it's true.
+ *
+ * **Every** platform must be download-only, not just one. A release on both Mirlo and Bandcamp
+ * may well exist as a vinyl pressing, and "Digital" would then be wrong about a physical product
+ * — so a single unflagged or unknown platform is enough to fall back to no label.
+ *
+ * Returns a plain capitalized label; callers apply their own casing (the release page shouts it).
+ */
+export function releaseTypeLabel(releaseType: string | null, platforms: string[]): string {
+  if (releaseType && releaseType !== 'other') {
+    return releaseType.charAt(0).toUpperCase() + releaseType.slice(1);
+  }
+
+  // No platforms means nothing is known about where it's sold, which is not evidence of digital.
+  if (platforms.length === 0) return '';
+  if (platforms.every(p => PLATFORMS[p]?.digitalOnly)) return 'Digital';
+
+  return '';
+}
+
 /** One release's source, with just enough offer data to summarize or badge with. */
 export interface ReleaseSourceSummary {
   platform: string;

--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate } from '../../../../api/shared/release-display';
+import { leadingOfferSummary, orderedSourcePlatforms, formatReleaseDate, releaseTypeLabel } from '../../../../api/shared/release-display';
 import { PLATFORMS } from '../../../../api/shared/platform-registry';
 import { PlatformIcon } from './PlatformIcon';
 import type { ArtistPagePayload } from '../types/artist-page';
@@ -141,12 +141,12 @@ function PageButton({
 function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: string }) {
   const date = formatReleaseDate(release.releaseDate, release.datePrecision);
 
-  // Capitalised here rather than with a `capitalize` class, which would apply to the whole line
-  // and turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
-  const type =
-    release.releaseType === 'other'
-      ? ''
-      : release.releaseType.charAt(0).toUpperCase() + release.releaseType.slice(1);
+  // Capitalised in the helper rather than with a `capitalize` class, which would apply to the
+  // whole line and turn "from $7" into "From $7" and "Name your price" into "Name Your Price".
+  const type = releaseTypeLabel(
+    release.releaseType,
+    release.sources.map(s => s.platform)
+  );
 
   // leadingOfferSummary, not the globally cheapest price: once a release has more than one
   // source, picking the absolute cheapest could rank a Discogs secondhand copy above a

--- a/apps/web/src/pages/AdminReleaseReviewPage.tsx
+++ b/apps/web/src/pages/AdminReleaseReviewPage.tsx
@@ -6,7 +6,7 @@ import { SkeletonScreen } from '../components/Skeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 import { PlatformIcon } from '../components/PlatformIcon';
 import { PLATFORMS } from '../../../../api/shared/platform-registry';
-import { formatReleaseDate } from '../../../../api/shared/release-display';
+import { formatReleaseDate, releaseTypeLabel } from '../../../../api/shared/release-display';
 import type { SourceId } from '../types';
 
 interface ReleaseReviewItem {
@@ -155,8 +155,7 @@ export function AdminReleaseReviewPage() {
 
 function ReleaseSummary({ item }: { item: ReleaseReviewItem }) {
   const date = formatReleaseDate(item.releaseDate, item.datePrecision);
-  const type =
-    item.releaseType === 'other' ? '' : item.releaseType.charAt(0).toUpperCase() + item.releaseType.slice(1);
+  const type = releaseTypeLabel(item.releaseType, item.platforms);
   const meta = [type, date].filter(Boolean).join(' · ');
 
   return (

--- a/apps/web/src/pages/ArtistReleasesPage.tsx
+++ b/apps/web/src/pages/ArtistReleasesPage.tsx
@@ -7,7 +7,7 @@ import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 import { PlatformIcon } from '../components/PlatformIcon';
 import { PLATFORMS } from '../../../../api/shared/platform-registry';
-import { formatReleaseDate } from '../../../../api/shared/release-display';
+import { formatReleaseDate, releaseTypeLabel } from '../../../../api/shared/release-display';
 import { sources } from '../services/sources';
 import { applyPendingOrder } from '../utils/releaseOrder';
 import type { SourceId } from '../types';
@@ -560,7 +560,7 @@ function ReleaseCard({
 }) {
   const busy = (key: string) => actionLoading === key;
   const date = formatReleaseDate(release.releaseDate, release.datePrecision);
-  const type = release.releaseType === 'other' ? '' : release.releaseType.charAt(0).toUpperCase() + release.releaseType.slice(1);
+  const type = releaseTypeLabel(release.releaseType, release.sources.map(s => s.platform));
   const meta = [type, date].filter(Boolean).join(' · ');
 
   return (

--- a/apps/web/tests/unit/ReleasesSection.test.tsx
+++ b/apps/web/tests/unit/ReleasesSection.test.tsx
@@ -167,3 +167,52 @@ describe('ReleasesSection', () => {
     expect(screen.queryByText(/more$/)).toBeNull();
   });
 });
+
+describe('release type label', () => {
+  afterEach(cleanup);
+
+  it('shows Digital for a Mirlo release whose kind Mirlo never told us', () => {
+    // Mirlo leaves `type` null on the overwhelming majority of releases (204 of 209 measured
+    // live), so 'other' is the normal outcome and this row would otherwise carry no type at all.
+    show([
+      release({
+        releaseType: 'other',
+        sources: [{ platform: 'mirlo', offers: [{ price: 4, currency: 'USD', availability: 'available' }] }],
+      }),
+    ]);
+
+    expect(screen.getByText(/Digital/)).toBeTruthy();
+  });
+
+  it('does not claim Digital when the release is also on a platform that sells physical', () => {
+    // Bandcamp presses vinyl. "Digital" on a row that links to a vinyl listing is a wrong claim
+    // about a physical product, so one non-digital platform drops the label entirely.
+    show([
+      release({
+        releaseType: 'other',
+        sources: [
+          { platform: 'mirlo', offers: [{ price: 4, currency: 'USD', availability: 'available' }] },
+          { platform: 'bandcamp', offers: [{ price: 25, currency: 'USD', availability: 'available' }] },
+        ],
+      }),
+    ]);
+
+    expect(screen.queryByText(/Digital/)).toBeNull();
+  });
+
+  it('never renders the word "Other" to a fan', () => {
+    show([release({ releaseType: 'other', sources: [] })]);
+    expect(screen.queryByText(/\bOther\b/)).toBeNull();
+  });
+
+  it('still prefers a real upstream type over the digital fallback', () => {
+    show([
+      release({
+        releaseType: 'ep',
+        sources: [{ platform: 'mirlo', offers: [] }],
+      }),
+    ]);
+    expect(screen.getByText(/Ep/)).toBeTruthy();
+    expect(screen.queryByText(/Digital/)).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "sync:bandcamp-dates": "npx tsx scripts/sync-bandcamp-dates.ts",
     "backfill:artist-rows": "npx tsx scripts/backfill-published-artist-rows.ts",
     "ingest:try": "npx tsx scripts/ingest-releases.ts",
+    "ingest:mirlo": "npx tsx scripts/ingest-mirlo.ts",
     "preview:release": "npx tsx scripts/preview-release-page.ts",
     "catalog:artist": "npx tsx scripts/catalog-artist.ts",
     "test:web": "cd apps/web && npx vitest run",

--- a/scripts/ingest-mirlo.ts
+++ b/scripts/ingest-mirlo.ts
@@ -1,0 +1,160 @@
+/**
+ * Try Mirlo release ingest against the real API, locally, without writing anything.
+ *
+ * Usage:
+ *   npx tsx scripts/ingest-mirlo.ts <mirlo-url-or-slug>
+ *   npx tsx scripts/ingest-mirlo.ts timerival
+ *   npx tsx scripts/ingest-mirlo.ts https://mirlo.space/timerival/releases
+ *   npx tsx scripts/ingest-mirlo.ts timerival --json
+ *   npx tsx scripts/ingest-mirlo.ts timerival --raw     (field-level audit of the response)
+ *
+ * Exercises the real path — the same slug derivation, the same parse, the same mapping to
+ * release rows production uses — and prints what *would* be written.
+ *
+ * **One request, whole discography, prices included.** Unlike the Bandcamp script there is no
+ * `--detail` flag, because there is no detail pass: `/v1/artists/{slug}` returns every release
+ * and its price in the same response. This is the cheapest source in the codebase.
+ *
+ * DRY RUN ONLY, DELIBERATELY. There is no --write flag, for the same reason
+ * scripts/ingest-releases.ts has none: .env points at the production Supabase, so a local write
+ * path would mean a laptop writing real `releases` rows. Everything with a decision in it is
+ * upstream of the database anyway, and `persistMirloReleases` is covered by unit tests.
+ *
+ * `--raw` exists because this endpoint has three fields that are easy to read wrongly:
+ * `minPrice` is in cents, `null` there is *not* zero, and `platformPercent` looks like a payout
+ * share but is not trustworthy as one. It prints them unmapped so a surprise is visible rather
+ * than absorbed silently by the mapping.
+ *
+ * Mirlo granted Unstream permission to use this endpoint (2026-08-05). Still one request per
+ * run — be a good neighbour and don't loop it.
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(import.meta.dirname ?? '.', '../.env') });
+
+const { ingestMirloArtist, mirloArtistSlug } = await import('../api/functions/release-ingest.js');
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const showRaw = args.includes('--raw');
+const target = args.find(a => !a.startsWith('--'));
+
+if (!target) {
+  console.error('Usage: npx tsx scripts/ingest-mirlo.ts <mirlo-url-or-slug> [--json] [--raw]');
+  process.exit(1);
+}
+
+// A bare word is treated as a Mirlo artist slug, which is how most artists are stored.
+const storedUrl = target.includes('://') ? target : `https://mirlo.space/${target}`;
+
+// The same derivation production applies, so a URL this rejects fails here too rather than
+// being quietly normalized into something that happens to work.
+const slug = mirloArtistSlug(storedUrl);
+if (!slug) {
+  console.error(`Could not derive a Mirlo artist slug from ${storedUrl}`);
+  console.error('Refused for one of three reasons, all deliberate: the host is not mirlo.space,');
+  console.error('there is no first path segment, or the segment is one of Mirlo’s own routes');
+  console.error('(/login, /pages, /admin, …) which sit at the same depth as artist profiles.');
+  process.exit(1);
+}
+
+const apiUrl = `https://api.mirlo.space/v1/artists/${encodeURIComponent(slug)}`;
+const headers: Record<string, string> = {
+  'User-Agent': 'Unstream/1.0 (https://unstream.stream - ethical music finder)',
+};
+// Sent when present, exactly as production does. Verified 2026-08-05: this endpoint answers
+// identically without it, so an absent key is not a failure — it just isn't attributed to us.
+if (process.env.MIRLO_API_KEY) headers['mirlo-api-key'] = process.env.MIRLO_API_KEY;
+
+if (!asJson) {
+  console.log(`\nFetching ${apiUrl} …`);
+  if (!process.env.MIRLO_API_KEY) console.log('(no MIRLO_API_KEY set — sending unauthenticated)');
+}
+
+const response = await globalThis.fetch(apiUrl, { headers });
+if (!response.ok) {
+  console.error(`Mirlo responded ${response.status}.`);
+  process.exit(1);
+}
+
+let body: unknown;
+try {
+  body = await response.json();
+} catch {
+  console.error('Mirlo returned a 200 with a non-JSON body — a challenge or error page.');
+  process.exit(2);
+}
+
+const releases = ingestMirloArtist(body, slug);
+
+// The distinction production depends on: null means the response wasn't an artist document at
+// all, which must never be recorded as "this artist has released nothing".
+if (releases === null) {
+  console.error('\nThe 200 was not a Mirlo artist document for this slug.');
+  console.error('Not an empty discography — the parse refused it, so nothing would be written.');
+  process.exit(2);
+}
+
+const raw = (body as { result?: { trackGroups?: unknown[] } }).result?.trackGroups ?? [];
+
+if (asJson) {
+  console.log(JSON.stringify({ apiUrl, slug, upstreamCount: raw.length, releases }, null, 2));
+  process.exit(0);
+}
+
+console.log(`\nWould write ${releases.length} release(s). Nothing was saved.`);
+console.log(`Mirlo returned ${raw.length} trackGroup(s); ${raw.length - releases.length} skipped ` +
+  '(drafts, hidden, or deleted).\n');
+
+const pad = (s: string, n: number) => (s.length >= n ? s.slice(0, n - 2) + '… ' : s.padEnd(n));
+console.log(pad('TYPE', 12) + pad('TITLE', 38) + pad('DATE', 12) + pad('STATUS', 11) + pad('PRICE', 12) + 'ART');
+console.log('-'.repeat(96));
+for (const r of releases) {
+  const offer = r.offers[0];
+  const price = !offer
+    ? 'no offer'
+    : offer.price === 0
+      ? 'name-your-price'
+      : `${offer.price} ${offer.currency ?? '?'}`;
+  console.log(
+    pad(r.releaseType, 12) +
+      pad(r.title, 38) +
+      pad(r.releaseDate ?? 'none', 12) +
+      pad(r.status, 11) +
+      pad(price, 12) +
+      (r.artworkUrl ? 'yes' : 'NO')
+  );
+}
+
+// Surfaced as counts because these are the things most likely to be quietly wrong, and
+// "no offer" versus "free" is the distinction with the most product consequence.
+const noOffer = releases.filter(r => r.offers.length === 0).length;
+const nyp = releases.filter(r => r.offers[0]?.price === 0).length;
+const undated = releases.filter(r => !r.releaseDate).length;
+const announced = releases.filter(r => r.status === 'announced').length;
+console.log(
+  `\nsummary: ${releases.length} releases · ${noOffer} with no offer · ${nyp} name-your-price · ` +
+    `${undated} undated · ${announced} announced`
+);
+console.log('note: "no offer" means Mirlo has no price configured. It is NOT free — publishing');
+console.log('      it as 0 would render "Name your price" and misstate the artist’s terms.\n');
+
+if (showRaw) {
+  console.log('Raw upstream fields, unmapped — the three that are easy to misread:\n');
+  console.log(pad('TITLE', 38) + pad('minPrice', 10) + pad('currency', 10) + pad('type', 8) + 'platformPercent');
+  console.log('-'.repeat(88));
+  for (const node of raw as Array<Record<string, unknown>>) {
+    console.log(
+      pad(String(node.title ?? '(untitled)'), 38) +
+        pad(node.minPrice === null ? 'null' : String(node.minPrice), 10) +
+        pad(String(node.currency ?? '—'), 10) +
+        pad(String(node.type ?? 'null'), 8) +
+        String(node.platformPercent ?? '—')
+    );
+  }
+  console.log('\nminPrice is in CENTS (400 = 4.00), and null is "no price set", not zero.');
+  console.log('platformPercent is printed for visibility only — the ingest deliberately ignores it,');
+  console.log('since it contradicts defaultPlatformFee and reached 100 on a free release.\n');
+}


### PR DESCRIPTION
Closes step 10 of the locked V1 Releases scope, and closes the Mirlo question that #405 was paused on. **Supersedes and replaces [#405](https://github.com/brandonlucasgreen/unstream/pull/405)**, now closed — Mirlo granted Unstream permission and issued an API key on 2026-08-05, which made the REST API available, and it has the prices Canimus doesn't.

Two commits, reviewable independently:

1. `f253664` — the Mirlo REST ingest
2. `e8e6e3c` — the "Digital" release-type label (touches the artist page, release page and admin queue, so worth reading on its own)

## One request per artist, discography *and* prices

`GET /v1/artists/{slug}` returns everything in one response, so **there is no detail pass at all**. Bandcamp needs a grid plus one fetch per release; Jam.coop needs an artist page plus one per album. Mirlo needs one. It is now the cheapest and richest release source in the codebase.

## Verified against live data, which is what #405 couldn't do

#405's fixtures came from pasted documentation, so they pinned *our assumptions* rather than Mirlo's field names. Every fixture here was captured from real responses — **209 releases across 31 artists** — and three findings changed the implementation:

| Finding | Why it matters |
|---|---|
| `minPrice` is **integer cents**, and `null` is not `0` | 56 of 209 releases have no price configured. Publishing those as `0` renders "Name your price" and advertises terms the artist never set. They get **no offer**. |
| **Currency casing is inconsistent** — `GBP` (40) *and* `gbp` (8), `usd` *and* `USD` | Stored raw, one currency becomes two. |
| **Drafts bypass every visibility flag** | Both real drafts report `isPublic: true`, `hideFromSearch: false`, `isGettable: true`. The filter keys on the empty title and the `mi-temp-slug-` prefix instead. |

Also: `releaseDate` was non-null on all 209 (contradicting an earlier note), genuine future dates exist, and `isPreorder: true` appears — so status gets a real signal rather than an inference from the date.

## `platformPercent` is deliberately ignored

It looks like a per-release payout share, which would beat the registry's static range outright. It isn't trustworthy as one: values run 7, 10, 15, 20, 25, 50, 100; it **contradicts the artist's own `defaultPlatformFee`** (one artist has `defaultPlatformFee: 7` with every release at `50`); and it reached `100` on a free release, which is meaningless as a fee. None of the outliers correlate with `fundraiser` or `isAllOrNothing`.

Payout stays on the platform registry until Mirlo tells us what the field means. A wrong number about an artist's money is worse than a coarse one. **Open question to raise with Mirlo** — if it means what it might, it's a real upgrade later.

## The API key gates nothing

Verified the same day: this endpoint returns **byte-identical responses** with `mirlo-api-key`, with `Authorization: Bearer`, and with **no auth at all**. It's a public read endpoint.

The key is still sent — it identifies us and future-proofs against them gating or rate-limiting by key — but an absent key must not disable the pass, and nothing here assumes an authenticated response differs. **What unblocked this work was the permission, not the key.** `Disallow: /v1/` is still in Mirlo's robots.txt; we poll it on direct consent rather than by ignoring it.

## No feature flag, and what that means on merge

`RELEASE_CATALOG_ENABLED` (production-only) is already the master gate, and #405's `MIRLO_CANIMUS_ENABLED` existed solely because the robots question was open. A second flag would be speculative config.

**So merging starts cataloguing Mirlo-linked artists in production** — ~66 artists had a Mirlo link as of 2026-08-02 — and adds `mirlo` to the recatalog sweep's pool. That's the intent, but it isn't dormant.

## The "Digital" label (second commit)

Mirlo, Faircamp and Jam.coop expose no type field, so their releases store `release_type: 'other'`. All five render sites already omitted the label entirely, so those rows showed no type at all. Where **every** platform selling a release is download-only, they now read "Digital".

Done in the display layer, not the data: extending the `release_type` CHECK constraint would put a *format* into a column that answers "what kind of work is this", and would make `'digital'` reachable for a Bandcamp release that only exists on vinyl. `digitalOnly` lives on the platform registry with per-platform evidence; absent means "not established", not "sells physical". One unflagged platform drops the label — a release on Mirlo *and* Bandcamp may well be a vinyl pressing.

## Verification

- `npm run build` ✅ · `test:api` **958 passing** (+5) · `test:unit` **640 passing** (+4) · `typecheck:api` ✅
- Lint unchanged from the repo's 71-problem / 64-error baseline
- **Eleven mutations proven to fail exactly their intended test** across both commits — including cents-not-divided, currency-not-normalized, uncertainty-collapsed-to-`[]`, null-minPrice-coerced-to-zero, and the vacuous `[].every()` that would have claimed "Digital" for a release with no sources
- Two teeth-probes initially revealed *weak tests rather than working ones*: the draft filter was only being exercised by the title check, and the sweep's `it.each` proved inclusion but never exclusion. Both were rewritten.
- End-to-end dry run against real artists via the new `npm run ingest:mirlo`: `timerival` 32 of 33 written (draft skipped, 400 cents → `4 USD`), `clive-murray` `type:'lp'` → `album` with GBP preserved, `dreamofomni` 666 cents → `6.66 CAD` with two `isGettable:false` CD comps correctly yielding no offer

## Before merging

**Set `MIRLO_API_KEY` in Netlify, Functions scope.** Not blocking — the pass works without it, it just isn't attributed to us.

Still untouched, per your earlier call: the three pre-existing unauthenticated `/v1/` calls in search, `enrichment.ts` and `check-releases.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)