### PR TITLE
Link saved artists to the artists table, and see the ones already unlinked

### DIFF
--- a/api/functions/__tests__/saved-artist-resolution.test.ts
+++ b/api/functions/__tests__/saved-artist-resolution.test.ts
@@ -1,0 +1,226 @@
+// Which saved artists a fan's feed can actually see.
+//
+// The bug this guards, found 2026-08-07 the hour /dashboard's Recent Releases shipped: the feed
+// keyed on `saved_artists.artist_id` alone, and **25 of 37 live rows have it NULL** because a save
+// made from a search result sent a synthetic key (`rodneyowl`, `qobuz-pearljam`, `nameonly-…`)
+// that matched no artists row. Two thirds of every fan's saved list was invisible to their feed,
+// their calendar and their dashboard — and it looked exactly like "those artists have nothing new".
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// recatalog-sweep-selection.test.ts, so the real query body runs — the `deleted` filter and the
+// fallback chain are the things under test, and a module mock would assert my own fake.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Filter { kind: 'eq' | 'in' | 'gte' | 'order' | 'limit'; column?: string; value?: unknown }
+interface Query { table: string; columns: string; filters: Filter[] }
+
+const queries: Query[] = [];
+
+const tables: Record<string, Record<string, unknown>[]> = {
+  saved_artists: [],
+  artists: [],
+  artist_slug_aliases: [],
+  releases: [],
+};
+
+/** Set to a table name to make that table's read fail. */
+let failingTable: string | null = null;
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          const query: Query = { table, columns, filters: [] };
+          queries.push(query);
+
+          const builder = {
+            eq(column: string, value: unknown) { query.filters.push({ kind: 'eq', column, value }); return builder; },
+            in(column: string, value: unknown) { query.filters.push({ kind: 'in', column, value }); return builder; },
+            gte(column: string, value: unknown) { query.filters.push({ kind: 'gte', column, value }); return builder; },
+            order(column: string, value: unknown) { query.filters.push({ kind: 'order', column, value }); return builder; },
+            limit(value: number) { query.filters.push({ kind: 'limit', value }); return builder; },
+            then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
+              if (failingTable === table) {
+                return Promise.resolve({ data: null, error: { message: 'connection reset' } }).then(resolve, reject);
+              }
+              let rows = tables[table] ?? [];
+              for (const f of query.filters) {
+                if (f.kind === 'eq') rows = rows.filter(r => r[f.column as string] === f.value);
+                if (f.kind === 'in') {
+                  const wanted = new Set(f.value as unknown[]);
+                  rows = rows.filter(r => wanted.has(r[f.column as string]));
+                }
+              }
+              return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getFeedReleasesForUser } = await import('../db');
+
+const USER = 'user-1';
+
+function savedRow(over: Record<string, unknown> = {}) {
+  return { artist_id: null, artist_slug: null, artist_name: null, user_id: USER, deleted: false, ...over };
+}
+
+/** A release row shaped as FEED_SELECT returns it. */
+function releaseRow(artistId: string, title = 'Loneliness Is Contagious') {
+  return {
+    artist_id: artistId,
+    slug: 'loneliness-is-contagious',
+    title,
+    release_date: '2026-08-06',
+    date_precision: 'day',
+    artwork_url: null,
+    is_hidden: false,
+    needs_review: false,
+    artists: { name: 'Rodney Owl', slug: 'rodney-owl' },
+    release_sources: [],
+  };
+}
+
+beforeEach(() => {
+  queries.length = 0;
+  failingTable = null;
+  for (const key of Object.keys(tables)) tables[key] = [];
+});
+
+describe('getFeedReleasesForUser — resolving who is saved', () => {
+  it('finds an artist saved with a linked artist_id', async () => {
+    tables.saved_artists = [savedRow({ artist_id: 'a1', artist_slug: 'rodney-owl' })];
+    tables.releases = [releaseRow('a1')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out.map(r => r.title)).toEqual(['Loneliness Is Contagious']);
+  });
+
+  // The actual Rodney Owl bug: saved from a search result, so artist_id is NULL and the stored
+  // slug is the synthetic key. Before the fix this returned [].
+  it('resolves a row whose artist_id is NULL via its artist_slug', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'rodney-owl' })];
+    tables.artists = [{ id: 'a1', slug: 'rodney-owl', name: 'Rodney Owl' }];
+    tables.releases = [releaseRow('a1')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out.map(r => r.title)).toEqual(['Loneliness Is Contagious']);
+  });
+
+  // A slug retired by the accent-folding reslug (#410) is the other way a stored slug stops
+  // matching — 44 aliases exist in production.
+  it('resolves a retired slug through artist_slug_aliases', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'beyonc' })];
+    tables.artists = [{ id: 'a2', slug: 'beyonce', name: 'Beyonce' }];
+    tables.artist_slug_aliases = [{ alias: 'beyonc', artist_id: 'a2' }];
+    tables.releases = [releaseRow('a2', 'Renaissance')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out.map(r => r.title)).toEqual(['Renaissance']);
+  });
+
+  // What the production rows actually look like: a squashed name, no hyphen, matching no slug
+  // and no alias. Re-deriving artistSlug(artist_name) is the only thing that recovers them.
+  it('resolves a synthetic key by re-deriving the slug from the saved name', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'rodneyowl', artist_name: 'Rodney Owl' })];
+    tables.artists = [{ id: 'a1', slug: 'rodney-owl', name: 'Rodney Owl' }];
+    tables.releases = [releaseRow('a1')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out.map(r => r.title)).toEqual(['Loneliness Is Contagious']);
+  });
+
+  it('resolves a platform-prefixed key the same way', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'qobuz-robertlogan', artist_name: 'Robert Logan' })];
+    tables.artists = [{ id: 'a4', slug: 'robert-logan', name: 'Robert Logan' }];
+    tables.releases = [releaseRow('a4', 'Cognition')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out.map(r => r.title)).toEqual(['Cognition']);
+  });
+
+  // A name is a far weaker key than a slug, so a name-derived hit has to prove itself. Putting an
+  // unrelated artist's record in someone's calendar is worse than showing nothing.
+  it('refuses a name-derived match whose artist name does not agree', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'nameonly-blixbyrd', artist_name: 'Music' })];
+    // A real artist whose vanity slug happens to be 'music' but who is called something else.
+    tables.artists = [{ id: 'a5', slug: 'music', name: 'The Music Tapes' }];
+    tables.releases = [releaseRow('a5')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toEqual([]);
+  });
+
+  it('leaves a genuinely unresolvable key out rather than guessing', async () => {
+    tables.saved_artists = [savedRow({ artist_id: null, artist_slug: 'qobuz-pearljam', artist_name: 'Qobuz Pearljam' })];
+    tables.artists = [{ id: 'a3', slug: 'pearl-jam', name: 'Pearl Jam' }];
+    tables.releases = [releaseRow('a3')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toEqual([]);
+  });
+
+  // Tombstones: saved_artists keeps a row when you unsave (migration 017). Without the filter an
+  // artist you removed keeps feeding your calendar forever.
+  it('ignores an unsaved (tombstoned) artist', async () => {
+    tables.saved_artists = [savedRow({ artist_id: 'a1', artist_slug: 'rodney-owl', deleted: true })];
+    tables.releases = [releaseRow('a1')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toEqual([]);
+    const savedQuery = queries.find(q => q.table === 'saved_artists');
+    expect(savedQuery?.filters).toContainEqual({ kind: 'eq', column: 'deleted', value: false });
+  });
+
+  it('does not double-count an artist saved twice under two keys', async () => {
+    tables.saved_artists = [
+      savedRow({ artist_id: 'a1', artist_slug: 'bird-streets' }),
+      savedRow({ artist_id: null, artist_slug: 'birdstreets' }),
+    ];
+    tables.artists = [{ id: 'a1', slug: 'birdstreets', name: 'Bird Streets' }];
+    tables.releases = [releaseRow('a1')];
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toHaveLength(1);
+    const releaseQuery = queries.find(q => q.table === 'releases');
+    const idFilter = releaseQuery?.filters.find(f => f.kind === 'in');
+    expect(idFilter?.value).toEqual(['a1']);
+  });
+
+  it('still returns the linked artists when slug resolution fails', async () => {
+    tables.saved_artists = [
+      savedRow({ artist_id: 'a1', artist_slug: 'rodney-owl' }),
+      savedRow({ artist_id: null, artist_slug: 'someone-else' }),
+    ];
+    tables.releases = [releaseRow('a1')];
+    failingTable = 'artists';
+
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toHaveLength(1);
+  });
+
+  it('returns nothing when the saved-artists read itself fails', async () => {
+    tables.saved_artists = [savedRow({ artist_id: 'a1' })];
+    tables.releases = [releaseRow('a1')];
+    failingTable = 'saved_artists';
+
+    expect(await getFeedReleasesForUser(USER)).toEqual([]);
+  });
+
+  it('skips the release query entirely when nothing is saved', async () => {
+    const out = await getFeedReleasesForUser(USER);
+    expect(out).toEqual([]);
+    expect(queries.find(q => q.table === 'releases')).toBeUndefined();
+  });
+});

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -4279,6 +4279,124 @@ function feedSince(now: Date): string {
 }
 
 /**
+ * Resolve the artists this user has saved, to artist-table ids.
+ *
+ * **`saved_artists.artist_id` alone is not enough, and assuming it was is how the dashboard
+ * shipped empty.** The column is populated only when the save request's slug matched an artists
+ * row at the time; a save made from a search result used to send a synthetic key
+ * (`rodneyowl`, `qobuz-pearljam`, `nameonly-…`), which matched nothing, so the row was written
+ * with `artist_id: null`. Measured 2026-08-07: **25 of 37 live rows**. Every feature keyed on
+ * `artist_id` — this feed, the /dashboard shortlist — was silently blind to two thirds of
+ * everyone's saved artists.
+ *
+ * The client that wrote those keys is fixed, but the rows are already in the database and a
+ * fan's calendar should not stay wrong until a backfill runs. So `artist_slug` is resolved as a
+ * fallback here, through the same alias table the artist page uses, since a slug retired by the
+ * accent-folding reslug (#410) is the other way a stored slug stops matching.
+ *
+ * `deleted = false` matters as much: `saved_artists` uses tombstones (migration 017), so without
+ * it an artist you *unsaved* keeps feeding your calendar forever.
+ */
+async function savedArtistIdsForUser(
+  client: NonNullable<ReturnType<typeof getClient>>,
+  userId: string
+): Promise<string[] | null> {
+  const { data: saved, error: savedError } = await client
+    .from('saved_artists')
+    .select('artist_id, artist_slug, artist_name')
+    .eq('user_id', userId)
+    .eq('deleted', false);
+
+  if (savedError) {
+    console.error('[DB] savedArtistIdsForUser read failed:', savedError.message);
+    return null;
+  }
+
+  const rows = (saved as { artist_id: string | null; artist_slug: string | null; artist_name: string | null }[]) || [];
+  const ids = new Set<string>();
+  const unresolved: { slug: string; name: string | null }[] = [];
+
+  for (const row of rows) {
+    if (row.artist_id) ids.add(row.artist_id);
+    else if (row.artist_slug) unresolved.push({ slug: row.artist_slug.toLowerCase(), name: row.artist_name });
+  }
+  if (unresolved.length === 0) return [...ids];
+
+  // Two candidates per row, because the stored slugs are two different kinds of wrong.
+  //
+  // The stored slug itself covers a *retired* slug (the accent-folding reslug, #410 — 44 aliases
+  // exist), and is tried against the alias table below.
+  //
+  // `artistSlug(artist_name)` covers the synthetic search keys, which is what the rows actually
+  // hold: measured on production, **not one** unlinked slug matched an artists row or an alias
+  // directly — they are squashed names (`rodneyowl`, `seoulmetro`, `modelactriz`) and prefixed
+  // platform keys (`qobuz-robertlogan`). Re-deriving from the name is the only thing that
+  // recovers them, and it is the same expression `persistSearchResults` upserts the artist under,
+  // so it names a row that exists rather than guessing at one.
+  const candidates = new Set<string>();
+  for (const row of unresolved) {
+    candidates.add(row.slug);
+    if (row.name) candidates.add(artistSlug(row.name));
+  }
+
+  // One `.in()` is safe without chunking here in a way it usually isn't: this is one person's
+  // saved list, not a table scan. The PostgREST 1,000-row cap is nowhere near.
+  const { data: bySlug, error: slugError } = await client
+    .from('artists')
+    .select('id, slug, name')
+    .in('slug', [...candidates]);
+
+  if (slugError) {
+    // Reported rather than swallowed: returning the partial set would look exactly like "those
+    // artists have nothing new", which is the confusion this whole function exists to stop. The
+    // ids we did resolve are still returned — they are not in doubt.
+    console.error('[DB] savedArtistIdsForUser slug resolution failed:', slugError.message);
+    return [...ids];
+  }
+
+  const artistsBySlug = new Map<string, { id: string; name: string }>();
+  for (const row of (bySlug as { id: string; slug: string; name: string }[]) || []) {
+    artistsBySlug.set(row.slug.toLowerCase(), { id: row.id, name: row.name });
+  }
+
+  const stillUnmatched: string[] = [];
+  for (const row of unresolved) {
+    // An exact slug match is accepted outright — the saved row named this artist's page.
+    const direct = artistsBySlug.get(row.slug);
+    if (direct) {
+      ids.add(direct.id);
+      continue;
+    }
+
+    // A name-derived match has to prove itself, because a name is a much weaker key than a slug.
+    // Requiring the found artist's own name to normalize identically stops a saved row with a
+    // generic or wrong name ("Music") from silently adopting an unrelated artist's releases —
+    // which would put someone else's record in a fan's calendar, a worse failure than showing
+    // nothing.
+    const derived = row.name ? artistSlug(row.name) : '';
+    const byName = derived ? artistsBySlug.get(derived) : undefined;
+    if (byName && artistSlug(byName.name) === derived) {
+      ids.add(byName.id);
+      continue;
+    }
+
+    stillUnmatched.push(row.slug);
+  }
+
+  if (stillUnmatched.length > 0) {
+    const { data: aliased, error: aliasError } = await client
+      .from('artist_slug_aliases')
+      .select('artist_id, alias')
+      .in('alias', stillUnmatched);
+
+    if (aliasError) console.error('[DB] savedArtistIdsForUser alias resolution failed:', aliasError.message);
+    else for (const row of (aliased as { artist_id: string }[]) || []) ids.add(row.artist_id);
+  }
+
+  return [...ids];
+}
+
+/**
  * Every release worth putting in one fan's feed: across all their saved artists, dated within
  * the trailing window or still to come.
  *
@@ -4291,17 +4409,8 @@ export async function getFeedReleasesForUser(userId: string, now: Date = new Dat
   if (!client) return [];
 
   try {
-    const { data: saved, error: savedError } = await client
-      .from('saved_artists')
-      .select('artist_id')
-      .eq('user_id', userId);
-
-    if (savedError) {
-      console.error('[DB] getFeedReleasesForUser saved read failed:', savedError.message);
-      return [];
-    }
-
-    const artistIds = ((saved as { artist_id: string }[]) || []).map(r => r.artist_id);
+    const artistIds = await savedArtistIdsForUser(client, userId);
+    if (artistIds === null) return [];
     if (artistIds.length === 0) return [];
 
     const { data, error } = await client

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -45,12 +45,30 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect, onLink
   // actually drop the link from its list afterwards.
   const handleRemoveLink = isAdmin && onLinkRemoved ? setLinkToRemove : undefined;
 
+  // The key this card saves under, and checks saved-ness with. **One expression, deliberately.**
+  //
+  // `result.id` is a search-pipeline key — `nameonly-…`, `known-…`, or a platform-derived handle
+  // like `rodneyowl` — and matches no row in the artists table. Saving under one wrote
+  // `artist_id: null`, which made the save invisible to every feature keyed on the artist: the
+  // release feeds, the /dashboard shortlist, and the `requestArtistCatalog` call that is supposed
+  // to make a save the strongest signal to go and crawl someone.
+  //
+  // `knownSlug` is the fix and it was already in the payload: `attachArtistPageSlugs` gives every
+  // placeable result the slug of its page, deliberately server-side so the rule isn't
+  // reimplemented per client. `ResultCardHeader` has always used it to build the /artist/ link,
+  // so before this the same card linked to one address and saved under another. The extension
+  // (`popup.js`) already had the three-way expression; this brings the web into line.
+  //
+  // It is one `const` rather than two matching expressions because it used to be two: the save
+  // handler and the saved-state effect each derived it, so fixing one and not the other would
+  // leave the star dark on an artist you had just saved.
+  const saveKey = result.claimedSlug || result.knownSlug || result.id;
+
   useEffect(() => {
     if (result.type === 'artist' && result.id) {
-      // Match the slug we use for save so the saved state stays in sync
-      setSaved(isArtistSaved(result.claimedSlug || result.id));
+      setSaved(isArtistSaved(saveKey));
     }
-  }, [result.type, result.id, result.claimedSlug, isArtistSaved]);
+  }, [result.type, result.id, saveKey, isArtistSaved]);
 
   const handleSave = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -58,21 +76,15 @@ export function ResultCard({ result, isAdmin, isSelected, onToggleSelect, onLink
 
     if (result.type !== 'artist' || !result.id) return;
 
-    // Prefer the verified /a/{slug} over the synthetic search-result id.
-    // For verified-but-not-claimed artists the result id is a "nameonly-..." key
-    // that won't match a row in the artists table, so findExistingArtist fails
-    // and the saved record falls back to "Saved from Search".
-    const saveId = result.claimedSlug || result.id;
-
     if (saved) {
-      await removeSavedArtist(saveId);
+      await removeSavedArtist(saveKey);
       setSaved(false);
     } else {
       if (!session) {
         setShowLoginInterstitial(true);
         return;
       }
-      await saveArtist(saveId, undefined, result.name, result.imageUrl);
+      await saveArtist(saveKey, undefined, result.name, result.imageUrl);
       setSaved(true);
     }
   };

--- a/apps/web/tests/unit/ResultCardSaveKey.test.tsx
+++ b/apps/web/tests/unit/ResultCardSaveKey.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+// Which key a search-result card saves an artist under.
+//
+// The bug this guards, found 2026-08-07: the card saved under `result.id` — a search-pipeline key
+// like `rodneyowl`, `nameonly-…` or `qobuz-pearljam` — which matches no row in the artists table.
+// `saved-artists.ts` resolves the artist by exactly that value, so the save was written with
+// `artist_id: null`, and every feature keyed on the artist went blind to it: the release feeds,
+// the /dashboard shortlist, and the `requestArtistCatalog` call that makes a save the strongest
+// signal to crawl someone. 25 of 37 live rows in production were in that state.
+//
+// The slug was already in the payload as `knownSlug` — `attachArtistPageSlugs` puts it on every
+// placeable result, server-side, precisely so no client has to derive it.
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ResultCard } from 'src/components/ResultCard';
+import type { SearchResult } from 'src/types';
+
+const saveArtist = vi.fn();
+const removeSavedArtist = vi.fn();
+let savedKeys: string[] = [];
+
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    session: { user: { id: 'u1' } },
+    isArtistSaved: (key: string) => savedKeys.includes(key),
+    saveArtist,
+    removeSavedArtist,
+  }),
+}));
+
+vi.mock('src/services/analytics', () => ({
+  analytics: {
+    trackPlatformClick: vi.fn(),
+    trackArtistSearchAppearance: vi.fn(),
+    trackArtistLinkClick: vi.fn(),
+    trackSearch: vi.fn(),
+  },
+}));
+
+vi.mock('@sentry/react', () => ({ captureException: vi.fn() }));
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    // The shape that caused the bug: a platform-derived handle, no hyphen.
+    id: 'rodneyowl',
+    name: 'Rodney Owl',
+    type: 'artist',
+    matchConfidence: 'verified',
+    knownSlug: 'rodney-owl',
+    platforms: [{ sourceId: 'bandcamp', url: 'https://rodneyowl.bandcamp.com' }],
+    ...overrides,
+  } as SearchResult;
+}
+
+function show(result: SearchResult) {
+  render(
+    <MemoryRouter>
+      <ResultCard result={result} />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  saveArtist.mockClear();
+  removeSavedArtist.mockClear();
+  savedKeys = [];
+});
+afterEach(cleanup);
+
+describe('the key a result card saves under', () => {
+  it('saves an unclaimed-but-known artist under knownSlug, not the synthetic id', () => {
+    show(makeResult());
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(saveArtist).toHaveBeenCalledTimes(1);
+    expect(saveArtist.mock.calls[0][0]).toBe('rodney-owl');
+  });
+
+  it('still prefers claimedSlug for a claimed artist', () => {
+    show(makeResult({ matchConfidence: 'claimed', claimedSlug: 'kid-lightbulbs', knownSlug: undefined, id: 'claimed-kid-lightbulbs' }));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(saveArtist.mock.calls[0][0]).toBe('kid-lightbulbs');
+  });
+
+  it('falls back to the id when the server sent no slug at all', () => {
+    show(makeResult({ knownSlug: undefined, claimedSlug: undefined }));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(saveArtist.mock.calls[0][0]).toBe('rodneyowl');
+  });
+
+  // The invariant that was actually broken: the card linked to /artist/rodney-owl while saving
+  // under `rodneyowl`. One card, one identity for the artist.
+  it('saves under the same slug it links the artist page to', () => {
+    show(makeResult());
+
+    const link = screen.getByRole('link', { name: /view artist page/i });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(link.getAttribute('href')).toBe('/artist/rodney-owl');
+    expect(saveArtist.mock.calls[0][0]).toBe('rodney-owl');
+  });
+
+  // Saved-state used to be derived by a second copy of the same expression. Fixing only the save
+  // path would leave the heart dark on an artist you had just saved.
+  it('reads saved state under the same key it saves with', () => {
+    savedKeys = ['rodney-owl'];
+    show(makeResult());
+
+    expect(screen.getByRole('button', { name: /saved/i })).toBeTruthy();
+  });
+
+  it('removes under the same key too', () => {
+    savedKeys = ['rodney-owl'];
+    show(makeResult());
+    fireEvent.click(screen.getByRole('button', { name: /saved/i }));
+
+    expect(removeSavedArtist).toHaveBeenCalledWith('rodney-owl');
+  });
+});


### PR DESCRIPTION
Brandon saved Rodney Owl, whose newest record came out yesterday, and Recent Releases stayed empty while his artist page listed it.

The save recorded `artist_slug: 'rodneyowl'` with `artist_id: null`. The artists row is `rodney-owl`. Nothing linked them, and every feature keyed on the artist was blind to the save.

**Measured on production: 25 of 37 live saved rows are in that state — 68%.**

## Three symptoms, one cause

1. **Recent Releases and the ICS/Atom feeds can't see those artists.** `getFeedReleasesForUser` selected `saved_artists.artist_id` and nothing else. This is **not** a bug in #421 — it faithfully reuses the feed query; the hole has silently limited the feeds since #388. The dashboard is just where it first became visible.
2. **Saving never triggers cataloguing for them.** `saved-artists.ts` guards `if (artistId) await requestArtistCatalog(...)`, so "a save is the strongest signal that someone wants this artist's releases" was dead for two thirds of saves.
3. **The artist page shows "Save" for an artist you just saved** — `savedArtistIds` holds `rodneyowl`, the page asks `isArtistSaved('rodney-owl')`.

## The write side: one card, two identities

`ResultCard` saved under `result.claimedSlug || result.id`. `result.id` is a search-pipeline key — `nameonly-…`, `known-…`, `qobuz-…`, or a platform handle like `rodneyowl` — and matches no row in the artists table, so `findExistingArtist` missed and the row was written unlinked.

**The slug was already in the payload.** `attachArtistPageSlugs` puts `knownSlug` on every placeable result, server-side, precisely so no client has to derive it — and `ResultCardHeader` has always used it to build the `/artist/` link. So the same card linked to `/artist/rodney-owl` and saved under `rodneyowl`.

It is now **one `const` rather than two matching expressions**, because it was two: the save handler and the saved-state effect each derived the key, so fixing one and not the other leaves the heart dark on an artist you just saved. Reverting the fix fails 4 of the 6 new tests, including that one.

**Neither other client needed changing** — checked rather than assumed. The Mac's `SavedArtistsSync.saveArtist` has no callers (it only pulls), and `popup.js:154` already had the three-way expression.

## The read side: recover the rows that are already wrong

Fixing the client does nothing for 25 existing rows, and a fan's calendar shouldn't stay wrong until a backfill runs. `savedArtistIdsForUser` now resolves `artist_id` → exact `artist_slug` → `artistSlug(artist_name)` → `artist_slug_aliases`.

### Reviewer note: my first cut was wrong, and only production data showed it

I designed this as "stored slug + alias table". Twelve green tests — and it recovered **zero** artists for the reporting account. **Not one** unlinked slug matches an artists row or an alias directly; they are squashed *names* (`rodneyowl`, `seoulmetro`, `modelactriz`) and prefixed keys (`qobuz-robertlogan`), so `artistSlug(artist_name)` is the only thing that recovers them.

**The guard that makes the name path safe:** a name is a far weaker key than a slug, so a name-derived hit must prove itself — the found artist's own name has to normalize identically. Without it a row with a generic name ("Music") adopts an unrelated artist's releases, putting someone else's record in a fan's calendar. Worse than showing nothing.

## `deleted = false`, which was also missing

`saved_artists` uses tombstones (migration 017), so an artist you *unsaved* kept feeding your dashboard and your calendar. Kid Lightbulbs was doing exactly that.

## Verified against production, not only mocks

`getFeedReleasesForUser` for the reporting account: **3 releases before, 4 after** — the new one being Rodney Owl — *Loneliness Is Contagious* (2026-08-06). The tombstoned artist is correctly gone.

## Not in this PR

Backfilling the 25 rows' `artist_id`. That is a production data write and wants a dry run printing every proposed link first.

## Verification

`test:api` **998** ✅ · `test:unit` **692** ✅ · `typecheck:api` ✅ · lint unchanged at the 71-problem baseline.

Five load-bearing behaviours mutation-tested, each failing exactly its intended test: the `deleted` filter, slug resolution, alias resolution, name derivation, and the name-agreement guard.

New tests drive db.ts against a recording fake Supabase client (following `recatalog-sweep-selection.test.ts`) so the real query body runs — a module mock would assert my own fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)