### PR TITLE
Stop a long release title scrolling the artist page sideways

### DIFF
--- a/apps/web/src/components/ReleasesSection.tsx
+++ b/apps/web/src/components/ReleasesSection.tsx
@@ -157,10 +157,14 @@ function ReleaseRow({ release, artistSlug }: { release: Release; artistSlug: str
   // itself, so the platform a fan sees leading the row is also the one the price came from.
   const platforms = orderedSourcePlatforms(release.sources);
 
+  // `min-w-0` on the row itself, not only on the text column inside it. This anchor is a grid
+  // item, and a grid item's automatic minimum size is its content — the title's `truncate` sets
+  // `white-space: nowrap`, so a long title made the row as wide as its own text and pushed the
+  // whole page sideways: 569px of scroll in a 375px viewport before this class.
   return (
     <a
       href={`/a/${encodeURIComponent(artistSlug)}/${encodeURIComponent(release.slug)}`}
-      className="flex items-center gap-3 px-3 py-2 rounded-xl border border-border hover:bg-bg-hover transition-colors"
+      className="flex items-center gap-3 px-3 py-2 rounded-xl border border-border hover:bg-bg-hover transition-colors min-w-0"
     >
       {release.artworkUrl ? (
         <img

--- a/apps/web/tests/unit/ReleasesSection.test.tsx
+++ b/apps/web/tests/unit/ReleasesSection.test.tsx
@@ -166,6 +166,19 @@ describe('ReleasesSection', () => {
     show([release()], 1);
     expect(screen.queryByText(/more$/)).toBeNull();
   });
+
+  // Measured in a real browser at a 375px viewport: without `min-w-0` on the row anchor the
+  // document's scrollWidth was 569px against a 343px grid, so the whole artist page scrolled
+  // sideways on a phone. The row is a grid item, and a grid item's automatic minimum size is its
+  // content — the title's `truncate` sets `white-space: nowrap`, so a long title sized the row to
+  // its own text. `min-w-0` on the inner text column is not enough; it has to be on the item.
+  //
+  // Asserted as a class because jsdom does no layout and reports scrollWidth as 0 either way.
+  it('lets a long title shrink the row rather than widening the page', () => {
+    show([release({ title: 'A Wilderness of Mirrors and Other Extremely Long Album Titles' })]);
+    const row = screen.getByRole('link', { name: /Wilderness/ });
+    expect(row.className.split(/\s+/)).toContain('min-w-0');
+  });
 });
 
 describe('release type label', () => {


### PR DESCRIPTION
Follow-up to the same defect fixed in `RecentReleasesSection` (#421). `ReleasesSection` — the release list on `/a/:slug` — has structurally identical markup and the same bug.

## What was wrong

The release rows are grid items inside `grid gap-2 sm:grid-cols-2`. A grid item's automatic minimum size is its content, and the title carries `truncate` (which sets `white-space: nowrap`), so a long title sized the whole row to its own text rather than shrinking inside its track. `min-w-0` was already on the inner text column; that isn't enough — it has to be on the grid item itself.

## Measured, not eyeballed

Rendered through a throwaway Vite harness in the artist page's real container chrome (`main.px-4` → `max-w-4xl mx-auto`), inside fixed-width iframes so each one is genuinely its own viewport (`resize_window` doesn't change `documentElement.clientWidth` in the browser pane). Fixture: a long release title plus a full meta line (`Album · 1 June 2024 · from $28 · ≈$22.40–$23.80 to artist`).

| viewport | | `clientWidth` | `scrollWidth` | grid track | row width |
|---|---|---|---|---|---|
| 375px | before | 375 | **569** | 343 | **553** |
| 375px | after | 375 | 375 | 343 | 343 |
| 414px | before | 414 | **569** | 382 | 553 |
| 414px | after | 414 | 414 | 382 | 382 |

Titles still truncate with an ellipsis and the meta line wraps as before; only the sideways page scroll is gone.

## Test

A regression test in `ReleasesSection.test.tsx` asserts the class, since jsdom does no layout and reports `scrollWidth` as 0 either way. Verified it has teeth: removing `min-w-0` from the component fails it.

The harness files were deleted; only the component and its test are in the diff.

## Checks

- `npx vitest run apps/web/tests/unit/ReleasesSection.test.tsx` — 17 passed
- `npm run test:unit` — 641 passed, 1 failed: `RichArtistProfile › renders the payout percent on each pill`, which fails identically on `main` with this branch stashed. Pre-existing, not from this change.
- `npm run lint` — 71 problems, the repo's existing baseline; none in the files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)