### PR TITLE
Fix the browser extension's release-alert layer

### DIFF
--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -1,9 +1,22 @@
 // Unstream Chrome Extension - Service Worker
 // Handles API calls, caching, badge updates, release alerts, and auth
+//
+// This file uses ES module imports, so **both** manifests must declare it as a module —
+// `"type": "module"` alongside `service_worker` in manifest.json and alongside `scripts` in
+// manifest-firefox.json. Firefox's manifest was missing it, which meant the first `import` was a
+// syntax error and none of this ran there at all: no release alerts, no badge, no auth. It fails
+// silently unless you open the extension's console, so check both files when adding an import.
 
 import { ALLOWED_RELEASE_DOMAINS } from '../lib/constants.js';
 import { getStoredSession, handleMagicLinkCallback, getAccessToken, signOut } from '../lib/supabase.js';
 import { reconcileCustomSites } from '../lib/custom-sites.js';
+import {
+  releasesFromResponse,
+  releaseNotificationBody,
+  releaseNotificationTitle,
+  selectUnseenReleases,
+  sinceDaysForCheck,
+} from '../lib/release-alerts.js';
 
 const API_BASE = 'https://unstream.stream/api';
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -546,62 +559,41 @@ async function checkForNewReleases() {
 
   // Get current state
   const { releaseCheckState = { knownReleases: {}, newReleases: [] } } = await chrome.storage.local.get('releaseCheckState');
+  if (!releaseCheckState.knownReleases) releaseCheckState.knownReleases = {};
+
+  // How far back to ask. Left unsent, the server looks back 31 days, so a browser that was closed
+  // for six weeks came back, found nothing older than that, and recorded a fresh check date —
+  // losing the gap permanently.
+  const sinceDays = sinceDaysForCheck(releaseCheckState.lastCheckDate);
 
   const foundNewReleases = [];
 
   for (const artistName of artistNames) {
     const artistData = savedArtistsData[artistName];
-    if (!artistData || !artistData.platforms) continue;
+    if (!artistData) continue;
 
-    // Build platforms dict
+    // Every link we hold for this artist, keyed by source.
+    //
+    // No filtering, and no skipping an artist who has none: the endpoint reads the catalogue
+    // first and ignores these entirely on that path — only its live-scrape fallback uses them,
+    // and only the sources it can scrape. Skipping anyone without a Bandcamp, Faircamp or Mirlo
+    // link meant never asking about the largest link population we have (there are more Discogs
+    // artist links in production than Bandcamp ones) over a question one database read answers.
     const platforms = {};
-    for (const p of artistData.platforms) {
-      if (['bandcamp', 'faircamp', 'mirlo'].includes(p.sourceId)) {
-        platforms[p.sourceId] = p.url;
-      }
+    for (const p of artistData.platforms || []) {
+      if (p && p.sourceId && p.url) platforms[p.sourceId] = p.url;
     }
-
-    if (Object.keys(platforms).length === 0) continue;
 
     // Call release check API
     try {
-      const result = await checkReleaseAPI(artistName, platforms);
+      const result = await checkReleaseAPI(artistName, platforms, sinceDays);
 
-      if (result && result.release) {
-        const release = result.release;
-        const key = artistName.toLowerCase();
-
-        // Check if already known (by release name across all platforms)
-        const knownReleases = releaseCheckState.knownReleases[key] || [];
-        const alreadyKnown = knownReleases.some(
-          kr => kr.releaseName.toLowerCase() === release.releaseName.toLowerCase()
-        );
-
-        if (!alreadyKnown) {
-          // New release found!
-          const newRelease = {
-            id: crypto.randomUUID(),
-            artistName: artistName,
-            releaseName: release.releaseName,
-            releaseDate: release.releaseDate,
-            releaseUrl: release.releaseUrl,
-            platform: release.platform,
-            detectedAt: new Date().toISOString(),
-          };
-
-          foundNewReleases.push(newRelease);
-
-          // Add to known releases
-          if (!releaseCheckState.knownReleases[key]) {
-            releaseCheckState.knownReleases[key] = [];
-          }
-          releaseCheckState.knownReleases[key].push({
-            releaseName: release.releaseName,
-            releaseDate: release.releaseDate,
-            platform: release.platform,
-          });
-        }
-      }
+      // Every release in the window, not just the newest — an artist who put out two records
+      // since the last check produces two alerts. selectUnseenReleases marks each one known as
+      // it accepts it, and is the only dedup point.
+      foundNewReleases.push(
+        ...selectUnseenReleases(releasesFromResponse(result), artistName, releaseCheckState.knownReleases)
+      );
     } catch (error) {
       console.error(`Release check failed for ${artistName}:`, error);
     }
@@ -631,13 +623,13 @@ async function checkForNewReleases() {
 }
 
 // Call the release check API
-async function checkReleaseAPI(artistName, platforms) {
+async function checkReleaseAPI(artistName, platforms, sinceDays) {
   const url = `${API_BASE}/check-releases`;
 
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ artistName, platforms }),
+    body: JSON.stringify({ artistName, platforms, sinceDays }),
   });
 
   if (!response.ok) {
@@ -676,14 +668,16 @@ async function dismissRelease(releaseId) {
   return { success: true };
 }
 
-// Send notification for new release
+// Send notification for new release.
+// Title and body come from release-alerts.js so this says the same thing the Mac app does — and,
+// for an announced release, stops claiming a record dated next month is already out.
 async function sendReleaseNotification(release) {
   try {
     await chrome.notifications.create(`release-${release.id}`, {
       type: 'basic',
       iconUrl: chrome.runtime.getURL('icons/icon128.png'),
-      title: `New Release from ${release.artistName}`,
-      message: `"${release.releaseName}" is out now on ${release.platform.charAt(0).toUpperCase() + release.platform.slice(1)}!`,
+      title: releaseNotificationTitle(release),
+      message: releaseNotificationBody(release),
       priority: 2,
     });
   } catch (error) {

--- a/apps/extension/lib/release-alerts.js
+++ b/apps/extension/lib/release-alerts.js
@@ -1,0 +1,213 @@
+// Release alerts: which of the server's results are new, and what an alert actually says.
+//
+// Pure functions, split out of the service worker so they can be tested without chrome.* — and
+// because every rule here already exists on the Mac side. `selectUnseenReleases` mirrors
+// `ReleaseAlertManager.selectUnseen`, `releaseNotificationBody` mirrors its `notificationBody(for:)`,
+// and `formatPlatformList` its `formatPlatformList`. apps/web/tests/unit/extension-release-alerts.test.ts
+// pins the same cases apps/mac/UnstreamTests/ReleaseAlertTests.swift pins, so the two clients
+// can't drift into saying different things about the same release.
+//
+// The server contract these read is documented at the top of api/functions/check-releases.ts:
+// `releases[]` carries every release in the window with every platform it's on, its status, and a
+// price summary. The extension used to read only the singular `release` and keep four of its
+// fields, which is what all of this fixes.
+
+import { SOURCE_CONFIG } from './constants.js';
+
+/** Never ask for a narrower window than the server's own default. */
+export const MIN_SINCE_DAYS = 31;
+/** The server caps the window here too; asking for more is silently clamped. */
+export const MAX_SINCE_DAYS = 365;
+/**
+ * Slack on top of the elapsed time. A release can be dated a few days before it is catalogued,
+ * and the check that "last ran" a week ago may itself have failed partway through, so asking for
+ * exactly the elapsed window leaves a seam at its edge.
+ */
+export const SINCE_DAYS_PADDING = 7;
+
+/**
+ * How far back this check should ask the server to look.
+ *
+ * Without this the extension took the server's 31-day default, so a browser closed for six weeks
+ * came back and permanently missed everything that had aged out in the meantime — the check found
+ * nothing, recorded a fresh `lastCheckDate`, and never looked at that period again.
+ */
+export function sinceDaysForCheck(lastCheckDate, now = Date.now()) {
+  const elapsedDays = (now - lastCheckDate) / (24 * 60 * 60 * 1000);
+  if (!Number.isFinite(elapsedDays) || elapsedDays <= 0) return MIN_SINCE_DAYS;
+
+  const asked = Math.ceil(elapsedDays) + SINCE_DAYS_PADDING;
+  return Math.min(Math.max(asked, MIN_SINCE_DAYS), MAX_SINCE_DAYS);
+}
+
+/**
+ * Every release the server reported, from either of its two shapes.
+ *
+ * `releases` is what the catalog path returns and is the one to read: it holds an artist's second
+ * record in the window, which the singular `release` cannot. The fallback to `release` covers a
+ * response from an older deploy rather than being the normal path.
+ */
+export function releasesFromResponse(result) {
+  if (!result) return [];
+  if (Array.isArray(result.releases)) return result.releases;
+  return result.release ? [result.release] : [];
+}
+
+/**
+ * Which of these results haven't we alerted on before? Marks each one it returns as known.
+ *
+ * **This is the only dedup point**, exactly as on the Mac. Identity is the release name, compared
+ * across platforms so one record on both Bandcamp and Mirlo is one alert rather than two — but
+ * *within* an artist, so a second, different record is always new.
+ *
+ * The old service worker read only `result.release`, took the newest release and marked that one
+ * known. An artist's second record in the window was therefore unreachable: by the next check the
+ * newest was already known, and nothing ever looked past it. That loses the release permanently,
+ * which is why this iterates everything the server sent.
+ *
+ * `knownReleases` is the persisted map (artist name, lowercased → known releases) and is mutated
+ * in place, mirroring the Swift's `inout` state.
+ */
+export function selectUnseenReleases(results, artistName, knownReleases) {
+  const key = artistName.toLowerCase();
+  if (!knownReleases[key]) knownReleases[key] = [];
+  const known = knownReleases[key];
+
+  const fresh = [];
+
+  for (const result of results) {
+    if (!result || !result.releaseName) continue;
+
+    const alreadyKnown = known.some(
+      kr => kr.releaseName.toLowerCase() === result.releaseName.toLowerCase()
+    );
+    if (alreadyKnown) continue;
+
+    known.push({
+      releaseName: result.releaseName,
+      releaseDate: result.releaseDate,
+      platform: result.platform,
+    });
+
+    fresh.push({
+      id: crypto.randomUUID(),
+      artistName,
+      releaseName: result.releaseName,
+      releaseDate: result.releaseDate,
+      releaseUrl: result.releaseUrl,
+      platform: result.platform,
+      // The three fields the old code dropped. `platforms` is the payout comparison — a record on
+      // Bandcamp and Mirlo said "Bandcamp" and the fan never learned about the other. `status`
+      // stopped an alert claiming a future-dated record is "out now". `offerSummary` was already
+      // being *read* by the popup while nothing wrote it, so it rendered the fallback copy
+      // instead of a price.
+      platforms:
+        Array.isArray(result.platforms) && result.platforms.length > 0
+          ? result.platforms
+          : [result.platform],
+      status: result.status || 'released',
+      offerSummary: result.offerSummary || '',
+      detectedAt: new Date().toISOString(),
+    });
+  }
+
+  return fresh;
+}
+
+/** A release dated in the future. It is announced, not out. */
+export function isUpcomingRelease(release) {
+  return release.status === 'announced';
+}
+
+/**
+ * A platform's proper name. SOURCE_CONFIG renders "Jam.coop" and "Ko-fi", which plain
+ * capitalization mangles into "Jamcoop" and "Kofi". An id it doesn't list at least gets a capital
+ * letter rather than being dropped.
+ */
+export function platformDisplayName(platform) {
+  if (SOURCE_CONFIG[platform]?.name) return SOURCE_CONFIG[platform].name;
+  return platform ? platform[0].toUpperCase() + platform.slice(1) : '';
+}
+
+/**
+ * "Bandcamp", "Bandcamp and Mirlo", "Bandcamp, Mirlo and 2 more" — a notification body has very
+ * little room, so a long list is summarized rather than truncated mid-name.
+ */
+export function formatPlatformList(platforms) {
+  const names = (platforms || []).filter(Boolean).map(platformDisplayName);
+
+  if (names.length === 0) return '';
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names[0]}, ${names[1]} and ${names.length - 2} more`;
+}
+
+/**
+ * "1 September". Day and month only, matching the Mac's wording for an announced release.
+ *
+ * Parsed and formatted in UTC: a stored date is a plain calendar date, and reading it in a
+ * negative-offset zone would shift a 1 September release to 31 August.
+ */
+function announcedDate(date) {
+  if (!date) return '';
+  const [year, month, day] = String(date).split('-').map(Number);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return '';
+
+  const monthName = new Date(Date.UTC(year, month - 1, day))
+    .toLocaleDateString('en-GB', { month: 'long', timeZone: 'UTC' });
+  return `${day} ${monthName}`;
+}
+
+/**
+ * Every platform an alert names.
+ *
+ * An alert stored by an earlier build has no `platforms` field at all — it kept only the one the
+ * alert leads with — so fall back to that rather than dropping the platform from the line
+ * entirely on upgrade. Mirrors how `NewRelease` decodes an old alert on the Mac.
+ */
+function alertPlatforms(release) {
+  return Array.isArray(release.platforms) && release.platforms.length > 0
+    ? release.platforms
+    : [release.platform].filter(Boolean);
+}
+
+/**
+ * What an alert says about a release, without repeating its name:
+ *
+ *   out now on Bandcamp and Mirlo · from $8 · ≈$6.80 to artist
+ *   announced for 1 September on Bandcamp
+ *
+ * Nothing is invented. No price yet means the clause is omitted rather than filled with a
+ * placeholder, and a release with no platforms at all still gets an honest "out now".
+ */
+export function releaseSummaryLine(release) {
+  const parts = [];
+  const where = formatPlatformList(alertPlatforms(release));
+
+  if (isUpcomingRelease(release)) {
+    const date = announcedDate(release.releaseDate);
+    const announced = date ? `announced for ${date}` : 'announced';
+    parts.push(where ? `${announced} on ${where}` : announced);
+  } else {
+    parts.push(where ? `out now on ${where}` : 'out now');
+  }
+
+  if (release.offerSummary) parts.push(release.offerSummary);
+
+  return parts.join(' · ');
+}
+
+/**
+ * The notification body. Was `"X" is out now on Bandcamp!` — one platform, no price, and a flat
+ * falsehood about a record that isn't out yet.
+ */
+export function releaseNotificationBody(release) {
+  return `"${release.releaseName}" — ${releaseSummaryLine(release)}`;
+}
+
+/** "Kid Lightbulbs — coming soon" for an announced release, matching the Mac. */
+export function releaseNotificationTitle(release) {
+  return isUpcomingRelease(release)
+    ? `${release.artistName} — coming soon`
+    : `New Release from ${release.artistName}`;
+}

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -14,7 +14,7 @@
     }
   },
   "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free, open source, no tracking.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -29,7 +29,8 @@
     "default_title": "Unstream"
   },
   "background": {
-    "scripts": ["background/service-worker.js"]
+    "scripts": ["background/service-worker.js"],
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Unstream - Support Music Directly",
   "description": "See where your money actually goes. Unstream shows artist payout percentages and finds them on 17 platforms. Free and open source.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -3,6 +3,7 @@
 import { isBandcampFriday } from '../lib/bandcamp-friday.js';
 import { ALLOWED_RELEASE_DOMAINS, SOURCE_CONFIG, PAYOUT_PERCENTAGES } from '../lib/constants.js';
 import { releaseSlugsFromUrl } from '../lib/release-display.js';
+import { releaseSummaryLine } from '../lib/release-alerts.js';
 import { renderReleaseGuide, guideMessage, guideLink } from '../lib/release-guide.js';
 import { renderArtistReleases } from '../lib/artist-releases.js';
 import { signInWithPassword, signInWithOtp, signOut, getStoredSession, getAccessToken, getDeviceId } from '../lib/supabase.js';
@@ -1179,12 +1180,11 @@ function buildReleaseItem(release) {
 
   const subtitle = document.createElement('span');
   subtitle.className = 'release-platform';
-  // The price line is the reason to open the guide, so it leads when we have one. Falling back
-  // to the platform's proper name where we have one \u2014 SOURCE_CONFIG renders "Jam.coop", not
-  // "Jamcoop". Platforms it doesn't list (Subvert) at least get a capital letter rather than
-  // the bare id; the CSS used to do that with `text-transform`, which can't stay now that this
-  // line is usually a price.
-  subtitle.textContent = release.offerSummary || `on ${platformDisplayName(release.platform)}`;
+  // "out now on Bandcamp and Mirlo \u00b7 from $8 \u00b7 \u2248$6.80 to artist" \u2014 every platform the record is
+  // on, then the price, which is the reason to open the guide. Word for word what the
+  // notification says, and it names every platform rather than the one the alert leads with:
+  // the payout comparison is the product, and this is the moment someone decides where to buy.
+  subtitle.textContent = releaseSummaryLine(release);
 
   infoDiv.appendChild(artistSpan);
   infoDiv.appendChild(titleSpan);
@@ -1238,11 +1238,6 @@ function openReleaseUrl(url) {
   if (isAllowedReleaseUrl(url)) {
     chrome.tabs.create({ url });
   }
-}
-
-function platformDisplayName(platform) {
-  if (SOURCE_CONFIG[platform]?.name) return SOURCE_CONFIG[platform].name;
-  return platform ? platform[0].toUpperCase() + platform.slice(1) : '';
 }
 
 /** Fetched guides, keyed by "artist/release", so reopening a row doesn't refetch. */

--- a/apps/web/tests/unit/extension-release-alerts.test.ts
+++ b/apps/web/tests/unit/extension-release-alerts.test.ts
@@ -1,0 +1,265 @@
+// The browser extension's release-alert rules: dedup, the notification wording, and the window
+// it asks the server for.
+//
+// These are the same rules the Mac app already follows, and the cases below are deliberately the
+// same cases apps/mac/UnstreamTests/ReleaseAlertTests.swift pins — Swift can't be driven from
+// vitest, so the two suites agreeing on the expected strings is what keeps the clients from
+// drifting into saying different things about the same release.
+//
+// The dedup tests exist because the bug they cover lost data permanently rather than merely
+// displaying it wrong: the service worker read the singular `release`, took the newest, and
+// marked only that one known. By the next check the newest was already known and nothing looked
+// past it, so an artist's second record in the window was unreachable forever.
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatPlatformList,
+  releaseNotificationBody,
+  releaseNotificationTitle,
+  releaseSummaryLine,
+  releasesFromResponse,
+  selectUnseenReleases,
+  sinceDaysForCheck,
+  MIN_SINCE_DAYS,
+  MAX_SINCE_DAYS,
+} from '../../../../apps/extension/lib/release-alerts.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function result(name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    releaseName: name,
+    releaseDate: '2025-09-01',
+    releaseUrl: `https://unstream.stream/a/someone/${name.toLowerCase().replace(/ /g, '-')}`,
+    platform: 'bandcamp',
+    platforms: ['bandcamp'],
+    status: 'released',
+    offerSummary: '',
+    ...overrides,
+  };
+}
+
+describe('selectUnseenReleases', () => {
+  it('lets a second record through while the first is still unread', () => {
+    const known: Record<string, unknown[]> = {};
+
+    const first = selectUnseenReleases([result('First Record')], 'Someone', known);
+    expect(first.map(r => r.releaseName)).toEqual(['First Record']);
+
+    // The exact shape of the bug: the newest is already known, so a single-release reader would
+    // stop here and never see the second one.
+    const second = selectUnseenReleases(
+      [result('Second Record'), result('First Record')],
+      'Someone',
+      known
+    );
+
+    expect(second.map(r => r.releaseName)).toEqual(['Second Record']);
+  });
+
+  it('takes both when one check reports two new records', () => {
+    const known: Record<string, unknown[]> = {};
+
+    const found = selectUnseenReleases([result('A'), result('B')], 'Someone', known);
+
+    expect(found.map(r => r.releaseName)).toEqual(['A', 'B']);
+  });
+
+  it('treats one record on two platforms as one alert', () => {
+    const known: Record<string, unknown[]> = {};
+
+    const found = selectUnseenReleases(
+      [
+        result('Infinite Normal', { platform: 'bandcamp' }),
+        result('Infinite Normal', { platform: 'mirlo' }),
+      ],
+      'Kid Lightbulbs',
+      known
+    );
+
+    expect(found).toHaveLength(1);
+  });
+
+  it('scopes known releases to the artist, since two artists can share a title', () => {
+    const known: Record<string, unknown[]> = {};
+    selectUnseenReleases([result('Greatest Hits')], 'Artist A', known);
+
+    const found = selectUnseenReleases([result('Greatest Hits')], 'Artist B', known);
+
+    expect(found).toHaveLength(1);
+  });
+
+  it('matches release names case-insensitively', () => {
+    const known: Record<string, unknown[]> = {};
+    selectUnseenReleases([result('A Record')], 'Sigur Rós', known);
+
+    const found = selectUnseenReleases([result('a record')], 'sigur rós', known);
+
+    expect(found).toEqual([]);
+  });
+
+  it('returns nothing when a re-check reports the same release', () => {
+    const known: Record<string, unknown[]> = {};
+    selectUnseenReleases([result('A')], 'Someone', known);
+
+    expect(selectUnseenReleases([result('A')], 'Someone', known)).toEqual([]);
+  });
+
+  it('persists the platform list, the status and the price summary', () => {
+    // These three were dropped by the old code. `offerSummary` in particular was already being
+    // read by the popup, where a `||` fallback rendered plausible copy instead of undefined.
+    const known: Record<string, unknown[]> = {};
+
+    const found = selectUnseenReleases(
+      [
+        result('Infinite Normal', {
+          platforms: ['bandcamp', 'mirlo'],
+          status: 'announced',
+          offerSummary: 'from $8 · ≈$6.80 to artist',
+        }),
+      ],
+      'Kid Lightbulbs',
+      known
+    );
+
+    expect(found[0].platforms).toEqual(['bandcamp', 'mirlo']);
+    expect(found[0].status).toBe('announced');
+    expect(found[0].offerSummary).toBe('from $8 · ≈$6.80 to artist');
+  });
+
+  it('falls back to the leading platform when the server sent no list', () => {
+    const known: Record<string, unknown[]> = {};
+
+    const found = selectUnseenReleases(
+      [result('A Record', { platforms: undefined, status: undefined, offerSummary: undefined })],
+      'Someone',
+      known
+    );
+
+    expect(found[0].platforms).toEqual(['bandcamp']);
+    expect(found[0].status).toBe('released');
+    expect(found[0].offerSummary).toBe('');
+  });
+});
+
+describe('releasesFromResponse', () => {
+  it('reads the plural field, which is the one that can hold a second record', () => {
+    const response = {
+      release: result('Newest'),
+      releases: [result('Newest'), result('Older')],
+    };
+
+    expect(releasesFromResponse(response).map(r => r.releaseName)).toEqual(['Newest', 'Older']);
+  });
+
+  it('falls back to the singular field for an older deploy', () => {
+    expect(releasesFromResponse({ release: result('Only One') })).toHaveLength(1);
+  });
+
+  it('reports nothing rather than throwing on an empty or missing response', () => {
+    expect(releasesFromResponse({ release: null, releases: [] })).toEqual([]);
+    expect(releasesFromResponse(null)).toEqual([]);
+  });
+});
+
+describe('release alert wording', () => {
+  function release(overrides: Record<string, unknown> = {}) {
+    return {
+      artistName: 'Kid Lightbulbs',
+      releaseName: 'Infinite Normal',
+      releaseDate: '2025-09-01',
+      platform: 'bandcamp',
+      platforms: ['bandcamp'],
+      status: 'released',
+      offerSummary: '',
+      ...overrides,
+    };
+  }
+
+  it('names every platform and the price', () => {
+    const body = releaseNotificationBody(
+      release({ platforms: ['bandcamp', 'mirlo'], offerSummary: 'from $8 · ≈$6.80 to artist' })
+    );
+
+    expect(body).toContain('Bandcamp and Mirlo');
+    expect(body).toContain('from $8');
+    expect(body).toContain('to artist');
+  });
+
+  it('omits the price clause rather than inventing one', () => {
+    const body = releaseNotificationBody(release());
+
+    expect(body).toBe('"Infinite Normal" — out now on Bandcamp');
+    expect(body).not.toContain('·');
+  });
+
+  it('reads an announced release as announced, not out now', () => {
+    const body = releaseNotificationBody(release({ status: 'announced' }));
+
+    expect(body).toBe('"Infinite Normal" — announced for 1 September on Bandcamp');
+    expect(body).not.toContain('out now');
+  });
+
+  it('titles an announced release as coming soon', () => {
+    expect(releaseNotificationTitle(release({ status: 'announced' }))).toBe(
+      'Kid Lightbulbs — coming soon'
+    );
+    expect(releaseNotificationTitle(release())).toBe('New Release from Kid Lightbulbs');
+  });
+
+  it('uses proper platform names rather than capitalizing the id', () => {
+    // Plain capitalization renders these "Jamcoop" and "Kofi".
+    const body = releaseNotificationBody(release({ platform: 'jamcoop', platforms: ['jamcoop'] }));
+
+    expect(body).toContain('Jam.coop');
+    expect(body).not.toContain('Jamcoop');
+  });
+
+  it('summarizes a long platform list rather than truncating a name', () => {
+    expect(formatPlatformList(['bandcamp', 'mirlo', 'jamcoop', 'discogs'])).toBe(
+      'Bandcamp, Mirlo and 2 more'
+    );
+    expect(formatPlatformList(['bandcamp'])).toBe('Bandcamp');
+    expect(formatPlatformList([])).toBe('');
+  });
+
+  it('gives the popup the same line as the notification, without the name', () => {
+    const r = release({ platforms: ['bandcamp', 'mirlo'], offerSummary: 'Name your price' });
+
+    expect(releaseSummaryLine(r)).toBe('out now on Bandcamp and Mirlo · Name your price');
+    expect(releaseNotificationBody(r)).toBe(`"Infinite Normal" — ${releaseSummaryLine(r)}`);
+  });
+
+  it('still names the platform on an alert stored by an older build', () => {
+    // 2.6.0 kept only `platform`. Those alerts survive the upgrade and must not lose the one
+    // piece of platform information they do have.
+    expect(releaseSummaryLine(release({ platforms: undefined }))).toBe('out now on Bandcamp');
+  });
+
+  it('still says something honest when there is no platform at all', () => {
+    expect(releaseSummaryLine(release({ platforms: [], platform: undefined }))).toBe('out now');
+  });
+});
+
+describe('sinceDaysForCheck', () => {
+  const now = Date.UTC(2026, 7, 7);
+
+  it('asks for the whole gap after a long sleep, plus padding', () => {
+    // Six weeks closed. Without this the extension took the server's 31-day default and
+    // permanently missed everything older than that.
+    expect(sinceDaysForCheck(now - 42 * DAY, now)).toBe(49);
+  });
+
+  it('never asks for less than the server default', () => {
+    expect(sinceDaysForCheck(now - 3 * DAY, now)).toBe(MIN_SINCE_DAYS);
+  });
+
+  it('never asks for more than the server accepts', () => {
+    expect(sinceDaysForCheck(now - 900 * DAY, now)).toBe(MAX_SINCE_DAYS);
+  });
+
+  it('falls back to the default on a first run or a nonsense timestamp', () => {
+    expect(sinceDaysForCheck(undefined, now)).toBe(MIN_SINCE_DAYS);
+    expect(sinceDaysForCheck(now + 5 * DAY, now)).toBe(MIN_SINCE_DAYS);
+  });
+});

--- a/apps/web/tests/unit/extension-release-check.test.ts
+++ b/apps/web/tests/unit/extension-release-check.test.ts
@@ -1,0 +1,205 @@
+// The extension's release check, driven end to end through the real service worker.
+//
+// The unit tests in extension-release-alerts.test.ts pin the rules; this pins the *wiring*, which
+// is where all four of these defects actually lived. The rules were never wrong — the service
+// worker read the singular `release` and kept four of its fields, so `offerSummary` was a field
+// the popup read and nothing ever wrote, and `platforms` and `status` were dropped between the
+// wire and storage. No amount of testing the helpers in isolation would have caught that.
+//
+// The service worker is a plain ES module with no build step, so it loads here under a stubbed
+// `chrome.*` exactly as it does in the browser, and the check is triggered the way the popup
+// triggers it: a CHECK_RELEASES_NOW message.
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+type MessageHandler = (
+  message: { type: string },
+  sender: unknown,
+  sendResponse: (value: unknown) => void
+) => unknown;
+
+const storage: Record<string, unknown> = {};
+const notifications: { id: string; title: string; message: string }[] = [];
+const requests: { artistName: string; platforms: Record<string, string>; sinceDays: number }[] = [];
+
+let messageHandler: MessageHandler;
+
+/** What the server sends for a catalogued artist: two records, one of them not out yet. */
+function catalogResponse(artistName: string) {
+  return {
+    artistName,
+    source: 'catalog',
+    release: {
+      releaseName: 'Infinite Normal',
+      releaseDate: '2026-09-01',
+      releaseUrl: 'https://unstream.stream/a/kid-lightbulbs/infinite-normal',
+      platform: 'bandcamp',
+    },
+    releases: [
+      {
+        releaseName: 'Infinite Normal',
+        releaseDate: '2026-09-01',
+        releaseUrl: 'https://unstream.stream/a/kid-lightbulbs/infinite-normal',
+        platform: 'bandcamp',
+        platforms: ['bandcamp', 'mirlo'],
+        status: 'announced',
+        offerSummary: 'from $8 · ≈$6.80 to artist',
+      },
+      {
+        releaseName: 'Ruined Castle',
+        releaseDate: '2026-07-20',
+        releaseUrl: 'https://unstream.stream/a/kid-lightbulbs/ruined-castle',
+        platform: 'mirlo',
+        platforms: ['mirlo'],
+        status: 'released',
+        offerSummary: 'Name your price',
+      },
+    ],
+  };
+}
+
+beforeAll(async () => {
+  const noop = () => {};
+  const listener = { addListener: noop, removeListener: noop };
+
+  // Seeded before the module loads: it restores state at import time.
+  storage.savedArtistsData = {
+    'Kid Lightbulbs': {
+      platforms: [
+        { sourceId: 'bandcamp', url: 'https://kidlightbulbs.bandcamp.com' },
+        // Deliberately a source the live-scrape fallback can't use. The old code skipped any
+        // artist without bandcamp/faircamp/mirlo, which is most of the artists we hold links for.
+        { sourceId: 'discogs', url: 'https://www.discogs.com/artist/1' },
+      ],
+    },
+    'Discogs Only': {
+      platforms: [{ sourceId: 'discogs', url: 'https://www.discogs.com/artist/2' }],
+    },
+  };
+  storage.releaseCheckState = {
+    // 42 days ago: a browser that was closed for six weeks.
+    lastCheckDate: Date.now() - 42 * 24 * 60 * 60 * 1000,
+    knownReleases: {},
+    newReleases: [],
+  };
+
+  (globalThis as Record<string, unknown>).chrome = {
+    runtime: {
+      onMessage: {
+        addListener: (handler: MessageHandler) => {
+          messageHandler = handler;
+        },
+      },
+      onInstalled: listener,
+      onStartup: listener,
+      getURL: (p: string) => `chrome-extension://test/${p}`,
+    },
+    alarms: { onAlarm: listener, clear: async () => {}, create: async () => {} },
+    storage: {
+      local: {
+        get: async (key: string | null) => {
+          if (key === null) return { ...storage };
+          return key in storage ? { [key]: storage[key] } : {};
+        },
+        set: async (values: Record<string, unknown>) => Object.assign(storage, values),
+        remove: async () => {},
+      },
+      sync: { get: async () => ({}) },
+    },
+    action: { setBadgeText: noop, setBadgeBackgroundColor: noop },
+    notifications: {
+      create: async (id: string, options: { title: string; message: string }) => {
+        notifications.push({ id, title: options.title, message: options.message });
+      },
+      onClicked: listener,
+    },
+    tabs: { create: async () => {} },
+    permissions: { onRemoved: listener, getAll: async () => ({ origins: [] }) },
+    scripting: { getRegisteredContentScripts: async () => [] },
+  };
+
+  vi.stubGlobal('fetch', async (url: string, init?: { body?: string }) => {
+    if (!String(url).includes('/check-releases')) {
+      return { ok: true, json: async () => ({}) };
+    }
+    const body = JSON.parse(init?.body || '{}');
+    requests.push(body);
+    if (body.artistName !== 'Kid Lightbulbs') {
+      // Never catalogued, and no scrapeable URL — exactly what the server returns for one.
+      return { ok: false, status: 400, json: async () => ({ error: 'no platform' }) };
+    }
+    return { ok: true, json: async () => catalogResponse(body.artistName) };
+  });
+
+  await import('../../../../apps/extension/background/service-worker.js');
+
+  await new Promise<void>(resolve => {
+    messageHandler({ type: 'CHECK_RELEASES_NOW' }, {}, () => resolve());
+  });
+});
+
+describe('the request the extension sends', () => {
+  it('asks for the whole window it was asleep for', () => {
+    // 43 — a hair over 42 days elapsed, rounded up — plus the 7-day padding. Without sinceDays
+    // the server looks back 31 days and the rest of that gap is lost for good.
+    expect(requests[0].sinceDays).toBe(50);
+  });
+
+  it('sends every link it holds, not just the three the scraper understands', () => {
+    expect(requests[0].platforms).toEqual({
+      bandcamp: 'https://kidlightbulbs.bandcamp.com',
+      discogs: 'https://www.discogs.com/artist/1',
+    });
+  });
+
+  it('still asks about an artist with no scrapeable link, since the catalogue may know them', () => {
+    expect(requests.map(r => r.artistName)).toContain('Discogs Only');
+  });
+});
+
+describe('what the check stores', () => {
+  function stored() {
+    return (storage.releaseCheckState as { newReleases: Record<string, unknown>[] }).newReleases;
+  }
+
+  it('keeps both of the artist\'s records, not just the newest', () => {
+    expect(stored().map(r => r.releaseName)).toEqual(['Infinite Normal', 'Ruined Castle']);
+  });
+
+  it('persists the platform list, the status and the price summary', () => {
+    const [announced, released] = stored();
+
+    expect(announced.platforms).toEqual(['bandcamp', 'mirlo']);
+    expect(announced.status).toBe('announced');
+    expect(announced.offerSummary).toBe('from $8 · ≈$6.80 to artist');
+    expect(released.offerSummary).toBe('Name your price');
+  });
+
+  it('marks every accepted release known, so the next check skips them all', () => {
+    const known = (storage.releaseCheckState as { knownReleases: Record<string, unknown[]> })
+      .knownReleases['kid lightbulbs'];
+
+    expect(known.map((k: Record<string, unknown>) => k.releaseName)).toEqual([
+      'Infinite Normal',
+      'Ruined Castle',
+    ]);
+  });
+});
+
+describe('what the notifications say', () => {
+  it('does not tell anyone a future-dated record is out now', () => {
+    const announced = notifications.find(n => n.message.includes('Infinite Normal'))!;
+
+    expect(announced.title).toBe('Kid Lightbulbs — coming soon');
+    expect(announced.message).toBe(
+      '"Infinite Normal" — announced for 1 September on Bandcamp and Mirlo · from $8 · ≈$6.80 to artist'
+    );
+  });
+
+  it('names every platform and the price on a released record', () => {
+    const released = notifications.find(n => n.message.includes('Ruined Castle'))!;
+
+    expect(released.title).toBe('New Release from Kid Lightbulbs');
+    expect(released.message).toBe('"Ruined Castle" — out now on Mirlo · Name your price');
+  });
+});


### PR DESCRIPTION
`apps/extension/background/service-worker.js` was last modified by a *search* PR that predates the entire Releases feature, and #396 updated only `popup/popup.js`. So the alert layer still spoke the pre-catalog `check-releases` contract while the popup had been rewritten against the new one.

## What was broken

**1. Only one release per artist could ever surface.** The worker read the singular `release`, took the newest, and marked only that one known. By the next check the newest was already known and nothing looked past it — so an artist's *second* record in the window was unreachable forever. Same permanent-loss shape that was fixed on the Mac by `ReleaseAlertManager.selectUnseen`; `selectUnseenReleases` mirrors that rule exactly.

**2. `offerSummary` was a field the popup read and nothing ever wrote.** Because the read had a `|| \`on \${platformDisplayName(...)}\`` fallback, the dead field rendered as plausible content instead of `undefined`, which is why nobody noticed.

**3. `platforms[]` was dropped.** A record on both Bandcamp and Mirlo showed as one platform — the payout comparison, which is the product's whole thesis, invisible at peak purchase intent.

**4. `status` was dropped.** So an alert said `"X" is out now on Bandcamp!` about a record dated next month. That doesn't merely fail, it states something false.

## What changed

- **Every release, deduped once.** `selectUnseenReleases` iterates everything the server sent, dedups by release name *within* an artist (so one record on two platforms is one alert, but a second record is always new), and marks each one known as it accepts it.
- **`platforms`, `status` and `offerSummary` persisted.** The popup row and the notification now read `out now on Bandcamp and Mirlo · from $8 · ≈$6.80 to artist`, and an announced release reads `announced for 1 September on Bandcamp` — word for word what the Mac says.
- **`sinceDays` is sent**, computed from `lastCheckDate` with 7 days of padding and clamped to the server's own 31/365 bounds. A browser closed for six weeks used to come back, take the 31-day default, find nothing, record a fresh check date, and lose the rest of the gap permanently.
- **The three-platform gate is gone.** `check-releases` reads the catalogue first and ignores `platforms` entirely on that path; only the live-scrape fallback needs URLs. Production holds 1,953 Discogs artist links against 1,810 Bandcamp, so skipping anyone without bandcamp/faircamp/mirlo skipped the largest link population over a question one DB read answers. An artist with no scrapeable link now sends an empty object and gets a real answer if they're catalogued (the endpoint 400s only when the catalogue *also* misses).

## One thing found along the way

**Firefox was running no background code at all.** `manifest-firefox.json` declared the background as a classic script, but `service-worker.js` has used ES `import`s since before this change — so the first import was a syntax error and release alerts, the badge and auth were all dead in Firefox. Fixed with `"type": "module"`, and the both-manifests requirement is now noted at the top of the file so the next import doesn't repeat it. It fails silently unless you open the extension console, which is presumably how it survived.

## Testing

Rules live in `lib/release-alerts.js` as pure functions so they're testable without `chrome.*`.

- `extension-release-alerts.test.ts` pins the rules against the same cases `apps/mac/UnstreamTests/ReleaseAlertTests.swift` pins — Swift can't be driven from vitest, so agreeing suites are what stop the clients drifting.
- `extension-release-check.test.ts` drives the **real service worker** end to end under a stubbed `chrome.*`, triggered the way the popup triggers it. All four defects were wiring, not logic, so testing the helpers alone would not have caught any of them.

Each fix was reverted individually to confirm exactly the intended test fails — including replaying the original bug (mark known, then skip the artist if they have any known release), which fails the second-record test and nothing else.

`npm run lint` holds at the known 71-problem baseline. `npm run test:api` is clean (958). `npm run test:unit` has one failure, `RichArtistProfile > renders the payout percent on each pill`, which **fails identically on a clean checkout of `main`** — it's today, 7 August, being a Bandcamp Friday, so the component renders the 93-97% override instead of the hardcoded 80-85%. Unrelated to this PR, and it will break the build one day a month until it's fixed.

I could not load the extension in a live Chrome or Firefox — launching a browser was denied in this session. What is verified instead: both manifests parse and point at files that exist, and the service worker's whole module graph loads and executes its real check path under the stubbed `chrome.*` in the integration test.

Extension bumped to 2.7.0 in both manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)