### PR TITLE
Split the dashboard's releases into Upcoming and Recent

### DIFF
--- a/api/functions/__tests__/me-recent-releases.test.ts
+++ b/api/functions/__tests__/me-recent-releases.test.ts
@@ -18,7 +18,7 @@ vi.mock('../ratelimit', () => ({
   getClientIp: mocks.getClientIp,
 }));
 
-import { handler, toRecentReleases, RECENT_RELEASE_LIMIT } from '../me-recent-releases';
+import { handler, splitRecentReleases, RECENT_RELEASE_LIMIT } from '../me-recent-releases';
 import type { FeedReleaseRow } from '../db';
 
 function row(overrides: Partial<FeedReleaseRow> = {}): FeedReleaseRow {
@@ -48,45 +48,100 @@ const GET = {
   headers: { authorization: 'Bearer valid-token' },
 };
 
-describe('toRecentReleases', () => {
-  it('orders newest first, so the cap trims the oldest and never the news', () => {
-    const ordered = toRecentReleases(
+const NOW = new Date('2026-08-07T12:00:00Z');
+
+describe('splitRecentReleases', () => {
+  it('keeps an unreleased album out of the recent list', () => {
+    const { upcoming, recent } = splitRecentReleases(
       [
-        row({ releaseSlug: 'old', releaseDate: '2026-07-10' }),
-        row({ releaseSlug: 'upcoming', releaseDate: '2026-09-30' }),
-        row({ releaseSlug: 'recent', releaseDate: '2026-08-05' }),
+        row({ releaseSlug: 'announced', releaseDate: '2026-09-30' }),
+        row({ releaseSlug: 'out', releaseDate: '2026-08-05' }),
       ],
+      NOW
+    );
+
+    expect(upcoming.map(r => r.releaseSlug)).toEqual(['announced']);
+    expect(recent.map(r => r.releaseSlug)).toEqual(['out']);
+  });
+
+  it('counts a release dated today as out, not coming', () => {
+    const { upcoming, recent } = splitRecentReleases([row({ releaseDate: '2026-08-07' })], NOW);
+
+    expect(upcoming).toHaveLength(0);
+    expect(recent).toHaveLength(1);
+  });
+
+  it('orders upcoming soonest first, so its cap drops the furthest off', () => {
+    const { upcoming } = splitRecentReleases(
+      [
+        row({ releaseSlug: 'later', releaseDate: '2026-12-01' }),
+        row({ releaseSlug: 'sooner', releaseDate: '2026-08-20' }),
+        row({ releaseSlug: 'soonest', releaseDate: '2026-08-08' }),
+      ],
+      NOW,
       2
     );
 
-    expect(ordered.map(r => r.releaseSlug)).toEqual(['upcoming', 'recent']);
+    expect(upcoming.map(r => r.releaseSlug)).toEqual(['soonest', 'sooner']);
+  });
+
+  it('orders recent newest first, so its cap drops the oldest and never the news', () => {
+    const { recent } = splitRecentReleases(
+      [
+        row({ releaseSlug: 'oldest', releaseDate: '2026-07-10' }),
+        row({ releaseSlug: 'newest', releaseDate: '2026-08-05' }),
+        row({ releaseSlug: 'middle', releaseDate: '2026-07-28' }),
+      ],
+      NOW,
+      2
+    );
+
+    expect(recent.map(r => r.releaseSlug)).toEqual(['newest', 'middle']);
+  });
+
+  it('caps each list separately, so a run of announcements cannot hide what is out', () => {
+    const { upcoming, recent } = splitRecentReleases(
+      [
+        ...Array.from({ length: RECENT_RELEASE_LIMIT + 2 }, (_, i) =>
+          row({ releaseSlug: `soon-${i}`, releaseDate: `2026-09-0${i + 1}` })
+        ),
+        row({ releaseSlug: 'out', releaseDate: '2026-08-01' }),
+      ],
+      NOW
+    );
+
+    expect(upcoming).toHaveLength(RECENT_RELEASE_LIMIT);
+    expect(recent.map(r => r.releaseSlug)).toEqual(['out']);
   });
 
   it('does not mutate the rows it was given', () => {
     const rows = [row({ releaseSlug: 'a', releaseDate: '2026-07-01' }), row({ releaseSlug: 'b', releaseDate: '2026-08-01' })];
-    toRecentReleases(rows);
+    splitRecentReleases(rows, NOW);
     expect(rows.map(r => r.releaseSlug)).toEqual(['a', 'b']);
   });
 
   it('keeps sources per-platform so the client can order them artist-paying-first', () => {
-    const [release] = toRecentReleases([
-      row({
-        sources: [
-          { platform: 'discogs', url: 'https://discogs.com/x', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
-          { platform: 'bandcamp', url: 'https://x.bandcamp.com/album/y', offers: [{ price: 25, currency: 'USD', availability: 'available' }] },
-        ],
-      }),
-    ]);
+    const { recent } = splitRecentReleases(
+      [
+        row({
+          sources: [
+            { platform: 'discogs', url: 'https://discogs.com/x', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
+            { platform: 'bandcamp', url: 'https://x.bandcamp.com/album/y', offers: [{ price: 25, currency: 'USD', availability: 'available' }] },
+          ],
+        }),
+      ],
+      NOW
+    );
 
-    expect(release.sources).toEqual([
+    expect(recent[0].sources).toEqual([
       { platform: 'discogs', offers: [{ price: 2.64, currency: 'USD', availability: 'available' }] },
       { platform: 'bandcamp', offers: [{ price: 25, currency: 'USD', availability: 'available' }] },
     ]);
   });
 
   it('carries date precision through, so a year-only date is never printed as a day', () => {
-    const [release] = toRecentReleases([row({ datePrecision: 'year' })]);
-    expect(release.datePrecision).toBe('year');
+    const { recent } = splitRecentReleases([row({ datePrecision: 'year' })], NOW);
+    expect(recent[0].datePrecision).toBe('year');
   });
 });
 
@@ -101,27 +156,37 @@ describe('me-recent-releases handler', () => {
     mocks.getFeedReleasesForUser.mockResolvedValue([]);
   });
 
-  it('returns the signed-in fan’s releases', async () => {
-    mocks.getFeedReleasesForUser.mockResolvedValue([row()]);
+  it('returns the signed-in fan’s releases as two lists', async () => {
+    // Dated in 2026-07 and 2100 rather than relative to today, so the split these assert stays the
+    // same whenever the suite runs.
+    mocks.getFeedReleasesForUser.mockResolvedValue([
+      row({ releaseSlug: 'out', releaseDate: '2026-07-01' }),
+      row({ releaseSlug: 'announced', releaseDate: '2100-01-01' }),
+    ]);
 
     const res = await handler(GET);
 
     expect(res.statusCode).toBe(200);
     expect(mocks.getFeedReleasesForUser).toHaveBeenCalledWith('user-1');
     const body = JSON.parse(res.body!);
-    expect(body.releases).toHaveLength(1);
-    expect(body.releases[0].artistName).toBe('Explosions in the Sky');
+    expect(body.recent.map((r: { releaseSlug: string }) => r.releaseSlug)).toEqual(['out']);
+    expect(body.upcoming.map((r: { releaseSlug: string }) => r.releaseSlug)).toEqual(['announced']);
+    expect(body.recent[0].artistName).toBe('Explosions in the Sky');
   });
 
-  it('caps the shortlist', async () => {
-    mocks.getFeedReleasesForUser.mockResolvedValue(
-      Array.from({ length: RECENT_RELEASE_LIMIT + 4 }, (_, i) =>
-        row({ releaseSlug: `r${i}`, releaseDate: `2026-08-0${(i % 9) + 1}` })
-      )
-    );
+  it('caps each shortlist', async () => {
+    mocks.getFeedReleasesForUser.mockResolvedValue([
+      ...Array.from({ length: RECENT_RELEASE_LIMIT + 4 }, (_, i) =>
+        row({ releaseSlug: `past-${i}`, releaseDate: `2026-07-0${(i % 9) + 1}` })
+      ),
+      ...Array.from({ length: RECENT_RELEASE_LIMIT + 4 }, (_, i) =>
+        row({ releaseSlug: `future-${i}`, releaseDate: `210${i % 9}-01-01` })
+      ),
+    ]);
 
-    const res = await handler(GET);
-    expect(JSON.parse(res.body!).releases).toHaveLength(RECENT_RELEASE_LIMIT);
+    const body = JSON.parse((await handler(GET)).body!);
+    expect(body.recent).toHaveLength(RECENT_RELEASE_LIMIT);
+    expect(body.upcoming).toHaveLength(RECENT_RELEASE_LIMIT);
   });
 
   it('401s without a valid bearer token, and never reads the database', async () => {

--- a/api/functions/me-recent-releases.ts
+++ b/api/functions/me-recent-releases.ts
@@ -1,7 +1,7 @@
 // API endpoint: /api/me/recent-releases
 //
-// GET — a shortlist of recent and upcoming releases by the signed-in fan's saved artists, for
-// the "Recent Releases" section of /dashboard.
+// GET — shortlists of upcoming and recent releases by the signed-in fan's saved artists, for the
+// "Upcoming Releases" and "Recent Releases" sections of /dashboard.
 //
 // Follows the same conventions as the other me-* endpoints (bearer auth against the anon client,
 // hand-rolled permissive CORS) and is in api/tsconfig.json's typecheck include — keep it there.
@@ -18,9 +18,13 @@ const CORS_HEADERS = {
 };
 
 /**
- * How many rows the dashboard shows. A shortlist, not a list: the section sits beside Saved
- * Artists and exists to say "here is what's new", so it has to stay glanceable. Six fills three
+ * How many rows each dashboard section shows. A shortlist, not a list: these sit beside Saved
+ * Artists and exist to say "here is what's new", so they have to stay glanceable. Six fills three
  * rows of the two-column grid.
+ *
+ * Applied to each list separately rather than to the pair, because a shared budget reintroduces
+ * the bug this split fixed in miniature: a fan with six albums already announced would lose sight
+ * of everything that actually came out.
  */
 export const RECENT_RELEASE_LIMIT = 6;
 
@@ -45,33 +49,58 @@ async function authenticateRequest(authHeader: string | undefined): Promise<stri
   return data.user.id;
 }
 
+function toShortlistRow(row: FeedReleaseRow) {
+  return {
+    artistName: row.artistName,
+    artistSlug: row.artistSlug,
+    title: row.title,
+    releaseSlug: row.releaseSlug,
+    releaseDate: row.releaseDate,
+    datePrecision: row.datePrecision,
+    artworkUrl: row.artworkUrl,
+    // Kept per-source rather than flattened into one price, so the client can order platforms
+    // artist-paying-first with the shared `release-display` helpers — the same figures the
+    // release page and the feeds use, rather than a ninth copy of the payout maths.
+    sources: row.sources.map(s => ({ platform: s.platform, offers: s.offers })),
+  };
+}
+
 /**
- * Newest first, then capped.
+ * Split the fan's window into what hasn't come out yet and what just did, each capped.
  *
- * `getFeedReleasesForUser` returns the same window ascending, because a calendar and a reader
- * both want the *next* thing at the top. A dashboard shortlist wants the opposite: descending
- * puts anything still to come above everything already out, and then the most recent release
- * above older ones — so the cap trims the oldest rather than silently dropping the news.
+ * `getFeedReleasesForUser` returns both in one ascending list — the right shape for a calendar or
+ * a reader, where the next thing belongs at the top. On the dashboard they answer two different
+ * questions, and mixing them meant an announced-but-unreleased album sat in a section headed
+ * "Recent Releases".
  *
- * Sorted on the ISO date string, which compares correctly without parsing.
+ * The split is on the date, not `releases.status`: this window is defined by dates, and a row
+ * dated next month is upcoming whatever a status column nothing keeps ticking over happens to
+ * say. Today counts as recent — it *is* out.
+ *
+ * Upcoming stays ascending, so its cap trims the furthest-off rather than the imminent; recent
+ * flips to descending, so its cap trims the oldest rather than the news. Sorted on the ISO date
+ * string, which compares correctly without parsing.
  */
-export function toRecentReleases(rows: FeedReleaseRow[], limit = RECENT_RELEASE_LIMIT) {
-  return [...rows]
-    .sort((a, b) => b.releaseDate.localeCompare(a.releaseDate))
-    .slice(0, limit)
-    .map(row => ({
-      artistName: row.artistName,
-      artistSlug: row.artistSlug,
-      title: row.title,
-      releaseSlug: row.releaseSlug,
-      releaseDate: row.releaseDate,
-      datePrecision: row.datePrecision,
-      artworkUrl: row.artworkUrl,
-      // Kept per-source rather than flattened into one price, so the client can order platforms
-      // artist-paying-first with the shared `release-display` helpers — the same figures the
-      // release page and the feeds use, rather than a ninth copy of the payout maths.
-      sources: row.sources.map(s => ({ platform: s.platform, offers: s.offers })),
-    }));
+export function splitRecentReleases(
+  rows: FeedReleaseRow[],
+  now: Date = new Date(),
+  limit = RECENT_RELEASE_LIMIT
+) {
+  const today = now.toISOString().slice(0, 10);
+
+  const upcoming = rows.filter(r => r.releaseDate > today);
+  const recent = rows.filter(r => r.releaseDate <= today);
+
+  return {
+    upcoming: [...upcoming]
+      .sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))
+      .slice(0, limit)
+      .map(toShortlistRow),
+    recent: [...recent]
+      .sort((a, b) => b.releaseDate.localeCompare(a.releaseDate))
+      .slice(0, limit)
+      .map(toShortlistRow),
+  };
 }
 
 export async function handler(event: {
@@ -105,6 +134,6 @@ export async function handler(event: {
     // One fan's saved artists — never cached by anything shared, the same rule the private feed
     // follows.
     headers: { ...CORS_HEADERS, 'Cache-Control': 'private, no-store' },
-    body: JSON.stringify({ releases: toRecentReleases(rows) }),
+    body: JSON.stringify(splitRecentReleases(rows)),
   };
 }

--- a/apps/web/src/components/RecentReleasesSection.tsx
+++ b/apps/web/src/components/RecentReleasesSection.tsx
@@ -4,7 +4,7 @@ import { PLATFORMS } from '../../../../api/shared/platform-registry';
 import { PlatformIcon } from './PlatformIcon';
 import type { SourceId } from '../types';
 
-/** One row of `/api/me/recent-releases`. */
+/** One row of either list returned by `/api/me/recent-releases`. */
 export interface RecentRelease {
   artistName: string;
   artistSlug: string;
@@ -24,12 +24,18 @@ export interface RecentRelease {
  *
  * Release alerts have only ever existed in the Mac app and the browser extension, and the private
  * release feed shipped with its only entry point buried on /settings — where, in the months it
- * has been live, not one fan ever minted a token. This section is the web's first fan-facing
- * release surface, and the natural home for that subscribe control.
+ * has been live, not one fan ever minted a token. This is the web's first fan-facing release
+ * surface, and the natural home for that subscribe control.
  *
- * The window (past 30 days plus everything upcoming) is `getFeedReleasesForUser`'s, deliberately:
- * the feed and this section answering differently about what counts as recent would read as a bug
- * in whichever one you happened to be looking at.
+ * **Two sections, not one.** The window (past 30 days plus everything upcoming) is
+ * `getFeedReleasesForUser`'s, deliberately — the feed and the dashboard disagreeing about what
+ * counts as recent would read as a bug in whichever one you happened to be looking at — but an
+ * album that isn't out yet is not a *recent release*, and a heading that said so was wrong on its
+ * own terms. Upcoming leads, because it is the news; the server sends the two lists already split
+ * and capped separately.
+ *
+ * Only the sections with something in them render. When neither does, one box says so under the
+ * "Recent Releases" heading rather than two boxes explaining the same silence.
  *
  * Presentational — the page fetches, and hands the auth-dependent subscribe panel in as a prop.
  *
@@ -38,82 +44,120 @@ export interface RecentRelease {
  * route for a two-segment `/a/` path, so a client-side navigation there renders nothing.
  */
 export function RecentReleasesSection({
-  releases,
+  upcoming,
+  recent,
   subscribePanel,
   error,
 }: {
-  releases: RecentRelease[];
+  upcoming: RecentRelease[];
+  recent: RecentRelease[];
   subscribePanel: ReactNode;
   error?: string | null;
 }) {
   const [showSubscribe, setShowSubscribe] = useState(false);
 
+  /*
+    One control for the pair, not one per section: both lists come out of the same feed token, so
+    a second button would be a second treatment for one action. It rides whichever heading comes
+    first, so it always sits at the top of the block.
+  */
+  const subscribeControl = (
+    <SubscribeToggle open={showSubscribe} onToggle={() => setShowSubscribe(v => !v)} />
+  );
+  const revealedPanel = showSubscribe ? (
+    <div className="mb-4 p-4 rounded-lg bg-bg-secondary border border-border">{subscribePanel}</div>
+  ) : null;
+
+  const groups = [
+    { title: 'Upcoming Releases', releases: upcoming },
+    { title: 'Recent Releases', releases: recent },
+  ].filter(group => group.releases.length > 0);
+
+  if (error || groups.length === 0) {
+    return (
+      <section>
+        <SectionHeading title="Recent Releases" action={subscribeControl} />
+        {revealedPanel}
+        {error ? (
+          <p className="text-sm text-text-muted">{error}</p>
+        ) : (
+          /*
+            Said rather than hidden. Most fans will have saved artists with nothing out this month,
+            and an empty section that vanishes reads as a feature that isn't working — where the
+            sentence explains both the window and that we are in fact watching. The page only
+            renders this at all once the fan has saved somebody, so there is no case where this box
+            greets someone with nothing to say.
+          */
+          <div className="text-center py-10 rounded-lg border border-border border-dashed">
+            <p className="text-text-muted">Nothing new from your saved artists this month.</p>
+            <p className="text-text-muted text-sm mt-1">
+              Releases from the past 30 days and anything already announced will show up here.
+            </p>
+          </div>
+        )}
+      </section>
+    );
+  }
+
   return (
-    <section>
-      <div className="flex items-center justify-between gap-3 mb-4">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <svg className="w-5 h-5 text-accent-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM21 16c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
-          </svg>
-          Recent Releases
-        </h2>
+    <div className="space-y-8">
+      {groups.map((group, index) => (
+        <section key={group.title}>
+          <SectionHeading title={group.title} action={index === 0 ? subscribeControl : null} />
+          {index === 0 && revealedPanel}
+          <div className="grid gap-2 sm:grid-cols-2">
+            {group.releases.map(release => (
+              <ReleaseRow key={`${release.artistSlug}/${release.releaseSlug}`} release={release} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
 
-        {/*
-          One control, not two, even though it offers two formats: the calendar and the RSS marks
-          both come from the same feed token, so a pair of buttons that did the same thing would
-          be two treatments for one action. The marks stay side by side and stroked at the same
-          weight — the artist page's heading treatment — because that pairing is what reads as
-          "subscribe" without a word of explanation.
+/** The dashboard's section heading treatment, shared so both headings match exactly. */
+function SectionHeading({ title, action }: { title: string; action: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 mb-4">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <svg className="w-5 h-5 text-accent-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM21 16c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
+        </svg>
+        {title}
+      </h2>
+      {action}
+    </div>
+  );
+}
 
-          A button rather than a link, unlike the artist page's, because a fan's feed URL contains
-          a credential that doesn't exist until they ask for one. Pressing this only reveals the
-          panel; minting still takes the explicit press inside it.
-        */}
-        <button
-          type="button"
-          onClick={() => setShowSubscribe(v => !v)}
-          aria-expanded={showSubscribe}
-          aria-label="Subscribe to these releases in a calendar app or RSS reader"
-          title="Subscribe in a calendar app or RSS reader"
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border transition-colors shrink-0 ${
-            showSubscribe
-              ? 'border-accent-primary/40 text-accent-primary bg-accent-primary/10'
-              : 'border-border text-text-muted hover:text-text-primary hover:border-border-hover'
-          }`}
-        >
-          <CalendarIcon />
-          <RssIcon />
-        </button>
-      </div>
-
-      {showSubscribe && (
-        <div className="mb-4 p-4 rounded-lg bg-bg-secondary border border-border">{subscribePanel}</div>
-      )}
-
-      {error ? (
-        <p className="text-sm text-text-muted">{error}</p>
-      ) : releases.length === 0 ? (
-        /*
-          Said rather than hidden. Most fans will have saved artists with nothing out this month,
-          and an empty section that vanishes reads as a feature that isn't working — where the
-          sentence explains both the window and that we are in fact watching. The page only
-          renders this section at all once the fan has saved somebody, so there is no case where
-          this box greets someone with nothing to say.
-        */
-        <div className="text-center py-10 rounded-lg border border-border border-dashed">
-          <p className="text-text-muted">Nothing new from your saved artists this month.</p>
-          <p className="text-text-muted text-sm mt-1">
-            Releases from the past 30 days and anything already announced will show up here.
-          </p>
-        </div>
-      ) : (
-        <div className="grid gap-2 sm:grid-cols-2">
-          {releases.map(release => (
-            <ReleaseRow key={`${release.artistSlug}/${release.releaseSlug}`} release={release} />
-          ))}
-        </div>
-      )}
-    </section>
+/**
+ * Two formats, one action: the calendar and the RSS marks both come from the same feed token, so
+ * a pair of buttons that did the same thing would be two treatments for one action. The marks stay
+ * side by side and stroked at the same weight — the artist page's heading treatment — because that
+ * pairing is what reads as "subscribe" without a word of explanation.
+ *
+ * A button rather than a link, unlike the artist page's, because a fan's feed URL contains a
+ * credential that doesn't exist until they ask for one. Pressing this only reveals the panel;
+ * minting still takes the explicit press inside it.
+ */
+function SubscribeToggle({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      aria-label="Subscribe to these releases in a calendar app or RSS reader"
+      title="Subscribe in a calendar app or RSS reader"
+      className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border transition-colors shrink-0 ${
+        open
+          ? 'border-accent-primary/40 text-accent-primary bg-accent-primary/10'
+          : 'border-border text-text-muted hover:text-text-primary hover:border-border-hover'
+      }`}
+    >
+      <CalendarIcon />
+      <RssIcon />
+    </button>
   );
 }
 
@@ -129,9 +173,8 @@ function ReleaseRow({ release }: { release: RecentRelease }) {
   // so the platform a fan sees leading the row is also the one the price came from.
   const platforms = orderedSourcePlatforms(release.sources);
 
-  // From the date, not `releases.status`: this window is defined by dates, and a row dated next
-  // month is upcoming whatever a status column that nothing keeps ticking over happens to say.
-  const upcoming = release.releaseDate > new Date().toISOString().slice(0, 10);
+  // No per-row "Coming" badge: it existed to stop an unreleased album disappearing into a list
+  // that otherwise read as history, and the heading above it now says that for the whole section.
 
   // `min-w-0` on the row belongs on the grid item itself, not only on the text column inside it:
   // a grid item's automatic minimum size is its content, so without it the single-column layout
@@ -182,14 +225,6 @@ function ReleaseRow({ release }: { release: RecentRelease }) {
           </span>
         )}
       </span>
-
-      {/* An upcoming release is the most interesting row here and the easiest to miss in a list
-          that otherwise reads as history. */}
-      {upcoming && (
-        <span className="text-[10px] font-bold uppercase tracking-wide text-accent-primary shrink-0">
-          Coming
-        </span>
-      )}
     </a>
   );
 }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ export function DashboardPage() {
   const { session, isLoading: authLoading } = useAuth();
   const [claimedProfiles, setClaimedProfiles] = useState<ClaimedProfile[]>([]);
   const [savedArtists, setSavedArtists] = useState<SavedArtist[]>([]);
+  const [upcomingReleases, setUpcomingReleases] = useState<RecentRelease[]>([]);
   const [recentReleases, setRecentReleases] = useState<RecentRelease[]>([]);
   const [releasesError, setReleasesError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -68,7 +69,8 @@ export function DashboardPage() {
         });
         if (!response.ok) throw new Error(`recent-releases failed: ${response.status}`);
         const data = await response.json();
-        setRecentReleases(data.releases || []);
+        setUpcomingReleases(data.upcoming || []);
+        setRecentReleases(data.recent || []);
       } catch (e) {
         Sentry.captureException(e, { extra: { context: 'dashboard.loadRecentReleases' } });
         setReleasesError("Couldn't load recent releases. Try refreshing.");
@@ -348,14 +350,15 @@ export function DashboardPage() {
           )}
 
           {/*
-            Recent Releases — above Saved Artists because it is the part of this page that
-            changes, and only rendered once the fan has saved somebody: an empty releases box for
-            a fan with no saved artists would be a second empty state saying the same thing as the
-            one below it.
+            Upcoming and Recent Releases — above Saved Artists because they are the part of this
+            page that changes, and only rendered once the fan has saved somebody: an empty releases
+            box for a fan with no saved artists would be a second empty state saying the same thing
+            as the one below it.
           */}
           {savedArtists.length > 0 && (
             <RecentReleasesSection
-              releases={recentReleases}
+              upcoming={upcomingReleases}
+              recent={recentReleases}
               error={releasesError}
               subscribePanel={<ReleaseFeedControls />}
             />

--- a/apps/web/tests/unit/RecentReleasesSection.test.tsx
+++ b/apps/web/tests/unit/RecentReleasesSection.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-// The "Recent Releases" shortlist on /dashboard — the web's first fan-facing release surface.
+// The "Upcoming Releases" / "Recent Releases" shortlists on /dashboard — the web's first
+// fan-facing release surface.
 //
 // What's worth locking here is the set of things that would be quietly wrong rather than broken:
-// a fabricated date on a year-only release, a secondhand marketplace ranked above a direct
-// purchase, an empty state that vanishes instead of explaining itself, and a subscribe control
-// that mints a credential nobody asked for.
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, screen, cleanup, within, fireEvent } from '@testing-library/react';
+// an unreleased album filed under "Recent", a fabricated date on a year-only release, a secondhand
+// marketplace ranked above a direct purchase, an empty state that vanishes instead of explaining
+// itself, and a subscribe control that mints a credential nobody asked for.
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { RecentReleasesSection, type RecentRelease } from 'src/components/RecentReleasesSection';
 
 function release(overrides: Partial<RecentRelease> = {}): RecentRelease {
@@ -27,10 +28,14 @@ function release(overrides: Partial<RecentRelease> = {}): RecentRelease {
 // <Link> throws without one, so this harness is what keeps the rows real anchors.
 // `/a/{artist}/{release}` is served only by the release-page edge function, and a client-side
 // navigation there matches no SPA route and renders a blank page.
-function show(releases: RecentRelease[], error: string | null = null) {
+function show(
+  lists: { upcoming?: RecentRelease[]; recent?: RecentRelease[] },
+  error: string | null = null
+) {
   return render(
     <RecentReleasesSection
-      releases={releases}
+      upcoming={lists.upcoming ?? []}
+      recent={lists.recent ?? []}
       error={error}
       subscribePanel={<p>subscribe panel</p>}
     />
@@ -41,9 +46,11 @@ afterEach(cleanup);
 
 describe('RecentReleasesSection', () => {
   it('links each release to its buying guide, by the release’s own artist', () => {
-    show([
-      release({ artistSlug: 'explosions-in-the-sky', releaseSlug: 'the-earth', title: 'The Earth' }),
-    ]);
+    show({
+      recent: [
+        release({ artistSlug: 'explosions-in-the-sky', releaseSlug: 'the-earth', title: 'The Earth' }),
+      ],
+    });
 
     expect(screen.getByRole('link', { name: /The Earth/ }).getAttribute('href')).toBe(
       '/a/explosions-in-the-sky/the-earth'
@@ -51,32 +58,34 @@ describe('RecentReleasesSection', () => {
   });
 
   it('names the artist on every row — the one thing an artist page never has to say', () => {
-    show([release({ artistName: 'Explosions in the Sky' })]);
+    show({ recent: [release({ artistName: 'Explosions in the Sky' })] });
     expect(screen.getByText('Explosions in the Sky')).toBeTruthy();
   });
 
   it('never states a date more precisely than the source did', () => {
-    show([release({ releaseDate: '2024-01-01', datePrecision: 'year' })]);
+    show({ recent: [release({ releaseDate: '2024-01-01', datePrecision: 'year' })] });
 
     expect(screen.getByText(/2024/).textContent).toContain('2024');
     expect(screen.queryByText(/1 January 2024/)).toBeNull();
   });
 
   it('quotes the price from the artist-paying source, not the cheapest one', () => {
-    show([
-      release({
-        sources: [
-          {
-            platform: 'discogs',
-            offers: [{ price: 2.64, currency: 'USD', availability: 'available' }],
-          },
-          {
-            platform: 'bandcamp',
-            offers: [{ price: 25, currency: 'USD', availability: 'available' }],
-          },
-        ],
-      }),
-    ]);
+    show({
+      recent: [
+        release({
+          sources: [
+            {
+              platform: 'discogs',
+              offers: [{ price: 2.64, currency: 'USD', availability: 'available' }],
+            },
+            {
+              platform: 'bandcamp',
+              offers: [{ price: 25, currency: 'USD', availability: 'available' }],
+            },
+          ],
+        }),
+      ],
+    });
 
     // Bandcamp pays the artist far more than a Discogs secondhand listing, so it leads even
     // though it is nearly ten times the price.
@@ -84,34 +93,44 @@ describe('RecentReleasesSection', () => {
     expect(screen.queryByText(/\$2\.64/)).toBeNull();
   });
 
-  it('marks a release dated in the future as coming', () => {
-    const nextYear = String(new Date().getUTCFullYear() + 1);
-    show([
-      release({ releaseDate: `${nextYear}-03-01`, releaseSlug: 'later' }),
-      release({ releaseDate: '2020-03-01', releaseSlug: 'earlier' }),
-    ]);
+  it('heads the two lists separately, upcoming first', () => {
+    show({
+      upcoming: [release({ releaseSlug: 'announced', title: 'Announced' })],
+      recent: [release({ releaseSlug: 'out', title: 'Out Now' })],
+    });
 
-    const rows = screen.getAllByRole('link');
-    expect(within(rows[0]).getByText('Coming')).toBeTruthy();
-    expect(within(rows[1]).queryByText('Coming')).toBeNull();
+    const headings = screen.getAllByRole('heading').map(h => h.textContent);
+    expect(headings).toEqual(['Upcoming Releases', 'Recent Releases']);
+
+    // And each row sits under its own heading — the whole point of the split.
+    const order = screen.getAllByRole('link').map(a => a.getAttribute('href'));
+    expect(order).toEqual(['/a/kid-lightbulbs/announced', '/a/kid-lightbulbs/out']);
+  });
+
+  it('renders only the list that has something in it', () => {
+    show({ recent: [release()] });
+
+    expect(screen.getAllByRole('heading').map(h => h.textContent)).toEqual(['Recent Releases']);
   });
 
   it('explains itself when there is nothing new, rather than disappearing', () => {
-    show([]);
+    show({});
     expect(screen.getByText(/Nothing new from your saved artists this month/)).toBeTruthy();
+    // One box, not two empty sections explaining the same silence.
+    expect(screen.getAllByRole('heading').map(h => h.textContent)).toEqual(['Recent Releases']);
     // The subscribe control has to survive the empty state — a fan with nothing out this month
     // is exactly who wants to be told when something is.
     expect(screen.getByRole('button', { name: /Subscribe to these releases/ })).toBeTruthy();
   });
 
   it('says so when the read failed, instead of claiming there is nothing new', () => {
-    show([], "Couldn't load recent releases. Try refreshing.");
+    show({}, "Couldn't load recent releases. Try refreshing.");
     expect(screen.getByText(/Couldn't load recent releases/)).toBeTruthy();
     expect(screen.queryByText(/Nothing new from your saved artists/)).toBeNull();
   });
 
   it('reveals the subscribe panel only on request', () => {
-    show([release()]);
+    show({ recent: [release()] });
 
     // Collapsed on mount: a feed token is a credential, and the panel behind this button is
     // where one gets minted.
@@ -125,33 +144,23 @@ describe('RecentReleasesSection', () => {
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('offers one subscribe control, not one per format', () => {
-    show([release()]);
-    // Two marks, one action. Two buttons hitting the same feed token would be two treatments
-    // for one action.
+  it('offers one subscribe control for the pair, not one per section or format', () => {
+    show({ upcoming: [release({ releaseSlug: 'announced' })], recent: [release()] });
+    // Two marks, two sections, one action. Both lists come out of the same feed token, so a
+    // second button would be a second treatment for one action.
     expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
   it('names the platforms for a screen reader, which the icons alone cannot', () => {
-    show([
-      release({
-        sources: [{ platform: 'jamcoop', offers: [] }],
-      }),
-    ]);
+    show({
+      recent: [
+        release({
+          sources: [{ platform: 'jamcoop', offers: [] }],
+        }),
+      ],
+    });
 
     // The registry's name, not the raw id.
     expect(screen.getByText(/Available on Jam\.coop/)).toBeTruthy();
-  });
-});
-
-describe('RecentReleasesSection date boundary', () => {
-  afterEach(() => vi.useRealTimers());
-
-  it('does not call today’s release "coming"', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-08-07T12:00:00Z'));
-
-    show([release({ releaseDate: '2026-08-07' })]);
-    expect(screen.queryByText('Coming')).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`/dashboard`'s "Recent Releases" section listed releases that aren't out yet. This splits it into two sections — **Upcoming Releases** above **Recent Releases** — with releases dated in the future in the first and the past 30 days in the second.

## Why

An album that has been announced but hasn't been released is not a *recent release*, so the heading was wrong on its own terms. The per-row "Coming" badge was papering over it. Brandon:

> They include upcoming releases. We should split this into 2 sections: Upcoming Releases and Recent Releases. Upcoming should include releases with a release date in the future; Recent should include releases in the past 30 days.

## How

**`api/functions/me-recent-releases.ts`** — `toRecentReleases` becomes `splitRecentReleases`, and the response body is `{ upcoming, recent }` rather than `{ releases }`. The window is unchanged: still `getFeedReleasesForUser`'s past 30 days plus everything upcoming, so the feed and the dashboard can't disagree about what counts as recent.

Three decisions worth a reviewer's attention:

- **Split on the date, not `releases.status`** — the same rule as the "Coming" badge it replaces. A row dated next month is upcoming whatever a status column nothing keeps ticking over happens to say. Today counts as *out*.
- **Each list capped at six separately**, not a shared budget of six. A shared cap would let a run of announcements hide everything that actually came out — which is this bug again in miniature.
- **Opposite sorts.** Upcoming stays ascending so its cap trims the furthest off; recent flips to descending so its cap trims the oldest rather than the news.

**`RecentReleasesSection.tsx`** — renders up to two sections, upcoming first. Only a section with rows in it renders; when neither has any, one box explains the silence under the "Recent Releases" heading rather than two boxes saying the same thing. The subscribe control stays a single button riding whichever heading comes first, since both lists come out of the same feed token.

The per-row **"Coming" badge is removed**: it existed to stop an unreleased album vanishing into a list that read as history, and a section heading now says that for every row at once.

## Reviewer notes

- **Response shape changed.** `/api/me/recent-releases` has exactly one consumer (`DashboardPage`), which is why the key could just change. A browser holding a stale pre-deploy SPA chunk would read neither key and show the empty state until it reloads — graceful, but wrong-looking for that short window.
- `apps/web/server/` (the dev shim) still has no route for this endpoint, so `npm run dev` can't show the section. Verified with a throwaway Vite harness instead.

## Testing

- 692 web unit tests, 1002 API tests, `typecheck:api` and the web `tsc -b` all pass. Lint is clean on the touched files (the 71 remaining problems are the repo's existing baseline).
- New coverage: the split itself (an unreleased album stays out of `recent`), the today boundary, both sort directions under a cap, and that the caps are independent. On the web side, that the two lists get their own headings in the right order, that an empty list doesn't render a heading, and that there is still exactly one subscribe button across both sections.
- Rendered all three states (both sections, recent-only, empty) in a throwaway harness. No console errors, and no horizontal overflow at 375px (`scrollWidth === clientWidth === 375`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)