### PR TITLE
Freeze the clock in the payout-pill tests

### DIFF
--- a/apps/web/tests/unit/RichArtistProfile.test.tsx
+++ b/apps/web/tests/unit/RichArtistProfile.test.tsx
@@ -2,7 +2,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { RichArtistProfile } from 'src/components/RichArtistProfile';
+import { isBandcampFriday } from 'src/utils/bandcamp-friday';
 import type { ArtistPagePayload } from 'src/types/artist-page';
+
+// SourceBadge reads the real clock to decide whether Bandcamp's payout shows as its usual
+// percentage or the Bandcamp Friday override, so the payout tests below freeze the clock
+// rather than asserting whatever today happens to be. Both dates are Pacific noon, the
+// timezone isBandcampFriday() compares in. Keep them in step with BANDCAMP_FRIDAY_DATES in
+// src/utils/bandcamp-friday.ts when that list is updated for a new year.
+const ORDINARY_FRIDAY = new Date('2026-08-14T12:00:00-07:00');
+const BANDCAMP_FRIDAY = new Date('2026-08-07T12:00:00-07:00');
 
 const basePayload: ArtistPagePayload = {
   artist: {
@@ -54,6 +63,7 @@ describe('RichArtistProfile', () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it('renders the artist name and image', () => {
@@ -130,8 +140,24 @@ describe('RichArtistProfile', () => {
   });
 
   it('renders the payout percent on each pill', () => {
+    expect(isBandcampFriday(ORDINARY_FRIDAY)).toBe(false);
+    vi.useFakeTimers();
+    vi.setSystemTime(ORDINARY_FRIDAY);
+
     render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
     expect(screen.getByText('80-85%')).toBeTruthy();
+    expect(screen.getByText('86-90%')).toBeTruthy();
+  });
+
+  it('shows Bandcamp\'s payout as ~97% on a Bandcamp Friday', () => {
+    expect(isBandcampFriday(BANDCAMP_FRIDAY)).toBe(true);
+    vi.useFakeTimers();
+    vi.setSystemTime(BANDCAMP_FRIDAY);
+
+    render(<RichArtistProfile payload={basePayload} slug="kid-lightbulbs" />);
+    expect(screen.getByText('~97%')).toBeTruthy();
+    expect(screen.queryByText('80-85%')).toBeNull();
+    // Only Bandcamp waives its share — every other platform keeps its usual payout.
     expect(screen.getByText('86-90%')).toBeTruthy();
   });
 


### PR DESCRIPTION
## What

`apps/web/tests/unit/RichArtistProfile.test.tsx > renders the payout percent on each pill` fails on every Bandcamp Friday — confirmed failing on `main` today (2026-08-07), and it recurs roughly monthly.

`SourceBadge` reads the real clock (`isBandcampFriday()` with no argument) to decide whether Bandcamp's pill shows its usual `80-85%` or the `~97%` Bandcamp Friday override. The test asserted `80-85%` unconditionally, so a red `npm run test:unit` was a calendar artifact rather than a real regression — and it blocks the Netlify build on those days.

## The fix

- Freeze the clock to an ordinary Friday (2026-08-14) in the existing payout test, so it asserts the same thing every day of the month.
- Add a companion case that freezes the clock to a real Bandcamp Friday (2026-08-07) and asserts `~97%`, that `80-85%` is gone, and that Patreon's payout is untouched — the override is now covered deliberately instead of by accident of the calendar.
- Each test asserts its date against `isBandcampFriday` before freezing. When `BANDCAMP_FRIDAY_DATES` is updated for a new year and 2026 falls out of the list, the failure points at the stale date rather than at the component.
- `vi.useRealTimers()` in `afterEach` so the frozen clock can't leak into the other 29 tests in the file.

Test-only change; no production code touched.

## Verification

- `npm run test:unit` — 642 passed, 47 files, green.
- `npm run lint` — 71 problems, unchanged from the existing baseline; none in this file.
- Both new assertions were mutation-checked against `SourceBadge.tsx`: forcing `isBCFriday = false` fails only the `~97%` case, forcing `isBCFriday = source.id === 'bandcamp'` fails only the ordinary-Friday case. `SourceBadge.tsx` was restored and is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)