### PR TITLE
Add Resend transactional emails for claim approval/rejection

### DIFF
--- a/.github/workflows/weekly-analytics-recap.yml
+++ b/.github/workflows/weekly-analytics-recap.yml
@@ -1,0 +1,54 @@
+name: Weekly analytics recap
+
+# Sends a weekly analytics recap email to every claimed, verified artist profile that hasn't
+# turned it off (see /settings' Notifications section). See
+# api/functions/weekly-analytics-recap.ts.
+#
+# A GitHub Actions cron rather than a scheduled Netlify function: there are no scheduled
+# Netlify functions in this repo — same precedent as recatalog-sweep.yml,
+# schedule-social-posts.yml, and upstash-keepalive.yml.
+#
+# ## Cadence: once a week, Monday mornings US time
+#
+# '0 13 * * 1' is 13:00 UTC Monday — 6am PT / 9am ET, so the recap lands at the start of an
+# artist's work week rather than overnight. Every run recomputes the "last 7 days" window from
+# when it actually fires, so this is safe to reschedule without a backfill.
+#
+# Safe to over-run: the function's own idempotency guard (email_log, keyed on artistId + the
+# Monday date of that week) means a duplicate invocation the same week sends nothing twice.
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch: # Manual trigger from the GitHub UI
+
+jobs:
+  recap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send the weekly analytics recap
+        env:
+          INTERNAL_FUNCTION_SECRET: ${{ secrets.INTERNAL_FUNCTION_SECRET }}
+        run: |
+          if [ -z "$INTERNAL_FUNCTION_SECRET" ]; then
+            echo "::error::INTERNAL_FUNCTION_SECRET secret is not set"
+            exit 1
+          fi
+
+          response=$(curl -sS -X POST -w '\n%{http_code}' \
+            -H "Authorization: Bearer $INTERNAL_FUNCTION_SECRET" \
+            https://unstream.stream/.netlify/functions/weekly-analytics-recap)
+
+          status=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          # Any non-200 fails the run on purpose — a recap job that reports success while
+          # refusing to do anything (database unreadable, auth misconfigured) is exactly the
+          # kind of silent failure worth catching instead of finding out from an artist asking
+          # where their email went.
+          if [ "$status" != "200" ]; then
+            echo "::error::Recap failed with HTTP $status: $body"
+            exit 1
+          fi
+
+          echo "Recap OK: $body"

--- a/api/functions/__tests__/me-notifications.test.ts
+++ b/api/functions/__tests__/me-notifications.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockCreateClient: vi.fn(() => ({ auth: { getUser: vi.fn() } })),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+
+import { handler } from '../me-notifications';
+
+const DEFAULTS = { newRelease: true, newPlatformLink: true, weeklyAnalyticsRecap: true };
+
+describe('me-notifications handler', () => {
+  const validEvent = {
+    httpMethod: 'GET',
+    headers: { authorization: 'Bearer valid-token' },
+    body: null,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'test@example.com' } },
+          error: null,
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ ...validEvent, headers: {} });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('GET returns all-enabled defaults when the user has no row yet', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual(DEFAULTS);
+  });
+
+  it('GET returns the stored toggles when a row exists', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({
+            data: { new_release: false, new_platform_link: true, weekly_analytics_recap: false },
+            error: null,
+          })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({
+      newRelease: false,
+      newPlatformLink: true,
+      weeklyAnalyticsRecap: false,
+    });
+  });
+
+  it('GET reports a database error rather than silently claiming defaults', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: { message: 'boom' } })),
+        })),
+      })),
+    });
+
+    const res = await handler(validEvent);
+    expect(res!.statusCode).toBe(500);
+  });
+
+  it('POST upserts only the provided field and returns the full resulting state', async () => {
+    const upsertFn = vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(() => Promise.resolve({
+          data: { new_release: false, new_platform_link: true, weekly_analytics_recap: true },
+          error: null,
+        })),
+      })),
+    }));
+    mocks.mockFrom.mockReturnValue({ upsert: upsertFn });
+
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ newRelease: false }),
+    });
+
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ newRelease: false, newPlatformLink: true, weeklyAnalyticsRecap: true });
+    expect(upsertFn).toHaveBeenCalledWith(
+      { user_id: 'user-1', new_release: false },
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('POST accepts multiple fields at once', async () => {
+    const upsertFn = vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(() => Promise.resolve({
+          data: { new_release: false, new_platform_link: false, weekly_analytics_recap: true },
+          error: null,
+        })),
+      })),
+    }));
+    mocks.mockFrom.mockReturnValue({ upsert: upsertFn });
+
+    await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ newRelease: false, newPlatformLink: false }),
+    });
+
+    expect(upsertFn).toHaveBeenCalledWith(
+      { user_id: 'user-1', new_release: false, new_platform_link: false },
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('POST rejects a non-boolean field', async () => {
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ newRelease: 'yes' }),
+    });
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('POST rejects a body with no recognized fields', async () => {
+    const res = await handler({
+      ...validEvent,
+      httpMethod: 'POST',
+      body: JSON.stringify({ somethingElse: true }),
+    });
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('POST rejects invalid JSON', async () => {
+    const res = await handler({ ...validEvent, httpMethod: 'POST', body: '{not json' });
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('handles OPTIONS preflight', async () => {
+    const res = await handler({ ...validEvent, httpMethod: 'OPTIONS' });
+    expect(res!.statusCode).toBe(204);
+  });
+
+  it('returns 404 for non-GET/POST methods', async () => {
+    const res = await handler({ ...validEvent, httpMethod: 'DELETE' });
+    expect(res!.statusCode).toBe(404);
+  });
+});

--- a/api/functions/__tests__/newsletter-subscribe.test.ts
+++ b/api/functions/__tests__/newsletter-subscribe.test.ts
@@ -88,7 +88,7 @@ describe('newsletter-subscribe handler', () => {
   it('sends the API key as a Token header and never in the body', async () => {
     fetchMock.mockResolvedValue(buttondownReply(201, { id: 'abc' }));
 
-    await handler(post({ email: 'fan@example.com', source: 'settings' }));
+    await handler(post({ email: 'fan@example.com', source: 'changelog' }));
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://api.buttondown.com/v1/subscribers');

--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../lib/sentry', () => ({
   Sentry: { captureException: mocks.captureException, captureMessage: mocks.captureMessage },
 }));
 
-import { sendNotificationOnce } from '../notifications';
+import { sendNotificationOnce, notifySavedArtistsOfNewRelease, notifySavedArtistsOfNewLinks } from '../notifications';
 
 /**
  * A minimal stand-in for the two chains sendNotificationOnce actually uses:
@@ -95,5 +95,115 @@ describe('sendNotificationOnce', () => {
       expect.objectContaining({ status: 'failed', error: 'bad address' }),
     );
     expect(mocks.captureMessage).toHaveBeenCalled();
+  });
+});
+
+/**
+ * A fuller fake client for the fanout functions, which call sendNotificationOnce for real
+ * (it isn't mocked — only sendTransactionalEmail is), so it needs to answer `saved_artists`,
+ * `artists`, `email_log`, and `auth.admin.getUserById` all in one client.
+ */
+function makeFanoutClient(opts: {
+  savedArtists?: { data: { user_id: string }[] | null; error?: unknown };
+  artistRow?: { data: { name: string; slug: string } | null; error?: unknown };
+  emails?: Record<string, string>;
+}) {
+  const savedArtistsResult = opts.savedArtists ?? { data: [], error: null };
+  const artistRowResult = opts.artistRow ?? { data: null, error: null };
+  const emails = opts.emails ?? {};
+
+  const from = vi.fn((table: string) => {
+    if (table === 'saved_artists') {
+      return { select: () => ({ eq: () => ({ eq: () => Promise.resolve(savedArtistsResult) }) }) };
+    }
+    if (table === 'artists') {
+      return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve(artistRowResult) }) }) };
+    }
+    if (table === 'email_log') {
+      return {
+        insert: () => ({
+          select: () => ({ single: () => Promise.resolve({ data: { id: `log-${Math.random()}` }, error: null }) }),
+        }),
+        update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  const getUserById = vi.fn((userId: string) =>
+    Promise.resolve(emails[userId] ? { data: { user: { email: emails[userId] } }, error: null } : { data: { user: null }, error: null }),
+  );
+
+  return { from, auth: { admin: { getUserById } } } as never;
+}
+
+describe('notifySavedArtistsOfNewRelease', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, messageId: 'msg_1' });
+  });
+
+  it('does nothing when nobody saved the artist', async () => {
+    const client = makeFanoutClient({ savedArtists: { data: [], error: null } });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', releasesFound: 5 });
+
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+  });
+
+  it('emails every saver about the artist by name, linking to their profile', async () => {
+    const client = makeFanoutClient({
+      savedArtists: { data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null },
+      artistRow: { data: { name: 'Test Artist', slug: 'test-artist' }, error: null },
+      emails: { u1: 'fan1@example.com', u2: 'fan2@example.com' },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', releasesFound: 5 });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
+    const recipients = mocks.sendTransactionalEmail.mock.calls.map(([params]) => params.to);
+    expect(recipients).toEqual(['fan1@example.com', 'fan2@example.com']);
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('unstream.stream/a/test-artist');
+  });
+});
+
+describe('notifySavedArtistsOfNewLinks', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, messageId: 'msg_1' });
+  });
+
+  it('does nothing when no platforms were discovered', async () => {
+    const client = makeFanoutClient({ savedArtists: { data: [{ user_id: 'u1' }], error: null } });
+
+    await notifySavedArtistsOfNewLinks({
+      client,
+      artistId: 'artist-1',
+      artistName: 'Test Artist',
+      artistSlug: 'test-artist',
+      platforms: [],
+    });
+
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+  });
+
+  it('excludes the claimant from the saver fanout', async () => {
+    const client = makeFanoutClient({
+      savedArtists: { data: [{ user_id: 'claimer' }, { user_id: 'fan' }], error: null },
+      emails: { claimer: 'claimer@example.com', fan: 'fan@example.com' },
+    });
+
+    await notifySavedArtistsOfNewLinks({
+      client,
+      artistId: 'artist-1',
+      artistName: 'Test Artist',
+      artistSlug: 'test-artist',
+      platforms: ['patreon'],
+      excludeUserId: 'claimer',
+    });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].to).toBe('fan@example.com');
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('patreon');
   });
 });

--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  sendTransactionalEmail: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('../../lib/resend', () => ({
+  sendTransactionalEmail: mocks.sendTransactionalEmail,
+}));
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureException: mocks.captureException, captureMessage: mocks.captureMessage },
+}));
+
+import { sendNotificationOnce } from '../notifications';
+
+/**
+ * A minimal stand-in for the two chains sendNotificationOnce actually uses:
+ *   .from('email_log').insert({...}).select('id').single()
+ *   .from('email_log').update({...}).eq('id', id)
+ */
+function fakeClient(opts: {
+  insertResult: { data: { id: string } | null; error: { code?: string } | null };
+  updateResult?: { error: unknown };
+}) {
+  const updateMock = vi.fn(() => ({
+    eq: vi.fn(() => Promise.resolve(opts.updateResult || { error: null })),
+  }));
+  const insertMock = vi.fn(() => ({
+    select: vi.fn(() => ({
+      single: vi.fn(() => Promise.resolve(opts.insertResult)),
+    })),
+  }));
+  const from = vi.fn(() => ({ insert: insertMock, update: updateMock }));
+  return { from, insertMock, updateMock } as unknown as { from: typeof from; insertMock: typeof insertMock; updateMock: typeof updateMock };
+}
+
+const baseParams = {
+  notificationType: 'claim_approved_auto',
+  referenceId: 'artist-1',
+  recipientEmail: 'artist@example.com',
+  subject: 'Subject',
+  html: '<p>Body</p>',
+  text: 'Body',
+};
+
+describe('sendNotificationOnce', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('sends the email and records the outcome once the log row is claimed', async () => {
+    const client = fakeClient({ insertResult: { data: { id: 'log-1' }, error: null } });
+    mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, messageId: 'msg_123' });
+
+    await sendNotificationOnce({ client: client as never, ...baseParams });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledWith({
+      to: baseParams.recipientEmail,
+      subject: baseParams.subject,
+      html: baseParams.html,
+      text: baseParams.text,
+    });
+    expect(client.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'sent', resend_message_id: 'msg_123' }),
+    );
+  });
+
+  it('skips sending when the same notification was already logged (duplicate key)', async () => {
+    const client = fakeClient({ insertResult: { data: null, error: { code: '23505' } } });
+
+    await sendNotificationOnce({ client: client as never, ...baseParams });
+
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports an unexpected insert error without sending', async () => {
+    const client = fakeClient({ insertResult: { data: null, error: { code: 'other' } } });
+
+    await sendNotificationOnce({ client: client as never, ...baseParams });
+
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+    expect(mocks.captureException).toHaveBeenCalled();
+  });
+
+  it('logs the failure when Resend rejects the send', async () => {
+    const client = fakeClient({ insertResult: { data: { id: 'log-1' }, error: null } });
+    mocks.sendTransactionalEmail.mockResolvedValue({ ok: false, error: 'bad address' });
+
+    await sendNotificationOnce({ client: client as never, ...baseParams });
+
+    expect(client.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', error: 'bad address' }),
+    );
+    expect(mocks.captureMessage).toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../lib/sentry', () => ({
   Sentry: { captureException: mocks.captureException, captureMessage: mocks.captureMessage },
 }));
 
-import { sendNotificationOnce, notifySavedArtistsOfNewRelease, notifySavedArtistsOfNewLinks } from '../notifications';
+import { sendNotificationOnce, notifySavedArtistsOfNewRelease, notifySavedArtistsOfNewLinks, filterByPreference } from '../notifications';
 
 /**
  * A minimal stand-in for the two chains sendNotificationOnce actually uses:
@@ -99,18 +99,21 @@ describe('sendNotificationOnce', () => {
 });
 
 /**
- * A fuller fake client for the fanout functions, which call sendNotificationOnce for real
- * (it isn't mocked — only sendTransactionalEmail is), so it needs to answer `saved_artists`,
- * `artists`, `email_log`, and `auth.admin.getUserById` all in one client.
+ * A fuller fake client for the fanout functions, which call sendNotificationOnce and
+ * filterByPreference for real (only sendTransactionalEmail is mocked), so it needs to answer
+ * `saved_artists`, `artists`, `email_log`, `notification_preferences`, and
+ * `auth.admin.getUserById` all in one client.
  */
 function makeFanoutClient(opts: {
   savedArtists?: { data: { user_id: string }[] | null; error?: unknown };
   artistRow?: { data: { name: string; slug: string } | null; error?: unknown };
   emails?: Record<string, string>;
+  optedOut?: Record<string, boolean>;
 }) {
   const savedArtistsResult = opts.savedArtists ?? { data: [], error: null };
   const artistRowResult = opts.artistRow ?? { data: null, error: null };
   const emails = opts.emails ?? {};
+  const optedOut = opts.optedOut ?? {};
 
   const from = vi.fn((table: string) => {
     if (table === 'saved_artists') {
@@ -118,6 +121,19 @@ function makeFanoutClient(opts: {
     }
     if (table === 'artists') {
       return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve(artistRowResult) }) }) };
+    }
+    if (table === 'notification_preferences') {
+      return {
+        select: () => ({
+          in: (_col: string, userIds: string[]) =>
+            Promise.resolve({
+              data: userIds
+                .filter(id => id in optedOut)
+                .map(id => ({ user_id: id, new_release: !optedOut[id], new_platform_link: !optedOut[id], weekly_analytics_recap: !optedOut[id] })),
+              error: null,
+            }),
+        }),
+      };
     }
     if (table === 'email_log') {
       return {
@@ -165,6 +181,20 @@ describe('notifySavedArtistsOfNewRelease', () => {
     expect(recipients).toEqual(['fan1@example.com', 'fan2@example.com']);
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('unstream.stream/a/test-artist');
   });
+
+  it('does not email a saver who turned new-release alerts off', async () => {
+    const client = makeFanoutClient({
+      savedArtists: { data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null },
+      artistRow: { data: { name: 'Test Artist', slug: 'test-artist' }, error: null },
+      emails: { u1: 'fan1@example.com', u2: 'fan2@example.com' },
+      optedOut: { u1: true },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', releasesFound: 5 });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].to).toBe('fan2@example.com');
+  });
 });
 
 describe('notifySavedArtistsOfNewLinks', () => {
@@ -205,5 +235,54 @@ describe('notifySavedArtistsOfNewLinks', () => {
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(1);
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].to).toBe('fan@example.com');
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('patreon');
+  });
+
+  it('does not email a saver who turned new-platform-link alerts off', async () => {
+    const client = makeFanoutClient({
+      savedArtists: { data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null },
+      emails: { u1: 'fan1@example.com', u2: 'fan2@example.com' },
+      optedOut: { u2: true },
+    });
+
+    await notifySavedArtistsOfNewLinks({
+      client,
+      artistId: 'artist-1',
+      artistName: 'Test Artist',
+      artistSlug: 'test-artist',
+      platforms: ['patreon'],
+    });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].to).toBe('fan1@example.com');
+  });
+});
+
+describe('filterByPreference', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns everyone unchanged when the list is empty', async () => {
+    const client = makeFanoutClient({});
+    expect(await filterByPreference(client, [], 'new_release')).toEqual([]);
+  });
+
+  it('drops only the user ids with that column explicitly false', async () => {
+    const client = makeFanoutClient({ optedOut: { u1: true } });
+
+    const result = await filterByPreference(client, ['u1', 'u2'], 'new_release');
+
+    expect(result).toEqual(['u2']);
+  });
+
+  it('fails open (keeps everyone) when the preference lookup errors', async () => {
+    const client = {
+      from: () => ({ select: () => ({ in: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }),
+    } as never;
+
+    const result = await filterByPreference(client, ['u1', 'u2'], 'new_release');
+
+    expect(result).toEqual(['u1', 'u2']);
+    expect(mocks.captureException).toHaveBeenCalled();
   });
 });

--- a/api/functions/__tests__/resend.test.ts
+++ b/api/functions/__tests__/resend.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureException: mocks.captureException, captureMessage: mocks.captureMessage },
+}));
+
+import { sendTransactionalEmail } from '../../lib/resend';
+
+function resendReply(status: number, payload: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(payload === undefined ? '' : JSON.stringify(payload)),
+  } as unknown as Response;
+}
+
+describe('sendTransactionalEmail', () => {
+  const fetchMock = vi.fn();
+  const params = { to: 'artist@example.com', subject: 'Hi', html: '<p>Hi</p>', text: 'Hi' };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.RESEND_API_KEY = 'test-key';
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it('sends the email and returns the Resend message id', async () => {
+    fetchMock.mockResolvedValue(resendReply(200, { id: 'msg_123' }));
+
+    const result = await sendTransactionalEmail(params);
+
+    expect(result).toEqual({ ok: true, messageId: 'msg_123' });
+  });
+
+  it('sends the API key as a Bearer header and never in the body', async () => {
+    fetchMock.mockResolvedValue(resendReply(200, { id: 'msg_123' }));
+
+    await sendTransactionalEmail(params);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init.headers.Authorization).toBe('Bearer test-key');
+    expect(init.body).not.toContain('test-key');
+    expect(JSON.parse(init.body)).toMatchObject({
+      to: params.to,
+      subject: params.subject,
+      html: params.html,
+      text: params.text,
+    });
+  });
+
+  it('fails loudly when RESEND_API_KEY is missing, so a lost notification is visible', async () => {
+    delete process.env.RESEND_API_KEY;
+
+    const result = await sendTransactionalEmail(params);
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('RESEND_API_KEY'),
+      'error',
+    );
+  });
+
+  it('reports an upstream failure instead of claiming the send worked', async () => {
+    fetchMock.mockResolvedValue(resendReply(422, { message: 'invalid from address' }));
+
+    const result = await sendTransactionalEmail(params);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('invalid from address');
+    expect(mocks.captureMessage).toHaveBeenCalled();
+  });
+
+  it('reports a network failure rather than guessing either way', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    const result = await sendTransactionalEmail(params);
+
+    expect(result.ok).toBe(false);
+    expect(mocks.captureException).toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/weekly-analytics-recap.test.ts
+++ b/api/functions/__tests__/weekly-analytics-recap.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const SECRET = 'test-internal-secret';
+const originalEnv = { ...process.env };
+
+const mocks = vi.hoisted(() => ({
+  getClient: vi.fn(),
+  sendNotificationOnce: vi.fn(),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ getClient: mocks.getClient }));
+vi.mock('../notifications', () => ({ sendNotificationOnce: mocks.sendNotificationOnce }));
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureMessage: mocks.captureMessage, captureException: mocks.captureException },
+}));
+
+import { handler } from '../weekly-analytics-recap';
+
+function post(headers: Record<string, string | undefined> = { authorization: `Bearer ${SECRET}` }) {
+  return handler({ httpMethod: 'POST', headers });
+}
+
+/** artist_profiles select().not() resolves directly; artist_analytics select().eq().gte() does too. */
+function makeClient(opts: {
+  profiles: { data: unknown; error?: unknown };
+  analyticsByArtist?: Record<string, { metric: string; count: number }[]>;
+}) {
+  const from = vi.fn((table: string) => {
+    if (table === 'artist_profiles') {
+      return { select: () => ({ not: () => Promise.resolve(opts.profiles) }) };
+    }
+    if (table === 'artist_analytics') {
+      return {
+        select: () => ({
+          eq: (_col: string, artistId: string) => ({
+            gte: () => Promise.resolve({ data: opts.analyticsByArtist?.[artistId] || [], error: null }),
+          }),
+        }),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+  return { from };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.INTERNAL_FUNCTION_SECRET = SECRET;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('weekly-analytics-recap auth', () => {
+  it('rejects a request with no Authorization header', async () => {
+    const r = await post({});
+    expect(r.statusCode).toBe(401);
+    expect(mocks.getClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-POST', async () => {
+    const r = await handler({ httpMethod: 'GET', headers: { authorization: `Bearer ${SECRET}` } });
+    expect(r.statusCode).toBe(405);
+  });
+});
+
+describe('weekly-analytics-recap', () => {
+  it('sends nothing when there are no verified profiles', async () => {
+    mocks.getClient.mockReturnValue(makeClient({ profiles: { data: [], error: null } }));
+
+    const r = await post();
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 0 });
+    expect(mocks.sendNotificationOnce).not.toHaveBeenCalled();
+  });
+
+  it('sends a recap per verified profile with this week\'s totals', async () => {
+    mocks.getClient.mockReturnValue(makeClient({
+      profiles: {
+        data: [
+          { artist_id: 'a1', email: 'artist1@example.com', artists: { name: 'Artist One', slug: 'artist-one' } },
+        ],
+        error: null,
+      },
+      analyticsByArtist: {
+        a1: [
+          { metric: 'search', count: 10 },
+          { metric: 'view', count: 4 },
+          { metric: 'click:bandcamp', count: 2 },
+          { metric: 'click:patreon', count: 1 },
+        ],
+      },
+    }));
+
+    const r = await post();
+
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body)).toEqual({ sent: 1, skipped: 0 });
+    expect(mocks.sendNotificationOnce).toHaveBeenCalledTimes(1);
+    const call = mocks.sendNotificationOnce.mock.calls[0][0];
+    expect(call.recipientEmail).toBe('artist1@example.com');
+    expect(call.notificationType).toBe('weekly_analytics_recap');
+    expect(call.referenceId).toMatch(/^a1:\d{4}-\d{2}-\d{2}$/);
+    expect(call.html).toContain('10 search appearances');
+    expect(call.html).toContain('4 profile views');
+    expect(call.html).toContain('3 link clicks');
+  });
+
+  it('skips a profile missing an artist slug rather than sending a broken link', async () => {
+    mocks.getClient.mockReturnValue(makeClient({
+      profiles: {
+        data: [{ artist_id: 'a1', email: 'artist1@example.com', artists: null }],
+        error: null,
+      },
+    }));
+
+    const r = await post();
+
+    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 1 });
+    expect(mocks.sendNotificationOnce).not.toHaveBeenCalled();
+  });
+
+  it('reports an upstream failure instead of claiming success', async () => {
+    mocks.getClient.mockReturnValue({
+      from: () => ({ select: () => ({ not: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }),
+    });
+
+    const r = await post();
+
+    expect(r.statusCode).toBe(503);
+    expect(mocks.captureMessage).toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/weekly-analytics-recap.test.ts
+++ b/api/functions/__tests__/weekly-analytics-recap.test.ts
@@ -6,12 +6,16 @@ const originalEnv = { ...process.env };
 const mocks = vi.hoisted(() => ({
   getClient: vi.fn(),
   sendNotificationOnce: vi.fn(),
+  filterByPreference: vi.fn(),
   captureMessage: vi.fn(),
   captureException: vi.fn(),
 }));
 
 vi.mock('../db', () => ({ getClient: mocks.getClient }));
-vi.mock('../notifications', () => ({ sendNotificationOnce: mocks.sendNotificationOnce }));
+vi.mock('../notifications', () => ({
+  sendNotificationOnce: mocks.sendNotificationOnce,
+  filterByPreference: mocks.filterByPreference,
+}));
 vi.mock('../../lib/sentry', () => ({
   Sentry: { captureMessage: mocks.captureMessage, captureException: mocks.captureException },
 }));
@@ -48,6 +52,8 @@ function makeClient(opts: {
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.INTERNAL_FUNCTION_SECRET = SECRET;
+  // Default: nobody has opted out. Individual tests override to exercise the filter.
+  mocks.filterByPreference.mockImplementation((_client, userIds) => Promise.resolve(userIds));
 });
 
 afterEach(() => {
@@ -74,7 +80,7 @@ describe('weekly-analytics-recap', () => {
     const r = await post();
 
     expect(r.statusCode).toBe(200);
-    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 0 });
+    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 0, optedOut: 0 });
     expect(mocks.sendNotificationOnce).not.toHaveBeenCalled();
   });
 
@@ -82,7 +88,7 @@ describe('weekly-analytics-recap', () => {
     mocks.getClient.mockReturnValue(makeClient({
       profiles: {
         data: [
-          { artist_id: 'a1', email: 'artist1@example.com', artists: { name: 'Artist One', slug: 'artist-one' } },
+          { artist_id: 'a1', user_id: 'u1', email: 'artist1@example.com', artists: { name: 'Artist One', slug: 'artist-one' } },
         ],
         error: null,
       },
@@ -99,7 +105,7 @@ describe('weekly-analytics-recap', () => {
     const r = await post();
 
     expect(r.statusCode).toBe(200);
-    expect(JSON.parse(r.body)).toEqual({ sent: 1, skipped: 0 });
+    expect(JSON.parse(r.body)).toEqual({ sent: 1, skipped: 0, optedOut: 0 });
     expect(mocks.sendNotificationOnce).toHaveBeenCalledTimes(1);
     const call = mocks.sendNotificationOnce.mock.calls[0][0];
     expect(call.recipientEmail).toBe('artist1@example.com');
@@ -113,15 +119,35 @@ describe('weekly-analytics-recap', () => {
   it('skips a profile missing an artist slug rather than sending a broken link', async () => {
     mocks.getClient.mockReturnValue(makeClient({
       profiles: {
-        data: [{ artist_id: 'a1', email: 'artist1@example.com', artists: null }],
+        data: [{ artist_id: 'a1', user_id: 'u1', email: 'artist1@example.com', artists: null }],
         error: null,
       },
     }));
 
     const r = await post();
 
-    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 1 });
+    expect(JSON.parse(r.body)).toEqual({ sent: 0, skipped: 1, optedOut: 0 });
     expect(mocks.sendNotificationOnce).not.toHaveBeenCalled();
+  });
+
+  it('does not email an artist who turned the weekly recap off', async () => {
+    mocks.getClient.mockReturnValue(makeClient({
+      profiles: {
+        data: [
+          { artist_id: 'a1', user_id: 'opted-out', email: 'quiet@example.com', artists: { name: 'Quiet Artist', slug: 'quiet-artist' } },
+          { artist_id: 'a2', user_id: 'opted-in', email: 'loud@example.com', artists: { name: 'Loud Artist', slug: 'loud-artist' } },
+        ],
+        error: null,
+      },
+    }));
+    mocks.filterByPreference.mockResolvedValue(['opted-in']);
+
+    const r = await post();
+
+    expect(mocks.filterByPreference).toHaveBeenCalledWith(expect.anything(), ['opted-out', 'opted-in'], 'weekly_analytics_recap');
+    expect(JSON.parse(r.body)).toEqual({ sent: 1, skipped: 0, optedOut: 1 });
+    expect(mocks.sendNotificationOnce).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotificationOnce.mock.calls[0][0].recipientEmail).toBe('loud@example.com');
   });
 
   it('reports an upstream failure instead of claiming success', async () => {

--- a/api/functions/admin-verify.ts
+++ b/api/functions/admin-verify.ts
@@ -4,6 +4,8 @@
 import { getClient } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
 import { Sentry } from '../lib/sentry';
+import { sendNotificationOnce } from './notifications';
+import { escapeHtml } from '../lib/html';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -201,6 +203,14 @@ export async function handler(event: {
     };
   }
 
+  // Needed for the decision email below regardless of outcome.
+  const { data: artistInfo } = await client
+    .from('artists')
+    .select('name, slug')
+    .eq('id', request.artist_id)
+    .single();
+  const artistName = artistInfo?.name || 'your artist profile';
+
   const now = new Date().toISOString();
 
   if (action === 'approve') {
@@ -312,6 +322,17 @@ export async function handler(event: {
         adminId: admin.userId,
       },
     });
+
+    const profileUrl = artistInfo?.slug ? `https://unstream.stream/a/${artistInfo.slug}` : 'https://unstream.stream';
+    void sendNotificationOnce({
+      client,
+      notificationType: 'claim_approved_manual',
+      referenceId: requestId,
+      recipientEmail: request.email,
+      subject: `Your claim of ${artistName} on Unstream is approved`,
+      html: `<p>Your claim of <strong>${escapeHtml(artistName)}</strong> on Unstream has been reviewed and approved — your profile is now live at <a href="${profileUrl}">${profileUrl}</a>.</p><p>You can edit your bio, photo, and links any time from your dashboard.</p>`,
+      text: `Your claim of ${artistName} on Unstream has been reviewed and approved — your profile is now live at ${profileUrl}.\n\nYou can edit your bio, photo, and links any time from your dashboard.`,
+    });
   } else {
     // Reject: just update the request status
     const { error: updateError } = await client
@@ -331,6 +352,16 @@ export async function handler(event: {
         body: JSON.stringify({ error: 'Failed to update verification request' }),
       };
     }
+
+    void sendNotificationOnce({
+      client,
+      notificationType: 'claim_rejected',
+      referenceId: requestId,
+      recipientEmail: request.email,
+      subject: `Your claim of ${artistName} on Unstream wasn't approved`,
+      html: `<p>Your claim of <strong>${escapeHtml(artistName)}</strong> on Unstream wasn't approved this time.${reviewerNotes ? ` The reviewer left this note: "${escapeHtml(reviewerNotes)}"` : ''}</p><p>If you think this was a mistake, reply to this email and we'll take another look.</p>`,
+      text: `Your claim of ${artistName} on Unstream wasn't approved this time.${reviewerNotes ? ` The reviewer left this note: "${reviewerNotes}"` : ''}\n\nIf you think this was a mistake, reply to this email and we'll take another look.`,
+    });
   }
 
   return {

--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -7,7 +7,7 @@ import { createClient } from '@supabase/supabase-js';
 import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
-import { sendNotificationOnce } from './notifications';
+import { sendNotificationOnce, notifySavedArtistsOfNewLinks } from './notifications';
 import { escapeHtml } from '../lib/html';
 
 const PLATFORM_PATTERNS: [string, RegExp][] = [
@@ -680,6 +680,21 @@ export async function handler(event: {
         subject: `Your claim of ${artist.name} on Unstream is verified`,
         html: `<p>Your claim of <strong>${escapeHtml(artist.name)}</strong> on Unstream has been verified — your profile is now live at <a href="https://unstream.stream/a/${escapeHtml(slug)}">unstream.stream/a/${escapeHtml(slug)}</a>.</p><p>You can edit your bio, photo, and links any time from your dashboard.</p>`,
         text: `Your claim of ${artist.name} on Unstream has been verified — your profile is now live at https://unstream.stream/a/${slug}.\n\nYou can edit your bio, photo, and links any time from your dashboard.`,
+      });
+    }
+
+    if (discoveredLinks.length > 0) {
+      // Excludes the claimant themselves — they already got the claim-approved email above and
+      // just added these links, so it isn't news to them.
+      void notifySavedArtistsOfNewLinks({
+        client,
+        artistId: artist.id,
+        artistName: artist.name,
+        artistSlug: slug,
+        platforms: discoveredLinks.map(l => l.platform),
+        excludeUserId: userId,
+      }).catch(err => {
+        Sentry.captureException(err, { extra: { context: 'notifySavedArtistsOfNewLinks', artistId: artist.id } });
       });
     }
 

--- a/api/functions/claim-artist.ts
+++ b/api/functions/claim-artist.ts
@@ -7,6 +7,8 @@ import { createClient } from '@supabase/supabase-js';
 import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
+import { sendNotificationOnce } from './notifications';
+import { escapeHtml } from '../lib/html';
 
 const PLATFORM_PATTERNS: [string, RegExp][] = [
   ['bandcamp', /([a-z0-9-]+)\.bandcamp\.com/i],
@@ -665,6 +667,21 @@ export async function handler(event: {
     }
 
     console.log(`[Claim] Verified "${artist.name}" — discovered ${discoveredLinks.length} platform links from website`);
+
+    const notifyEmail = (profile.email || authUser.email || '').trim();
+    if (notifyEmail) {
+      // Fire-and-forget: a failed notification email must never fail a successful claim.
+      // sendNotificationOnce logs its own failures to Sentry and is a no-op on retry.
+      void sendNotificationOnce({
+        client,
+        notificationType: 'claim_approved_auto',
+        referenceId: artist.id,
+        recipientEmail: notifyEmail,
+        subject: `Your claim of ${artist.name} on Unstream is verified`,
+        html: `<p>Your claim of <strong>${escapeHtml(artist.name)}</strong> on Unstream has been verified — your profile is now live at <a href="https://unstream.stream/a/${escapeHtml(slug)}">unstream.stream/a/${escapeHtml(slug)}</a>.</p><p>You can edit your bio, photo, and links any time from your dashboard.</p>`,
+        text: `Your claim of ${artist.name} on Unstream has been verified — your profile is now live at https://unstream.stream/a/${slug}.\n\nYou can edit your bio, photo, and links any time from your dashboard.`,
+      });
+    }
 
     // Build full link list for the review step (existing + newly discovered, deduplicated)
     const allLinksMap = new Map<string, { platform: string; url: string }>();

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -17,6 +17,7 @@ import {
   uniqueReleaseSlug,
 } from './release-utils';
 import { requestArtistCatalog } from './request-catalog';
+import { notifySavedArtistsOfNewRelease } from './notifications';
 import { Sentry } from '../lib/sentry';
 import { isNonArtistSlug } from '../lib/non-artist-names';
 import { isExcludedArtistSlug } from '../lib/excluded-artists';
@@ -577,25 +578,37 @@ export async function recordCatalogOutcome(
         .maybeSingle();
       const prev = (data as { consecutive_failures: number } | null)?.consecutive_failures ?? 0;
       patch.consecutive_failures = prev + 1;
-    } else if (outcome.releasesFound === 0) {
-      // A run that finds 0 releases where it previously found 20 is a parser break or a bot
-      // challenge, not an artist deleting their catalogue — and it is recorded as a *success*,
-      // so nothing else about it looks wrong. Report the transition, because the alternative
-      // is a pipeline that degrades into finding nothing and never says so.
-      //
-      // Only the transition: an artist who has always had 0 releases is not news, and this
-      // fires on every trigger, not just the scheduled sweep.
+    } else {
+      // Read once and branch: a drop to zero is a parser/bot-challenge alert (see below), an
+      // increase is news for anyone who saved this artist. Fetched for every successful run,
+      // not just the sweep, since demand-driven catalog triggers (a save, a search) are exactly
+      // where a fan is most likely to be waiting on this.
       const { data } = await client
         .from('release_catalog_state')
         .select('releases_found')
         .eq('artist_id', artistId)
         .maybeSingle();
       const previous = (data as { releases_found: number | null } | null)?.releases_found ?? 0;
-      if (previous > 0) {
+
+      if (outcome.releasesFound === 0 && previous > 0) {
+        // A run that finds 0 releases where it previously found 20 is a parser break or a bot
+        // challenge, not an artist deleting their catalogue — and it is recorded as a *success*,
+        // so nothing else about it looks wrong. Report the transition, because the alternative
+        // is a pipeline that degrades into finding nothing and never says so.
+        //
+        // Only the transition: an artist who has always had 0 releases is not news, and this
+        // fires on every trigger, not just the scheduled sweep.
         Sentry.captureMessage('[catalog] release count dropped to zero', {
           level: 'warning',
           tags: { area: 'release-catalog', kind: 'releases-dropped-to-zero' },
           extra: { artistId, previousReleasesFound: previous },
+        });
+      } else if (outcome.releasesFound > previous) {
+        // Fire-and-forget: notifySavedArtistsOfNewRelease bails out immediately if nobody saved
+        // this artist (true for nearly everything the sweep touches) and logs its own failures
+        // to Sentry — a notification email must never affect cataloging's own success/failure.
+        void notifySavedArtistsOfNewRelease({ client, artistId, releasesFound: outcome.releasesFound }).catch(err => {
+          Sentry.captureException(err, { extra: { context: 'notifySavedArtistsOfNewRelease', artistId } });
         });
       }
     }

--- a/api/functions/me-notifications.ts
+++ b/api/functions/me-notifications.ts
@@ -1,0 +1,143 @@
+// API endpoint: /api/me/notification-preferences
+// GET  — returns the current user's toggles for saved-artist and analytics-recap emails.
+// POST — updates one or more toggles. Body: { newRelease?, newPlatformLink?, weeklyAnalyticsRecap? }
+//
+// A user who has never touched these has no row in notification_preferences at all — GET
+// reports that as all-true (the default) without creating one, and POST upserts a row only
+// once they actually change something. Every sender (notifications.ts,
+// weekly-analytics-recap.ts) treats a missing row the same way.
+
+import { createClient } from '@supabase/supabase-js';
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+const DEFAULT_PREFERENCES = {
+  newRelease: true,
+  newPlatformLink: true,
+  weeklyAnalyticsRecap: true,
+};
+
+interface PreferencesRow {
+  new_release: boolean;
+  new_platform_link: boolean;
+  weekly_analytics_recap: boolean;
+}
+
+function toResponseShape(row: PreferencesRow | null) {
+  if (!row) return DEFAULT_PREFERENCES;
+  return {
+    newRelease: row.new_release,
+    newPlatformLink: row.new_platform_link,
+    weeklyAnalyticsRecap: row.weekly_analytics_recap,
+  };
+}
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { userId: data.user.id };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    const { data: row, error } = await client
+      .from('notification_preferences')
+      .select('new_release, new_platform_link, weekly_analytics_recap')
+      .eq('user_id', user.userId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[me-notifications] Error fetching preferences:', error.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load notification preferences' }) };
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(toResponseShape(row)) };
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    const patch: Partial<PreferencesRow> = {};
+    if ('newRelease' in body) {
+      if (typeof body.newRelease !== 'boolean') {
+        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'newRelease must be a boolean' }) };
+      }
+      patch.new_release = body.newRelease;
+    }
+    if ('newPlatformLink' in body) {
+      if (typeof body.newPlatformLink !== 'boolean') {
+        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'newPlatformLink must be a boolean' }) };
+      }
+      patch.new_platform_link = body.newPlatformLink;
+    }
+    if ('weeklyAnalyticsRecap' in body) {
+      if (typeof body.weeklyAnalyticsRecap !== 'boolean') {
+        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'weeklyAnalyticsRecap must be a boolean' }) };
+      }
+      patch.weekly_analytics_recap = body.weeklyAnalyticsRecap;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'No recognized preference fields in body' }) };
+    }
+
+    // Upsert: most users have no row yet. Unset fields fall back to the column default (true)
+    // on first insert via onConflict merge semantics — an existing row keeps its other columns.
+    const { data: row, error } = await client
+      .from('notification_preferences')
+      .upsert({ user_id: user.userId, ...patch }, { onConflict: 'user_id' })
+      .select('new_release, new_platform_link, weekly_analytics_recap')
+      .single();
+
+    if (error) {
+      console.error('[me-notifications] Error updating preferences:', error.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update notification preferences' }) };
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(toResponseShape(row)) };
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/functions/newsletter-subscribe.ts
+++ b/api/functions/newsletter-subscribe.ts
@@ -1,6 +1,12 @@
 // API endpoint: /api/newsletter/subscribe
 // POST — adds an email address to the Unstream newsletter on Buttondown.
-// Body: { email: string, source?: 'changelog' | 'guides' | 'settings' }
+// Body: { email: string, source?: 'changelog' | 'guides' }
+//
+// Deliberately not offered from /settings: that page already has its own opt-out toggles for
+// product email (see notification_preferences / NotificationPreferences.tsx), and pairing that
+// with an opt-*in* newsletter form in the same section read as "you still need to sign up for
+// this" even to people already getting product email. Buttondown signup lives only where
+// someone has just shown interest in a specific kind of content — guides, changelog.
 //
 // Why a proxy rather than Buttondown's own embed: the embed needs third-party script and
 // frame hosts in the CSP and can't be styled to match the site. Going through a function
@@ -36,7 +42,7 @@ const UPSTREAM_TIMEOUT_MS = 8000;
 // Tags let Buttondown segment by where somebody signed up. `source` is client-supplied and
 // Buttondown creates tags on demand, so anything off this list is dropped rather than
 // forwarded — otherwise a stranger with curl could fill the account with junk tags.
-const ALLOWED_SOURCES = new Set(['changelog', 'guides', 'settings']);
+const ALLOWED_SOURCES = new Set(['changelog', 'guides']);
 
 // Deliberately loose. Address syntax is far more permissive than any regex people actually
 // write, and the confirmation email is the real check — this only catches obvious typos and

--- a/api/functions/notifications.ts
+++ b/api/functions/notifications.ts
@@ -115,6 +115,41 @@ async function resolveEmails(client: SupabaseClient, userIds: string[]): Promise
   return emails;
 }
 
+export type NotificationPreferenceColumn = 'new_release' | 'new_platform_link' | 'weekly_analytics_recap';
+
+/**
+ * Drops user ids who have explicitly turned this notification off. A user with no row in
+ * notification_preferences has never touched their settings and is treated as enabled — see
+ * the migration comment. A lookup failure fails *open* (keeps everyone) rather than closed:
+ * silently suppressing a notification someone opted into by default is the "cache uncertainty
+ * as a negative" mistake this codebase specifically avoids elsewhere, and it would look
+ * identical to nothing being wrong.
+ */
+export async function filterByPreference(
+  client: SupabaseClient,
+  userIds: string[],
+  column: NotificationPreferenceColumn,
+): Promise<string[]> {
+  if (userIds.length === 0) return userIds;
+
+  const { data, error } = await client
+    .from('notification_preferences')
+    .select(`user_id, ${column}`)
+    .in('user_id', userIds);
+
+  if (error) {
+    Sentry.captureException(error, { extra: { context: 'filterByPreference', column } });
+    return userIds;
+  }
+
+  const optedOut = new Set(
+    (data as Record<string, unknown>[] | null || [])
+      .filter(row => row[column] === false)
+      .map(row => row.user_id as string),
+  );
+  return userIds.filter(id => !optedOut.has(id));
+}
+
 interface NewReleaseParams {
   client: SupabaseClient;
   artistId: string;
@@ -134,7 +169,10 @@ interface NewReleaseParams {
 export async function notifySavedArtistsOfNewRelease(params: NewReleaseParams): Promise<void> {
   const { client, artistId, releasesFound } = params;
 
-  const userIds = await getActiveSavers(client, artistId);
+  let userIds = await getActiveSavers(client, artistId);
+  if (userIds.length === 0) return;
+
+  userIds = await filterByPreference(client, userIds, 'new_release');
   if (userIds.length === 0) return;
 
   const { data: artist, error } = await client
@@ -185,7 +223,10 @@ export async function notifySavedArtistsOfNewLinks(params: NewPlatformLinkParams
   const { client, artistId, artistName, artistSlug, platforms, excludeUserId } = params;
   if (platforms.length === 0) return;
 
-  const userIds = await getActiveSavers(client, artistId, excludeUserId);
+  let userIds = await getActiveSavers(client, artistId, excludeUserId);
+  if (userIds.length === 0) return;
+
+  userIds = await filterByPreference(client, userIds, 'new_platform_link');
   if (userIds.length === 0) return;
 
   const emails = await resolveEmails(client, userIds);

--- a/api/functions/notifications.ts
+++ b/api/functions/notifications.ts
@@ -1,0 +1,78 @@
+// Transactional email notifications for account-lifecycle events (claim approved/rejected,
+// and future triggers such as release alerts). Wraps sendTransactionalEmail with an
+// idempotency guard so a retried request or a second admin click can't send the same
+// notification twice.
+//
+// email_log is the source of truth for "did we already send this": the insert's unique
+// constraint on (notification_type, reference_id) is what makes the guard atomic under
+// concurrent calls, not an application-level check-then-send race.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sendTransactionalEmail } from '../lib/resend';
+import { Sentry } from '../lib/sentry';
+
+interface NotifyOnceParams {
+  client: SupabaseClient;
+  notificationType: string;
+  referenceId: string;
+  recipientEmail: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * Sends a transactional email at most once per (notificationType, referenceId). Failures —
+ * duplicate send, missing API key, Resend error — are logged to Sentry and swallowed; a
+ * notification email is never allowed to fail the request that triggered it.
+ */
+export async function sendNotificationOnce(params: NotifyOnceParams): Promise<void> {
+  const { client, notificationType, referenceId, recipientEmail, subject, html, text } = params;
+
+  const { data: logRow, error: insertError } = await client
+    .from('email_log')
+    .insert({
+      notification_type: notificationType,
+      reference_id: referenceId,
+      recipient_email: recipientEmail,
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    if (insertError.code === UNIQUE_VIOLATION) {
+      // Already sent (or in flight) for this reference — the guard working, not a failure.
+      return;
+    }
+    Sentry.captureException(insertError, {
+      extra: { context: 'sendNotificationOnce.insert', notificationType, referenceId },
+    });
+    return;
+  }
+
+  const result = await sendTransactionalEmail({ to: recipientEmail, subject, html, text });
+
+  const { error: updateError } = await client
+    .from('email_log')
+    .update({
+      status: result.ok ? 'sent' : 'failed',
+      resend_message_id: result.messageId || null,
+      error: result.error || null,
+    })
+    .eq('id', logRow.id);
+
+  if (updateError) {
+    Sentry.captureException(updateError, {
+      extra: { context: 'sendNotificationOnce.update', notificationType, referenceId },
+    });
+  }
+
+  if (!result.ok) {
+    Sentry.captureMessage(`sendNotificationOnce: failed to send ${notificationType}`, {
+      level: 'error',
+      extra: { referenceId, error: result.error },
+    });
+  }
+}

--- a/api/functions/notifications.ts
+++ b/api/functions/notifications.ts
@@ -1,15 +1,16 @@
-// Transactional email notifications for account-lifecycle events (claim approved/rejected,
-// and future triggers such as release alerts). Wraps sendTransactionalEmail with an
-// idempotency guard so a retried request or a second admin click can't send the same
-// notification twice.
+// Transactional email notifications: account-lifecycle events (claim approved/rejected) and
+// saved-artist fan alerts (new release, new platform link). Wraps sendTransactionalEmail with
+// an idempotency guard so a retried request, a second admin click, or a second sweep pass
+// can't send the same notification to the same person twice.
 //
 // email_log is the source of truth for "did we already send this": the insert's unique
-// constraint on (notification_type, reference_id) is what makes the guard atomic under
-// concurrent calls, not an application-level check-then-send race.
+// constraint on (notification_type, reference_id, recipient_email) is what makes the guard
+// atomic under concurrent calls, not an application-level check-then-send race.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { sendTransactionalEmail } from '../lib/resend';
 import { Sentry } from '../lib/sentry';
+import { escapeHtml } from '../lib/html';
 
 interface NotifyOnceParams {
   client: SupabaseClient;
@@ -73,6 +74,134 @@ export async function sendNotificationOnce(params: NotifyOnceParams): Promise<vo
     Sentry.captureMessage(`sendNotificationOnce: failed to send ${notificationType}`, {
       level: 'error',
       extra: { referenceId, error: result.error },
+    });
+  }
+}
+
+/**
+ * user_ids of everyone currently saving an artist (tombstoned rows excluded), optionally
+ * minus one user — used to skip notifying someone about their own action (e.g. the person
+ * who just claimed the artist).
+ */
+async function getActiveSavers(client: SupabaseClient, artistId: string, excludeUserId?: string): Promise<string[]> {
+  const { data, error } = await client
+    .from('saved_artists')
+    .select('user_id')
+    .eq('artist_id', artistId)
+    .eq('deleted', false);
+
+  if (error) {
+    Sentry.captureException(error, { extra: { context: 'getActiveSavers', artistId } });
+    return [];
+  }
+
+  const userIds = (data as { user_id: string }[] | null || []).map(row => row.user_id);
+  return excludeUserId ? userIds.filter(id => id !== excludeUserId) : userIds;
+}
+
+/**
+ * Resolves auth user ids to email addresses via the admin API — saved_artists has no email
+ * column of its own, unlike artist_profiles / verification_requests. One request per user,
+ * which is fine at current save volumes (tens, not thousands, of savers per artist per
+ * CLAUDE.md's numbers); revisit if a single artist's saver count grows large.
+ */
+async function resolveEmails(client: SupabaseClient, userIds: string[]): Promise<string[]> {
+  const emails: string[] = [];
+  for (const userId of userIds) {
+    const { data, error } = await client.auth.admin.getUserById(userId);
+    if (error || !data.user?.email) continue;
+    emails.push(data.user.email);
+  }
+  return emails;
+}
+
+interface NewReleaseParams {
+  client: SupabaseClient;
+  artistId: string;
+  releasesFound: number;
+}
+
+/**
+ * Tells everyone who saved this artist that a new release showed up. Called from
+ * recordCatalogOutcome whenever releases_found increases; cheap to call on every catalog run
+ * because it bails out before any lookup if nobody has saved the artist — true for the large
+ * majority of catalogued artists (see CLAUDE.md's saved-vs-catalogued ratio).
+ *
+ * referenceId encodes the *count*, not just the artist, so a later increase (5 -> 8 -> 12)
+ * sends a fresh notification each time instead of being deduped against the first one ever
+ * sent for that artist.
+ */
+export async function notifySavedArtistsOfNewRelease(params: NewReleaseParams): Promise<void> {
+  const { client, artistId, releasesFound } = params;
+
+  const userIds = await getActiveSavers(client, artistId);
+  if (userIds.length === 0) return;
+
+  const { data: artist, error } = await client
+    .from('artists')
+    .select('name, slug')
+    .eq('id', artistId)
+    .maybeSingle();
+  if (error || !artist?.slug) {
+    if (error) Sentry.captureException(error, { extra: { context: 'notifySavedArtistsOfNewRelease', artistId } });
+    return;
+  }
+
+  const emails = await resolveEmails(client, userIds);
+  const profileUrl = `https://unstream.stream/a/${artist.slug}`;
+  const referenceId = `${artistId}:${releasesFound}`;
+
+  for (const email of emails) {
+    void sendNotificationOnce({
+      client,
+      notificationType: 'new_release',
+      referenceId,
+      recipientEmail: email,
+      subject: `New release from ${artist.name}`,
+      html: `<p><strong>${escapeHtml(artist.name)}</strong>, an artist you saved on Unstream, has a new release up. See it at <a href="${profileUrl}">${profileUrl}</a>.</p>`,
+      text: `${artist.name}, an artist you saved on Unstream, has a new release up. See it at ${profileUrl}.`,
+    });
+  }
+}
+
+interface NewPlatformLinkParams {
+  client: SupabaseClient;
+  artistId: string;
+  artistName: string;
+  artistSlug: string;
+  platforms: string[];
+  excludeUserId?: string;
+}
+
+/**
+ * Tells everyone who saved this artist (other than the person who just triggered the
+ * discovery, if any) that new platform links showed up. Currently only called from the claim
+ * flow's link-back verification, which discovers links once per claim — not from the
+ * search/enrichment upsert paths in db.ts, since those run on every search and don't yet
+ * distinguish a genuinely new link from a refreshed existing one. Wiring those in needs the
+ * same before/after comparison recordCatalogOutcome uses for releases.
+ */
+export async function notifySavedArtistsOfNewLinks(params: NewPlatformLinkParams): Promise<void> {
+  const { client, artistId, artistName, artistSlug, platforms, excludeUserId } = params;
+  if (platforms.length === 0) return;
+
+  const userIds = await getActiveSavers(client, artistId, excludeUserId);
+  if (userIds.length === 0) return;
+
+  const emails = await resolveEmails(client, userIds);
+  const profileUrl = `https://unstream.stream/a/${artistSlug}`;
+  const platformList = platforms.join(', ');
+  const referenceId = `${artistId}:${[...platforms].sort().join(',')}`;
+
+  for (const email of emails) {
+    void sendNotificationOnce({
+      client,
+      notificationType: 'new_platform_link',
+      referenceId,
+      recipientEmail: email,
+      subject: `${artistName} added new places to support them`,
+      html: `<p><strong>${escapeHtml(artistName)}</strong>, an artist you saved on Unstream, just added links on: ${escapeHtml(platformList)}. See them at <a href="${profileUrl}">${profileUrl}</a>.</p>`,
+      text: `${artistName}, an artist you saved on Unstream, just added links on: ${platformList}. See them at ${profileUrl}.`,
     });
   }
 }

--- a/api/functions/weekly-analytics-recap.ts
+++ b/api/functions/weekly-analytics-recap.ts
@@ -1,10 +1,7 @@
-// Scheduled job: a weekly analytics recap email for every claimed, verified artist profile.
-//
-// Not yet wired to a cron. This function is complete and tested, but unlike recatalog-sweep
-// there is no .github/workflows/*.yml invoking it — sending a recurring email to every
-// verified artist on a schedule is a product decision (cadence, opt-out) worth a deliberate
-// go-ahead rather than shipping silently alongside its plumbing. Wire it up the same way as
-// recatalog-sweep.yml (a POST with the internal bearer secret) once that's decided.
+// Scheduled job: a weekly analytics recap email for every claimed, verified artist profile
+// that hasn't opted out. Invoked by .github/workflows/weekly-analytics-recap.yml, the same
+// GitHub Actions cron pattern as recatalog-sweep.ts — there are no scheduled Netlify functions
+// in this repo.
 //
 // Reuses the same tables the artist-facing dashboard reads (api/functions/analytics-stats.ts)
 // rather than its RPC — this runs with the service-role client, which bypasses RLS, so a
@@ -12,7 +9,7 @@
 
 import { getClient } from './db';
 import { isInternalRequest } from './middleware';
-import { sendNotificationOnce } from './notifications';
+import { sendNotificationOnce, filterByPreference } from './notifications';
 import { escapeHtml } from '../lib/html';
 import { Sentry } from '../lib/sentry';
 
@@ -28,6 +25,7 @@ function weekStartKey(date: Date): string {
 
 interface VerifiedProfileRow {
   artist_id: string;
+  user_id: string;
   email: string;
   artists: { name: string; slug: string } | { name: string; slug: string }[] | null;
 }
@@ -66,7 +64,7 @@ export async function handler(event: {
 
   const { data: profiles, error: profilesError } = await client
     .from('artist_profiles')
-    .select('artist_id, email, artists(name, slug)')
+    .select('artist_id, user_id, email, artists(name, slug)')
     .not('verified_at', 'is', null);
 
   if (profilesError) {
@@ -79,16 +77,26 @@ export async function handler(event: {
 
   const rows = (profiles || []) as VerifiedProfileRow[];
   if (rows.length === 0) {
-    return { statusCode: 200, body: JSON.stringify({ sent: 0, skipped: 0 }) };
+    return { statusCode: 200, body: JSON.stringify({ sent: 0, skipped: 0, optedOut: 0 }) };
   }
+
+  const enabledUserIds = new Set(
+    await filterByPreference(client, rows.map(r => r.user_id), 'weekly_analytics_recap'),
+  );
 
   const since = new Date(Date.now() - RECAP_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const weekKey = weekStartKey(new Date());
 
   let sent = 0;
   let skipped = 0;
+  let optedOut = 0;
 
   for (const row of rows) {
+    if (!enabledUserIds.has(row.user_id)) {
+      optedOut++;
+      continue;
+    }
+
     const artist = Array.isArray(row.artists) ? row.artists[0] : row.artists;
     if (!artist?.slug || !row.email) {
       skipped++;
@@ -130,5 +138,5 @@ export async function handler(event: {
     sent++;
   }
 
-  return { statusCode: 200, body: JSON.stringify({ sent, skipped }) };
+  return { statusCode: 200, body: JSON.stringify({ sent, skipped, optedOut }) };
 }

--- a/api/functions/weekly-analytics-recap.ts
+++ b/api/functions/weekly-analytics-recap.ts
@@ -1,0 +1,134 @@
+// Scheduled job: a weekly analytics recap email for every claimed, verified artist profile.
+//
+// Not yet wired to a cron. This function is complete and tested, but unlike recatalog-sweep
+// there is no .github/workflows/*.yml invoking it — sending a recurring email to every
+// verified artist on a schedule is a product decision (cadence, opt-out) worth a deliberate
+// go-ahead rather than shipping silently alongside its plumbing. Wire it up the same way as
+// recatalog-sweep.yml (a POST with the internal bearer secret) once that's decided.
+//
+// Reuses the same tables the artist-facing dashboard reads (api/functions/analytics-stats.ts)
+// rather than its RPC — this runs with the service-role client, which bypasses RLS, so a
+// direct read of artist_analytics needs no RPC wrapper.
+
+import { getClient } from './db';
+import { isInternalRequest } from './middleware';
+import { sendNotificationOnce } from './notifications';
+import { escapeHtml } from '../lib/html';
+import { Sentry } from '../lib/sentry';
+
+const RECAP_WINDOW_DAYS = 7;
+
+/** The Monday (UTC) on or before `date`, as YYYY-MM-DD — the recap's dedup key for "this week". */
+function weekStartKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const daysSinceMonday = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - daysSinceMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+interface VerifiedProfileRow {
+  artist_id: string;
+  email: string;
+  artists: { name: string; slug: string } | { name: string; slug: string }[] | null;
+}
+
+interface AnalyticsRow {
+  metric: string;
+  count: number;
+}
+
+function summarize(rows: AnalyticsRow[]): { searches: number; views: number; clicks: number } {
+  let searches = 0, views = 0, clicks = 0;
+  for (const row of rows) {
+    if (row.metric === 'search') searches += row.count;
+    else if (row.metric === 'view') views += row.count;
+    else if (row.metric.startsWith('click:')) clicks += row.count;
+  }
+  return { searches, views, clicks };
+}
+
+export async function handler(event: {
+  httpMethod?: string;
+  headers?: Record<string, string | undefined>;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  if (!isInternalRequest(event.headers?.authorization ?? event.headers?.Authorization)) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const { data: profiles, error: profilesError } = await client
+    .from('artist_profiles')
+    .select('artist_id, email, artists(name, slug)')
+    .not('verified_at', 'is', null);
+
+  if (profilesError) {
+    Sentry.captureMessage('[weekly-analytics-recap] could not load verified profiles', {
+      level: 'error',
+      extra: { error: profilesError.message },
+    });
+    return { statusCode: 503, body: JSON.stringify({ error: profilesError.message }) };
+  }
+
+  const rows = (profiles || []) as VerifiedProfileRow[];
+  if (rows.length === 0) {
+    return { statusCode: 200, body: JSON.stringify({ sent: 0, skipped: 0 }) };
+  }
+
+  const since = new Date(Date.now() - RECAP_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const weekKey = weekStartKey(new Date());
+
+  let sent = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const artist = Array.isArray(row.artists) ? row.artists[0] : row.artists;
+    if (!artist?.slug || !row.email) {
+      skipped++;
+      continue;
+    }
+
+    const { data: analyticsRows, error: analyticsError } = await client
+      .from('artist_analytics')
+      .select('metric, count')
+      .eq('artist_id', row.artist_id)
+      .gte('date', since);
+
+    if (analyticsError) {
+      Sentry.captureException(analyticsError, {
+        extra: { context: 'weekly-analytics-recap.analytics', artistId: row.artist_id },
+      });
+      skipped++;
+      continue;
+    }
+
+    const { searches, views, clicks } = summarize((analyticsRows || []) as AnalyticsRow[]);
+    const profileUrl = `https://unstream.stream/a/${artist.slug}`;
+
+    await sendNotificationOnce({
+      client,
+      notificationType: 'weekly_analytics_recap',
+      referenceId: `${row.artist_id}:${weekKey}`,
+      recipientEmail: row.email,
+      subject: `Your week on Unstream: ${searches + views} looks, ${clicks} link clicks`,
+      html: `<p>Here's how <strong>${escapeHtml(artist.name)}</strong> did on Unstream over the last 7 days:</p>
+<ul>
+  <li>${searches} search appearances</li>
+  <li>${views} profile views</li>
+  <li>${clicks} link clicks</li>
+</ul>
+<p>See the full breakdown on your <a href="${profileUrl}">artist dashboard</a>.</p>`,
+      text: `Here's how ${artist.name} did on Unstream over the last 7 days:\n\n- ${searches} search appearances\n- ${views} profile views\n- ${clicks} link clicks\n\nSee the full breakdown on your artist dashboard: ${profileUrl}`,
+    });
+    sent++;
+  }
+
+  return { statusCode: 200, body: JSON.stringify({ sent, skipped }) };
+}

--- a/api/lib/html.ts
+++ b/api/lib/html.ts
@@ -1,0 +1,7 @@
+// Shared HTML-escaping helper for Netlify functions that build HTML server-side (currently
+// transactional email bodies). Edge functions (api/edge/) run on Deno and can't import this —
+// they keep their own copy in sync instead. See CLAUDE.md's XSS defense note.
+
+export function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/api/lib/resend.ts
+++ b/api/lib/resend.ts
@@ -1,0 +1,81 @@
+/**
+ * Server-side Resend client for transactional emails (claim approvals, and future
+ * account-lifecycle notifications). Mirrors the direct-fetch pattern used for Buttondown in
+ * api/functions/newsletter-subscribe.ts rather than pulling in the Resend SDK.
+ *
+ * Requires RESEND_API_KEY in the environment. Also requires unstream.stream (or the sending
+ * subdomain used in FROM_ADDRESS) to be a verified domain in the Resend dashboard — Resend
+ * rejects sends from unverified domains, so this can't be tested end-to-end until that's done.
+ */
+
+import { Sentry } from './sentry';
+
+const RESEND_SEND_URL = 'https://api.resend.com/emails';
+const UPSTREAM_TIMEOUT_MS = 8000;
+
+const FROM_ADDRESS = 'Unstream <notifications@unstream.stream>';
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export interface SendEmailResult {
+  ok: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+export async function sendTransactionalEmail(params: SendEmailParams): Promise<SendEmailResult> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    // A missing key must never look like a silently-skipped send — that's how a broken claim
+    // notification goes unnoticed for a month.
+    Sentry.captureMessage('sendTransactionalEmail: RESEND_API_KEY is not set', 'error');
+    return { ok: false, error: 'RESEND_API_KEY not set' };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(RESEND_SEND_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: FROM_ADDRESS,
+        to: params.to,
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+      }),
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // Timeout or network failure — we don't know whether Resend received it, so say so
+    // rather than guessing in either direction.
+    Sentry.captureException(error, { extra: { context: 'sendTransactionalEmail.fetch', to: params.to } });
+    return { ok: false, error: error instanceof Error ? error.message : 'network error' };
+  }
+
+  const raw = await response.text();
+  let payload: { id?: string; message?: string } = {};
+  try {
+    payload = raw ? JSON.parse(raw) : {};
+  } catch {
+    // Non-JSON body — handled by the status check below.
+  }
+
+  if (response.ok) {
+    return { ok: true, messageId: payload.id };
+  }
+
+  Sentry.captureMessage(
+    `sendTransactionalEmail: Resend returned ${response.status} (${payload.message || 'no message'})`,
+    'error',
+  );
+  return { ok: false, error: payload.message || `HTTP ${response.status}` };
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -69,6 +69,8 @@
     "functions/__tests__/resend.test.ts",
     "functions/__tests__/notifications.test.ts",
     "functions/weekly-analytics-recap.ts",
-    "functions/__tests__/weekly-analytics-recap.test.ts"
+    "functions/__tests__/weekly-analytics-recap.test.ts",
+    "functions/me-notifications.ts",
+    "functions/__tests__/me-notifications.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -63,6 +63,10 @@
     "functions/artist-merge.ts",
     "functions/admin-artist-duplicates.ts",
     "functions/__tests__/artist-merge.test.ts",
-    "functions/__tests__/persist-identity-match.test.ts"
+    "functions/__tests__/persist-identity-match.test.ts",
+    "functions/claim-artist.ts",
+    "functions/admin-verify.ts",
+    "functions/__tests__/resend.test.ts",
+    "functions/__tests__/notifications.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -67,6 +67,8 @@
     "functions/claim-artist.ts",
     "functions/admin-verify.ts",
     "functions/__tests__/resend.test.ts",
-    "functions/__tests__/notifications.test.ts"
+    "functions/__tests__/notifications.test.ts",
+    "functions/weekly-analytics-recap.ts",
+    "functions/__tests__/weekly-analytics-recap.test.ts"
   ]
 }

--- a/apps/web/src/components/NewsletterSignup.tsx
+++ b/apps/web/src/components/NewsletterSignup.tsx
@@ -5,12 +5,9 @@ type Status = 'idle' | 'submitting' | 'pending' | 'already_subscribed' | 'error'
 
 interface NewsletterSignupProps {
   /** Where the signup happened. Sent to Buttondown as a tag; the API rejects anything else. */
-  source: 'changelog' | 'guides' | 'settings';
-  /** Omit where the surrounding container already provides one, as /settings sections do. */
+  source: 'changelog' | 'guides';
   heading?: string;
   blurb: string;
-  /** Pre-fill the field — used on /settings, where we already know the signed-in address. */
-  defaultEmail?: string;
   /** Absolute or root-relative URL of the matching RSS feed, offered as the no-email option. */
   feedUrl?: string;
   feedLabel?: string;
@@ -30,11 +27,10 @@ export function NewsletterSignup({
   source,
   heading,
   blurb,
-  defaultEmail = '',
   feedUrl,
   feedLabel = 'RSS feed',
 }: NewsletterSignupProps) {
-  const [email, setEmail] = useState(defaultEmail);
+  const [email, setEmail] = useState('');
   const [status, setStatus] = useState<Status>('idle');
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/web/src/components/NotificationPreferences.tsx
+++ b/apps/web/src/components/NotificationPreferences.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface Preferences {
+  newRelease: boolean;
+  newPlatformLink: boolean;
+  weeklyAnalyticsRecap: boolean;
+}
+
+const TOGGLES: { key: keyof Preferences; label: string; description: string }[] = [
+  {
+    key: 'newRelease',
+    label: 'New releases',
+    description: 'When an artist you saved puts out a new release.',
+  },
+  {
+    key: 'newPlatformLink',
+    label: 'New places to support',
+    description: 'When an artist you saved adds a link to a new platform.',
+  },
+  {
+    key: 'weeklyAnalyticsRecap',
+    label: 'Weekly analytics recap',
+    description: 'A weekly summary of searches, views, and clicks for artists you\'ve claimed.',
+  },
+];
+
+export function NotificationPreferences() {
+  const { session } = useAuth();
+  const [preferences, setPreferences] = useState<Preferences | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [togglingKey, setTogglingKey] = useState<keyof Preferences | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPreferences = useCallback(async () => {
+    if (!session) return;
+    try {
+      const res = await fetch('/api/me/notification-preferences', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to fetch notification preferences');
+      const data = await res.json();
+      setPreferences(data);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'NotificationPreferences.fetchPreferences' } });
+      setError('Failed to load notification preferences.');
+    } finally {
+      setLoading(false);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    fetchPreferences();
+  }, [fetchPreferences]);
+
+  const handleToggle = async (key: keyof Preferences) => {
+    if (!session || !preferences) return;
+    const next = !preferences[key];
+    setTogglingKey(key);
+    setError(null);
+    try {
+      const res = await fetch('/api/me/notification-preferences', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ [key]: next }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update notification preferences');
+      }
+      const data = await res.json();
+      setPreferences(data);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'NotificationPreferences.toggle', key } });
+      setError(e instanceof Error ? e.message : 'Failed to update notification preferences.');
+    } finally {
+      setTogglingKey(null);
+    }
+  };
+
+  if (loading) {
+    return <p className="text-sm text-text-muted">Loading notification preferences…</p>;
+  }
+
+  if (!preferences) {
+    return error ? <p className="text-sm text-red-400">{error}</p> : null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      {TOGGLES.map(({ key, label, description }) => {
+        const enabled = preferences[key];
+        const busy = togglingKey === key;
+        return (
+          <div key={key} className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm text-text-primary">{label}</p>
+              <p className="text-xs text-text-muted">{description}</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              aria-label={label}
+              disabled={busy}
+              onClick={() => handleToggle(key)}
+              className={`shrink-0 mt-0.5 relative w-10 h-6 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                enabled ? 'bg-accent-secondary' : 'bg-border'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
+                  enabled ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -9,7 +9,6 @@ import { LocationField } from '../components/LocationField';
 import { PasswordChangeForm } from '../components/PasswordChangeForm';
 import { SharingControls } from '../components/SharingControls';
 import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
-import { NewsletterSignup } from '../components/NewsletterSignup';
 import { NotificationPreferences } from '../components/NotificationPreferences';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
@@ -111,14 +110,10 @@ export function SettingsPage() {
           {/* Notifications section */}
           <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
             <h2 className="text-lg font-semibold">Notifications</h2>
-            <NewsletterSignup
-              source="settings"
-              blurb="Subscribe to the Unstream newsletter for new features, music news, tips and tricks for getting more out of Unstream, and more."
-              defaultEmail={settings?.email ?? ''}
-            />
-            <div className="pt-4 border-t border-border">
-              <NotificationPreferences />
-            </div>
+            <p className="text-sm text-text-muted">
+              Emails about artists you've saved and, if you've claimed a profile, your own stats.
+            </p>
+            <NotificationPreferences />
           </section>
 
           {/* Password section */}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { PasswordChangeForm } from '../components/PasswordChangeForm';
 import { SharingControls } from '../components/SharingControls';
 import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
 import { NewsletterSignup } from '../components/NewsletterSignup';
+import { NotificationPreferences } from '../components/NotificationPreferences';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 
@@ -115,6 +116,9 @@ export function SettingsPage() {
               blurb="Subscribe to the Unstream newsletter for new features, music news, tips and tricks for getting more out of Unstream, and more."
               defaultEmail={settings?.email ?? ''}
             />
+            <div className="pt-4 border-t border-border">
+              <NotificationPreferences />
+            </div>
           </section>
 
           {/* Password section */}

--- a/apps/web/tests/unit/NewsletterSignup.test.tsx
+++ b/apps/web/tests/unit/NewsletterSignup.test.tsx
@@ -93,10 +93,9 @@ describe('NewsletterSignup', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 
-  it('pre-fills a known address and offers the feed as the no-email option', () => {
-    renderSignup({ defaultEmail: 'me@example.com', feedUrl: '/changelog.xml' });
+  it('offers the feed as the no-email option when a feedUrl is given', () => {
+    renderSignup({ feedUrl: '/changelog.xml' });
 
-    expect((screen.getByLabelText('Email address') as HTMLInputElement).value).toBe('me@example.com');
     expect(screen.getByRole('link', { name: /RSS feed/ }).getAttribute('href')).toBe('/changelog.xml');
   });
 });

--- a/apps/web/tests/unit/NotificationPreferences.test.tsx
+++ b/apps/web/tests/unit/NotificationPreferences.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { NotificationPreferences } from '../../src/components/NotificationPreferences';
+
+describe('NotificationPreferences', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ session: { access_token: 'test-token' } });
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders all three toggles reflecting the fetched state', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ newRelease: true, newPlatformLink: false, weeklyAnalyticsRecap: true }),
+    });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByText('New releases')).not.toBeNull();
+    });
+    expect(screen.getByText('New places to support')).not.toBeNull();
+    expect(screen.getByText('Weekly analytics recap')).not.toBeNull();
+
+    expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'New places to support' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('switch', { name: 'Weekly analytics recap' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('toggles a preference off and reflects the server response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ newRelease: true, newPlatformLink: true, weeklyAnalyticsRecap: true }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ newRelease: false, newPlatformLink: true, weeklyAnalyticsRecap: true }),
+    });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
+    });
+
+    fireEvent.click(screen.getByRole('switch', { name: 'New releases' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('false');
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/me/notification-preferences',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ newRelease: false }),
+      }),
+    );
+  });
+
+  it('shows an error and leaves the toggle unchanged when the update fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ newRelease: true, newPlatformLink: true, weeklyAnalyticsRecap: true }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Failed to update notification preferences' }),
+    });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
+    });
+
+    fireEvent.click(screen.getByRole('switch', { name: 'New releases' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update notification preferences')).not.toBeNull();
+    });
+    expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/apps/web/tests/unit/admin-verify-ownership.test.ts
+++ b/apps/web/tests/unit/admin-verify-ownership.test.ts
@@ -71,6 +71,23 @@ function makeClientMock() {
     }
     if (table === 'artists') {
       return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({ data: { name: 'Test Artist', slug: 'test-artist' }, error: null }),
+          })),
+        })),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    }
+    if (table === 'email_log') {
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'log-1' }, error: null }),
+          }),
+        }),
         update: vi.fn().mockReturnValue({
           eq: vi.fn().mockResolvedValue({ error: null }),
         }),
@@ -208,6 +225,11 @@ describe('admin-verify: approve with stale request (artist already claimed)', ()
       }
       if (table === 'artists') {
         return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { name: 'Test Artist', slug: 'test-artist' }, error: null }),
+            })),
+          })),
           update: vi.fn().mockReturnValue({
             eq: vi.fn().mockResolvedValue({ error: null }),
           }),
@@ -267,6 +289,23 @@ describe('admin-verify: approve with stale request (artist already claimed)', ()
       }
       if (table === 'artists') {
         return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { name: 'Test Artist', slug: 'test-artist' }, error: null }),
+            })),
+          })),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        };
+      }
+      if (table === 'email_log') {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: 'log-1' }, error: null }),
+            }),
+          }),
           update: vi.fn().mockReturnValue({
             eq: vi.fn().mockResolvedValue({ error: null }),
           }),

--- a/netlify.toml
+++ b/netlify.toml
@@ -147,6 +147,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/me/notification-preferences"
+  to = "/.netlify/functions/me-notifications"
+  status = 200
+
+[[redirects]]
   from = "/api/public/saved-artists/*"
   to = "/.netlify/functions/public-saved-artists"
   status = 200

--- a/supabase/migrations/20260808000000_email-log.sql
+++ b/supabase/migrations/20260808000000_email-log.sql
@@ -1,20 +1,30 @@
 -- Migration: email_log
 --
 -- Idempotency guard and audit trail for transactional emails sent via Resend (claim
--- approved/rejected notifications, and future triggers like release alerts). The unique
--- index on (notification_type, reference_id) is the guard: a retried request or a second
--- admin click on the same verification request can't send the same notification twice,
--- because the second insert hits the constraint and is treated as "already handled" rather
--- than as an error.
+-- approved/rejected, new-release and new-platform-link alerts to saved-artist fans, and the
+-- weekly analytics recap). The unique index on (notification_type, reference_id,
+-- recipient_email) is the guard: a retried request, a second admin click, or a second sweep
+-- pass can't send the same notification to the same person twice, because the second insert
+-- hits the constraint and is treated as "already handled" rather than as an error.
 --
--- reference_id is deliberately not a foreign key — it points at different tables depending
--- on notification_type (artists.id for an auto-verified claim, verification_requests.id for
--- a manual review decision), so there's no single table it could reference.
-
+-- recipient_email is part of the key (not just notification_type + reference_id) because
+-- several notification types fan out one event to many recipients — e.g. "new release found"
+-- notifies every saver of that artist, not one fixed address.
+--
+-- reference_id is text, not a foreign key, and its shape varies by notification_type:
+--   claim_approved_auto / claim_approved_manual / claim_rejected  -> the artist or request id
+--   new_release / new_platform_link                               -> artistId + a state marker
+--                                                                     (e.g. the new release
+--                                                                     count) so a *later*
+--                                                                     change re-notifies
+--                                                                     instead of being deduped
+--                                                                     against the first send
+--   weekly_analytics_recap                                        -> artistId + the Monday
+--                                                                     date of that week
 CREATE TABLE IF NOT EXISTS email_log (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   notification_type text NOT NULL,
-  reference_id uuid NOT NULL,
+  reference_id text NOT NULL,
   recipient_email text NOT NULL,
   status text NOT NULL DEFAULT 'sending' CHECK (status IN ('sending', 'sent', 'failed')),
   resend_message_id text,
@@ -24,11 +34,11 @@ CREATE TABLE IF NOT EXISTS email_log (
 );
 
 -- The idempotency guard itself: at most one row ever exists per (notification_type,
--- reference_id), regardless of status. There's no retry path today, so a 'failed' row
--- staying failed is correct — a future retry mechanism would need to delete the row first,
--- which is a deliberate, visible action rather than an accidental double-send.
+-- reference_id, recipient_email), regardless of status. There's no retry path today, so a
+-- 'failed' row staying failed is correct — a future retry mechanism would need to delete the
+-- row first, which is a deliberate, visible action rather than an accidental double-send.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_email_log_dedup
-  ON email_log (notification_type, reference_id);
+  ON email_log (notification_type, reference_id, recipient_email);
 
 CREATE INDEX IF NOT EXISTS idx_email_log_created_at
   ON email_log (created_at DESC);
@@ -47,4 +57,4 @@ ALTER TABLE email_log ENABLE ROW LEVEL SECURITY;
 COMMENT ON TABLE email_log IS
   'Idempotency guard and audit trail for transactional emails sent via Resend. Server-only; no RLS policies by design.';
 COMMENT ON COLUMN email_log.reference_id IS
-  'Points at different tables depending on notification_type — not a foreign key.';
+  'Shape varies by notification_type — not a foreign key. See table comment.';

--- a/supabase/migrations/20260808000000_email-log.sql
+++ b/supabase/migrations/20260808000000_email-log.sql
@@ -1,0 +1,50 @@
+-- Migration: email_log
+--
+-- Idempotency guard and audit trail for transactional emails sent via Resend (claim
+-- approved/rejected notifications, and future triggers like release alerts). The unique
+-- index on (notification_type, reference_id) is the guard: a retried request or a second
+-- admin click on the same verification request can't send the same notification twice,
+-- because the second insert hits the constraint and is treated as "already handled" rather
+-- than as an error.
+--
+-- reference_id is deliberately not a foreign key — it points at different tables depending
+-- on notification_type (artists.id for an auto-verified claim, verification_requests.id for
+-- a manual review decision), so there's no single table it could reference.
+
+CREATE TABLE IF NOT EXISTS email_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  notification_type text NOT NULL,
+  reference_id uuid NOT NULL,
+  recipient_email text NOT NULL,
+  status text NOT NULL DEFAULT 'sending' CHECK (status IN ('sending', 'sent', 'failed')),
+  resend_message_id text,
+  error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- The idempotency guard itself: at most one row ever exists per (notification_type,
+-- reference_id), regardless of status. There's no retry path today, so a 'failed' row
+-- staying failed is correct — a future retry mechanism would need to delete the row first,
+-- which is a deliberate, visible action rather than an accidental double-send.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_log_dedup
+  ON email_log (notification_type, reference_id);
+
+CREATE INDEX IF NOT EXISTS idx_email_log_created_at
+  ON email_log (created_at DESC);
+
+DROP TRIGGER IF EXISTS trg_email_log_updated_at ON email_log;
+CREATE TRIGGER trg_email_log_updated_at
+  BEFORE UPDATE ON email_log
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- Server-only: this is internal send bookkeeping, nothing a client should ever read or
+-- write. RLS on with no policies means the service-role client (which bypasses RLS) is the
+-- only reader or writer — same pattern as release_catalog_state and bandcamp_slug_probes.
+ALTER TABLE email_log ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE email_log IS
+  'Idempotency guard and audit trail for transactional emails sent via Resend. Server-only; no RLS policies by design.';
+COMMENT ON COLUMN email_log.reference_id IS
+  'Points at different tables depending on notification_type — not a foreign key.';

--- a/supabase/migrations/20260808120000_notification-preferences.sql
+++ b/supabase/migrations/20260808120000_notification-preferences.sql
@@ -1,0 +1,47 @@
+-- Migration: notification_preferences
+--
+-- Per-user opt-out toggles for the saved-artist and analytics-recap emails sent via Resend
+-- (new_release, new_platform_link, weekly_analytics_recap — see api/functions/notifications.ts
+-- and api/functions/weekly-analytics-recap.ts). Claim-lifecycle emails (approved/rejected) are
+-- not covered here — those are a direct reply to an action the user just took, not an ongoing
+-- subscription.
+--
+-- Defaults to enabled: saving an artist is treated as consent to hear about it, and claiming
+-- and verifying a profile is treated as consent to see your own weekly stats. Rows are created
+-- lazily on first toggle (see me-notifications.ts), not at signup, so a missing row is the
+-- common case and must read as "all enabled" — every notification-sending call site treats a
+-- missing row the same as a row with all three columns true.
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  new_release boolean NOT NULL DEFAULT true,
+  new_platform_link boolean NOT NULL DEFAULT true,
+  weekly_analytics_recap boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS trg_notification_preferences_updated_at ON notification_preferences;
+CREATE TRIGGER trg_notification_preferences_updated_at
+  BEFORE UPDATE ON notification_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- User-editable (unlike email_log): same auth.uid() = user_id pattern as saved_artists. Server
+-- code paths use the service-role client and bypass this, same as user-sharing.ts /
+-- me-location.ts — RLS here is a backstop against any future direct client-side access.
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own notification preferences"
+  ON notification_preferences FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own notification preferences"
+  ON notification_preferences FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own notification preferences"
+  ON notification_preferences FOR UPDATE
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE notification_preferences IS
+  'Per-user opt-out toggles for saved-artist and analytics-recap emails. A missing row means all three are enabled — see table comment.';


### PR DESCRIPTION
Wires up the first, cheapest notification trigger identified in the Buttondown-vs-Resend
strategy discussion: artist claim approved (auto link-back and manual admin review) and
claim rejected. Both paths already had a verified email in scope, making this the lowest-
effort starting point before tackling release-found alerts, which need new delta-detection
plumbing in the recatalog pipeline first.

- api/lib/resend.ts: thin fetch-based Resend client, mirrors the Buttondown pattern in
  newsletter-subscribe.ts rather than adding the SDK as a dependency.
- api/functions/notifications.ts: sendNotificationOnce wraps the send with an idempotency
  guard backed by the new email_log table, so a retried request or a second admin click
  can't double-send.
- supabase/migrations/20260808000000_email-log.sql: server-only email_log table (RLS on, no
  policies) with a unique index on (notification_type, reference_id) as the send-once guard.
- Hooked into claim-artist.ts's auto-verify path and admin-verify.ts's approve/reject path.
- Added claim-artist.ts and admin-verify.ts to api/tsconfig.json's typecheck include — both
  came back clean under strict mode, so they're now covered going forward.

Requires RESEND_API_KEY in Netlify and a verified sending domain in the Resend dashboard
before this can send in production; unset, sendTransactionalEmail fails loudly to Sentry
rather than silently dropping notifications.