### PR TITLE
Recognize WebKit's MIME wording as a stale-build asset error

### DIFF
--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -29,10 +29,15 @@ export function isStaleBuildAssetError(message: string): boolean {
     message.includes('Failed to fetch dynamically imported module') ||
     // Firefox
     message.includes('error loading dynamically imported module') ||
-    // Safari
+    // Safari, when the fetch itself failed
     message.includes('Importing a module script failed') ||
-    // Any engine, when the SPA catch-all serves index.html in place of the chunk
+    // Chromium, when the SPA catch-all serves index.html in place of the chunk
     message.includes('Expected a JavaScript module script') ||
+    // WebKit's wording for the same MIME rejection: "'text/html' is not a valid
+    // JavaScript MIME type." Different enough from the Chromium sentence above
+    // that it needs its own clause — missing it meant every iOS visitor caught by
+    // a deploy got the error screen instead of the reload.
+    message.includes('is not a valid JavaScript MIME type') ||
     // Vite's preload helper, when a stylesheet for a route chunk is missing
     message.includes('Unable to preload CSS for')
   )

--- a/apps/web/tests/unit/sentry-stale-build.test.ts
+++ b/apps/web/tests/unit/sentry-stale-build.test.ts
@@ -30,6 +30,15 @@ describe('isStaleBuildAssetError', () => {
     )).toBe(true);
   });
 
+  it("matches WebKit's wording for the same MIME rejection", () => {
+    // Real event from iOS 18.7 / Mobile Safari 26.6 on 2026-08-06, reaching the
+    // error boundary on /artist-edit/:slug/releases. WebKit words the MIME
+    // rejection nothing like Chromium does, so it escaped the clause above.
+    expect(isStaleBuildAssetError(
+      "TypeError: 'text/html' is not a valid JavaScript MIME type."
+    )).toBe(true);
+  });
+
   it("matches Vite's CSS preload failure", () => {
     expect(isStaleBuildAssetError(
       'Unable to preload CSS for /assets/ArtistEditPage-Bq1x9fLm.css'


### PR DESCRIPTION
Fixes a Sentry-reported `TypeError: 'text/html' is not a valid JavaScript MIME type.` on
`/artist-edit/cory-miller/releases`, iOS 18.7 / Mobile Safari 26.6.

## What was happening

Every page in `apps/web/src/main.tsx` is lazy-loaded, so each chunk filename carries a content
hash. A tab left open across a deploy asks for a chunk the new deploy no longer has, and Netlify's
SPA catch-all answers that request with `200 text/html` rather than `404` — so the browser refuses
to run it as a module. Still reproducible against production with the chunk named in the report:

```
$ curl -sI https://unstream.stream/assets/index-Bn4C7Uoe.js | head -3
HTTP/2 200
content-type: text/html; charset=UTF-8
```

We already handle this. `lazyWithRetry` reloads the tab once when `isStaleBuildAssetError` matches,
and that classifier knew Chromium's sentence for the MIME rejection — *"Expected a JavaScript
module script but the server responded with a MIME type of 'text/html'"*. WebKit words the
identical failure as a completely different sentence: *"'text/html' is not a valid JavaScript MIME
type."*

So on iOS the classifier returned false, `lazyWithRetry` rethrew instead of reloading, and the
person got the "Unstream hit an unexpected error" screen. The event also missed the
`stale-build-asset` fingerprint and the `route` tag, which is why it arrived in Sentry looking like
an unrelated one-off TypeError rather than as the deploy it was.

## Verified against the deployed bundle, not just the source

The live entry chunk `assets/index-Bl1j9bhQ.js` contains `Importing a module script failed` once
and `is not a valid JavaScript MIME type` zero times — the gap is in production, not only on a
branch.

One detail a reviewer should know: this particular event carried `release = unknown`, meaning that
tab predates #390 and had no `lazyWithRetry` at all, so that person would have hit the error screen
regardless. The classifier gap is still real and current — any iOS visitor on today's build gets
the same outcome at the next deploy.

## Changes

- `apps/web/src/services/sentry.ts` — added the WebKit wording, and relabelled the neighbouring
  clause as Chromium's since "Safari" was doing double duty for two different failure modes.
- `apps/web/tests/unit/sentry-stale-build.test.ts` — a case pinned to the literal message from the
  report. Confirmed it has teeth: removing the new clause fails it.

## Testing

`npm run lint` (71 problems, unchanged baseline), 641 web unit tests, 958 API tests, and
`tsc -b apps/web` all pass. Not preview-verifiable — it only fires on a genuine post-deploy MIME
rejection, which the dev server can't produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)