### PR TITLE
Fix three release-alert defects in the Apple app

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		8916C6D428EE94E16E491566 /* ReleasesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8F1E48E643DCC1EECD4A93 /* ReleasesTab.swift */; platformFilters = (ios, ); };
 		8961565967B20B3F28A7877E /* GlobalHotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B52C116B5CC91BC40D028AF /* GlobalHotkeyManager.swift */; platformFilters = (macos, ); };
 		8A4181366EB270C58A708C65 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AC0E531396E8C63A2001CF /* SearchBarView.swift */; platformFilters = (macos, ); };
+		8AE1365921AE81ECF06371F4 /* NewReleasesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3C1FFEBBA8D8B753BDB0B /* NewReleasesListView.swift */; platformFilters = (macos, ); };
 		8C94768621D55383151FD59F /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1581BE8FAF07C7C9D3CD99F5 /* SearchResponse.swift */; };
 		8CD55AA9054F310B1DBD51DA /* ServicesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEF52280B036F1EB34F4127 /* ServicesProvider.swift */; platformFilters = (macos, ); };
 		917C407BBA300BE70B9BDEFB /* ScrobbleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEE83E95439F19BFC679216 /* ScrobbleManager.swift */; platformFilters = (macos, ); };
@@ -173,6 +174,7 @@
 		B245CC3DBF71C4B066A96632 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		B4745357EE3AD119D3F7B059 /* BandcampFriday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandcampFriday.swift; sourceTree = "<group>"; };
 		B733B6764210C3CAE08F12E0 /* SavedArtistsSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedArtistsSync.swift; sourceTree = "<group>"; };
+		BAF3C1FFEBBA8D8B753BDB0B /* NewReleasesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewReleasesListView.swift; sourceTree = "<group>"; };
 		BC8C8A39D8800BDBA893E0EA /* NowPlaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlaying.swift; sourceTree = "<group>"; };
 		BE9E59C365D8F116C435B8BC /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		BE9F88505AF840EC94B5C0BC /* FaircampReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaircampReleaseChecker.swift; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 		F284A719009A53D4D7A04F14 /* macOS */ = {
 			isa = PBXGroup;
 			children = (
+				BAF3C1FFEBBA8D8B753BDB0B /* NewReleasesListView.swift */,
 				9B08A02BD24EAF475A2689D6 /* NowPlayingView.swift */,
 				EF4E58F91C106A97A5179125 /* PopoverView.swift */,
 				45AC0E531396E8C63A2001CF /* SearchBarView.swift */,
@@ -572,6 +575,7 @@
 				7FA2720BFA00323DC8E66A9A /* ListenBrainzService.swift in Sources */,
 				DAF5726D4B93EA321E5D4643 /* MediaObserver.swift in Sources */,
 				47ADDB550C3A545314574336 /* MirloReleaseChecker.swift in Sources */,
+				8AE1365921AE81ECF06371F4 /* NewReleasesListView.swift in Sources */,
 				F20D83D3642078C9B2C45ED0 /* NowPlaying.swift in Sources */,
 				64514560D09214DE420ED24D /* NowPlayingNotificationManager.swift in Sources */,
 				27A98FF82168ECEF095C04D6 /* NowPlayingView.swift in Sources */,

--- a/apps/mac/Unstream/Info-iOS.plist
+++ b/apps/mac/Unstream/Info-iOS.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.0</string>
+	<string>3.5.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.0</string>
+	<string>3.5.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/mac/Unstream/Models/ReleaseAlert.swift
+++ b/apps/mac/Unstream/Models/ReleaseAlert.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// A new release detected for a saved artist
 struct NewRelease: Codable, Identifiable {
-    let id: UUID
+    /// Derived from the release, never generated. See `stableId(releaseUrl:artistName:releaseName:)`.
+    let id: String
     let artistName: String
     let releaseName: String
     let releaseDate: Date
@@ -31,6 +32,15 @@ struct NewRelease: Codable, Identifiable {
         platformCatalog[platform]?.name ?? platform.capitalized
     }
 
+    /// "1 September". Day and month only — an alert is always about the near future or the
+    /// recent past, so the year is noise. One property rather than two formatters so the
+    /// notification and the releases list can't drift into different date shapes.
+    var displayDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d MMMM"
+        return formatter.string(from: releaseDate)
+    }
+
     init(
         artistName: String,
         releaseName: String,
@@ -41,7 +51,7 @@ struct NewRelease: Codable, Identifiable {
         status: String = "released",
         offerSummary: String = ""
     ) {
-        self.id = UUID()
+        self.id = Self.stableId(releaseUrl: releaseUrl, artistName: artistName, releaseName: releaseName)
         self.artistName = artistName
         self.releaseName = releaseName
         self.releaseDate = releaseDate
@@ -53,11 +63,52 @@ struct NewRelease: Codable, Identifiable {
         self.detectedAt = Date()
     }
 
+    /// A release's identity, and the one thing about it that has to be the same on every device.
+    ///
+    /// This used to be a fresh `UUID()`, generated independently per device, and the iCloud
+    /// dismissal sync published *those*: one Mac dismissed "Infinite Normal" and synced its
+    /// UUID, the other held the same release under a different one, and nothing ever matched.
+    /// The only cross-device behaviour the app claimed did nothing at all.
+    ///
+    /// Two schemes, each prefixed so one can never be mistaken for the other:
+    ///
+    /// - `release:{artistSlug}/{releaseSlug}` when `releaseUrl` is an Unstream release page,
+    ///   which is what a catalog-backed alert carries. Both devices are naming the same
+    ///   catalogue entry, so this is a real shared key.
+    /// - `name:{artist}/{title}` for an alert from the server's live-scrape fallback, whose
+    ///   `releaseUrl` is one platform's page and carries no slugs. Deliberately weaker, and the
+    ///   prefix says so: it keys on the artist and title the server hands both devices rather
+    ///   than on a URL that could differ between them. It is also exactly the identity
+    ///   `isKnownReleaseByName` already dedups on, so the two agree about what "the same
+    ///   release" means.
+    ///
+    /// Not a UUID any more. A readable key is worth more here — it shows up in the iCloud store
+    /// and in notification identifiers — and deriving a UUID from a string would mean
+    /// hand-rolling UUIDv5 for no gain.
+    static func stableId(releaseUrl: String, artistName: String, releaseName: String) -> String {
+        if let slugs = ReleaseDetailService.slugs(fromReleaseURL: releaseUrl) {
+            return "release:\(slugs.artist)/\(slugs.release)"
+        }
+        return "name:\(idComponent(artistName))/\(idComponent(releaseName))"
+    }
+
+    /// Case and surrounding whitespace shouldn't split one release into two identities. A
+    /// slash is folded because the key uses one as its separator.
+    private static func idComponent(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "/", with: "-")
+    }
+
     // Decoded with defaults so alerts persisted by an earlier build — which had none of the
-    // three new fields — still load instead of throwing the whole stored list away.
+    // three newer fields — still load instead of throwing the whole stored list away.
+    //
+    // `id` is recomputed rather than read back for the same reason it changed shape: a stored
+    // id is either a v3.4.0 random UUID, which is worthless, or a key this same function would
+    // produce anyway. Recomputing is what makes two devices that upgrade separately converge on
+    // the same identity for a release they both already had.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(UUID.self, forKey: .id)
         artistName = try c.decode(String.self, forKey: .artistName)
         releaseName = try c.decode(String.self, forKey: .releaseName)
         releaseDate = try c.decode(Date.self, forKey: .releaseDate)
@@ -67,6 +118,7 @@ struct NewRelease: Codable, Identifiable {
         platforms = try c.decodeIfPresent([String].self, forKey: .platforms) ?? [platform]
         status = try c.decodeIfPresent(String.self, forKey: .status) ?? "released"
         offerSummary = try c.decodeIfPresent(String.self, forKey: .offerSummary) ?? ""
+        id = Self.stableId(releaseUrl: releaseUrl, artistName: artistName, releaseName: releaseName)
     }
 }
 

--- a/apps/mac/Unstream/ReleaseAlertManager.swift
+++ b/apps/mac/Unstream/ReleaseAlertManager.swift
@@ -18,7 +18,11 @@ class ReleaseAlertManager: ObservableObject {
 
     private let releaseAPI = ReleaseCheckAPI()
     private let iCloudStore = NSUbiquitousKeyValueStore.default
-    private let dismissedIdsKey = "dismissedReleaseIds"
+    // A new key, not the old "dismissedReleaseIds". That one holds per-device random UUIDs from
+    // v3.4.0 and earlier, which can never match a stable release id — reusing it would only let
+    // dead entries push real ones out of the 200-entry cap. It's left in place rather than
+    // deleted so an older device still syncing against it isn't fighting this one.
+    private let dismissedIdsKey = "dismissedReleaseKeys"
 
     private weak var supportListManager: SupportListManager?
 
@@ -58,9 +62,10 @@ class ReleaseAlertManager: ObservableObject {
 
     // MARK: - Public Methods
 
-    /// Get the new release for a specific artist, if any
-    func newRelease(for artistName: String) -> NewRelease? {
-        newReleases.first { $0.artistName.lowercased() == artistName.lowercased() && $0.isActive }
+    /// Every unread release for one artist — plural, because an artist can put out two records
+    /// between checks and the saved-artists list used to show only `.first` of them.
+    func newReleases(for artistName: String) -> [NewRelease] {
+        newReleases.filter { $0.artistName.lowercased() == artistName.lowercased() && $0.isActive }
     }
 
     /// Dismiss a new release notification (syncs dismissed state via iCloud KVS)
@@ -200,25 +205,23 @@ class ReleaseAlertManager: ObservableObject {
         let entries = supportListManager.entries
         var foundNewReleases: [NewRelease] = []
 
-        for entry in entries {
-            // Build platforms dictionary for API call
-            var platforms: [String: String] = [:]
+        // Asked once, before the loop, because the `defer` above moves `lastCheckDate` to now.
+        let sinceDays = Self.lookbackDays(since: checkState.lastCheckDate)
 
-            if let bandcampUrl = entry.platforms.first(where: { $0.sourceId == "bandcamp" })?.url {
-                platforms["bandcamp"] = bandcampUrl
-            }
-            if let faircampUrl = entry.platforms.first(where: { $0.sourceId == "faircamp" })?.url {
-                platforms["faircamp"] = faircampUrl
-            }
-            if let mirloUrl = entry.platforms.first(where: { $0.sourceId == "mirlo" })?.url {
-                platforms["mirlo"] = mirloUrl
-            }
-            // Skip if no supported platforms
-            guard !platforms.isEmpty else { continue }
+        for entry in entries {
+            // Every link we hold, and no gate on which ones. The server tries the release
+            // catalogue first and ignores `platforms` entirely on that path, so an artist known
+            // only through Discogs or Jam.coop — Discogs is the *largest* link population we
+            // have — used to be skipped over a question one database read answers.
+            let platforms = Self.platformUrls(for: entry)
 
             // The server returns every release in the window, not just the newest, so an artist
             // who put out two records since the last check produces two alerts.
-            foundNewReleases.append(contentsOf: await checkViaAPI(artistName: entry.artistName, platforms: platforms))
+            foundNewReleases.append(contentsOf: await checkViaAPI(
+                artistName: entry.artistName,
+                platforms: platforms,
+                sinceDays: sinceDays
+            ))
         }
 
         // Update state with new releases.
@@ -244,14 +247,64 @@ class ReleaseAlertManager: ObservableObject {
     }
 
     /// Ask the server what's new for one artist, and keep only what we haven't seen before.
-    private func checkViaAPI(artistName: String, platforms: [String: String]) async -> [NewRelease] {
+    private func checkViaAPI(
+        artistName: String,
+        platforms: [String: String],
+        sinceDays: Int?
+    ) async -> [NewRelease] {
         do {
-            let results = try await releaseAPI.checkReleases(artistName: artistName, platforms: platforms)
+            let results = try await releaseAPI.checkReleases(
+                artistName: artistName,
+                platforms: platforms,
+                sinceDays: sinceDays
+            )
             return Self.selectUnseen(results, artistName: artistName, state: &checkState)
         } catch {
             print("API check failed for \(artistName): \(error)")
             return []
         }
+    }
+
+    /// Which of a saved artist's links to send with an alert check.
+    ///
+    /// All of them, keyed by platform id. The server reads this only on its live-scrape
+    /// fallback, and only for the platforms it can scrape, so anything else is ignored rather
+    /// than harmful — while filtering here is what caused the bug: the old version built a
+    /// dictionary from bandcamp, faircamp and mirlo alone and then skipped the artist entirely
+    /// when it came out empty, even though the catalogue path never looks at it.
+    ///
+    /// First link wins if an artist somehow has two for one platform, and empty URLs are
+    /// dropped rather than sent as blanks for the server to reject.
+    nonisolated static func platformUrls(for entry: SupportEntry) -> [String: String] {
+        var urls: [String: String] = [:]
+        for platform in entry.platforms where !platform.url.isEmpty {
+            if urls[platform.sourceId] == nil {
+                urls[platform.sourceId] = platform.url
+            }
+        }
+        return urls
+    }
+
+    /// How far back to ask the server to look, given when we last checked.
+    ///
+    /// Nil means "use the server's default" (31 days), which is right on a first run and was
+    /// also — wrongly — what every run sent before this. A laptop closed for six weeks woke up,
+    /// asked for the last 31 days, and permanently missed everything that had aged past that
+    /// window while it slept.
+    ///
+    /// The window is the gap since the last check plus a week of padding, because a release can
+    /// be *dated* days before it appears anywhere we can see it. It never asks for less than
+    /// the 31 days it used to get, and never more than the 365 the server caps at — asking for
+    /// more would be silently clamped, and a request that means what it says is easier to debug.
+    nonisolated static func lookbackDays(since lastCheck: Date?, now: Date = Date()) -> Int? {
+        guard let lastCheck else { return nil }
+
+        let elapsed = now.timeIntervalSince(lastCheck) / (24 * 60 * 60)
+        // A last-check date in the future is a clock change, not a time machine: fall back to
+        // the default rather than deriving a nonsense window from it.
+        guard elapsed > 0 else { return nil }
+
+        return min(365, max(31, Int(elapsed.rounded(.up)) + 7))
     }
 
     /// Which of these results haven't we alerted on before? Marks each one it returns as known.
@@ -317,9 +370,7 @@ class ReleaseAlertManager: ObservableObject {
 
         let where_ = formatPlatformList(release.platforms)
         if release.isUpcoming {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "d MMMM"
-            let date = formatter.string(from: release.releaseDate)
+            let date = release.displayDate
             parts.append(where_.isEmpty ? "announced for \(date)" : "announced for \(date) on \(where_)")
         } else {
             parts.append(where_.isEmpty ? "out now" : "out now on \(where_)")
@@ -363,7 +414,7 @@ class ReleaseAlertManager: ObservableObject {
             content.userInfo = ["releaseUrl": release.releaseUrl]
 
             let request = UNNotificationRequest(
-                identifier: "releaseAlert-\(release.id.uuidString)",
+                identifier: "releaseAlert-\(release.id)",
                 content: content,
                 trigger: nil
             )
@@ -394,18 +445,17 @@ class ReleaseAlertManager: ObservableObject {
 
     // MARK: - Dismissed Release Sync (iCloud KVS)
 
-    private func loadDismissedIds() -> Set<UUID> {
+    private func loadDismissedIds() -> Set<String> {
         guard let strings = iCloudStore.array(forKey: dismissedIdsKey) as? [String] else {
             return []
         }
-        return Set(strings.compactMap { UUID(uuidString: $0) })
+        return Set(strings)
     }
 
-    private func saveDismissedId(_ id: UUID) {
+    private func saveDismissedId(_ id: String) {
         var ids = (iCloudStore.array(forKey: dismissedIdsKey) as? [String]) ?? []
-        let idString = id.uuidString
-        if !ids.contains(idString) {
-            ids.append(idString)
+        if !ids.contains(id) {
+            ids.append(id)
             // Cap at 200 entries to avoid unbounded growth
             if ids.count > 200 {
                 ids = Array(ids.suffix(200))

--- a/apps/mac/Unstream/Views/Shared/SupportListView.swift
+++ b/apps/mac/Unstream/Views/Shared/SupportListView.swift
@@ -62,7 +62,7 @@ struct SupportListView: View {
                     SupportEntryView(
                         entry: entry,
                         isRefreshing: supportListManager.isRefreshing(entry),
-                        newRelease: releaseAlertManager.newRelease(for: entry.artistName),
+                        newReleases: releaseAlertManager.newReleases(for: entry.artistName),
                         onRemove: {
                             supportListManager.removeEntry(entry)
                         },
@@ -132,7 +132,9 @@ struct SavedArtistsSearchBar: View {
 struct SupportEntryView: View {
     let entry: SupportEntry
     let isRefreshing: Bool
-    var newRelease: NewRelease?
+    /// All of this artist's unread releases, not just the newest — two records in one week is
+    /// exactly the case a fan most wants to see, and it was the case that got truncated.
+    var newReleases: [NewRelease] = []
     let onRemove: () -> Void
     let onRefresh: () -> Void
 
@@ -209,8 +211,8 @@ struct SupportEntryView: View {
                 #endif
             }
 
-            // New release indicator
-            if let release = newRelease {
+            // New release indicators, one per unread release
+            ForEach(newReleases) { release in
                 NewReleaseBadge(release: release)
             }
 

--- a/apps/mac/Unstream/Views/macOS/NewReleasesListView.swift
+++ b/apps/mac/Unstream/Views/macOS/NewReleasesListView.swift
@@ -1,0 +1,178 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// Every unread release, in one place, on the Mac.
+///
+/// iOS has had a Releases tab since the catalog work; macOS had a per-artist badge that showed
+/// one release per artist and a debug-only count in Settings — and a signed-in user, who sees
+/// the synced-artists list rather than the local one, had no release surface at all. The
+/// flagship client was the weaker one.
+///
+/// This is deliberately a drill-down rather than a third tab: it is additive, it reuses the
+/// popover's existing back header, Escape and ⌘[ handling, and it doesn't ask the app's
+/// top-level navigation to change shape. Whether Releases eventually earns a permanent tab
+/// alongside Search and Saved is a product call, not a bug fix.
+struct NewReleasesListView: View {
+    @ObservedObject var releaseAlertManager: ReleaseAlertManager
+
+    /// The popover pushes the buying guide onto its own stack rather than opening a window.
+    let openGuide: (ReleaseGuideTarget) -> Void
+
+    var body: some View {
+        ScrollView {
+            if releaseAlertManager.newReleases.isEmpty {
+                // Reachable by dismissing the last release while looking at the list. Popping
+                // the user back out from under their own click would be worse than saying so.
+                VStack(spacing: 8) {
+                    Image(systemName: "sparkles")
+                        .font(.title2)
+                        .foregroundColor(.secondary)
+                    Text("No new releases")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("We check your saved artists weekly.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary.opacity(0.7))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 24)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(releaseAlertManager.newReleases) { release in
+                        NewReleaseRow(
+                            release: release,
+                            openGuide: openGuide,
+                            onDismiss: { releaseAlertManager.dismissRelease(release) }
+                        )
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+}
+
+private struct NewReleaseRow: View {
+    let release: NewRelease
+    let openGuide: (ReleaseGuideTarget) -> Void
+    let onDismiss: () -> Void
+
+    @State private var isHovering = false
+
+    private var url: URL? { URL(string: release.releaseUrl) }
+
+    /// "Where to Buy" for a catalogued release, whose link is our own page; the shop's name for
+    /// an alert from the older scrape path, because that is genuinely where the link goes.
+    private var openTitle: String {
+        release.guideTarget != nil ? "Open on Unstream" : "Open on \(release.displayPlatform)"
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: open) {
+                HStack(spacing: 8) {
+                    Image(systemName: release.isUpcoming ? "calendar" : "sparkles")
+                        .foregroundColor(.yellow)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(release.artistName)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                        Text(release.releaseName)
+                            .font(.caption)
+                            .lineLimit(1)
+                        // The price is the reason to click, so it leads once we have one.
+                        Text(secondaryLine)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: release.guideTarget != nil ? "chevron.right" : "arrow.up.right")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilityText)
+            .help(helpText)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovering ? 1 : 0.3)
+            .accessibilityLabel("Dismiss \(release.releaseName)")
+            .help("Dismiss")
+        }
+        .padding(10)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .onHover { isHovering = $0 }
+        // Draggable and copyable like every other link in the app — a release is a thing a Mac
+        // user drags into a note or a message. Not `linkActions`, because this menu also has to
+        // carry Dismiss: the ✕ is hover-dimmed, so the context menu is the keyboard and
+        // VoiceOver path to it.
+        .draggableLink(url)
+        .contextMenu {
+            if release.guideTarget != nil {
+                Button("Where to Buy", action: open)
+            }
+            if let url {
+                Button(openTitle) { NSWorkspace.shared.open(url) }
+                Divider()
+                Button("Copy Link") { copyToClipboard(url: url) }
+                ShareLink(item: url)
+            }
+            Divider()
+            Button("Dismiss", action: onDismiss)
+        }
+    }
+
+    /// One line, so it carries the single most useful fact: when an announced record lands, or
+    /// what a released one costs. Falls back to the platform rather than inventing either.
+    private var secondaryLine: String {
+        if release.isUpcoming { return "Announced for \(release.displayDate)" }
+        if !release.offerSummary.isEmpty { return release.offerSummary }
+        return "On \(release.displayPlatform)"
+    }
+
+    private var accessibilityText: String {
+        release.guideTarget != nil
+            ? "\(release.releaseName) by \(release.artistName). Show where to buy."
+            : "\(release.releaseName) by \(release.artistName) on \(release.displayPlatform)"
+    }
+
+    private var helpText: String {
+        release.guideTarget != nil
+            ? "Where to buy \(release.releaseName)"
+            : "Open \(release.releaseName) on \(release.displayPlatform)"
+    }
+
+    /// The payout comparison in the app for a catalogued release; the browser only for an alert
+    /// from the older scrape path, which has no guide behind it.
+    private func open() {
+        if let target = release.guideTarget {
+            openGuide(target)
+        } else if let url {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+private extension View {
+    /// `.draggable` needs a non-optional payload; a release with an unparseable URL simply
+    /// isn't draggable rather than dragging something empty.
+    @ViewBuilder
+    func draggableLink(_ url: URL?) -> some View {
+        if let url { self.draggable(url) } else { self }
+    }
+}
+#endif

--- a/apps/mac/Unstream/Views/macOS/PopoverView.swift
+++ b/apps/mac/Unstream/Views/macOS/PopoverView.swift
@@ -9,12 +9,14 @@ enum PopoverTab {
 enum PopoverRoute: Hashable {
     case artistReleases(slug: String, name: String)
     case releaseGuide(ReleaseGuideTarget)
+    case newReleases
 
     /// Shown centred in the back header, so it's obvious which level you're on.
     var title: String {
         switch self {
         case .artistReleases: return "Releases"
         case .releaseGuide: return "Where to Buy"
+        case .newReleases: return "New Releases"
         }
     }
 }
@@ -128,6 +130,10 @@ struct PopoverView: View {
                     }
                 case let .releaseGuide(target):
                     ReleaseGuideView(target: target)
+                case .newReleases:
+                    NewReleasesListView(releaseAlertManager: releaseAlertManager) { target in
+                        route.append(.releaseGuide(target))
+                    }
                 }
             }
             .frame(maxHeight: 350)
@@ -141,12 +147,16 @@ struct PopoverView: View {
             // A real segmented control: correct selection emphasis in both appearances
             // and in an inactive window, which the hand-rolled accent-tinted pills got
             // wrong (they read as a heavy blue slab in dark mode).
-            Picker("View", selection: $selectedTab) {
-                Text("Search").tag(PopoverTab.search)
-                Text(savedTabTitle).tag(PopoverTab.supportList)
+            HStack(spacing: 8) {
+                Picker("View", selection: $selectedTab) {
+                    Text("Search").tag(PopoverTab.search)
+                    Text(savedTabTitle).tag(PopoverTab.supportList)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                newReleasesButton
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
             .padding(.horizontal, 12)
             .padding(.top, 10)
 
@@ -342,6 +352,32 @@ struct PopoverView: View {
         .padding(.vertical, 8)
     }
 
+    /// The way into the unread-releases list, shown only when there are some.
+    ///
+    /// A bell beside the segmented control rather than a third segment: this is news that comes
+    /// and goes, not a place the app always has. When there is nothing unread there is nothing
+    /// to offer, and an always-present empty tab would be a worse trade in a 320-point popover.
+    @ViewBuilder
+    private var newReleasesButton: some View {
+        let count = releaseAlertManager.newReleases.count
+        if count > 0 {
+            Button(action: { route = [.newReleases] }) {
+                HStack(spacing: 3) {
+                    Image(systemName: "bell.badge.fill")
+                        .foregroundColor(.yellow)
+                    Text("\(count)")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .fixedSize()
+            .help(count == 1 ? "1 new release" : "\(count) new releases")
+            .accessibilityLabel(count == 1 ? "1 new release" : "\(count) new releases")
+        }
+    }
+
     /// The saved count rides in the segment label — a segmented control has no badge
     /// slot, and the count is useful enough to keep.
     private var savedTabTitle: String {
@@ -382,6 +418,13 @@ struct PopoverView: View {
                 selectedTab = .supportList
             }
             .keyboardShortcut("2", modifiers: .command)
+
+            // Registered only while there is something to show, matching the button beside the
+            // segmented control — a shortcut to an empty list would be a dead key.
+            if !releaseAlertManager.newReleases.isEmpty {
+                Button("New Releases") { route = [.newReleases] }
+                    .keyboardShortcut("3", modifiers: .command)
+            }
 
             // Escape backs out of a drill-down, which is what Escape should do. Registered only
             // while one is open, so everywhere else Escape keeps its usual job of dismissing the

--- a/apps/mac/UnstreamShareExtension/Info.plist
+++ b/apps/mac/UnstreamShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.0</string>
+	<string>3.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/mac/UnstreamTests/ReleaseAlertTests.swift
+++ b/apps/mac/UnstreamTests/ReleaseAlertTests.swift
@@ -242,4 +242,197 @@ final class ReleaseAlertTests: XCTestCase {
         XCTAssertEqual(decoded.offerSummary, "")
         XCTAssertFalse(decoded.isUpcoming)
     }
+
+    // MARK: - Stable identity (the iCloud dismissal sync)
+
+    /// `NewRelease.id` was a fresh `UUID()` per device, and the iCloud dismissal sync published
+    /// those ids as the dismissed set. Device A dismissed a release and synced UUID X; device B
+    /// held the same release under UUID Y; nothing ever matched, so the sync did nothing at all.
+    /// These pin the property that makes it work: same release, same id, wherever it's built.
+
+    func testTwoDevicesDeriveTheSameIdForTheSameCatalogRelease() {
+        let onOneMac = release()
+        let onAnother = release()
+
+        XCTAssertEqual(onOneMac.id, onAnother.id, "A release's id must not depend on where it was built")
+    }
+
+    func testCatalogIdComesFromTheReleasePageNotTheDisplayNames() {
+        // Same catalogue entry, two spellings of the artist as the server happened to send it.
+        let accented = NewRelease(
+            artistName: "Sigur Rós",
+            releaseName: "Á",
+            releaseDate: Date(timeIntervalSince1970: 0),
+            releaseUrl: "https://unstream.stream/a/sigur-ros/a",
+            platform: "bandcamp"
+        )
+        let plain = NewRelease(
+            artistName: "Sigur Ros",
+            releaseName: "A",
+            releaseDate: Date(timeIntervalSince1970: 0),
+            releaseUrl: "https://unstream.stream/a/sigur-ros/a",
+            platform: "bandcamp"
+        )
+
+        XCTAssertEqual(accented.id, "release:sigur-ros/a")
+        XCTAssertEqual(accented.id, plain.id)
+    }
+
+    /// The live-scrape path hands back a *platform* URL, which carries no slugs — so the key
+    /// degrades to the artist and title, and says so in its prefix rather than pretending to be
+    /// a catalogue key.
+    func testScrapedAlertsKeyOnArtistAndTitleInstead() {
+        let onBandcamp = NewRelease(
+            artistName: "Kid Lightbulbs",
+            releaseName: "Infinite Normal",
+            releaseDate: Date(timeIntervalSince1970: 0),
+            releaseUrl: "https://kidlightbulbs.bandcamp.com/album/infinite-normal",
+            platform: "bandcamp"
+        )
+        let onMirlo = NewRelease(
+            artistName: "kid lightbulbs ",
+            releaseName: "Infinite Normal",
+            releaseDate: Date(timeIntervalSince1970: 0),
+            releaseUrl: "https://mirlo.space/kidlightbulbs/release/infinite-normal",
+            platform: "mirlo"
+        )
+
+        XCTAssertEqual(onBandcamp.id, "name:kid lightbulbs/infinite normal")
+        XCTAssertEqual(
+            onBandcamp.id, onMirlo.id,
+            "Two devices handed different shop URLs for one record must still agree on its id"
+        )
+    }
+
+    func testAScrapedKeyCanNeverBeMistakenForACatalogKey() {
+        let scraped = NewRelease(
+            artistName: "a/b",
+            releaseName: "c",
+            releaseDate: Date(timeIntervalSince1970: 0),
+            releaseUrl: "https://example.bandcamp.com/album/c",
+            platform: "bandcamp"
+        )
+
+        XCTAssertTrue(scraped.id.hasPrefix("name:"), scraped.id)
+        XCTAssertFalse(scraped.id.hasPrefix("release:"), scraped.id)
+    }
+
+    /// The id is also the SwiftUI `ForEach` key, so two live alerts must never share one.
+    func testTwoReleasesByOneArtistHaveDifferentIds() {
+        var state = ReleaseCheckState()
+        let found = ReleaseAlertManager.selectUnseen(
+            [result("First Record"), result("Second Record")], artistName: "Someone", state: &state
+        )
+
+        XCTAssertEqual(Set(found.map(\.id)).count, 2)
+    }
+
+    /// A v3.4.0 build persisted a random UUID under `id`. Reading it back would keep that device
+    /// pinned to an identity no other device shares, so decoding recomputes instead.
+    func testDecodingRecomputesTheIdRatherThanTrustingAStoredUUID() throws {
+        let stored = UUID().uuidString
+        let legacy = """
+        {
+          "id": "\(stored)",
+          "artistName": "Kid Lightbulbs",
+          "releaseName": "Infinite Normal",
+          "releaseDate": 750000000,
+          "releaseUrl": "https://unstream.stream/a/kid-lightbulbs/infinite-normal",
+          "platform": "bandcamp",
+          "detectedAt": 750000000
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(NewRelease.self, from: legacy)
+
+        XCTAssertEqual(decoded.id, "release:kid-lightbulbs/infinite-normal")
+        XCTAssertNotEqual(decoded.id, stored)
+    }
+
+    func testAnAlertSurvivesAnEncodeDecodeRoundTripWithItsIdIntact() throws {
+        let original = release()
+        let data = try JSONEncoder().encode(original)
+
+        let decoded = try JSONDecoder().decode(NewRelease.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+    }
+
+    // MARK: - Which links get sent (the three-platform gate)
+
+    private func entry(_ platforms: [(String, String)]) -> SupportEntry {
+        SupportEntry(
+            artistName: "Someone",
+            imageUrl: nil,
+            platforms: platforms.map { SavedPlatform(sourceId: $0.0, url: $0.1) }
+        )
+    }
+
+    /// The old client built its platforms dictionary from bandcamp, faircamp and mirlo alone and
+    /// then skipped the artist when it came out empty — even though the server answers from the
+    /// release catalogue first and never reads the dictionary on that path. Discogs is the
+    /// largest link population we have, so this skipped more artists than it covered.
+    func testDiscogsOnlyArtistStillGetsTheirLinksSent() {
+        let urls = ReleaseAlertManager.platformUrls(for: entry([("discogs", "https://discogs.com/artist/1")]))
+
+        XCTAssertEqual(urls, ["discogs": "https://discogs.com/artist/1"])
+    }
+
+    func testEverySavedLinkIsSentNotJustTheScrapableThree() {
+        let urls = ReleaseAlertManager.platformUrls(for: entry([
+            ("bandcamp", "https://someone.bandcamp.com"),
+            ("jamcoop", "https://jam.coop/someone"),
+            ("instagram", "https://instagram.com/someone"),
+        ]))
+
+        XCTAssertEqual(Set(urls.keys), ["bandcamp", "jamcoop", "instagram"])
+    }
+
+    func testBlankUrlsAreDroppedAndTheFirstLinkPerPlatformWins() {
+        let urls = ReleaseAlertManager.platformUrls(for: entry([
+            ("bandcamp", "https://first.bandcamp.com"),
+            ("bandcamp", "https://second.bandcamp.com"),
+            ("faircamp", ""),
+        ]))
+
+        XCTAssertEqual(urls, ["bandcamp": "https://first.bandcamp.com"])
+    }
+
+    // MARK: - How far back to look (the closed laptop)
+
+    private func daysAgo(_ days: Double, from now: Date) -> Date {
+        now.addingTimeInterval(-days * 24 * 60 * 60)
+    }
+
+    func testFirstEverCheckLetsTheServerChooseTheWindow() {
+        XCTAssertNil(ReleaseAlertManager.lookbackDays(since: nil))
+    }
+
+    /// The defect: a laptop closed for six weeks woke up, asked for the server's default 31 days,
+    /// and permanently lost everything that had aged past that window while it slept.
+    func testASixWeekGapAsksForSixWeeksPlusPadding() {
+        let now = Date()
+
+        let days = ReleaseAlertManager.lookbackDays(since: daysAgo(42, from: now), now: now)
+
+        XCTAssertEqual(days, 49)
+    }
+
+    func testAShortGapStillAsksForTheFullMonthWeUsedToGet() {
+        let now = Date()
+
+        XCTAssertEqual(ReleaseAlertManager.lookbackDays(since: daysAgo(1, from: now), now: now), 31)
+    }
+
+    func testAVeryOldCheckIsCappedAtTheServersCeiling() {
+        let now = Date()
+
+        XCTAssertEqual(ReleaseAlertManager.lookbackDays(since: daysAgo(900, from: now), now: now), 365)
+    }
+
+    func testALastCheckDateInTheFutureFallsBackToTheDefault() {
+        let now = Date()
+
+        XCTAssertNil(ReleaseAlertManager.lookbackDays(since: now.addingTimeInterval(3600), now: now))
+    }
 }

--- a/apps/mac/project.yml
+++ b/apps/mac/project.yml
@@ -85,8 +85,8 @@ targets:
         CFBundleName: UnstreamShare
         CFBundleDisplayName: Share to Unstream
         CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
-        CFBundleVersion: "14"
-        CFBundleShortVersionString: "3.4.0"
+        CFBundleVersion: "15"
+        CFBundleShortVersionString: "3.5.0"
         CFBundlePackageType: XPC!
         NSExtension:
           NSExtensionAttributes:


### PR DESCRIPTION
Three defects in the shipped release-alert client, plus the macOS gap that showed up while fixing them.

## 1. The iCloud dismissal sync was a no-op

`NewRelease.id` was a fresh `UUID()` — generated independently on each device — and `saveDismissedId` published *those* through `NSUbiquitousKeyValueStore` as the dismissed set. Dismiss "Infinite Normal" on one Mac, sync UUID X; the other Mac holds the same release under UUID Y; nothing ever matches. The one cross-device feature the app claimed did nothing at all.

The id is now derived from the release. Two schemes, prefixed so they can't be confused:

| Alert source | `releaseUrl` | id |
|---|---|---|
| Catalogue (`getReleasesForAlerts`) | `https://unstream.stream/a/{artist}/{release}` | `release:kid-lightbulbs/infinite-normal` |
| Live-scrape fallback | the platform's own page | `name:kid lightbulbs/infinite normal` |

The fallback degrades honestly rather than pretending: a scraped alert has no slugs, so it keys on the artist and title the server hands both devices — which is also exactly the identity `isKnownReleaseByName` already dedups on — and the `name:` prefix says out loud that it isn't a catalogue key.

Three things this had to not break, all covered by tests:

- **v3.4.0's stored alerts still decode.** `init(from:)` keeps its defaults-supplying shape and simply stops reading `id`, recomputing it instead. That's deliberate, not incidental: a stored id is either a worthless random UUID or a key this function would produce anyway, and recomputing is what makes two devices that upgrade separately converge on the same identity for a release they both already had.
- **Ids stay unique within the list**, since `id` is the SwiftUI `ForEach` key in `ReleasesTab`.
- **The notification identifier follows** — `releaseAlert-{id}`.

The dismissed set moves to a new KVS key (`dismissedReleaseKeys`). The old one holds per-device UUIDs that can never match a stable id; reusing it would only let dead entries push real ones out of the 200-entry cap. It's left in place rather than deleted so an older device still syncing against it isn't fighting this one.

## 2. Both clients gated on three platforms while the catalogue covers five

`ReleaseAlertManager` built its platforms dictionary from bandcamp/faircamp/mirlo and then `continue`d when it came out empty — but `check-releases` tries the catalogue first and ignores `platforms` entirely on that path. Only the live-scrape fallback needs URLs. So an artist known only through Discogs (1,953 links in production, against Bandcamp's 1,810) was skipped for a question one DB read answers.

Now every link the artist has is sent, keyed by platform id, and nobody is skipped. The server reads only the keys it can scrape, so the extra ones cost nothing.

## 3. `sinceDays` was supported but never sent

`ReleaseCheckAPI` has taken `sinceDays: Int? = nil` since the parameter was added for exactly this; the manager never passed it. A laptop closed for six weeks woke up, asked for the default 31 days, and permanently lost anything that had aged past that window while it slept (spec §5 defect 5).

The window is now the gap since the last check plus a week of padding — a release can be *dated* days before it appears anywhere we can see it — floored at the 31 days we used to get and capped at the server's 365, so the request means what it says instead of being silently clamped. Computed before the loop, because the `defer` moves `lastCheckDate` to now.

## Also: macOS had less than the description suggested

`SupportListView` used `newRelease(for:)`, which returns `.first`. But the bigger hole: a **signed-in** macOS user sees `SyncedArtistsView`, which has no release UI at all — so on the flagship client, release alerts appeared nowhere outside notifications and a DEBUG count in Settings.

Two changes, both small because the scaffolding existed:

- The saved-artists list shows **every** unread release for an artist, not `.first`.
- The popover gains a **New Releases** drill-down: a bell + count beside the segmented control (shown only when there are unread releases), ⌘3, and rows that push each release's buying guide onto the existing route stack. It reuses the back header, Escape and ⌘[ that `.releaseGuide` already had; rows are draggable and carry a context menu with Where to Buy / Open / Copy Link / Share / Dismiss, since the ✕ is hover-dimmed and keyboard and VoiceOver users need a non-hover path to it.

**What I did not build:** a permanent Releases tab alongside Search and Saved, mirroring iOS. That changes the app's top-level navigation, needs a real empty state, and is a product call rather than a bug fix — the drill-down is additive and doesn't foreclose it.

I also didn't add a `shipped-features.json` entry: those are coarse feature-level items and `announced: false` drives a social post, which a bug-fix release probably shouldn't. Say the word if you'd like one.

## Verification

- **71 XCTests pass** (`ReleaseAlertTests` +17), macOS and iOS both build.
- **Each new test was proved to have teeth** by reverting the behaviour it guards and confirming the failure:
  - `stableId` → `UUID().uuidString`: 6 identity tests fail, the legacy-decode test still passes.
  - decode the stored `id` instead of recomputing: `testDecodingRecomputesTheIdRatherThanTrustingAStoredUUID` fails.
  - re-add the bandcamp/faircamp/mirlo filter: both `platformUrls` coverage tests fail.
  - `lookbackDays` → always nil: the three window tests fail.
- The new macOS row was rendered to PNG in light and dark and checked for truncation and the announced/released variants.
- Decisions are pure statics — `NewRelease.stableId`, `ReleaseAlertManager.platformUrls(for:)`, `ReleaseAlertManager.lookbackDays(since:now:)` — following the `selectUnseen` precedent.

Version 3.4.0 → 3.5.0, build 14 → 15, across all four files; `xcodegen generate` re-run for the new source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)