### PR TITLE
Resolve retired artist slugs in the release JSON and artist feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,24 +219,34 @@ Sentry, since it is otherwise recorded as a perfectly ordinary success.
 Every other catalog trigger is demand-driven — a save, a search, an artist's own button, the admin
 command — and `check-releases` only *reads* the catalogue. So without a scheduled refresh an artist
 who is saved but never searched gets catalogued once and their release alerts quietly stop. That
-is what `api/functions/recatalog-sweep.ts` fixes, run daily by `.github/workflows/recatalog-sweep.yml`.
+is what `api/functions/recatalog-sweep.ts` fixes, run every six hours by
+`.github/workflows/recatalog-sweep.yml` (25 artists per run, so 100 a day).
 
-The pool is **every artist with a bandcamp, discogs, faircamp or jamcoop link** — measured
-2026-08-02: 2,564 of them, against 9 artists saved by anybody, so a saved-only sweep sat idle
-almost every run. Alerts aren't the only consumer either: `/a/:slug` renders a release list for
-any catalogued artist, and those pages exist because somebody *searched*. Keep that platform list
-identical to `catalogArtist`'s "no bandcamp, discogs, faircamp, or jam.coop link stored" check —
-an artist with only an official site is recorded as a *failure*, so sweeping them poisons
-`consecutive_failures`.
+The pool is **every artist with a bandcamp, discogs, faircamp, jam.coop or mirlo link** —
+`CATALOGUEABLE_PLATFORMS` in `db.ts` is the list. Keep it identical to `catalogArtist`'s "no
+bandcamp, discogs, faircamp, jam.coop, or mirlo link stored" check — an artist with only an
+official site is recorded as a *failure*, so sweeping them poisons `consecutive_failures`. The two
+have to change together: Mirlo was added to both in the same PR (#415) for exactly that reason.
+
+Why the pool isn't saved-only, which is how it shipped: measured 2026-08-02 there were 2,564
+artists with a catalogue-able link against 9 saved by anybody, so the sweep's whole universe fit
+in one batch and it sat idle almost every run. Alerts aren't the only consumer either — `/a/:slug`
+renders a release list for any catalogued artist, and those pages exist because somebody
+*searched*. The ratio is what matters and it hasn't moved: as of 2026-08-07 there are 5,977
+releases across 803 catalogued artists, and 36 live `saved_artists` rows in total. Treat every
+number in this paragraph as a dated measurement, not a current count — re-measure before
+reasoning from one.
 
 `getStaleCatalogCandidates` in `db.ts` orders them: saved first (an alert is a promise to a
 person, and there are few enough that they never starve behind the backfill), then never
 catalogued, then oldest `last_attempted_at`, then savers as a pure tiebreak. It asks
-`requestArtistCatalog` for up to 25 under the `scheduled` trigger. No rate limiting of its own —
-the 7-day cooldown and the hourly cap in `claimArtistForCatalog` still decide — so running it
-twice is a no-op. It returns a real summary rather than 202, and any refusal is a non-2xx that
-fails the workflow: a scheduled job that reports success while doing nothing is the same silent
-failure it was built to fix.
+`requestArtistCatalog` for up to 25 under the `scheduled` trigger. It adds no limit of its own: it
+drops artists inside the 7-day re-catalogue cooldown up front, reading the same
+`RECATALOG_COOLDOWN_HOURS` constant so a bounded batch isn't spent on artists that would be
+refused a moment later, but `claimArtistForCatalog` — that cooldown plus the per-trigger hourly cap
+— stays the authority. So running the sweep twice is a no-op. It returns a real summary rather than
+202, and any refusal is a non-2xx that fails the workflow: a scheduled job that reports success
+while doing nothing is the same silent failure it was built to fix.
 
 **Paging, not `.limit()`.** PostgREST caps every response at 1,000 rows whatever limit you ask
 for, and truncates *silently*. A single `.select()` over `artist_links` returns 1,000 of ~3,900
@@ -369,7 +379,7 @@ GitHub Actions (`.github/workflows/`):
 - `schedule-social-posts.yml` — weekly (Mondays) social post generation, committed back to the repo.
 - `semantic-revert-check.yml` — runs `scripts/semantic-revert-check.py` on every PR to flag changes that quietly undo earlier fixes. If it flags your PR, take it seriously: the bug loops it was built for are described in `docs/retros/UNS-100-bifurcation-retro.md`.
 - `upstash-keepalive.yml` — twice weekly, writes one Redis key so the free-tier database isn't reaped for inactivity (which silently killed caching and rate limiting once).
-- `recatalog-sweep.yml` — every 6 hours, POSTs `/.netlify/functions/recatalog-sweep` so release catalogues get built and stay fresh. See "Keeping catalogues fresh" below.
+- `recatalog-sweep.yml` — every 6 hours, POSTs `/.netlify/functions/recatalog-sweep` so release catalogues get built and stay fresh. See "Keeping catalogues fresh" above.
 
 ## Engineering principles
 

--- a/api/functions/__tests__/feed-releases.test.ts
+++ b/api/functions/__tests__/feed-releases.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   getFeedReleasesForUser: vi.fn(),
   getFeedReleasesForArtist: vi.fn(),
   getFeedReleasesForHandle: vi.fn(),
+  resolveArtistSlugAlias: vi.fn(),
 }));
 
 vi.mock('../ratelimit', () => ({
@@ -25,6 +26,7 @@ vi.mock('../db', () => ({
   getFeedReleasesForUser: mocks.getFeedReleasesForUser,
   getFeedReleasesForArtist: mocks.getFeedReleasesForArtist,
   getFeedReleasesForHandle: mocks.getFeedReleasesForHandle,
+  resolveArtistSlugAlias: mocks.resolveArtistSlugAlias,
 }));
 
 import { handler, parsePath, requestPath } from '../feed-releases';
@@ -70,6 +72,7 @@ beforeEach(() => {
   mocks.getFeedReleasesForUser.mockResolvedValue([]);
   mocks.getFeedReleasesForArtist.mockResolvedValue(null);
   mocks.getFeedReleasesForHandle.mockResolvedValue(null);
+  mocks.resolveArtistSlugAlias.mockResolvedValue(null);
 });
 
 describe('requestPath', () => {
@@ -236,6 +239,44 @@ describe('the public artist feed', () => {
   it('404s an unknown artist', async () => {
     const r = await get('/a/nobody/releases.xml');
     expect(r.statusCode).toBe(404);
+  });
+
+  // A calendar client keeps fetching whatever URL it was handed and never reports a 404 to
+  // anybody, so an artist re-slugged after somebody subscribed would silently lose them.
+  it('resolves a retired artist slug through the alias table', async () => {
+    mocks.getFeedReleasesForArtist.mockImplementation(async (slug: string) =>
+      slug === 'beyonce' ? { artistName: 'Beyoncé', releases: [row()] } : null
+    );
+    mocks.resolveArtistSlugAlias.mockResolvedValue('beyonce');
+
+    const r = await get('/a/beyonc/releases.xml');
+
+    expect(r.statusCode).toBe(200);
+    expect(mocks.resolveArtistSlugAlias).toHaveBeenCalledWith('beyonc');
+    // Self-link and feed id both canonical: the link should point at the address that still
+    // works, and one id per artist keeps a reslug from splitting subscribers across two feeds.
+    expect(r.body).toContain('/a/beyonce/releases.xml');
+    expect(r.body).toContain('tag:unstream.stream,2026:feed/a/beyonce');
+    expect(r.body).not.toContain('beyonc/releases.xml');
+  });
+
+  it('never reads the alias table when the live slug answers', async () => {
+    mocks.getFeedReleasesForArtist.mockResolvedValue({ artistName: 'Kid Lightbulbs', releases: [row()] });
+
+    const r = await get('/a/kid-lightbulbs/releases.xml');
+
+    expect(r.statusCode).toBe(200);
+    expect(mocks.resolveArtistSlugAlias).not.toHaveBeenCalled();
+    expect(mocks.getFeedReleasesForArtist).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s when the slug is neither live nor an alias', async () => {
+    mocks.resolveArtistSlugAlias.mockResolvedValue(null);
+
+    const r = await get('/a/nobody/releases.ics');
+
+    expect(r.statusCode).toBe(404);
+    expect(mocks.getFeedReleasesForArtist).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/api/functions/__tests__/release-detail.test.ts
+++ b/api/functions/__tests__/release-detail.test.ts
@@ -10,6 +10,9 @@
 //     direct purchase from the artist.
 //   - A failed lookup is a 503 that is never cached, not a 404. This response carries a CDN
 //     s-maxage, so a 404 on an outage would be a convincing lie the CDN then holds.
+//   - A retired artist slug resolves through `artist_slug_aliases`, and only on a miss. Without it
+//     a release URL minted before an artist was re-slugged 404s in the native buying guide while
+//     /api/artist answers the same alias fine.
 //
 // The two query-level properties — `is_hidden` filtered, `needs_review` deliberately not — can't
 // be seen from here, because this file mocks `../db` out. They're covered in
@@ -21,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   checkRateLimit: vi.fn(),
   getClientIp: vi.fn(() => '1.2.3.4'),
   getReleaseDetail: vi.fn(),
+  resolveArtistSlugAlias: vi.fn(),
   isBandcampFriday: vi.fn(() => false),
   captureMessage: vi.fn(),
 }));
@@ -29,7 +33,10 @@ vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.checkRateLimit,
   getClientIp: mocks.getClientIp,
 }));
-vi.mock('../db', () => ({ getReleaseDetail: mocks.getReleaseDetail }));
+vi.mock('../db', () => ({
+  getReleaseDetail: mocks.getReleaseDetail,
+  resolveArtistSlugAlias: mocks.resolveArtistSlugAlias,
+}));
 vi.mock('../../shared/bandcamp-friday', () => ({ isBandcampFriday: mocks.isBandcampFriday }));
 vi.mock('../../lib/sentry', () => ({ Sentry: { captureMessage: mocks.captureMessage } }));
 
@@ -100,6 +107,7 @@ beforeEach(() => {
   mocks.checkRateLimit.mockResolvedValue({ limited: false });
   mocks.isBandcampFriday.mockReturnValue(false);
   mocks.getReleaseDetail.mockResolvedValue({ detail: detail(), failed: false });
+  mocks.resolveArtistSlugAlias.mockResolvedValue(null);
 });
 
 // The bug this suite missed the first time. The endpoint originally read its slugs from
@@ -266,6 +274,98 @@ describe('absence versus failure', () => {
     const res = await get();
     expect(res.statusCode).toBe(500);
     expect(res.body).not.toContain('boom');
+  });
+});
+
+// `artist_slug_aliases` holds 44 rows in production, most of them minted by the accent-folding
+// reslug in #410 (`beyonc` -> `beyonce`). A release URL built under the old slug is a URL a fan can
+// still be holding — in a months-old alert, a shared link, a Mac app cache — and before this the
+// native "Where to buy" panel 404'd every one of them while /api/artist resolved the same alias
+// happily.
+describe('retired artist slugs', () => {
+  /** The lookup answers only for `beyonce`, the slug that survived the reslug. */
+  function onlyCanonical() {
+    const canonical = { ...detail(), artist: { slug: 'beyonce', name: 'Beyoncé', imageUrl: null } };
+    mocks.getReleaseDetail.mockImplementation(async (artistSlug: string) =>
+      artistSlug === 'beyonce' ? { detail: canonical, failed: false } : { detail: null, failed: false }
+    );
+  }
+
+  it('resolves a retired slug through the alias table and serves the release', async () => {
+    onlyCanonical();
+    mocks.resolveArtistSlugAlias.mockResolvedValue('beyonce');
+
+    const res = await get({ artist: 'beyonc', release: 'get-mean' });
+    const json = await body(res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.resolveArtistSlugAlias).toHaveBeenCalledWith('beyonc');
+    expect(mocks.getReleaseDetail).toHaveBeenNthCalledWith(1, 'beyonc', 'get-mean');
+    expect(mocks.getReleaseDetail).toHaveBeenNthCalledWith(2, 'beyonce', 'get-mean');
+    expect(json.artist.slug).toBe('beyonce');
+  });
+
+  // A client offers this as "open the full guide". release-page.ts doesn't resolve aliases, so
+  // echoing the requested slug back would hand a fan a URL that renders nothing.
+  it('reports the canonical slug in pageUrl and the cache tag, not the one asked for', async () => {
+    onlyCanonical();
+    mocks.resolveArtistSlugAlias.mockResolvedValue('beyonce');
+
+    const res = await get({ artist: 'beyonc', release: 'get-mean' });
+    expect((await body(res)).pageUrl).toBe('https://unstream.stream/a/beyonce/get-mean');
+    expect(res.headers['Cache-Tag']).toBe('release-detail-beyonce-get-mean');
+  });
+
+  // The live slug always wins, and the overwhelming majority of requests use one — so the alias
+  // read must not happen on the hit path at all.
+  it('never reads the alias table when the live slug answers', async () => {
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.resolveArtistSlugAlias).not.toHaveBeenCalled();
+    expect(mocks.getReleaseDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s when the slug is neither live nor an alias', async () => {
+    mocks.getReleaseDetail.mockResolvedValue({ detail: null, failed: false });
+    mocks.resolveArtistSlugAlias.mockResolvedValue(null);
+
+    const res = await get({ artist: 'nobody', release: 'get-mean' });
+    expect(res.statusCode).toBe(404);
+    expect(mocks.getReleaseDetail).toHaveBeenCalledTimes(1);
+  });
+
+  // The alias exists but the release under the canonical artist doesn't — a renamed or suppressed
+  // record. Still one 404, and not a third query.
+  it('404s when the alias resolves but the release is gone', async () => {
+    mocks.getReleaseDetail.mockResolvedValue({ detail: null, failed: false });
+    mocks.resolveArtistSlugAlias.mockResolvedValue('beyonce');
+
+    const res = await get({ artist: 'beyonc', release: 'no-such-release' });
+    expect(res.statusCode).toBe(404);
+    expect(mocks.getReleaseDetail).toHaveBeenCalledTimes(2);
+  });
+
+  // A Supabase outage is not evidence that a slug was retired. Retrying through the alias table
+  // would spend a second query to arrive at the same 503 — and the 503 is what must survive.
+  it('does not consult the alias table when the lookup itself failed', async () => {
+    mocks.getReleaseDetail.mockResolvedValue({ detail: null, failed: true });
+
+    const res = await get({ artist: 'beyonc', release: 'get-mean' });
+    expect(res.statusCode).toBe(503);
+    expect(mocks.resolveArtistSlugAlias).not.toHaveBeenCalled();
+    expect(mocks.getReleaseDetail).toHaveBeenCalledTimes(1);
+  });
+
+  // A stale alias row pointing at the slug that was just tried would otherwise buy a second
+  // identical query for nothing.
+  it('does not re-query when the alias points at the slug already tried', async () => {
+    mocks.getReleaseDetail.mockResolvedValue({ detail: null, failed: false });
+    mocks.resolveArtistSlugAlias.mockResolvedValue('boy-harsher');
+
+    const res = await get({ artist: 'boy-harsher', release: 'get-mean' });
+    expect(res.statusCode).toBe(404);
+    expect(mocks.getReleaseDetail).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/api/functions/feed-releases.ts
+++ b/api/functions/feed-releases.ts
@@ -28,6 +28,7 @@ import {
   getFeedReleasesForHandle,
   getFeedReleasesForUser,
   getFeedTokenOwner,
+  resolveArtistSlugAlias,
   type FeedReleaseRow,
 } from './db';
 import { buildAtom, buildIcs, type FeedRelease } from '../shared/feed-format';
@@ -217,7 +218,22 @@ export async function handler(event: {
     );
   }
 
-  const artist = await getFeedReleasesForArtist(route.slug);
+  let slug = route.slug;
+  let artist = await getFeedReleasesForArtist(slug);
+
+  // A retired artist slug still resolves, for the same reason release-detail.ts resolves one and
+  // with more at stake: a calendar client keeps fetching whatever URL it was handed, forever and
+  // silently. A 404 here is a subscription that stops updating without ever telling the fan, so
+  // an artist re-slugged after somebody subscribed would quietly lose them.
+  //
+  // Only after the live slug misses, so a real artist who later takes that slug always wins.
+  if (!artist) {
+    const canonical = await resolveArtistSlugAlias(slug);
+    if (canonical && canonical !== slug) {
+      slug = canonical;
+      artist = await getFeedReleasesForArtist(slug);
+    }
+  }
   if (!artist) return notFound();
 
   return render(
@@ -226,8 +242,11 @@ export async function handler(event: {
     {
       title: `${artist.artistName} — releases`,
       description: `Releases by ${artist.artistName}, from Unstream`,
-      selfUrl: `${SITE}/a/${encodeURIComponent(route.slug)}/releases.${route.format}`,
-      feedId: `tag:unstream.stream,2026:feed/a/${route.slug}`,
+      // Both derived from the canonical slug: the self-link should point at the address that
+      // still works, and one feed id per artist means a reslug doesn't split subscribers into
+      // two feeds as far as their reader is concerned.
+      selfUrl: `${SITE}/a/${encodeURIComponent(slug)}/releases.${route.format}`,
+      feedId: `tag:unstream.stream,2026:feed/a/${slug}`,
     },
     false
   );

--- a/api/functions/release-detail.ts
+++ b/api/functions/release-detail.ts
@@ -12,13 +12,21 @@
 // query (`getReleaseDetail`) and apply the same payout rules, so a native client can never
 // describe a release differently from the web page a fan would see for it.
 //
+// **Retired artist slugs resolve here and not on the HTML page.** This endpoint reads
+// `artist_slug_aliases` on a miss, the way /api/artist and the artist page do. `release-page.ts`
+// does not: on an unknown artist slug it falls through to the SPA, which has no route for a
+// two-segment /a/ path, so /a/{retired-slug}/{release} renders nothing in a browser today. That
+// is a gap in the page, not a reason to reproduce it here — the answers still agree wherever the
+// page produces one, and `pageUrl` below is built from the canonical slug so a client's "open the
+// full guide" lands on a URL that renders.
+//
 // **`payoutPercent` is computed here, per source, on purpose.** Payout figures are duplicated by
 // hand across eight files in this repo, and that drift is what let the Discord bot quote an
 // unsourced '86-95%' for Jam.coop to users for months (fixed in PR #389). A client that reads
 // the number off the response cannot drift. It also can't miss the Bandcamp Friday override
 // below, which no client currently knows exists.
 
-import { getReleaseDetail, type ReleaseDetailSource } from './db';
+import { getReleaseDetail, resolveArtistSlugAlias, type ReleaseDetailSource } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { Sentry } from '../lib/sentry';
 import { PLATFORMS } from '../shared/platform-registry';
@@ -139,7 +147,26 @@ export async function handler(event: {
   }
 
   try {
-    const { detail, failed } = await getReleaseDetail(artist, release);
+    // The artist slug the answer is actually about, which is not always the one asked for.
+    let artistSlug = artist;
+    let { detail, failed } = await getReleaseDetail(artistSlug, release);
+
+    // A retired slug still resolves, the same way /api/artist and the artist page resolve one.
+    // Most of the 44 aliases in production came from the accent-folding reslug in #410
+    // (`beyonc` -> `beyonce`), and a release URL minted before that — in an alert, a shared link,
+    // a Mac app cache — is a URL a fan can still be holding.
+    //
+    // Only on a miss, and only after the live slug has had its go, so a real artist who later
+    // takes that slug always wins. `failed` is excluded deliberately: a lookup that broke is not
+    // evidence that a slug is retired, and running the alias read anyway would spend a second
+    // query during an outage to arrive at the same 503.
+    if (!detail && !failed) {
+      const canonical = await resolveArtistSlugAlias(artistSlug);
+      if (canonical && canonical !== artistSlug) {
+        artistSlug = canonical;
+        ({ detail, failed } = await getReleaseDetail(artistSlug, release));
+      }
+    }
 
     // The lookup itself broke. A 503 with no caching, never a 404 — a Supabase outage rendered
     // as "this release doesn't exist" would be a convincing lie, and one the CDN would then
@@ -198,7 +225,9 @@ export async function handler(event: {
         ...CORS_HEADERS,
         'Cache-Control': 'public, max-age=0, must-revalidate',
         'Netlify-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=86400',
-        'Cache-Tag': `release-detail-${artist}-${release}`,
+        // Tagged by the canonical slug, so one purge clears the response whichever slug was
+        // asked for — an alias URL and the live URL are separate CDN entries of the same answer.
+        'Cache-Tag': `release-detail-${artistSlug}-${release}`,
       },
       body: JSON.stringify({
         artist: detail.artist,
@@ -214,8 +243,11 @@ export async function handler(event: {
           sources,
         },
         // The page URL, so a native client can offer "open the full guide" without rebuilding
-        // the URL shape — and so the two surfaces stay tied together if it ever changes.
-        pageUrl: `https://unstream.stream/a/${encodeURIComponent(artist)}/${encodeURIComponent(release)}`,
+        // the URL shape — and so the two surfaces stay tied together if it ever changes. Built
+        // from the canonical slug rather than the requested one: the HTML page does *not* resolve
+        // aliases (see the file header), so echoing a retired slug back here would hand a client
+        // a link that renders nothing.
+        pageUrl: `https://unstream.stream/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release)}`,
         bandcampFriday,
       }),
     };


### PR DESCRIPTION
Two small, unrelated fixes.

## 1. `release-detail.ts` didn't resolve slug aliases

`GET /api/release/{artist}/{release}` — the JSON the Mac app's `ReleaseGuideView` and the extension's `lib/release-guide.js` render the buying guide from — looked the artist up with a plain `.eq('slug', …)`. `artist_slug_aliases` holds 44 rows in production, most minted by the accent-folding reslug in #410 (`beyonc` → `beyonce`), so a release URL built before that 404'd in the native "Where to buy" panel while `/api/artist` resolved the same alias happily.

It now reads the alias table on a miss, the way [artist-lookup.ts](api/functions/artist-lookup.ts:31) does:

- **Only on a miss**, so a live slug always wins and the hot path pays nothing.
- **Never after a failed lookup.** A Supabase outage is not evidence that a slug was retired; retrying through the alias table would spend a second query to reach the same 503, and the 503 is the thing that has to survive.
- `pageUrl` and the CDN cache tag are built from the **canonical** slug, so a client's "open the full guide" lands on a URL that renders and one purge clears both entries.

### The two neighbours I was asked to check

**`getReleasesForAlerts` — no change, and not for symmetry's sake.** It looks up by `artistSlug(artistName)`, derived from a *name* rather than read off a URL, and `artistSlug` folds accents ([db.ts:60](api/functions/db.ts:60)). It re-derives the current canonical form on every call, so it never sees a retired slug. Changing it would add a query to the alert path for a case that can't arise.

**`/a/{artist}/releases.{ics,xml}` — fixed.** Same gap, worse failure mode: a calendar client keeps fetching whatever URL it was handed, forever, and never reports a 404 to anybody. An artist re-slugged after somebody subscribed silently lost them. Self-link and feed id are canonical too, so a reslug doesn't split subscribers across two feed identities.

### One correction to the premise

The brief said an aliased release URL "opens fine in a browser." It doesn't. `api/edge/release-page.ts` doesn't resolve aliases either — on an unknown artist slug it `context.next()`s to `artist-page-static`, which hands non-crawlers straight to the SPA, and the SPA has **no route** for a two-segment `/a/` path ([main.tsx:79](apps/web/src/main.tsx:79) is `/a/:slug` only). So `/a/{retired-slug}/{release}` renders nothing in a browser today.

That doesn't change the fix — resolving here is correct and matches every other slug-serving endpoint — but the JSON endpoint is now *ahead* of the HTML page rather than catching up to it. Recorded in the file header. Fixing the page needs the Deno-duplicated alias query plus a decision about 301-vs-render, which is more than this PR should carry.

## 2. CLAUDE.md's catalogue-platform list was stale

The "Keeping catalogues fresh" section described the sweep pool as bandcamp/discogs/faircamp/jamcoop in both sentences — including the one warning not to let that list drift from `catalogArtist`'s check. #415 added `'mirlo'` to `CATALOGUEABLE_PLATFORMS` and to `catalogArtist` together, so only the documentation drifted. While there, sanity-checked the rest of the section against the code:

- "run daily" → **every six hours** (`cron: '0 1,7,13,19 * * *'`, 25 artists a run, 100 a day). The Deployment section already said six hours; the two disagreed.
- "No rate limiting of its own" → `getStaleCatalogCandidates` *does* drop cooldown artists up front, reading the same `RECATALOG_COOLDOWN_HOURS`; `claimArtistForCatalog` remains the authority. Said so.
- The population figures are now explicitly dated measurements (2026-08-02: 2,564 catalogue-able / 9 saved; 2026-08-07: 5,977 releases, 803 catalogued artists, 36 live `saved_artists` rows) with a note to re-measure rather than reason from them.
- Fixed a "see … below" pointing at a section that is above.

Ordering, batch size and the `getStaleCatalogCandidates` priority description all match the code as written.

## Testing

- `api/functions/__tests__/release-detail.test.ts` — 7 new cases: alias resolution, canonical `pageUrl`/`Cache-Tag`, no alias read on the hit path, 404 when neither live nor aliased, 404 when the alias resolves but the release is gone, no alias read after a failed lookup, and no second query when an alias points at the slug already tried.
- `api/functions/__tests__/feed-releases.test.ts` — 3 new cases for the artist feed.
- **Teeth proven:** with the alias branch removed from both files, 4 of the new tests fail (the rest are guardrails that should pass either way).
- `npm run test:api` 968 passed · `npm run typecheck:api` clean (both files are in the include list) · `npm run lint` at the known 71-problem baseline, unchanged.

⚠️ `npm run test:unit` has **one pre-existing failure** unrelated to this branch: `RichArtistProfile.test.tsx > renders the payout percent on each pill` expects `80-85%` and today (2026-08-07) is a Bandcamp Friday, so the component renders `~97%`. Verified failing identically on `main`. It will pass again tomorrow, and it will fail again on the next Bandcamp Friday — worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)