### PR TITLE
Fix the intermittent failure in AuthContext-save-reporting.test.tsx

### DIFF
--- a/apps/web/tests/unit/AuthContext-save-reporting.test.tsx
+++ b/apps/web/tests/unit/AuthContext-save-reporting.test.tsx
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useEffect } from 'react';
-import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import { render, waitFor, cleanup, act } from '@testing-library/react';
 import { AuthProvider, useAuth } from 'src/contexts/AuthContext';
 
 const mocks = vi.hoisted(() => ({
@@ -54,7 +54,7 @@ const held: { current: ReturnType<typeof useAuth> | null } = { current: null };
 function Probe() {
   const auth = useAuth();
   useEffect(() => { held.current = auth; });
-  return <div data-testid="probe">{auth.session ? 'signed-in' : 'signed-out'}</div>;
+  return null;
 }
 
 function api(): ReturnType<typeof useAuth> {
@@ -62,15 +62,31 @@ function api(): ReturnType<typeof useAuth> {
   return held.current;
 }
 
+// Waits on the captured context, not on a rendered proxy for it. Waiting for the DOM to say
+// "signed-in" was a race: that text lands when React commits, but `held.current` is written by a
+// passive effect React flushes later, and waitFor can resolve on the commit's MutationObserver
+// microtask. `api()` then handed back the pre-session snapshot, whose saveArtist hits
+// `if (!session) return` — so the call reported nothing and every assertion below failed.
 async function mountSignedIn() {
   mocks.getSession.mockResolvedValue({ data: { session } });
   render(<AuthProvider><Probe /></AuthProvider>);
-  await waitFor(() => expect(screen.getByTestId('probe').textContent).toBe('signed-in'));
+  await waitFor(() => expect(held.current?.session).toBeTruthy());
 }
 
-/** The options passed alongside the first captureMessage call. */
-function reportOptions() {
-  return mocks.captureMessage.mock.calls[0][1] as {
+/**
+ * The options passed alongside the named report. Looked up by message rather than taken from
+ * call 0 so a test reads the report it claims to be inspecting, and so a missing report says so
+ * instead of throwing on an empty call list.
+ */
+function reportOptions(message: string) {
+  const call = mocks.captureMessage.mock.calls.find(([m]) => m === message);
+  if (!call) {
+    throw new Error(
+      `No captureMessage call for "${message}". Reported instead: ` +
+      `${JSON.stringify(mocks.captureMessage.mock.calls.map(([m]) => m))}`
+    );
+  }
+  return call[1] as {
     level: string;
     tags: Record<string, string>;
     extra: Record<string, unknown>;
@@ -98,7 +114,7 @@ describe('AuthContext — reporting a failed save', () => {
     });
 
     expect(mocks.captureMessage).toHaveBeenCalledWith('Save artist failed (rolled back)', expect.anything());
-    const options = reportOptions();
+    const options = reportOptions('Save artist failed (rolled back)');
     expect(options.tags.status_code).toBe('400');
     expect(options.tags.context).toBe('auth.saveArtist');
     expect(options.extra.serverError).toBe('Invalid artist slug format');
@@ -116,8 +132,9 @@ describe('AuthContext — reporting a failed save', () => {
       await api().saveArtist('radiohead', undefined, 'Radiohead');
     });
 
-    expect(reportOptions().tags.status_code).toBe('401');
-    expect(reportOptions().extra.serverError).toBe('Not authenticated');
+    const options = reportOptions('Save artist failed (rolled back)');
+    expect(options.tags.status_code).toBe('401');
+    expect(options.extra.serverError).toBe('Not authenticated');
   });
 
   it('survives a response with no JSON body', async () => {
@@ -131,8 +148,9 @@ describe('AuthContext — reporting a failed save', () => {
       await api().saveArtist('radiohead', undefined, 'Radiohead');
     });
 
-    expect(reportOptions().tags.status_code).toBe('502');
-    expect(reportOptions().extra.serverError).toBe('(no body)');
+    const options = reportOptions('Save artist failed (rolled back)');
+    expect(options.tags.status_code).toBe('502');
+    expect(options.extra.serverError).toBe('(no body)');
   });
 
   it('rolls the optimistic save back as well as reporting it', async () => {
@@ -179,8 +197,9 @@ describe('AuthContext — reporting a failed save', () => {
     });
 
     expect(mocks.captureMessage).toHaveBeenCalledWith('Remove artist failed (rolled back)', expect.anything());
-    expect(reportOptions().tags.status_code).toBe('400');
-    expect(reportOptions().extra.serverError).toBe('artistId must be an artist slug, not an id');
+    const options = reportOptions('Remove artist failed (rolled back)');
+    expect(options.tags.status_code).toBe('400');
+    expect(options.extra.serverError).toBe('artistId must be an artist slug, not an id');
   });
 
   it('reports a failed saved-artists load with its status code', async () => {
@@ -195,7 +214,8 @@ describe('AuthContext — reporting a failed save', () => {
     });
 
     expect(mocks.captureMessage).toHaveBeenCalledWith('Dashboard saved-artists load failed', expect.anything());
-    expect(reportOptions().tags.status_code).toBe('500');
-    expect(reportOptions().extra.serverError).toBe('Database not configured');
+    const options = reportOptions('Dashboard saved-artists load failed');
+    expect(options.tags.status_code).toBe('500');
+    expect(options.extra.serverError).toBe('Database not configured');
   });
 });


### PR DESCRIPTION
## What was wrong

`apps/web/tests/unit/AuthContext-save-reporting.test.tsx` failed intermittently — seen once in a `npm run test:unit` run, then unreproducible in isolation. Because the build gate blocks Netlify deploys, a flake here makes a real regression and a spurious failure indistinguishable, and the usual response ("re-run it") is exactly what would let a real one through.

## The race

`mountSignedIn` waited for the DOM to read `signed-in`, but every test then drives `held.current` — which is written by a **passive effect**. Those are two different events:

- the text lands when React commits;
- the effect flushes on a later macrotask;
- `waitFor` can resolve on the commit's MutationObserver microtask, i.e. before the effect.

`api()` then handed back the pre-session context snapshot, whose `saveArtist` hits `if (!session) return` ([AuthContext.tsx:185](https://github.com/brandonlucasgreen/unstream/blob/main/apps/web/src/contexts/AuthContext.tsx#L185)). The call under test silently did nothing, so nothing was reported — surfacing either as `captureMessage` "Number of calls: 0" or as a `TypeError` on `mock.calls[0][1]`.

No product code is at fault; the assertions were correct, the setup wasn't.

## Reproduction

Repetition doesn't surface it — **250 unloaded iterations and 10 clean full-suite runs all passed.** CPU contention does: 10 background busy-loops plus 120 runs of the single file produced **4 failures, across three different tests** (not just the one originally reported).

An instrumented probe pinned the mechanism: of 60 iterations, the single one where `held.current.session` was still `null` after the wait was exactly the one where nothing was reported (`{"iterations":60,"staleHeld":1,"noReport":1}`).

## The fix

- `mountSignedIn` waits on `held.current?.session` — the value the test is about to use — instead of a rendered proxy for it. `Probe` returns `null` since nothing reads its output any more. This costs ~50ms per test (interval polling rather than a DOM mutation) and is tolerant of any session-arrival timing.
- `reportOptions(message)` looks the report up by message rather than reading `mock.calls[0][1]`. Two of the three reproduced failures were opaque `TypeError: Cannot read properties of undefined` from that index; a missing report now names itself and lists what *was* reported.

## Verification

- **0 failures in 250 runs** under the identical load that produced 4/120 before the fix.
- `test:unit` 636 passed · `test:api` 923 passed · root and `apps/web` `tsc -b` clean · lint unchanged at the known 71-problem baseline.

## For reviewers

Two things I found but deliberately left alone, to keep this diff to the flake:

- **One test was passing for the wrong reason.** "rolls the optimistic save back" only asserts `isArtistSaved` is `false` — which a no-op save also satisfies, so it went green under the race while the code under test never ran. The fix protects it, but it still has no teeth of its own against a regression in the rollback path.
- **The fetch spy is never restored.** `vi.clearAllMocks()` clears calls but not spies, and each `mockResolvedValue` hands out a *single* `Response`, whose body can only be read once. Nothing triggers a second fetch per test today, so it isn't firing — but it's the next flake in the same family if one ever does. Happy to harden it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
