### PR TITLE
Resolve retired artist slugs on the release page

### DIFF
--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -172,9 +172,45 @@ export default async function handler(request: Request, context: Context) {
         .maybeSingle()
         .abortSignal(controller.signal);
 
+      // A retired slug still resolves. Most of the aliases in production (44 of them as of
+      // 2026-08-07) came from the accent-folding reslug in #410 (`beyonc` -> `beyonce`), and a
+      // release URL minted before that — in an alert, a shared link, a Mac app cache — is a URL
+      // a fan can still be holding.
+      // Falling through instead would hand it to artist-page-static, which hands non-crawlers to
+      // the SPA, which has no route for a two-segment /a/ path: a blank page.
+      //
+      // Checked only *after* the live slug misses, so a real artist who later takes that slug
+      // always wins.
+      //
+      // A 301 to the canonical URL rather than rendering here, matching artist-page-static:
+      // rendering the same page at two URLs is duplicate content. The redirect is about the
+      // artist slug alone — if the release doesn't exist under the canonical slug either, that
+      // request answers with the usual bounce to the artist page.
+      //
+      // Duplicates resolveArtistSlugAlias in api/functions/db.ts — edge functions run on Deno and
+      // cannot import from api/functions.
       if (!artistData) {
+        const { data: alias } = await supabase
+          .from('artist_slug_aliases')
+          .select('artists!inner(slug)')
+          .eq('alias', artistSlug.toLowerCase())
+          .maybeSingle()
+          .abortSignal(controller.signal);
+
+        const canonical = (alias as { artists?: { slug?: string } } | null)?.artists?.slug;
         clearTimeout(timeoutId);
-        return context.next();
+        if (!canonical) return context.next();
+
+        // max-age=3600, not the year a permanent redirect invites: browsers cache a 301
+        // aggressively, and a slug that gets reassigned to a real artist has to be able to stop
+        // redirecting. Same cap artist-page-static uses.
+        return new Response(null, {
+          status: 301,
+          headers: {
+            Location: `/a/${encodeURIComponent(canonical)}/${encodeURIComponent(releaseSlug)}`,
+            'Cache-Control': 'public, max-age=3600',
+          },
+        });
       }
       artist = artistData;
 

--- a/api/functions/release-detail.ts
+++ b/api/functions/release-detail.ts
@@ -12,13 +12,11 @@
 // query (`getReleaseDetail`) and apply the same payout rules, so a native client can never
 // describe a release differently from the web page a fan would see for it.
 //
-// **Retired artist slugs resolve here and not on the HTML page.** This endpoint reads
-// `artist_slug_aliases` on a miss, the way /api/artist and the artist page do. `release-page.ts`
-// does not: on an unknown artist slug it falls through to the SPA, which has no route for a
-// two-segment /a/ path, so /a/{retired-slug}/{release} renders nothing in a browser today. That
-// is a gap in the page, not a reason to reproduce it here — the answers still agree wherever the
-// page produces one, and `pageUrl` below is built from the canonical slug so a client's "open the
-// full guide" lands on a URL that renders.
+// **Retired artist slugs resolve, here and on the HTML page.** This endpoint reads
+// `artist_slug_aliases` on a miss, the way /api/artist and the artist page do; `release-page.ts`
+// does the same and 301s to the canonical URL. The two answer a retired slug differently on
+// purpose — a redirect is right for a page and wrong for a client that asked a question — but
+// neither leaves a fan holding an alias URL with nothing behind it.
 //
 // **`payoutPercent` is computed here, per source, on purpose.** Payout figures are duplicated by
 // hand across eight files in this repo, and that drift is what let the Discord bot quote an
@@ -244,9 +242,8 @@ export async function handler(event: {
         },
         // The page URL, so a native client can offer "open the full guide" without rebuilding
         // the URL shape — and so the two surfaces stay tied together if it ever changes. Built
-        // from the canonical slug rather than the requested one: the HTML page does *not* resolve
-        // aliases (see the file header), so echoing a retired slug back here would hand a client
-        // a link that renders nothing.
+        // from the canonical slug rather than the requested one: echoing a retired slug back
+        // would hand a client a link that only works by way of a redirect.
         pageUrl: `https://unstream.stream/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release)}`,
         bandcampFriday,
       }),

--- a/scripts/preview-release-page.ts
+++ b/scripts/preview-release-page.ts
@@ -24,8 +24,9 @@
  * the type/date/offer mapping, and the entire rendered page including payout estimates and
  * Bandcamp Friday handling.
  *
- * Faked: only the two database reads. Nothing is written anywhere — there is no database
- * connection at all, which is the point.
+ * Faked: only the database reads, including one alias row so the retired-slug redirect can be
+ * seen (there is a link for it on the index page). Nothing is written anywhere — there is no
+ * database connection at all, which is the point.
  *
  * One Bandcamp request for the grid, then one per release page you open. Be a good neighbour.
  */
@@ -87,20 +88,35 @@ const stubDir = mkdtempSync(join(tmpdir(), 'unstream-release-preview-'));
 
 writeFileSync(join(stubDir, 'edge.ts'), `export type Context = { next: () => Response };\n`);
 
-// The two database reads the edge function makes, answered from memory. `_table` is set by
-// from() and read by then(), which works because the function awaits each query before
-// starting the next one.
+// The three database reads the edge function makes, answered from memory. `_table` and the
+// `.eq()` filters are recorded by the builder and read by then(), which works because the
+// function awaits each query before starting the next one.
+//
+// The filters matter: the artists read has to *miss* for a retired slug, or the alias branch
+// this harness exists to show can never run.
 writeFileSync(join(stubDir, 'supabase.ts'), `
 export let artist: any = null;
 export let release: any = null;
-export function setRows(a: any, r: any) { artist = a; release = r; }
+export let alias: any = null;
+export function setRows(a: any, r: any, al: any = null) { artist = a; release = r; alias = al; }
 export function createClient() {
   const q: any = {
     _table: '',
-    select: () => q, eq: () => q, abortSignal: () => q, maybeSingle: () => q,
-    then: (resolve: any) => resolve({ data: q._table === 'artists' ? artist : release }),
+    _filters: {} as Record<string, unknown>,
+    select: () => q,
+    eq: (column: string, value: unknown) => { q._filters[column] = value; return q; },
+    abortSignal: () => q,
+    maybeSingle: () => q,
+    then: (resolve: any) => resolve({ data: rowFor() }),
   };
-  return { from(table: string) { q._table = table; return q; } };
+  function rowFor() {
+    if (q._table === 'artists') return q._filters.slug === artist?.slug ? artist : null;
+    if (q._table === 'artist_slug_aliases') {
+      return q._filters.alias === alias?.alias ? { artists: { slug: artist?.slug } } : null;
+    }
+    return release;
+  }
+  return { from(table: string) { q._table = table; q._filters = {}; return q; } };
 }
 `);
 
@@ -133,11 +149,18 @@ function escape(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+/**
+ * A stand-in for a row in `artist_slug_aliases`. Requests under it miss the artists table and
+ * take the alias branch in the edge function, which 301s to the canonical URL.
+ */
+const RETIRED_SLUG = `${artistSlug}-retired`;
+
 function indexPage(): string {
   const rows = releases.map(r =>
     `<li style="margin:6px 0"><a href="/a/${artistSlug}/${r.slug}">${escape(r.title)}</a>
      <span style="color:#888;font-size:13px"> — ${r.releaseType}${detailCache.has(r.slug) ? ' · fetched' : ''}</span></li>`
   ).join('');
+  const first = releases[0];
   return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Release page preview</title>
     <style>body{font-family:system-ui;max-width:640px;margin:40px auto;padding:0 24px;line-height:1.5}
     a{color:#e55a2b}code{background:#eee;padding:1px 5px;border-radius:4px}</style></head><body>
@@ -145,7 +168,12 @@ function indexPage(): string {
     <p style="color:#666">${releases.length} releases from <code>${escape(landedUrl)}</code>.
     Opening one fetches its release page from Bandcamp (one request) and renders it through the
     real edge function. Nothing is written anywhere.</p>
-    <ul style="padding-left:18px">${rows}</ul></body></html>`;
+    <ul style="padding-left:18px">${rows}</ul>
+    ${first ? `<p style="color:#666">Retired slug:
+      <a href="/a/${RETIRED_SLUG}/${first.slug}"><code>/a/${RETIRED_SLUG}/${escape(first.slug)}</code></a>
+      — misses the artists table, resolves through <code>artist_slug_aliases</code>, and 301s to
+      the canonical URL.</p>` : ''}
+    </body></html>`;
 }
 
 const server = createServer(async (req, res) => {
@@ -157,15 +185,17 @@ const server = createServer(async (req, res) => {
     return;
   }
 
-  const match = path.match(/^\/a\/[^/]+\/([^/]+)\/?$/);
-  const release = match ? releases.find(r => r.slug === match[1]) : undefined;
+  const match = path.match(/^\/a\/([^/]+)\/([^/]+)\/?$/);
+  const requestedArtist = match?.[1];
+  const release = match ? releases.find(r => r.slug === match[2]) : undefined;
   if (!release) {
     res.writeHead(302, { Location: '/' });
     res.end();
     return;
   }
 
-  if (!detailCache.has(release.slug)) {
+  // A retired slug redirects before the release is ever read, so there is nothing to fetch for it.
+  if (requestedArtist === artistSlug && !detailCache.has(release.slug)) {
     console.log(`  fetching ${release.source.url}`);
     const detailResponse = await safeFetch(release.source.url, 15_000);
     const outcome = detailResponse?.ok
@@ -186,7 +216,7 @@ const server = createServer(async (req, res) => {
     | undefined;
 
   setRows(
-    { id: 'preview-artist', name: artistName, image_url: null },
+    { id: 'preview-artist', slug: artistSlug, name: artistName, image_url: null },
     {
       title: release.title,
       release_type: release.releaseType,
@@ -205,7 +235,8 @@ const server = createServer(async (req, res) => {
           })),
         },
       ],
-    }
+    },
+    { alias: RETIRED_SLUG }
   );
 
   const response = await renderReleasePage(
@@ -213,7 +244,11 @@ const server = createServer(async (req, res) => {
     { next: () => new Response('fell through to the SPA', { status: 404 }) }
   );
 
-  res.writeHead(response.status, { 'Content-Type': 'text/html; charset=utf-8' });
+  // The function's own headers, not a hand-set Content-Type: a redirect carries its answer in
+  // Location and Cache-Control, and dropping those would make the redirect branches unviewable.
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => { headers[key] = value; });
+  res.writeHead(response.status, headers);
   res.end(await response.text());
 });
 


### PR DESCRIPTION
Stacked on #418 — **base is `fix/release-detail-slug-aliases`, not `main`.** GitHub will retarget this to `main` automatically once #418 merges. It's stacked rather than parallel because #418's comments in `release-detail.ts` describe this gap as an open one; merging them independently would land a knowingly-wrong load-bearing comment on `main` whichever went first.

## The bug

`/a/{artist}/{release}` renders **nothing** when the artist slug is a retired one — 44 rows in `artist_slug_aliases` as of today, most left by the accent-folding reslug in #410 (`beyonc` → `beyonce`).

`api/edge/release-page.ts` looked the artist up with a plain `.eq('slug', …)` and on a miss called `context.next()`. The next matching edge function is `artist-page-static`, which hands non-crawlers straight to the SPA — and the SPA has no route for a two-segment `/a/` path (`main.tsx` only has `/a/:slug`). So a fan following a release alert minted before the reslug gets a blank page.

#418 closed the same gap in the JSON twin (`/api/release/{artist}/{release}`) and the `/a/{artist}/releases.{ics,xml}` feeds. The HTML page — the one a person actually looks at — was the last surface still behind them.

## Two decisions

**301, not render-in-place.** `artist-page-static.ts` already 301s for a retired artist slug, and rendering identical content at two URLs is duplicate content plus a second page competing with the canonical one. The redirect is about the artist slug *alone*: if the release doesn't exist under the canonical slug either, that request answers with the existing 302 bounce to the artist page. `Cache-Control` caps at an hour rather than the year a permanent redirect invites — browsers cache a 301 aggressively, and a slug later reassigned to a real artist has to be able to stop redirecting. Same cap `artist-page-static` uses.

**The alias query is duplicated in Deno.** Edge functions can't import from `api/functions/`, so this copies the shape of the block in `artist-page-static.ts` and keeps its comment saying why the duplication exists. Resolved **only after the live slug misses**, so a real artist who later takes that slug always wins.

Also updates the two comments in `release-detail.ts` that described this as a gap in the page, since it no longer is.

## Verification

`api/edge/*` isn't in `api/tsconfig.json`'s typecheck include, so this was verified by rendering locally with `npm run preview:release`. That harness couldn't reach the new branch as written — its Supabase stub ignored `.eq()` filters, so the artists read always hit and the miss path was unreachable. It now records the filters, answers an alias row, and links a retired slug from the index page so the redirect is one click away.

```
--- retired slug ---
HTTP/1.1 301 Moved Permanently
cache-control: public, max-age=3600
location: /a/explosionsinthesky/end

--- retired slug, following the redirect ---
final=http://localhost:8845/a/explosionsinthesky/end status=200

--- canonical slug ---
status=200

--- unknown, non-alias slug ---
fell through to the SPA
```

`npm run test:api` (968 passing), `npm run typecheck:api`, `vite build` and `npm run lint` (71 problems, unchanged from the repo baseline) all clean. `npm run build` stops on one pre-existing failure — `RichArtistProfile.test.tsx` expecting `80-85%` where Bandcamp Friday shows `~97%`. Today is the first Friday of the month; it failed identically on `main` at 56a88f7 when I ran it. #420 merged three minutes later and fixes it — this branch just predates it and will pick it up on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
