### PR TITLE
Let the deadline, not a fetch count, stop the release-detail pass

### DIFF
--- a/.github/workflows/recatalog-sweep.yml
+++ b/.github/workflows/recatalog-sweep.yml
@@ -22,10 +22,23 @@ name: Release catalogue sweep
 #   - The ~2,400 artists with no catalogue at all drain in about three weeks.
 #
 # What it costs the sites we crawl: the background function paces itself at one second between
-# artists, at most 100 Bandcamp release-page fetches per run on top of one grid page each. Four
-# runs is on the order of 400-500 sequential Bandcamp requests a day — well under one a minute
-# averaged, against robots-permitted paths. The lever if the tail needs to be tighter is this
-# cadence, not the batch size, which is capped by what one invocation can do.
+# artists and one second between release-page fetches, and stops starting them nine minutes into
+# a fifteen-minute invocation. At the response times measured on 2026-08-07 that deadline allows
+# roughly 160 release pages per run, on top of one grid page per Bandcamp artist (~17 of a
+# 25-artist batch). Four runs is therefore on the order of 700 sequential Bandcamp requests a day,
+# with a hard ceiling of 1,300 if Bandcamp ever answers fast enough to reach the 300-fetch
+# backstop — around one request a minute averaged, and never more than one a second, against
+# robots-permitted paths.
+#
+# That was ~470/day until the detail cap was raised from 100, which had been rationing one
+# invocation's release-page reads across the whole batch and leaving the artists late in each
+# sweep unpriced. The extra cost is also self-limiting: a release page is re-read only every 30
+# days, so once the backlog drains the raised cap goes largely unspent and the steady state is
+# roughly 170 re-reads a day.
+#
+# The lever if the *artist* tail needs to be tighter is this cadence, not the batch size, which is
+# capped by what one invocation can do. Note the two are different problems — see the
+# SWEEP_BATCH_SIZE comment in api/functions/recatalog-sweep.ts.
 #
 # Safe to over-run. A duplicate invocation finds the same artists claimed and does nothing, so
 # re-running by hand is free.

--- a/api/functions/__tests__/catalog-detail-budget.test.ts
+++ b/api/functions/__tests__/catalog-detail-budget.test.ts
@@ -1,0 +1,345 @@
+// What stops the release-detail pass — and what must not.
+//
+// The pass reads one page per release for dates, formats and prices, so it is the one part of
+// ingest whose cost scales with catalogue size rather than artist count. Two limits bound it: a
+// wall-clock deadline (`DETAIL_BUDGET_MS`) and an invocation-wide fetch count
+// (`MAX_DETAIL_FETCHES_PER_RUN`). **The deadline is meant to be the one that fires.**
+//
+// It wasn't. The count sat at 100 and was shared across a batch of up to 25 artists — 4 fetches
+// each against a per-artist cap of 40 — so the artists late in every batch got no detail pass at
+// all, while the invocation finished in a 5-7 minute span against a 9-minute deadline. Measured
+// against production on 2026-08-07 that left 1,057 `release_sources` never read, 867 of them
+// Bandcamp. Once a source is read it gets a price 99%+ of the time, so nothing here was a parser
+// problem; it was rationing.
+//
+// These tests pin both halves: the count no longer rations a batch, and the deadline still stops
+// the pass. Pacing is asserted too, because the fix was to raise a *count* while leaving the
+// request *rate* alone — the reverse would be the outage this codebase has had before.
+//
+// Timers are faked so the 1s-per-request pacing costs no real seconds. That means Date.now()
+// advances by exactly the pacing the code asks for, which is what makes the deadline assertions
+// meaningful rather than incidental.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  claimArtistForCatalog: vi.fn(),
+  getArtistForCatalog: vi.fn(),
+  persistReleases: vi.fn(),
+  persistFaircampReleases: vi.fn(),
+  persistReleaseDetail: vi.fn(),
+  recordCatalogOutcome: vi.fn(),
+  attachDiscoveredSource: vi.fn(),
+  persistDiscogsReleases: vi.fn(),
+  persistJamcoopReleases: vi.fn(),
+  persistMirloReleases: vi.fn(),
+  persistMusicBrainzEnrichment: vi.fn(),
+  safeFetch: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  claimArtistForCatalog: mocks.claimArtistForCatalog,
+  getArtistForCatalog: mocks.getArtistForCatalog,
+  persistReleases: mocks.persistReleases,
+  persistFaircampReleases: mocks.persistFaircampReleases,
+  persistReleaseDetail: mocks.persistReleaseDetail,
+  recordCatalogOutcome: mocks.recordCatalogOutcome,
+  attachDiscoveredSource: mocks.attachDiscoveredSource,
+  persistDiscogsReleases: mocks.persistDiscogsReleases,
+  persistJamcoopReleases: mocks.persistJamcoopReleases,
+  persistMirloReleases: mocks.persistMirloReleases,
+  persistMusicBrainzEnrichment: mocks.persistMusicBrainzEnrichment,
+}));
+
+vi.mock('../safe-fetch', () => ({
+  safeFetch: mocks.safeFetch,
+  safeHostname: (u: string) => {
+    try {
+      return new URL(u).hostname;
+    } catch {
+      return '<unparseable>';
+    }
+  },
+}));
+
+// The parsers, the allowlist and the budget arithmetic are all real. Only the network and the
+// database are stubbed.
+import { handler } from '../catalog-artist-background';
+
+const SECRET = 'test-secret-value';
+
+/** A grid page carrying `count` releases, in the shape ingestBandcampGrid actually reads. */
+function gridPage(count: number): string {
+  const items = Array.from({ length: count }, (_, i) => {
+    const n = i + 1;
+    return `<li data-item-id="album-${n}" data-band-id="203035041" class="music-grid-item">
+      <a href="/album/release-${n}">
+        <div class="art"><img src="https://f4.bcbits.com/img/a105950668${n}_2.jpg" alt="" /></div>
+        <p class="title">Release ${n}</p>
+      </a>
+    </li>`;
+  });
+  return `<html><body><ol class="editable-grid music-grid">${items.join('\n')}</ol></body></html>`;
+}
+
+/** A release page with a real date and a real digital offer, as JSON-LD. */
+function detailPage(): string {
+  return `<html><head><script type="application/ld+json">${JSON.stringify({
+    '@type': 'MusicAlbum',
+    datePublished: '15 Sep 2023 00:00:00 GMT',
+    albumRelease: [
+      {
+        '@type': 'MusicRelease',
+        musicReleaseFormat: 'DigitalFormat',
+        offers: { '@type': 'Offer', price: 10, priceCurrency: 'USD', availability: 'InStock' },
+      },
+    ],
+  })}</script></head><body></body></html>`;
+}
+
+function ok(body: string, url: string) {
+  return { ok: true, status: 200, url, text: () => Promise.resolve(body) };
+}
+
+function artistIds(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `${i}`.padStart(8, '0') + '-1111-1111-1111-111111111111');
+}
+
+/** Bandcamp: every artist has `releasesEach` releases, none of them ever read. */
+function setUpBandcamp(releasesEach: number) {
+  mocks.claimArtistForCatalog.mockResolvedValue(true);
+  mocks.getArtistForCatalog.mockImplementation((id: string) =>
+    Promise.resolve({ id, name: `Artist ${id.slice(0, 4)}`, bandcampUrl: `https://a${id.slice(0, 4)}.bandcamp.com` })
+  );
+  mocks.persistReleases.mockImplementation((artistId: string, releases: { source: { url: string } }[]) =>
+    Promise.resolve(
+      releases.slice(0, releasesEach).map((r, i) => ({
+        releaseId: `${artistId}-rel-${i}`,
+        sourceId: `${artistId}-src-${i}`,
+        url: r.source.url,
+        detailCheckedAt: null,
+        curatedFields: [],
+      }))
+    )
+  );
+  mocks.persistReleaseDetail.mockResolvedValue(true);
+}
+
+/** How many of the recorded fetches were individual release pages rather than a grid. */
+function detailFetchCount(): number {
+  return mocks.safeFetch.mock.calls.filter(c => String(c[0]).includes('/album/')).length;
+}
+
+function post(body: unknown) {
+  return handler({ httpMethod: 'POST', headers: { authorization: `Bearer ${SECRET}` }, body: JSON.stringify(body) });
+}
+
+/** Run the handler to completion with timers faked, so pacing costs no real time. */
+async function runHandler(body: unknown) {
+  const promise = post(body);
+  await vi.runAllTimersAsync();
+  return promise;
+}
+
+const originalEnv = { ...process.env };
+let logs: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  process.env.INTERNAL_FUNCTION_SECRET = SECRET;
+  process.env.RELEASE_CATALOG_ENABLED = 'true';
+  process.env.URL = 'https://unstream.stream';
+
+  logs = [];
+  vi.spyOn(console, 'log').mockImplementation(m => void logs.push(String(m)));
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  // MusicBrainz enrichment runs for every artist. Declining it keeps these tests about the
+  // Bandcamp and Faircamp budgets, and matches what the pass does with an unreachable upstream.
+  mocks.fetch.mockResolvedValue({ ok: false, status: 503 } as Response);
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  process.env = { ...originalEnv };
+});
+
+describe('the detail pass is bounded by its deadline, not by a fetch count', () => {
+  // The regression test for the starvation. Three artists with 40 releases each is 120 due pages,
+  // above the old invocation-wide cap of 100 — so at 100 the third artist would be cut off
+  // partway, which is exactly what left whole artists' catalogues unpriced in production.
+  it('reads every due release across a batch that would have exceeded the old cap of 100', async () => {
+    setUpBandcamp(40);
+    mocks.safeFetch.mockImplementation((url: string) =>
+      Promise.resolve(url.includes('/album/') ? ok(detailPage(), url) : ok(gridPage(40), url))
+    );
+
+    const response = await runHandler({ artistIds: artistIds(3), trigger: 'scheduled' });
+
+    expect(response.statusCode).toBe(200);
+    expect(detailFetchCount()).toBe(120);
+    // Not merely "more than 100": every artist got a full pass, including the last one.
+    expect(mocks.persistReleaseDetail).toHaveBeenCalledTimes(120);
+    expect(logs.filter(l => l.includes('detail budget spent'))).toEqual([]);
+  });
+
+  // The deadline is the intended stopping condition, so it has to actually fire. Given a slow
+  // upstream, the pass must run out of time long before it runs out of count — and say so.
+  it('stops on the deadline when the upstream is slow, and names it', async () => {
+    setUpBandcamp(40);
+    // 5s per release page. With the 1s spacing that is 6s a fetch, so the 9-minute deadline
+    // allows roughly 90 — far short of both the 1,000 due and the 300-fetch backstop.
+    mocks.safeFetch.mockImplementation(async (url: string) => {
+      if (!url.includes('/album/')) return ok(gridPage(40), url);
+      await new Promise(resolve => setTimeout(resolve, 5_000));
+      return ok(detailPage(), url);
+    });
+
+    await runHandler({ artistIds: artistIds(25), trigger: 'scheduled' });
+
+    const stopped = logs.filter(l => l.includes('detail budget spent'));
+    expect(stopped.length).toBeGreaterThan(0);
+    expect(stopped.every(l => l.includes('(deadline)'))).toBe(true);
+    expect(detailFetchCount()).toBeLessThan(300);
+  });
+
+  // The backstop still exists. It is deliberately above what the deadline permits at real
+  // response times, so this only fires when the upstream answers instantly — but "high" must not
+  // have become "absent", or a pathologically fast run would be unbounded.
+  it('still refuses to exceed 300 fetches in one invocation', async () => {
+    setUpBandcamp(40);
+    mocks.safeFetch.mockImplementation((url: string) =>
+      Promise.resolve(url.includes('/album/') ? ok(detailPage(), url) : ok(gridPage(40), url))
+    );
+
+    // 25 artists x 40 releases = 1,000 due, with no latency at all to spend the deadline on.
+    await runHandler({ artistIds: artistIds(25), trigger: 'scheduled' });
+
+    expect(detailFetchCount()).toBe(300);
+    expect(logs.some(l => l.includes('detail budget spent (run-cap)'))).toBe(true);
+  });
+
+  // The fix raised a count and left the rate alone. That distinction is the whole safety
+  // argument — these are robots-permitted paths, but ~1 request/second is a deliberate courtesy
+  // and past outages here were self-inflicted by crawling harder than a host wanted.
+  it('still paces release-page requests about a second apart', async () => {
+    setUpBandcamp(10);
+    const at: number[] = [];
+    mocks.safeFetch.mockImplementation((url: string) => {
+      if (url.includes('/album/')) at.push(Date.now());
+      return Promise.resolve(url.includes('/album/') ? ok(detailPage(), url) : ok(gridPage(10), url));
+    });
+
+    await runHandler({ artistIds: artistIds(1), trigger: 'scheduled' });
+
+    expect(at.length).toBe(10);
+    const gaps = at.slice(1).map((t, i) => t - at[i]);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(1_000);
+  });
+});
+
+describe('Faircamp prices have their own allowance', () => {
+  /** Faircamp: `count` release links on the homepage, each with or without a purchase page. */
+  function setUpFaircamp(count: number, withPurchase: boolean) {
+    mocks.claimArtistForCatalog.mockResolvedValue(true);
+    mocks.getArtistForCatalog.mockImplementation((id: string) =>
+      Promise.resolve({ id, name: `Artist ${id.slice(0, 4)}`, faircampUrl: `https://music.a${id.slice(0, 4)}.example/` })
+    );
+    mocks.persistFaircampReleases.mockImplementation((artistId: string, releases: { externalUrl: string }[]) =>
+      Promise.resolve(
+        releases.map((r, i) => ({
+          releaseId: `${artistId}-rel-${i}`,
+          sourceId: `${artistId}-src-${i}`,
+          url: r.externalUrl,
+          detailCheckedAt: null,
+          curatedFields: [],
+        }))
+      )
+    );
+    mocks.persistReleaseDetail.mockResolvedValue(true);
+
+    const home = `<html><body>${Array.from(
+      { length: count },
+      (_, i) => `<div class="release"><a href="rel-${i + 1}/"><p>Release ${i + 1}</p></a></div>`
+    ).join('')}</body></html>`;
+
+    mocks.safeFetch.mockImplementation((url: string) => {
+      if (url.includes('/purchase/')) {
+        return Promise.resolve(ok('<html><body><span>7.50 EUR</span></body></html>', url));
+      }
+      if (/\/rel-\d+\/$/.test(url)) {
+        const purchase = withPurchase ? `<a href="purchase/tok${url.match(/rel-(\d+)/)?.[1]}/">Buy</a>` : '';
+        return Promise.resolve(
+          ok(
+            `<html><head><meta property="og:title" content="Release" /></head><body>${purchase}</body></html>`,
+            url
+          )
+        );
+      }
+      return Promise.resolve(ok(home, url));
+    });
+  }
+
+  const purchaseFetches = () => mocks.safeFetch.mock.calls.filter(c => String(c[0]).includes('/purchase/')).length;
+  const releasePageFetches = () => mocks.safeFetch.mock.calls.filter(c => /\/rel-\d+\/$/.test(String(c[0]))).length;
+
+  // The structural fix. Purchase pages used to share the release-page budget and were fetched
+  // after it, so prices were last in line for an allowance the release pages had already spent:
+  // the two counts could never sum above 150. Now each has its own pool, so they can.
+  it('reads prices after the release-page budget is exhausted', async () => {
+    setUpFaircamp(30, true);
+
+    // Six artists x (1 homepage + 30 release pages) is 186 release-page fetches against a budget
+    // of 150, so that budget genuinely runs out inside this batch.
+    await runHandler({ artistIds: artistIds(6), trigger: 'scheduled' });
+
+    expect(releasePageFetches()).toBeGreaterThan(100);
+    expect(purchaseFetches()).toBeGreaterThan(0);
+    // The decisive assertion: under one shared budget this sum could not exceed 150.
+    expect(releasePageFetches() + purchaseFetches()).toBeGreaterThan(150);
+    // Each pool still holds its own ceiling.
+    expect(releasePageFetches()).toBeLessThanOrEqual(150);
+    expect(purchaseFetches()).toBeLessThanOrEqual(120);
+  });
+
+  // A free, unlisted or code-unlocked Faircamp release has no purchase page at all, so there is
+  // no price to read and never will be. Recording that settled fact is what stops it being filed
+  // under "we haven't looked yet" — the conflation that made 73+ of these read as starvation when
+  // the catalogue was cross-tabbed. Measured 2026-08-07: whole instances are like this.
+  it('records a release with no purchase page as checked, without fetching one', async () => {
+    setUpFaircamp(3, false);
+
+    await runHandler({ artistIds: artistIds(1), trigger: 'scheduled' });
+
+    expect(purchaseFetches()).toBe(0);
+    expect(mocks.persistReleaseDetail).toHaveBeenCalledTimes(3);
+    // No offers and no status: the call exists only to stamp detail_checked_at. Writing a price
+    // of zero here would advertise "name your price" terms the artist never set.
+    for (const [, detail] of mocks.persistReleaseDetail.mock.calls) {
+      expect(detail).toMatchObject({ offers: [], status: null });
+    }
+  });
+
+  // The other side of that: an unreadable purchase page is *not* a settled fact. It must stay
+  // unstamped so a later run retries, which is the "never cache uncertainty" rule this codebase
+  // has been bitten by more than any other.
+  it('leaves a release unstamped when its purchase page cannot be read', async () => {
+    setUpFaircamp(2, true);
+    const inner = mocks.safeFetch.getMockImplementation()!;
+    mocks.safeFetch.mockImplementation((url: string, ...rest: unknown[]) =>
+      String(url).includes('/purchase/')
+        ? Promise.resolve({ ok: false, status: 502, url: String(url), text: () => Promise.resolve('') })
+        : (inner as (u: string, ...r: unknown[]) => Promise<unknown>)(String(url), ...rest)
+    );
+
+    await runHandler({ artistIds: artistIds(1), trigger: 'scheduled' });
+
+    expect(purchaseFetches()).toBe(2);
+    expect(mocks.persistReleaseDetail).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -76,19 +76,55 @@ const DELAY_BETWEEN_ARTISTS_MS = 1_000;
  * permanently unread. 40 covers every catalogue measured so far — 22 for Kid Lightbulbs, 16 for
  * Sufjan Stevens, 33 for the largest live Mirlo artist — and costs 40 paced seconds for one
  * artist. The invocation-wide cap below still bounds a whole batch.
+ *
+ * Left alone deliberately when that invocation-wide cap was raised: measured 2026-08-07, the
+ * largest catalogue in the database is 25 releases (p90 19, median 7), so this has never been the
+ * binding constraint and raising it would change nothing. It stays as headroom for a discography
+ * larger than anything seen yet.
  */
 const MAX_DETAIL_FETCHES_PER_ARTIST = 40;
 
-/** Invocation-wide, so a 25-artist batch can't multiply into hundreds of requests. */
-const MAX_DETAIL_FETCHES_PER_RUN = 100;
+/**
+ * Invocation-wide backstop, shared across the batch. **`DETAIL_BUDGET_MS` below is what is meant
+ * to stop this pass; this number only exists so a pathologically fast run can't sprint.**
+ *
+ * It was 100, which inverted that: measured against production on 2026-08-07, a 25-artist batch
+ * spent ~2.05s per detail fetch (1s spacing plus ~1s of Bandcamp response) and finished the whole
+ * invocation in a 5-7 minute span — nowhere near the 9-minute deadline. It stopped because it ran
+ * out of *count*. Averaged over `MAX_ARTISTS_PER_RUN` that was 4 fetches per artist against a
+ * per-artist cap of 40, so the artists late in each batch got no detail pass at all: 1,057
+ * `release_sources` had never been read, 867 of them Bandcamp, across 141 artists. Once a source
+ * is read it gets a price 99%+ of the time, so this was never a parser problem.
+ *
+ * 300 is a backstop rather than a target. The 9-minute deadline leaves ~325s for detail work once
+ * the batch's fixed overhead is paid (~215s measured: inter-artist sleeps, grid fetches,
+ * MusicBrainz's mandatory ~1/sec, Discogs at 2.6s), which is ~158 fetches at the measured pace —
+ * so the deadline binds first, as intended. 300 sits above that and still well below the 540 that
+ * `DELAY_BETWEEN_DETAIL_FETCHES_MS` alone would permit in 9 minutes, so a run where Bandcamp
+ * answers unusually fast is bounded instead of unbounded.
+ *
+ * Raising a count under a fixed deadline cannot extend the invocation: the pass stops *starting*
+ * fetches at the deadline whatever this says. The rate is untouched — see the delay below.
+ */
+const MAX_DETAIL_FETCHES_PER_RUN = 300;
 
-/** Roughly one request per second sustained — far below what one browser page load costs. */
+/**
+ * Roughly one request per second sustained — far below what one browser page load costs.
+ *
+ * This is the courtesy, and it is deliberately **not** the thing to turn up for throughput. These
+ * paths are robots-permitted, but several outages here were self-inflicted by crawling harder than
+ * a host wanted; raising the count above is the safe axis, raising this rate is not.
+ */
 const DELAY_BETWEEN_DETAIL_FETCHES_MS = 1_000;
 
 /**
  * Stop starting detail fetches this long into the invocation. Netlify background functions get
  * 15 minutes; leaving headroom means a run ends by finishing rather than by being killed
  * mid-write.
+ *
+ * This — not `MAX_DETAIL_FETCHES_PER_RUN` — is the intended stopping condition, so the log line
+ * in `catalogDetails` says which of the two actually fired. A run that reports the count is a run
+ * whose ceiling has drifted back into being arbitrary.
  */
 const DETAIL_BUDGET_MS = 9 * 60_000;
 
@@ -150,19 +186,53 @@ const ENRICHMENT_CUTOFF_MS = 13 * 60_000;
 /** One request per candidate release page, spaced out rather than in a burst. */
 const DELAY_BETWEEN_FAIRCAMP_FETCHES_MS = 1_000;
 
-/** Bounds cost for an artist with an unusually large Faircamp archive. */
-const MAX_FAIRCAMP_RELEASES_PER_ARTIST = 20;
+/**
+ * Bounds cost for an artist with an unusually large Faircamp archive.
+ *
+ * Raised from 20 once the live instances were counted (2026-08-07): music.kidlightbulbs.com offers
+ * 23 release candidates and www.willchatham.com at least 30, so at 20 the tail of both sites could
+ * never be reached at all — not "reached late", never.
+ *
+ * 30 rather than more because `ingestFaircampHomeLinks` stops at `FAIRCAMP_MAX_CANDIDATES`, which
+ * is also 30: a larger number here would be dead, since the parser never hands over a 31st
+ * candidate to spend it on. Keep the two together if either moves.
+ */
+const MAX_FAIRCAMP_RELEASES_PER_ARTIST = 30;
 
 /**
- * Invocation-wide, across every artist in the batch: homepage, release pages and purchase
- * pages combined. A release costs up to two requests, not one, because Faircamp keeps the price
- * on a separate purchase page — hence the headroom over the old ceiling of 100.
+ * Invocation-wide, across every artist in the batch: homepage and release pages.
+ *
+ * A Faircamp release costs up to **two** requests, not one, because Faircamp keeps the price on a
+ * separate purchase page — which is why this ceiling was raised from 100 to 150 when prices were
+ * first read, and why there are now two budgets rather than one.
+ *
+ * Purchase pages are no longer counted here; they have their own allowance below. They used to
+ * share this one, and because they are fetched *after* the release-page pass they inherited
+ * whatever was left of it, which made prices structurally last in line for a budget the release
+ * pages had already spent.
  */
 const MAX_FAIRCAMP_FETCHES_PER_RUN = 150;
+
+/**
+ * Invocation-wide allowance for purchase pages — the second of a release's two requests — held
+ * separately from the release-page budget above so a large archive can't consume the prices' share
+ * before the prices are read.
+ *
+ * Sized off the same measurement: ~0.9 Faircamp artists land in a 25-artist batch, and one artist
+ * needs at most `MAX_FAIRCAMP_RELEASES_PER_ARTIST` purchase pages, so this covers roughly four
+ * Faircamp-heavy artists arriving in one batch — which the sweep's "never catalogued first"
+ * ordering can genuinely do, since artists added together sort together.
+ *
+ * Unlike Bandcamp there is no central rate limit being respected here: every Faircamp instance is a
+ * different self-hosted domain, so this bounds pages-per-artist rather than a shared API's tolerance.
+ */
+const MAX_FAIRCAMP_PRICE_FETCHES_PER_RUN = 120;
 
 interface FaircampBudget {
   fetchesLeft: number;
   deadline: number;
+  /** Purchase pages only. See MAX_FAIRCAMP_PRICE_FETCHES_PER_RUN. */
+  priceFetchesLeft: number;
 }
 
 // --- Jam.coop budgets ----------------------------------------------------------
@@ -278,6 +348,7 @@ export async function handler(event: {
   const faircampBudget: FaircampBudget = {
     fetchesLeft: MAX_FAIRCAMP_FETCHES_PER_RUN,
     deadline: Date.now() + ENRICHMENT_CUTOFF_MS,
+    priceFetchesLeft: MAX_FAIRCAMP_PRICE_FETCHES_PER_RUN,
   };
   const jamcoopBudget: JamcoopBudget = {
     fetchesLeft: MAX_JAMCOOP_FETCHES_PER_RUN,
@@ -684,6 +755,10 @@ async function catalogFaircamp(artistId: string, faircampUrl: string, budget: Fa
  * doesn't exist until `persistFaircampReleases` has created it. Same 30-day rule as Bandcamp's
  * detail pass, so a re-catalog of an unchanged Faircamp site costs nothing extra.
  *
+ * Spends `priceFetchesLeft`, not the release-page budget: running after that pass used to mean
+ * inheriting its remainder, so on a large archive the prices were rationed by how many release
+ * pages had already been read.
+ *
  * Never throws — a purchase page that won't load leaves the release with no price, which is what
  * it already had.
  */
@@ -693,15 +768,32 @@ async function catalogFaircampPrices(
   budget: FaircampBudget
 ): Promise<void> {
   for (const release of written) {
-    const purchaseUrl = purchaseUrls.get(release.url);
-    if (!purchaseUrl || !needsDetail(release)) continue;
+    if (!needsDetail(release)) continue;
 
-    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
-      console.log('[catalog] faircamp budget spent before prices were read');
+    const purchaseUrl = purchaseUrls.get(release.url);
+    if (!purchaseUrl) {
+      // Not a failure and not a gap: Faircamp emits no purchase page for a free, unlisted or
+      // code-unlocked release, so there is no price to read and there never will be. Recorded
+      // rather than skipped, because leaving `detail_checked_at` null files a settled fact under
+      // "we haven't looked yet" — which is what made 73+ of these look like budget starvation
+      // when the catalogue was cross-tabbed. Measured 2026-08-07: whole instances are like this
+      // (music.bedlamsteps.uk, www.willchatham.com, music.lminiero.it, music.axwax.eu,
+      // music.futzle.com). The 30-day rule still brings it back round if the artist adds one.
+      await persistReleaseDetail(release, {
+        releaseDate: null,
+        datePrecision: 'unknown',
+        status: null,
+        offers: [],
+      });
+      continue;
+    }
+
+    if (budget.priceFetchesLeft <= 0 || Date.now() > budget.deadline) {
+      console.log('[catalog] faircamp price budget spent before prices were read');
       return;
     }
     await sleep(DELAY_BETWEEN_FAIRCAMP_FETCHES_MS);
-    budget.fetchesLeft--;
+    budget.priceFetchesLeft--;
 
     try {
       const response = await safeFetch(purchaseUrl, 10_000);
@@ -1022,11 +1114,20 @@ async function catalogDetails(
   let attempted = 0;
 
   for (const release of due) {
-    if (budget.fetchesLeft <= 0 || Date.now() > budget.deadline) {
+    const outOfFetches = budget.fetchesLeft <= 0;
+    const pastDeadline = Date.now() > budget.deadline;
+    if (outOfFetches || pastDeadline) {
       // Said out loud rather than returning quietly: a silent cap reads as "we checked
       // everything and there were no prices", which is the wrong conclusion to hand anyone
       // looking at why a release page is bare.
-      console.log(`[catalog] detail budget spent — ${due.length - attempted} release(s) left for a later run`);
+      //
+      // Which limit fired is the useful half. The deadline is the intended stopping condition;
+      // `run-cap` means MAX_DETAIL_FETCHES_PER_RUN has drifted back below what the deadline
+      // allows and is rationing the batch again, which is the bug this pass had for months.
+      const limit = pastDeadline ? 'deadline' : 'run-cap';
+      console.log(
+        `[catalog] detail budget spent (${limit}) — ${due.length - attempted} release(s) left for a later run`
+      );
       break;
     }
 

--- a/api/functions/recatalog-sweep.ts
+++ b/api/functions/recatalog-sweep.ts
@@ -47,6 +47,13 @@ import { Sentry } from '../lib/sentry';
  * artists daily: saved artists (single figures) come round as soon as their 7-day cooldown
  * expires, and the ~2,500-artist tail rotates about monthly, which is the right shape for
  * artist-page freshness. Raise the cron frequency if the tail needs to be tighter.
+ *
+ * That "cadence, not this number" rule is about **artists reached**, and it still holds. It did
+ * not hold for *releases priced*, which is a different quantity and was starved somewhere else
+ * entirely: `MAX_DETAIL_FETCHES_PER_RUN` rationed one invocation's release-page reads across the
+ * whole batch, so the artists late in every sweep were reached and then left unpriced. Raising the
+ * cadence would not have fixed that — it would have re-reached the same artists sooner and starved
+ * them again, at four times the request rate. The fix belonged at that cap; see its comment.
  */
 const SWEEP_BATCH_SIZE = 25;
 


### PR DESCRIPTION
~1,050 release sources in the catalogue have no price. This is why.

## What was actually happening

`MAX_DETAIL_FETCHES_PER_RUN = 100` is invocation-wide and shared across a batch of up to `MAX_ARTISTS_PER_RUN = 25` — an average of **4** release-page reads per artist, against a per-artist cap of **40**. So the artists late in every sweep were reached and then left unpriced.

Meanwhile the invocation was nowhere near its own deadline. Reconstructing per-invocation throughput from `release_catalog_state` (clustering artists by `last_attempted_at`), the last 20 scheduled sweeps show a **median of 102 releases detailed in a 5–7 minute span**, against a 9-minute detail deadline and a 15-minute Netlify ceiling. It stopped because it ran out of *count*, not time — we were using about two thirds of the wall clock already allotted.

Cross-tabbing every `release_sources` row by "has `detail_checked_at`" × "has any `release_offers`" (production, 2026-08-07):

| platform | never read | read, no price | read, priced |
|---|---|---|---|
| bandcamp | **867** | 31 | 3,947 |
| faircamp | **121** | 0 | 55 |
| discogs | **43** | 0 | 796 |
| mirlo | 7 | 0 | 32 |
| jamcoop | 0 | 0 | 136 |

Once a source is read it gets a price 99%+ of the time, so nothing here is a parser problem and no re-scrape of already-read pages is needed. The 988 unread bandcamp+faircamp sources sit on just 141 artists, mean 7 each — and the largest catalogue in the whole database is 25 releases, so the per-artist cap of 40 has never once been the binding constraint. It is left alone.

## The change

**Bandcamp: `MAX_DETAIL_FETCHES_PER_RUN` 100 → 300**, so the 9-minute deadline is what stops the pass — which is what it was always meant to be. 300 is a backstop, not a target: the deadline leaves ~325s for detail work once the batch's fixed overhead is paid (~215s of inter-artist sleeps, grid fetches, MusicBrainz's mandatory ~1/sec, Discogs at 2.6s), which is ~158 fetches at the measured pace. 300 sits above that and well below the 540 the 1s spacing alone would permit in 9 minutes.

**The rate is untouched.** Raising a *count* under a fixed deadline cannot extend the invocation or the request rate — the pass stops *starting* fetches at the deadline whatever the count says. Pacing stays at ~1 request/second and there is a test that fails if it doesn't. Raising the rate would be the unsafe axis and isn't done here.

**The log line now names which limit fired** (`deadline` vs `run-cap`), so a future drift back into rationing is visible instead of silent.

**Faircamp: purchase pages get their own allowance.** They were fetched *after* the release-page pass and inherited whatever was left of the shared 150, so prices were structurally last in line for a budget the release pages had already spent. Per-artist release cap 20 → 30 to match `FAIRCAMP_MAX_CANDIDATES` in the parser (at 20, the tail of a 23- or 30-release site could never be reached at all — not reached late, never).

## Worth flagging: Faircamp's 121 is mostly *not* starvation

I probed the fully-unread instances live before changing their budgets, and the numbers don't support the budget story. Five of five fully-unread sites emit **no purchase page at all** on their release pages — `music.bedlamsteps.uk`, `www.willchatham.com`, `music.lminiero.it`, `music.axwax.eu`, `music.futzle.com` — while both *partially*-read sites do have one. Faircamp emits no purchase page for a free, unlisted or code-unlocked release, so for ~73 of those 121 sources there is no price to read and never will be. Two more sites (`www.base.at`, `sknob.fr`, ~32 sources) now return zero release candidates from their homepage at all, which is separate markup drift and out of scope here.

Only ~13 sources — `music.kidlightbulbs.com` and `futurecabaret.com` — are the genuinely budget-shaped slice. The budget split above is still right, but it will not move 121.

So this PR also **records the no-purchase-page case as checked**. Leaving `detail_checked_at` null filed a settled fact under "we haven't looked yet", and that conflation is exactly what made these read as starvation in the cross-tab. An unreadable purchase page is still left unstamped for retry — "we couldn't read it" and "there is nothing to read" are different claims, and only the second is cacheable.

## What this costs the sites we crawl

Stated explicitly so it's reviewable:

| | before | after |
|---|---|---|
| Bandcamp release pages per invocation | 100 (count-bound) | ~160 (deadline-bound), 300 hard ceiling |
| Bandcamp requests/day, 4 scheduled sweeps | ~470 | **~700**, worst case **1,300** |
| sustained request rate | ~1/sec, never faster | unchanged |

Worst case 1,300/day is under one request a minute averaged, and never more than one a second instantaneously, against robots-permitted paths.

The extra cost is also self-limiting: a release page is re-read only every 30 days, so once the backlog drains the raised cap goes largely unspent — steady state is roughly 170 re-reads a day, which the old 470/day already covered. The spend is the backlog, not a permanent increase.

## Why not the cron cadence

`recatalog-sweep.ts` argues "the lever for total throughput is the cron cadence, not this number", and that's still true — for **artists reached**. It was not true for **releases priced**, which is a different quantity starved somewhere else entirely. Raising the cadence would have re-reached the same artists sooner and starved them again, at four times the request rate. The cadence stays at every 6 hours; I've recorded the distinction in both files so the next person doesn't have to re-derive it.

## Verification

- `npm run lint` — clean for these files (the repo's 71-problem baseline is pre-existing and untouched)
- `npm run test:api` — 965 passing, including 7 new tests in `catalog-detail-budget.test.ts`
- `npm run typecheck:api` — clean (`catalog-artist-background.ts` is in the include list)
- `npm run ingest:try -- kidlightbulbs --detail=3` — real fetch/parse/map path, prices read correctly
- Every new test was checked for teeth by reverting each constant and confirming the matching failure

The tests drive the real handler with real parsers and the real allowlist, faking only the network, the database and the clock — so the budget arithmetic and pacing run for real.

**Heads up, unrelated:** `apps/web/tests/unit/RichArtistProfile.test.tsx` ("renders the payout percent on each pill") fails on `main` too — verified by checking main out clean. Since `npm run build` runs the unit tests, main's build is currently red independently of this PR. Not touched here.

## After deploy

Re-run the cross-tab in a few days; the number that matters is **never read**, not "no price". The drain is gradual by design — a budget change only takes effect for artists whose 7-day cooldown has expired, and 796 of the 2,672-artist pool are inside it right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)