### PR TITLE
Add terms of use, rewrite the privacy policy against what the code actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,5 @@ When adding a new migration, create a file in `supabase/migrations/` named `YYYY
 - [Roadmap](https://github.com/users/brandonlucasgreen/projects/4)
 - [Public metrics](https://unstream.goatcounter.com)
 - [Privacy policy](https://unstream.stream/privacy-policy)
+- [Terms of use](https://unstream.stream/terms)
 - [Support Unstream](https://unstream.stream/support)

--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -525,6 +525,8 @@ export default async function handler(request: Request, context: Context) {
         <a href="https://letterbird.co/hi-d2078591" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Contact</a>
         <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
         <a href="/privacy-policy" style="color:var(--muted);text-decoration:none">Privacy policy</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/terms" style="color:var(--muted);text-decoration:none">Terms of use</a>
       </nav>
     </div>
   </footer>
@@ -628,6 +630,8 @@ export default async function handler(request: Request, context: Context) {
         <a href="https://letterbird.co/hi-d2078591" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Contact</a>
         <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
         <a href="/privacy-policy" style="color:var(--muted);text-decoration:none">Privacy policy</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/terms" style="color:var(--muted);text-decoration:none">Terms of use</a>
       </nav>
     </div>
   </footer>

--- a/api/edge/noscript-search.ts
+++ b/api/edge/noscript-search.ts
@@ -259,6 +259,8 @@ function renderPage(query: string, results: SearchResult[], error?: string): str
         <a href="https://liberapay.com/brandonlucasgreen/donate" target="_blank" rel="noopener noreferrer">Donate</a>
         <span class="footer-dot">&#x2022;</span>
         <a href="/privacy-policy">Privacy</a>
+        <span class="footer-dot">&#x2022;</span>
+        <a href="/terms">Terms</a>
       </nav>
     </div>
   </footer>

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -437,6 +437,8 @@ export default async function handler(request: Request, context: Context) {
         <a href="https://letterbird.co/hi-d2078591" target="_blank" rel="noopener noreferrer" style="color:var(--muted);text-decoration:none">Contact</a>
         <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
         <a href="/privacy-policy" style="color:var(--muted);text-decoration:none">Privacy policy</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/terms" style="color:var(--muted);text-decoration:none">Terms of use</a>
       </nav>
     </div>
   </footer>

--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -219,6 +219,8 @@ export default async function handler(request: Request, context: Context) {
         <a href="/support" style="color:var(--muted);text-decoration:none">Support</a>
         <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
         <a href="/privacy-policy" style="color:var(--muted);text-decoration:none">Privacy policy</a>
+        <span style="color:var(--muted);opacity:0.4;font-size:10px">&#x2022;</span>
+        <a href="/terms" style="color:var(--muted);text-decoration:none">Terms of use</a>
       </nav>
     </div>
   </footer>

--- a/api/functions/cache.ts
+++ b/api/functions/cache.ts
@@ -11,6 +11,17 @@ import { getRedis, reportRedisFailure } from './redis';
 const DEFAULT_TTL = 30 * 60;
 
 /**
+ * Cache keys are `artist:<platform>:<normalized query>` — the query is the key, that's what a
+ * cache is. But it doesn't belong in a log line or a Sentry breadcrumb: knowing *which* platform
+ * hit or missed is the whole diagnostic value, and the artist name adds nothing to it. Keep the
+ * shape, drop the term.
+ */
+function redactKey(key: string): string {
+  const parts = key.split(':');
+  return parts.length > 2 ? `${parts.slice(0, 2).join(':')}:…` : key;
+}
+
+/**
  * Get a value from cache
  */
 export async function cacheGet<T>(key: string): Promise<T | null> {
@@ -20,12 +31,12 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
   try {
     const value = await client.get<T>(key);
     if (value) {
-      console.log(`[Cache] HIT: ${key}`);
+      console.log(`[Cache] HIT: ${redactKey(key)}`);
     }
     return value;
   } catch (error) {
     // Indistinguishable from a miss to the caller, which is why it must be reported.
-    reportRedisFailure(`cacheGet(${key})`, error);
+    reportRedisFailure(`cacheGet(${redactKey(key)})`, error);
     return null;
   }
 }
@@ -39,10 +50,10 @@ export async function cacheSet<T>(key: string, value: T, ttlSeconds: number = DE
 
   try {
     await client.set(key, value, { ex: ttlSeconds });
-    console.log(`[Cache] SET: ${key} (TTL: ${ttlSeconds}s)`);
+    console.log(`[Cache] SET: ${redactKey(key)} (TTL: ${ttlSeconds}s)`);
     return true;
   } catch (error) {
-    reportRedisFailure(`cacheSet(${key})`, error);
+    reportRedisFailure(`cacheSet(${redactKey(key)})`, error);
     return false;
   }
 }
@@ -97,10 +108,10 @@ export async function cacheDelete(key: string): Promise<boolean> {
 
   try {
     await client.del(key);
-    console.log(`[Cache] DEL: ${key}`);
+    console.log(`[Cache] DEL: ${redactKey(key)}`);
     return true;
   } catch (error) {
-    reportRedisFailure(`cacheDelete(${key})`, error);
+    reportRedisFailure(`cacheDelete(${redactKey(key)})`, error);
     return false;
   }
 }
@@ -125,10 +136,10 @@ export async function cacheDeleteByArtist(artistName: string): Promise<void> {
 
     if (keys.length > 0) {
       await Promise.all(keys.map(k => client.del(k)));
-      console.log(`[Cache] Purged ${keys.length} cached entries for artist "${artistName}"`);
+      console.log(`[Cache] Purged ${keys.length} cached entries for one artist`);
     }
   } catch (error) {
-    reportRedisFailure(`cacheDeleteByArtist(${artistName})`, error);
+    reportRedisFailure('cacheDeleteByArtist', error);
   }
 }
 

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -2988,7 +2988,7 @@ export async function getBandcampProbe(
 
     // A negative from a narrower candidate set must not answer for a wider one.
     if (candidates.length > 0 && !negativeCoversCandidates(row.probed_slugs, candidates)) {
-      console.log(`[DB] Re-probing "${queryNorm}": cached negative covered ${JSON.stringify(row.probed_slugs)}, query needs ${JSON.stringify(candidates)}`);
+      console.log(`[DB] Re-probing: cached negative covered ${row.probed_slugs?.length ?? 0} slug(s), query needs ${candidates.length}`);
       return null;
     }
 
@@ -3604,7 +3604,7 @@ export async function persistEnrichment(
 
     // Never overwrite links for claimed artists — they manage their own links
     if (artist.match_confidence === 'claimed') {
-      console.log(`[DB] Skipping enrichment for claimed artist "${artistName}"`);
+      console.log('[DB] Skipping enrichment for a claimed artist');
       return;
     }
 
@@ -3677,9 +3677,9 @@ export async function persistEnrichment(
       .eq('id', artistId);
 
     const locationLog = mbData.location ? ` + location` : '';
-    console.log(`[DB] Enriched "${artistName}" with ${enrichmentLinks.length} MusicBrainz links${locationLog}`);
+    console.log(`[DB] Enriched with ${enrichmentLinks.length} MusicBrainz links${locationLog}`);
   } catch (error) {
-    console.error(`[DB] Error enriching "${artistName}":`, error);
+    console.error('[DB] Error enriching artist:', error);
   }
 }
 

--- a/api/functions/search-musicbrainz.ts
+++ b/api/functions/search-musicbrainz.ts
@@ -96,14 +96,14 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
     const artists = data.artists || [];
 
     if (artists.length === 0) {
-      console.log(`[MusicBrainz] No results for "${query}", falling back to Bandcamp/Mirlo location`);
+      console.log('[MusicBrainz] No results, falling back to Bandcamp/Mirlo location');
       return { ...emptyResult, location: await enrichLocationFallback(query) };
     }
 
     const artist = artists[0];
     // Only consider exact/near-exact matches
     if (artist.score < 95) {
-      console.log(`[MusicBrainz] Low confidence match for "${query}" (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
+      console.log(`[MusicBrainz] Low confidence match (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
       return { ...emptyResult, location: await enrichLocationFallback(query) };
     }
 
@@ -122,7 +122,7 @@ async function searchMusicBrainz(query: string): Promise<MusicBrainzSearchRespon
       artistNormalized.includes(queryNormalized) && queryNormalized.length > artistNormalized.length * 0.7;
 
     if (!isNameMatch) {
-      console.log(`[MusicBrainz] Skipping "${artist.name}" - doesn't match query "${query}", falling back to Bandcamp/Mirlo location`);
+      console.log('[MusicBrainz] Top match does not match the query, falling back to Bandcamp/Mirlo location');
       return { ...emptyResult, location: await enrichLocationFallback(query) };
     }
 
@@ -446,7 +446,7 @@ export async function handler(event: { queryStringParameters?: Record<string, st
     );
 
     if (cached) {
-      console.log(`[MusicBrainz] Cache hit for "${normalizedQuery}"`);
+      console.log('[MusicBrainz] Cache hit');
     }
 
     if (result === null) {

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -434,7 +434,7 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
     const artists = data.artists || [];
 
     if (artists.length === 0) {
-      console.log(`[MusicBrainz] No results for "${query}", falling back to Bandcamp/Mirlo location`);
+      console.log('[MusicBrainz] No results, falling back to Bandcamp/Mirlo location');
       return { ...emptyResult, location: await enrichLocationFallback(query) };
     }
 
@@ -443,7 +443,7 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
     // still worth reporting as discovery candidates — they just don't get to claim
     // the MB identity (official site, socials, location) for themselves.
     if (artist.score < 95) {
-      console.log(`[MusicBrainz] Low confidence match for "${query}" (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
+      console.log(`[MusicBrainz] Low confidence match (score ${artist.score}), falling back to Bandcamp/Mirlo location`);
       return {
         ...emptyResult,
         suggestedNames: collectMbSuggestions(artists, query),
@@ -466,7 +466,7 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
       artistNormalized.includes(queryNormalized) && queryNormalized.length > artistNormalized.length * 0.7;
 
     if (!isNameMatch) {
-      console.log(`[MusicBrainz] Skipping "${artist.name}" - doesn't match query "${query}", falling back to Bandcamp/Mirlo location`);
+      console.log('[MusicBrainz] Top match does not match the query, falling back to Bandcamp/Mirlo location');
       return {
         ...emptyResult,
         suggestedNames: collectMbSuggestions(artists, query),
@@ -1072,7 +1072,7 @@ async function searchAmpwall(query: string): Promise<Map<string, string>> {
   );
 
   if (cached) {
-    console.log(`[Ampwall] Cache hit for "${query}"`);
+    console.log('[Ampwall] Cache hit');
   }
 
   // Convert array back to Map (Redis doesn't serialize Maps well)

--- a/api/search/enrichment.ts
+++ b/api/search/enrichment.ts
@@ -444,12 +444,12 @@ export async function searchPeerTubeChannels(artistName: string): Promise<Social
         (normalizedQuery.includes(normalizedDisplay) && normalizedDisplay.length > normalizedQuery.length * 0.5);
 
       if (isMatch) {
-        console.log(`[Sepia Search] Found PeerTube channel for "${artistName}": ${channel.displayName} on ${channel.host} (${channel.videosCount} videos)`);
+        console.log(`[Sepia Search] Found PeerTube channel on ${channel.host} (${channel.videosCount} videos)`);
         return { platform: 'peertube', url: channel.url };
       }
     }
 
-    console.log(`[Sepia Search] No matching PeerTube channel for "${artistName}" (${data.total} total results)`);
+    console.log(`[Sepia Search] No matching PeerTube channel (${data.total} total results)`);
     return null;
   } catch (error: unknown) {
     const err = error as { message?: string };

--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -1068,6 +1068,23 @@ body {
   cursor: not-allowed;
 }
 
+.auth-legal {
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+  color: #8B95A5;
+  margin-top: 8px;
+}
+
+.auth-legal a {
+  color: #60A5FA;
+  text-decoration: none;
+}
+
+.auth-legal a:hover {
+  text-decoration: underline;
+}
+
 .magic-link-sent {
   text-align: center;
   padding: 16px 0;

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -129,6 +129,14 @@
             <div id="auth-error" class="auth-error hidden"></div>
           </form>
           <button id="auth-magic-link" class="auth-magic-link">Send magic link instead</button>
+          <!-- A magic link creates an account when there isn't one, so this form is a sign-up
+               form too. Same consent line as the web app's LegalConsent component. -->
+          <p class="auth-legal">
+            By continuing you agree to Unstream's
+            <a href="https://unstream.stream/terms" target="_blank" rel="noopener noreferrer">Terms of Use</a>
+            and
+            <a href="https://unstream.stream/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+          </p>
           <div id="magic-link-sent" class="magic-link-sent hidden">
             <span class="empty-icon">📧</span>
             <p>Check your email for a sign-in link.</p>

--- a/apps/mac/Unstream/Views/Shared/SignInView.swift
+++ b/apps/mac/Unstream/Views/Shared/SignInView.swift
@@ -103,6 +103,15 @@ struct SignInView: View {
                 .buttonStyle(.bordered)
                 .disabled(email.isEmpty || password.isEmpty || auth.isLoading)
             }
+
+            // A magic link creates an account when there isn't one, and this sheet also has an
+            // explicit Create Account button — so the consent line belongs here, matching the
+            // web app's LegalConsent component word for word.
+            Text("By continuing you agree to Unstream's [Terms of Use](https://unstream.stream/terms) and [Privacy Policy](https://unstream.stream/privacy-policy).")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
         }
         .padding()
         .frame(maxWidth: 320)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -69,6 +69,14 @@
       </div>
     </noscript>
     <script type="module" src="/src/main.tsx"></script>
+    <!-- Give GoatCounter the page, not the query string. Its default path is
+         `location.pathname + location.search`, and a search puts the artist name straight into
+         the URL (/?q=artist+name), so the default records every search term as a page path — on
+         a dashboard that's public. We only want page-level counts here; a search that goes wrong
+         is Sentry's job, not the analytics tool's.
+         Events fired from services/analytics.ts pass an explicit path and are unaffected.
+         This must stay ahead of count.js: settings are read when it loads. -->
+    <script>window.goatcounter = { path: function () { return location.pathname || '/' } }</script>
     <script data-goatcounter="https://unstream.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
   </body>

--- a/apps/web/src/components/ClaimEmailStep.tsx
+++ b/apps/web/src/components/ClaimEmailStep.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { LegalConsent } from './LegalConsent';
 
 interface ClaimEmailStepProps {
   email: string;
@@ -31,10 +31,9 @@ export function ClaimEmailStep({ email, setEmail, loading, onSubmit }: ClaimEmai
       >
         {loading ? 'Sending...' : 'Send sign-in link'}
       </button>
-      <p className="text-xs text-text-muted text-center">
-        By clicking you accept Unstream's{' '}
-        <Link to="/privacy-policy" className="text-accent-primary hover:underline">Privacy Policy</Link>
-      </p>
+      <LegalConsent>
+        You also confirm you're this artist, or authorized to act for them.
+      </LegalConsent>
     </form>
   );
 }

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -37,6 +37,8 @@ export function Footer() {
           </a>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/privacy-policy" className="hover:text-text-primary transition-colors">Privacy policy</Link>
+          <span className="text-text-muted/40 text-xs">&#x2022;</span>
+          <Link to="/terms" className="hover:text-text-primary transition-colors">Terms of use</Link>
         </nav>
       </div>
     </footer>

--- a/apps/web/src/components/LegalConsent.tsx
+++ b/apps/web/src/components/LegalConsent.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+
+/**
+ * The consent line shown wherever someone can create an Unstream account.
+ *
+ * A magic link creates an account when there isn't one already, so every sign-in form here is
+ * also a sign-up form — which is why this sits on all of them rather than on a dedicated
+ * "register" screen we don't have. Keep the wording identical across surfaces: consent is only
+ * worth pointing at later if it said the same thing everywhere.
+ *
+ * The non-web clients carry their own copy of this line (the extension popup and the Apple
+ * apps' sign-in sheet). Change one, change those too.
+ */
+export function LegalConsent({ children }: { children?: React.ReactNode }) {
+  return (
+    <p className="text-xs text-text-muted text-center">
+      By continuing you agree to Unstream's{' '}
+      <Link to="/terms" className="text-accent-primary hover:underline">Terms of Use</Link>
+      {' '}and{' '}
+      <Link to="/privacy-policy" className="text-accent-primary hover:underline">Privacy Policy</Link>.
+      {children ? <> {children}</> : null}
+    </p>
+  );
+}

--- a/apps/web/src/components/LoginInterstitial.tsx
+++ b/apps/web/src/components/LoginInterstitial.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { LegalConsent } from './LegalConsent';
 
 interface LoginInterstitialProps {
   artistId: string;
@@ -155,6 +156,10 @@ export function LoginInterstitial({ artistId, artistName, onClose }: LoginInters
                 </button>
               </form>
             )}
+
+            <div className="mt-3">
+              <LegalConsent />
+            </div>
 
             <button
               onClick={onClose}

--- a/apps/web/src/components/SharingControls.tsx
+++ b/apps/web/src/components/SharingControls.tsx
@@ -119,6 +119,12 @@ export function SharingControls() {
     return (
       <div className="rounded-lg border border-border p-4 bg-bg-secondary">
         <p className="text-sm text-text-primary">Your saved artists are private.</p>
+        <p className="text-xs text-text-muted mt-1">
+          Making them public publishes your username, the artists you've saved, and your location
+          if you've set one, at a link anyone can open and search engines can index. Your email
+          address is never published. See the{' '}
+          <Link to="/terms#section-6" className="text-accent-primary hover:underline">Terms of Use</Link>.
+        </p>
         {error && <p className="text-sm text-red-400 mt-2">{error}</p>}
         <button
           onClick={() => handleToggle(true)}

--- a/apps/web/src/data/faq.ts
+++ b/apps/web/src/data/faq.ts
@@ -67,8 +67,14 @@ We also link to a number of alternative services that can help you reduce your d
     content: `Unstream uses the [Faircamp Webring](http://faircamp.webr.ing) as a source for finding Faircamp sites for independent artists. If your Faircamp site isn't appearing in the results, consider joining the webring [at this link](https://faircamp.webr.ing/#instructions). Or, you can [email me](mailto:support@unstream.stream) your Faircamp URL and I'll have it added to the results.`
   },
   {
-    title: "What data does Unstream track?",
-    content: `Virtually nothing. We track visit and visitor counts, by location and source (ie. where you came to Unstream from), but no personal data is captured.`
+    title: "What data does Unstream track? Are my searches anonymous?",
+    content: `**Your searches are not linked to you.** There's no search history attached to your account, because we never build one — signing in doesn't change that. We do keep the search terms themselves for a short while, cached so the next person looking for the same artist doesn't cost a dozen platforms another round of requests, but there's nothing stored alongside them that says who searched. Search terms are deliberately kept out of our analytics and our server logs.
+
+**Without an account, nothing identifies you.** We count visits and page views through [GoatCounter](https://www.goatcounter.com), which is cookie-free and doesn't track you between sites, and we count things like "a search returned no results" so we can tell what's broken. The stats artists see on their dashboard are pure daily totals — how many searches an artist appeared in, how many clicks each platform link got — with no user, no session, and no IP attached to them.
+
+**With an account, we store what the account is for:** your email address, the artists you've saved, and any notes you added, so they can sync between the website, the extension and the apps. A username and a location are optional extras, and both are private until you choose to share your list.
+
+We don't sell any of it, we don't run ads, and there are no third-party trackers on the site. The [privacy policy](/privacy-policy) is the long version, and it's specific rather than vague — it names every place data goes and how long each thing is kept. You can ask for a copy of everything we hold on you, or ask us to delete it, by [emailing support](mailto:support@unstream.stream).`
   },
   {
     title: "I am ethically opposed to AI in music. Is AI at all used in Unstream?",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -31,6 +31,7 @@ const KnownArtistsPage = lazyWithRetry(() => import('./pages/KnownArtistsPage.ts
 const RoadmapPage = lazyWithRetry(() => import('./pages/RoadmapPage.tsx').then(m => ({ default: m.RoadmapPage })))
 const SupportPage = lazyWithRetry(() => import('./pages/SupportPage.tsx').then(m => ({ default: m.SupportPage })))
 const PrivacyPolicyPage = lazyWithRetry(() => import('./pages/PrivacyPolicyPage.tsx').then(m => ({ default: m.PrivacyPolicyPage })))
+const TermsOfUsePage = lazyWithRetry(() => import('./pages/TermsOfUsePage.tsx').then(m => ({ default: m.TermsOfUsePage })))
 const AdminMergePage = lazyWithRetry(() => import('./pages/AdminMergePage.tsx').then(m => ({ default: m.AdminMergePage })))
 const AdminVerifyPage = lazyWithRetry(() => import('./pages/AdminVerifyPage.tsx').then(m => ({ default: m.AdminVerifyPage })))
 const AdminLinksPage = lazyWithRetry(() => import('./pages/AdminLinksPage.tsx').then(m => ({ default: m.AdminLinksPage })))
@@ -90,6 +91,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="/roadmap" element={<RoadmapPage />} />
               <Route path="/support" element={<SupportPage />} />
               <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+              <Route path="/terms" element={<TermsOfUsePage />} />
               <Route path="/guides" element={<GuidesIndexPage />} />
               <Route path="/guides/:slug" element={<GuidePage />} />
               <Route path="/admin/merge" element={<AdminMergePage />} />

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -8,6 +8,7 @@ import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
+import { LegalConsent } from '../components/LegalConsent';
 
 type ViewMode = 'form' | 'magicLinkSent' | 'resetSent';
 
@@ -202,6 +203,8 @@ export function LoginPage() {
                   <p className="text-center text-xs text-text-muted">
                     Don't have an account yet? <a href="https://unstream.stream" className="text-accent-primary hover:underline">Search for an artist</a> you like and click Save.
                   </p>
+
+                  <LegalConsent />
                 </>
               )}
             </>

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -285,7 +285,8 @@ export function PrivacyPolicyPage() {
                 <li><strong>Search results cache</strong> — usually 30 minutes.</li>
                 <li><strong>Rate-limiting records</strong> — at most 24 hours.</li>
                 <li><strong>The record of which artist names we've checked on Bandcamp</strong> — kept indefinitely. It contains no personal data.</li>
-                <li><strong>Artist performance stats and product usage events</strong> — kept indefinitely as historical trends. Neither is linked to an account.</li>
+                <li><strong>Artist performance stats</strong> — kept indefinitely as historical trends. Anonymous from the moment they're recorded.</li>
+                <li><strong>Product usage events</strong> — the session token is erased after 90 days, leaving a count with nothing identifying attached. The counts themselves are kept as historical trends.</li>
                 <li><strong>Newsletter subscription</strong> — until you unsubscribe.</li>
                 <li><strong>Backups</strong> — deleted data can persist in backups for a short period after deletion before ageing out.</li>
               </ul>

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -159,19 +159,27 @@ export function PrivacyPolicyPage() {
                   forever. It stores the normalized artist name and the result — nothing about who
                   asked.
                 </li>
-                <li>
-                  Short-lived server logs, which include the artist name being looked up, kept
-                  briefly by our hosting provider for debugging.
-                </li>
               </ul>
               <P>
-                A search does put the artist name in the page address
-                (<code>unstream.stream/?q=artist+name</code>), so it's worth saying where that
-                address does and doesn't go. Our website analytics is deliberately configured to
-                drop the query string, so it records a visit to the home page and never the search
-                term. The one exception is an error report: if a search fails, the report sent to
-                Sentry includes the page address, artist name and all, because that's usually the
-                only way to work out what broke.
+                Those two exist so that looking up a popular artist doesn't cost a dozen platforms
+                a fresh round of requests every time somebody asks. A cache has to be keyed by the
+                thing it's caching for, so the search term is the key — but nothing is stored
+                beside it that could connect it to a person.
+              </P>
+              <P>
+                Everywhere the search term <em>isn't</em> needed, we've taken it out. It's kept out
+                of our server logs, which record which platform answered and how, not what was
+                asked for. A search puts the artist name in the page address
+                (<code>unstream.stream/?q=artist+name</code>), and our website analytics is
+                configured to drop the query string, so it records a visit to the home page and
+                never the term. Error reports have the query stripped from the page address too.
+              </P>
+              <P>
+                The one deliberate exception: when a search comes back with nothing at all, we
+                record the term on its own so we can see which artists people are looking for and
+                failing to find. It's what tells us where our coverage is missing, it's recorded
+                once per term per day however many people search it, and it carries nothing about
+                who searched.
               </P>
             </Section>
 
@@ -214,7 +222,7 @@ export function PrivacyPolicyPage() {
                 <li><strong>Supabase</strong> — the database and authentication.</li>
                 <li><strong>Upstash</strong> — the temporary cache and rate-limiting store.</li>
                 <li><strong>GoatCounter</strong> — cookie-free website analytics.</li>
-                <li><strong>Sentry</strong> — error reports, configured not to send IP addresses, cookies or request headers. An error report does include the address of the page it happened on.</li>
+                <li><strong>Sentry</strong> — error reports, configured not to send IP addresses, cookies or request headers, and with the query string stripped from the page address.</li>
                 <li><strong>Buttondown</strong> — the newsletter, if you subscribe.</li>
                 <li><strong>Liberapay</strong> and <strong>Apple</strong> — donations and in-app support purchases. We never see your payment details.</li>
                 <li><strong>Discord</strong> — if you use the Unstream bot in a Discord server.</li>

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -323,10 +323,10 @@ export function PrivacyPolicyPage() {
 
             <Section title="Security">
               <P>
-                Access to the database is restricted by row-level security policies, so accounts
-                can only reach their own rows. API keys are stored as hashes, never in plaintext.
-                Passwords are handled by Supabase Auth and we never see them. Traffic is encrypted
-                in transit.
+                Your account data — your saved artists, your username and location, your feed
+                token — is protected by database policies that scope every row to its owner. API
+                keys are stored as hashes, never in plaintext. Passwords are handled by Supabase
+                Auth and we never see them. Traffic is encrypted in transit.
               </P>
               <P>
                 No system is perfectly secure, and we won't pretend otherwise. If you find a

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -104,8 +104,9 @@ export function PrivacyPolicyPage() {
                 </li>
                 <li>
                   <strong>Website analytics.</strong> GoatCounter, which is privacy-focused and
-                  cookie-free, records page views using its own daily-rotating visitor hash. See
-                  "About your searches" below for one important detail about this.
+                  cookie-free, records page views using its own daily-rotating visitor hash. It's
+                  configured to receive the page you visited and not the query string, so a search
+                  reaches it as a visit to the home page rather than as an artist name.
                 </li>
               </ul>
 
@@ -164,12 +165,13 @@ export function PrivacyPolicyPage() {
                 </li>
               </ul>
               <P>
-                One thing worth knowing: because a search puts the artist name in the page address
-                (<code>unstream.stream/?q=artist+name</code>), that address — artist name included
-                — is also recorded by our website analytics as an ordinary page view. It sits
-                against a daily-rotating visitor hash, not against you, but it does mean the search
-                term leaves our servers. If you'd rather it didn't, the artist index and the
-                artist pages get you to the same place without a query in the URL.
+                A search does put the artist name in the page address
+                (<code>unstream.stream/?q=artist+name</code>), so it's worth saying where that
+                address does and doesn't go. Our website analytics is deliberately configured to
+                drop the query string, so it records a visit to the home page and never the search
+                term. The one exception is an error report: if a search fails, the report sent to
+                Sentry includes the page address, artist name and all, because that's usually the
+                only way to work out what broke.
               </P>
             </Section>
 
@@ -212,7 +214,7 @@ export function PrivacyPolicyPage() {
                 <li><strong>Supabase</strong> — the database and authentication.</li>
                 <li><strong>Upstash</strong> — the temporary cache and rate-limiting store.</li>
                 <li><strong>GoatCounter</strong> — cookie-free website analytics.</li>
-                <li><strong>Sentry</strong> — error reports, configured not to send IP addresses, cookies or request headers.</li>
+                <li><strong>Sentry</strong> — error reports, configured not to send IP addresses, cookies or request headers. An error report does include the address of the page it happened on.</li>
                 <li><strong>Buttondown</strong> — the newsletter, if you subscribe.</li>
                 <li><strong>Liberapay</strong> and <strong>Apple</strong> — donations and in-app support purchases. We never see your payment details.</li>
                 <li><strong>Discord</strong> — if you use the Unstream bot in a Discord server.</li>

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -4,136 +4,369 @@ import { Link } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 
+/**
+ * Privacy Policy for the hosted service and the clients that sign into it.
+ *
+ * Every claim on this page was checked against the code and the migrations, because the previous
+ * version had drifted: it still said saved artists lived only on your device, which stopped
+ * being true when sync shipped, and it predated public sharing, the newsletter, the release
+ * feeds and the public API.
+ *
+ * The rule for editing: if a feature changes what is collected, where it goes, or how long it's
+ * kept, this page changes in the same PR. A privacy policy that describes last year's product
+ * is a liability, not a protection. `docs/specs/data-collection-audit.md` is the working
+ * inventory this page is written from — update it alongside.
+ */
 export function PrivacyPolicyPage() {
   return (
     <div className="min-h-screen">
 
       <Header />
 
-      {/* Content */}
       <main className="pt-8 px-4 pb-16">
         <div className="max-w-3xl mx-auto">
           <article className="prose prose-lg dark:prose-invert max-w-none prose-a:text-accent-primary text-text-primary">
             <h2 className="font-display text-3xl font-semibold text-text-primary mb-6">Privacy Policy</h2>
-            <p className="text-text-muted text-sm mb-8">Last updated: March 13, 2026</p>
+            <p className="text-text-muted text-sm mb-8">Last updated: August 8, 2026</p>
 
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Overview</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                Unstream is committed to protecting your privacy. This policy explains what data we collect, how we use it, and your rights regarding that data.
-              </p>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                <strong>The short version:</strong> We collect minimal data, we don't sell your information, and we don't track you across the web.
-              </p>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                Our{' '}
+            <div className="mb-10 p-5 rounded-lg bg-bg-secondary border border-border not-prose">
+              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">The short version</h3>
+              <ul className="list-disc ml-5 text-text-primary/90 space-y-2 text-base">
+                <li>
+                  You can use Unstream without an account, and we'd rather you didn't have to make one.
+                </li>
+                <li>
+                  We don't sell your data, we don't run ad trackers, and we don't follow you around
+                  the web.
+                </li>
+                <li>
+                  <strong>We don't record who searched for what.</strong> We do keep the search
+                  terms themselves — cached so the next person's search is fast — with nothing
+                  attached that says it was you.
+                </li>
+                <li>
+                  Your saved artists are stored on our servers, tied to your account, so they can
+                  sync between your devices. They're private unless you deliberately publish them.
+                </li>
+                <li>
+                  Your username, your location, and public sharing are all optional and all off
+                  until you turn them on.
+                </li>
+                <li>
+                  Ask us for your data or ask us to delete it at{' '}
+                  <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                    support@unstream.stream
+                  </a>
+                  , and we'll do it.
+                </li>
+              </ul>
+            </div>
+
+            <Section title="How much we know about you, honestly">
+              <P>
+                "Anonymous" is a word that gets used loosely, so here's the real breakdown. Three
+                categories, and we've been strict about which is which.
+              </P>
+
+              <h4 className="font-semibold text-text-primary mt-5 mb-2">Genuinely anonymous</h4>
+              <P>
+                Nothing identifies you, not even indirectly, and there's no way for us to work
+                backwards to a person.
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>
+                  <strong>Artist performance stats.</strong> The numbers on an artist's dashboard
+                  are daily totals per artist: how many searches they appeared in, how many times
+                  their page was viewed, how many times each platform link was clicked. A counter
+                  goes up by one. No user ID, no session, no IP address, nothing about who did it
+                  or what else they did.
+                </li>
+              </ul>
+
+              <h4 className="font-semibold text-text-primary mt-5 mb-2">Pseudonymous — not linked to you, but not nothing</h4>
+              <P>
+                No name or email is attached, but there's some kind of identifier involved. We call
+                this out rather than filing it under "anonymous", because that would be a stretch.
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>
+                  <strong>Product usage events.</strong> Things like "a search happened and
+                  returned 12 results" or "somebody clicked a Bandcamp link", so we can tell
+                  whether a feature works. Each carries a session token that is a one-way keyed
+                  hash of your IP address, your browser's user agent, and today's date. It changes
+                  every day, we can't reverse it into an IP, and it can't follow you from one day
+                  to the next. We never store the raw IP.
+                </li>
+                <li>
+                  <strong>Rate-limiting records.</strong> To stop abuse we count requests per IP
+                  address in a temporary store. This one is a raw IP address, held for at most 24
+                  hours, and used for nothing else.
+                </li>
+                <li>
+                  <strong>Website analytics.</strong> GoatCounter, which is privacy-focused and
+                  cookie-free, records page views using its own daily-rotating visitor hash. See
+                  "About your searches" below for one important detail about this.
+                </li>
+              </ul>
+
+              <h4 className="font-semibold text-text-primary mt-5 mb-2">Linked to your account</h4>
+              <P>Once you create an account, this is tied to you and we can look it up:</P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>Your email address, and a securely hashed password if you set one.</li>
+                <li>
+                  The artists you've saved, any notes you attached, which ones you've marked as
+                  supported, and when.
+                </li>
+                <li>
+                  A device identifier for each device you sync from — a random ID generated on
+                  install, used to work out which device made which change. It isn't a hardware
+                  identifier and it tells us nothing about your device.
+                </li>
+                <li>Your username and location, if you set them.</li>
+                <li>The secret token behind your personal release feed, if you've created one.</li>
+                <li>
+                  For artists: your claimed profile — bio, photo, links, featured release — and
+                  anything you wrote in a manual verification request.
+                </li>
+                <li>For API users: your email, a label for each key, and a hash of the key itself.</li>
+              </ul>
+            </Section>
+
+            <Section title="About your searches">
+              <P>
+                People assume searches are the sensitive part, so this gets its own section rather
+                than a footnote.
+              </P>
+              <P>
+                <strong>We do not record who searched for what.</strong> No search is ever written
+                against your account, and signing in doesn't change that — your search history
+                isn't something we hold, because we never build one.
+              </P>
+              <P>
+                <strong>We do store the search terms themselves</strong>, detached from any person,
+                in three places:
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>
+                  A results cache, so a popular artist doesn't cost every visitor a fresh round of
+                  requests to a dozen platforms. Entries are keyed by the artist name and normally
+                  expire within 30 minutes.
+                </li>
+                <li>
+                  A permanent record of which artist names we've already checked on Bandcamp, and
+                  what we found. This is what stops us hammering Bandcamp with the same lookups
+                  forever. It stores the normalized artist name and the result — nothing about who
+                  asked.
+                </li>
+                <li>
+                  Short-lived server logs, which include the artist name being looked up, kept
+                  briefly by our hosting provider for debugging.
+                </li>
+              </ul>
+              <P>
+                One thing worth knowing: because a search puts the artist name in the page address
+                (<code>unstream.stream/?q=artist+name</code>), that address — artist name included
+                — is also recorded by our website analytics as an ordinary page view. It sits
+                against a daily-rotating visitor hash, not against you, but it does mean the search
+                term leaves our servers. If you'd rather it didn't, the artist index and the
+                artist pages get you to the same place without a query in the URL.
+              </P>
+            </Section>
+
+            <Section title="What's public, and only if you choose">
+              <P>
+                Everything in your account is private by default. There are exactly two ways
+                something becomes publicly visible, and both are things you have to switch on.
+              </P>
+              <P>
+                <strong>Sharing your saved artists.</strong> Setting a username doesn't publish
+                anything on its own. Turning on sharing publishes a page at{' '}
+                <code>unstream.stream/u/your-username</code> showing your username, the artists
+                you've saved, which ones you've marked as supported, and your location if you've
+                set one. Anyone can open it without an account, and search engines can index it.
+                Your email address is never published, and neither are your notes.
+              </P>
+              <P>
+                You can turn sharing off, change your username, or clear your location at any time
+                in your settings. The page goes down, but copies already made by caches, archives
+                or other people are beyond our reach. There's more on this in section 6 of the{' '}
+                <Link to="/terms#section-6" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  Terms of Use
+                </Link>
+                .
+              </P>
+              <P>
+                <strong>Claiming an artist profile.</strong> Once verified, your bio, photo, links,
+                location and featured release are shown publicly on your artist page. That's the
+                point of claiming it. The email address you claimed with is not shown.
+              </P>
+            </Section>
+
+            <Section title="Where your data goes">
+              <P>
+                We use a small number of providers to run the Service. They process data on our
+                behalf, and none of them get your data to use for their own purposes.
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li><strong>Netlify</strong> — hosting and serverless functions.</li>
+                <li><strong>Supabase</strong> — the database and authentication.</li>
+                <li><strong>Upstash</strong> — the temporary cache and rate-limiting store.</li>
+                <li><strong>GoatCounter</strong> — cookie-free website analytics.</li>
+                <li><strong>Sentry</strong> — error reports, configured not to send IP addresses, cookies or request headers.</li>
+                <li><strong>Buttondown</strong> — the newsletter, if you subscribe.</li>
+                <li><strong>Liberapay</strong> and <strong>Apple</strong> — donations and in-app support purchases. We never see your payment details.</li>
+                <li><strong>Discord</strong> — if you use the Unstream bot in a Discord server.</li>
+              </ul>
+              <P>
+                Separately, we read from public music and metadata sources — MusicBrainz, Wikidata,
+                Wikipedia, Discogs, Bandcamp, Mirlo and the other platforms we list. We send them
+                an artist name to search for. We never send them anything about you.
+              </P>
+              <P>
+                These providers are based in the United States, and that's where your data is
+                stored and processed. If you're in the UK or EEA, that means your data is
+                transferred outside your home region.
+              </P>
+            </Section>
+
+            <Section title="The apps and the extension">
+              <P>
+                <strong>Browser extension.</strong> It reads the artist and track showing on the
+                streaming sites it supports, so it can look them up. That reading happens in your
+                browser; the artist name is sent to our search API the same way a search on the
+                website is. It never reads your credentials, your listening history, your playlists,
+                or anything on other sites. Saved artists live in your browser's local storage, and
+                sync to your account only if you sign in.
+              </P>
+              <P>
+                <strong>macOS and iOS apps.</strong> They read now-playing information from your
+                device for the same purpose. Saved artists are stored on your device, and sync to
+                your account only if you sign in. Optional extras stay on your device: if you
+                connect ListenBrainz, your listening data goes from your device to ListenBrainz
+                under their privacy policy and never through us, and if you connect Plex, your
+                token and server address stay in your device's keychain and talk only to your own
+                server.
+              </P>
+            </Section>
+
+            <Section title="What we don't collect">
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>A history of your searches, tied to you.</li>
+                <li>Credentials for any streaming service.</li>
+                <li>Your listening history or playlists, except where you've explicitly connected ListenBrainz, which we don't see.</li>
+                <li>Advertising or cross-site tracking cookies. We don't run ads.</li>
+                <li>Your payment details.</li>
+                <li>Anything from web pages other than the streaming player pages the extension supports.</li>
+                <li>Precise or device-derived location. The only location we hold is one you typed in yourself.</li>
+                <li>Special-category data — health, politics, religion, biometrics. We have no use for it and don't ask.</li>
+              </ul>
+              <P>We also don't sell personal data, and we don't share it for advertising. There's no version of this where that changes without us telling you first.</P>
+            </Section>
+
+            <Section title="Why we're allowed to hold it">
+              <P>
+                If you're in the UK or EEA, the legal bases we rely on are: <strong>contract</strong>{' '}
+                for the things your account needs in order to work (your email, your saved artists,
+                sync); <strong>consent</strong> for anything optional you switched on (the
+                newsletter, public sharing, a location); and <strong>legitimate interests</strong>{' '}
+                for keeping the Service running, secure, and not overwhelmed by abuse — the
+                rate-limiting records, the error reports, and the anonymous and pseudonymous usage
+                counts. Where we rely on consent, you can withdraw it at any time without affecting
+                what came before.
+              </P>
+            </Section>
+
+            <Section title="How long we keep it">
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li><strong>Account data</strong> — until you delete your account.</li>
+                <li><strong>Removed saved artists</strong> — a deletion marker is kept for 30 days so your other devices learn about the removal, then permanently erased.</li>
+                <li><strong>Search results cache</strong> — usually 30 minutes.</li>
+                <li><strong>Rate-limiting records</strong> — at most 24 hours.</li>
+                <li><strong>The record of which artist names we've checked on Bandcamp</strong> — kept indefinitely. It contains no personal data.</li>
+                <li><strong>Artist performance stats and product usage events</strong> — kept indefinitely as historical trends. Neither is linked to an account.</li>
+                <li><strong>Newsletter subscription</strong> — until you unsubscribe.</li>
+                <li><strong>Backups</strong> — deleted data can persist in backups for a short period after deletion before ageing out.</li>
+              </ul>
+            </Section>
+
+            <Section title="Your rights">
+              <P>
+                Depending on where you live you may have the right to access your data, correct it,
+                delete it, take a copy elsewhere, object to or restrict how we use it, and withdraw
+                consent. We extend all of these to everyone, wherever you are, because running two
+                standards would be worse for everybody.
+              </P>
+              <P>
+                Some you can exercise yourself, right now: your saved artists, username, location
+                and sharing setting are all editable in{' '}
+                <Link to="/settings" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  your settings
+                </Link>
+                , your newsletter subscription has an unsubscribe link on every issue, and your
+                release feed token can be rotated or revoked.
+              </P>
+              <P>
+                For anything else — a copy of everything we hold on you, or deletion of your
+                account and its data — email{' '}
+                <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  support@unstream.stream
+                </a>
+                . We'll respond within 30 days and we won't make you justify the request. If you're
+                in the UK or EEA you also have the right to complain to your data protection
+                authority.
+              </P>
+              <P>
+                You can clear local data without involving us at all: remove the browser extension
+                or clear its storage, or delete the app from your device.
+              </P>
+            </Section>
+
+            <Section title="Security">
+              <P>
+                Access to the database is restricted by row-level security policies, so accounts
+                can only reach their own rows. API keys are stored as hashes, never in plaintext.
+                Passwords are handled by Supabase Auth and we never see them. Traffic is encrypted
+                in transit.
+              </P>
+              <P>
+                No system is perfectly secure, and we won't pretend otherwise. If you find a
+                vulnerability, please tell us at support@unstream.stream — we'll take it seriously
+                and we won't come after you for reporting it in good faith. If a breach affects
+                your personal data, we'll tell you and the relevant regulator as the law requires.
+              </P>
+            </Section>
+
+            <Section title="Children">
+              <P>
+                Unstream isn't directed at children under 13, and we don't knowingly collect their
+                data. You must be at least 13 to create an account, or older where your country
+                requires it. If you believe a child under 13 has an account, tell us and we'll
+                remove it.
+              </P>
+            </Section>
+
+            <Section title="Changes to this policy">
+              <P>
+                We'll update this page as the Service changes, and update the "Last updated" date
+                when we do. For changes that materially affect how we handle your data, we'll give
+                notice on the site and, if you have an account, by email — before the change takes
+                effect where we reasonably can.
+              </P>
+            </Section>
+
+            <Section title="Contact">
+              <P>
+                Questions, requests, or corrections:{' '}
+                <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  support@unstream.stream
+                </a>
+                . The{' '}
                 <Link to="/terms" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
                   Terms of Use
                 </Link>{' '}
-                cover the rest of the relationship: what Unstream does, what you agree to when you create an account, and what becomes public if you share your saved artists.
-              </p>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">What We Collect</h3>
-
-              <h4 className="font-semibold text-text-primary mt-4 mb-2">Web App (unstream.stream)</h4>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li>Search queries you enter (artist names) - used only to fetch results</li>
-                <li>Basic analytics (page views, search counts) - no personal identifiers</li>
-                <li>Anonymous, aggregate artist engagement data (search appearances, page views, link clicks) - stored as daily totals per artist with no personal identifiers, IP addresses, or session data. Used to provide verified artists with performance insights on their dashboard.</li>
-              </ul>
-
-              <h4 className="font-semibold text-text-primary mt-4 mb-2">Artist Profiles (for artists who claim their page)</h4>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li>Email address - used for authentication and account recovery via Supabase Auth</li>
-                <li>Artist profile information you provide (bio, platform links, featured release embeds) - stored in our database and displayed publicly on your artist page</li>
-                <li>Your artist page URL slug - publicly visible</li>
-              </ul>
-
-              <h4 className="font-semibold text-text-primary mt-4 mb-2">Browser Extension (Chrome / Firefox)</h4>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li>Currently playing track information (artist name, song title) from Spotify, YouTube, YouTube Music, and Apple Music - used only to search for alternative platforms</li>
-                <li>Saved artists - stored locally in your browser</li>
-                <li>Anonymous, aggregate artist engagement signals (search appearances, link clicks) - no personal identifiers stored, only daily totals per artist</li>
-              </ul>
-
-              <h4 className="font-semibold text-text-primary mt-4 mb-2">macOS App</h4>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li>Currently playing track information from your system - used only to search for alternative platforms</li>
-                <li>Saved artists - stored locally on your device</li>
-                <li>Anonymous, aggregate artist engagement signals (search appearances, link clicks) - no personal identifiers stored, only daily totals per artist</li>
-              </ul>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">What We Don't Collect</h3>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li>Personal information (name, email, address) - unless you contact support or create an artist profile</li>
-                <li>Login credentials for streaming services</li>
-                <li>Listening history or playlists</li>
-                <li>Cookies for tracking or advertising</li>
-                <li>Any data from pages other than the specific streaming service player pages</li>
-              </ul>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Third-Party Services</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                We use the following third-party services:
-              </p>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li><strong>Liberapay</strong> - for processing optional donations</li>
-                <li><strong>Supabase</strong> - for artist account authentication and profile data storage</li>
-                <li><strong>MusicBrainz</strong> - for fetching artist metadata and social links</li>
-                <li><strong>Bandcamp, Qobuz, and other music platforms</strong> - for searching artist availability</li>
-              </ul>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                We do not share your personal data with these services beyond what is necessary to provide the functionality (e.g., sending an artist name to search for results).
-              </p>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Data Storage</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                For listeners, all user preferences and saved artists are stored locally on your device using browser storage (for the extension) or app storage (for macOS).
-              </p>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                For artists who claim their page, account and profile data (email, bio, links, embeds) is stored in our database hosted by Supabase. You can request deletion of your artist account and all associated data by contacting us at{' '}
-                <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
-                  support@unstream.stream
-                </a>.
-              </p>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Your Rights</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                You can clear all locally stored data at any time by:
-              </p>
-              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
-                <li><strong>Browser Extension:</strong> Remove the extension or clear extension data in your browser settings</li>
-                <li><strong>macOS App:</strong> Delete the app and its associated data from your system</li>
-                <li><strong>Artist Profile:</strong> Contact us at support@unstream.stream to request deletion of your account and all associated profile data</li>
-              </ul>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Changes to This Policy</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                We may update this privacy policy from time to time. We will notify users of any material changes by updating the "Last updated" date at the top of this page.
-              </p>
-            </section>
-
-            <section className="mb-8">
-              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">Contact</h3>
-              <p className="text-text-primary/90 leading-relaxed mb-3">
-                If you have any questions about this privacy policy, please contact us at{' '}
-                <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
-                  support@unstream.stream
-                </a>.
-              </p>
-            </section>
+                cover the rest of the relationship.
+              </P>
+            </Section>
           </article>
         </div>
       </main>
@@ -141,4 +374,17 @@ export function PrivacyPolicyPage() {
       <Footer />
     </div>
   );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-8">
+      <h3 className="font-display text-xl font-semibold text-text-primary mb-3">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return <p className="text-text-primary/90 leading-relaxed mb-3">{children}</p>;
 }

--- a/apps/web/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/web/src/pages/PrivacyPolicyPage.tsx
@@ -1,4 +1,6 @@
 
+import { Link } from 'react-router-dom';
+
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 
@@ -22,6 +24,13 @@ export function PrivacyPolicyPage() {
               </p>
               <p className="text-text-primary/90 leading-relaxed mb-3">
                 <strong>The short version:</strong> We collect minimal data, we don't sell your information, and we don't track you across the web.
+              </p>
+              <p className="text-text-primary/90 leading-relaxed mb-3">
+                Our{' '}
+                <Link to="/terms" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  Terms of Use
+                </Link>{' '}
+                cover the rest of the relationship: what Unstream does, what you agree to when you create an account, and what becomes public if you share your saved artists.
               </p>
             </section>
 

--- a/apps/web/src/pages/TermsOfUsePage.tsx
+++ b/apps/web/src/pages/TermsOfUsePage.tsx
@@ -1,0 +1,581 @@
+import { Link } from 'react-router-dom';
+
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+/**
+ * Terms of Use for the hosted service at unstream.stream, plus the apps that sign into it.
+ *
+ * Two things to keep true when editing:
+ *
+ * 1. Unstream is described here as an independent project with no incorporated entity behind
+ *    it. If that ever changes, the entity's legal name belongs in §2 and §20, and nowhere else.
+ * 2. The factual sections (§5–§14) describe what the product actually does. When a feature
+ *    changes what it collects, publishes, or emails, this page changes with it — a terms page
+ *    that describes a product you no longer ship is worse than no terms page at all.
+ */
+export function TermsOfUsePage() {
+  return (
+    <div className="min-h-screen">
+
+      <Header />
+
+      <main className="pt-8 px-4 pb-16">
+        <div className="max-w-3xl mx-auto">
+          <article className="prose prose-lg dark:prose-invert max-w-none prose-a:text-accent-primary text-text-primary">
+            <h2 className="font-display text-3xl font-semibold text-text-primary mb-6">Terms of Use</h2>
+            <p className="text-text-muted text-sm mb-8">Last updated: August 8, 2026</p>
+
+            <div className="mb-10 p-5 rounded-lg bg-bg-secondary border border-border not-prose">
+              <h3 className="font-display text-xl font-semibold text-text-primary mb-3">The short version</h3>
+              <p className="text-text-primary/90 leading-relaxed mb-3 text-base">
+                This summary is here to be read. It isn't a substitute for the full terms below, and where the two
+                disagree, the full terms win.
+              </p>
+              <ul className="list-disc ml-5 text-text-primary/90 space-y-2 text-base">
+                <li>
+                  Unstream is a free search tool that points you to places to buy music and support artists directly.
+                  We don't host music, sell it, or take a cut of anything you spend — those purchases happen on other
+                  platforms, under their terms.
+                </li>
+                <li>
+                  You only need an account to save artists, sync them across devices, or run an artist profile. You're
+                  responsible for what happens under your account.
+                </li>
+                <li>
+                  If you switch on public sharing, your username, your saved artists, and your location (if you set
+                  one) become visible to anyone with the link. Switching it off stops that going forward, but copies
+                  other people or search engines already made are out of our hands.
+                </li>
+                <li>
+                  Claiming an artist profile is you telling us that you are that artist, or that you're authorized to
+                  act for them. Claiming one you have no right to gets it taken away.
+                </li>
+                <li>
+                  Everything here is provided as-is. Search results, platform links, and payout percentages are a
+                  careful best effort, not a guarantee.
+                </li>
+                <li>
+                  If something looks wrong, email{' '}
+                  <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                    support@unstream.stream
+                  </a>
+                  . We would much rather fix it than argue about it.
+                </li>
+              </ul>
+            </div>
+
+            <Section n={1} title="Agreement to these terms">
+              <P>
+                These Terms of Use ("Terms") are an agreement between you and Unstream. They cover the website at
+                unstream.stream, the Unstream browser extension, the Unstream apps for macOS and iOS, the Unstream
+                Discord bot, our public API, and any other service we offer that links to this page (together, the
+                "Service").
+              </P>
+              <P>
+                By using the Service — searching, creating an account, claiming an artist profile, or calling the API —
+                you agree to these Terms. If you don't agree, please don't use the Service.
+              </P>
+              <P>
+                Our{' '}
+                <Link to="/privacy-policy" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  Privacy Policy
+                </Link>{' '}
+                explains what data we collect and why. It's part of this agreement.
+              </P>
+            </Section>
+
+            <Section n={2} title="Who we are">
+              <P>
+                Unstream is an independent project, run and paid for by one person rather than a company. "Unstream",
+                "we", and "us" in these Terms mean that project and whoever operates it. "You" means whoever is using
+                the Service.
+              </P>
+              <P>
+                The Service is free to use. There is no paid tier, no subscription, and nothing you have to buy to get
+                the whole product. Donations and in-app tips are covered in section 13.
+              </P>
+            </Section>
+
+            <Section n={3} title="Eligibility and age">
+              <P>
+                You must be at least 13 years old to create an Unstream account. If you're in the European Economic
+                Area, the United Kingdom, or anywhere else that sets a higher minimum age for consenting to online
+                services on your own, you must meet that age instead, or have your parent or guardian agree to these
+                Terms for you.
+              </P>
+              <P>
+                Unstream isn't directed at children under 13, and we don't knowingly keep accounts for them. If you
+                believe a child under 13 has an account, tell us at support@unstream.stream and we'll remove it.
+              </P>
+              <P>
+                If you're using the Service on behalf of an organization — a label, a management company, a band's
+                shared account — you're confirming you're authorized to accept these Terms for that organization.
+              </P>
+            </Section>
+
+            <Section n={4} title="Your account">
+              <P>
+                You can sign in with a one-time link sent to your email, or with a password. Either way, your email
+                address is your account. Keep it secure: anyone who can read your inbox can sign in as you.
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>Give us an email address you actually control, and keep it current.</li>
+                <li>Don't share your account, your password, or your sign-in links with anyone else.</li>
+                <li>
+                  You're responsible for everything done through your account, except activity that happens after you
+                  tell us it's been compromised.
+                </li>
+                <li>Tell us promptly at support@unstream.stream if you think someone else has access to it.</li>
+                <li>One person, one account. Don't create accounts to evade a suspension or a rate limit.</li>
+              </ul>
+              <P>
+                You can delete your account and the data attached to it at any time by emailing
+                support@unstream.stream.
+              </P>
+            </Section>
+
+            <Section n={5} title="What Unstream does — and what it doesn't">
+              <P>
+                Unstream searches music platforms for an artist you name and shows you where to find them, grouped by
+                category, with an estimate of how much of your money reaches the artist on each one.
+              </P>
+              <P>
+                <strong>We are a directory and a search tool.</strong> We don't host, sell, stream, or license music.
+                We aren't a party to anything you buy. Every purchase, subscription, download, and refund is between
+                you and the platform you buy from, under that platform's terms.
+              </P>
+              <P>Some specific limits worth being blunt about:</P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>
+                  <strong>Results can be wrong.</strong> Matching an artist name across platforms is genuinely hard.
+                  Two artists share a name; a page turns out to be a fan account; a platform's search misses somebody
+                  who's plainly there. We work at this constantly and we still get it wrong. Check before you buy.
+                </li>
+                <li>
+                  <strong>Payout percentages are estimates.</strong> They come from each platform's own published fees
+                  and don't account for payment processing, currency conversion, label or distributor splits, or deals
+                  we can't see. Treat them as a guide to the shape of the ecosystem, not as an accounting of a specific
+                  sale.
+                </li>
+                <li>
+                  <strong>A listing isn't an endorsement</strong> — of a platform, an artist, or a release. A missing
+                  listing isn't a judgment either; it usually means we didn't find one.
+                </li>
+                <li>
+                  <strong>Release information may be stale or incomplete.</strong> We catalogue releases from artists'
+                  own pages on a schedule, so new releases can take a while to appear and removed ones can linger.
+                </li>
+              </ul>
+            </Section>
+
+            <Section n={6} title="Saved artists, sharing, and public pages">
+              <P>
+                A signed-in account lets you save artists, mark artists you've supported, and sync that list between
+                the website, the browser extension, and the Apple apps. By default, that list is private to you.
+              </P>
+              <P>
+                You can also claim a username and switch on public sharing, which publishes your list at
+                unstream.stream/u/your-username. <strong>Before you do, understand what becomes public:</strong>
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>Your username.</li>
+                <li>The artists you've saved, and which ones you've marked as supported.</li>
+                <li>Your location, if you've set one in your settings.</li>
+              </ul>
+              <P>
+                Your email address is never published. The page is open to anyone with the link — no account needed —
+                and it can be indexed by search engines, archived, screenshotted, and shared onward.
+              </P>
+              <P>
+                You can turn sharing off, change your username, or clear your location at any time in your settings.
+                That takes the page down going forward, and we'll ask search engines to drop it, but{' '}
+                <strong>we can't retrieve copies that already exist</strong> in caches, archives, or someone else's
+                screenshot. Please share deliberately.
+              </P>
+              <P>
+                Usernames are first come, first served, and a set of names are reserved for the Service itself. We may
+                reclaim a username that impersonates someone, infringes a trademark, or is chosen to abuse or mislead.
+              </P>
+              <P>
+                Your personal release feed has a secret token in its URL. Anyone with that URL can read the feed, so
+                treat it like a password — and rotate or revoke it from your settings if it gets out.
+              </P>
+            </Section>
+
+            <Section n={7} title="Artist profiles and claims">
+              <P>
+                Unstream generates a page for artists we find, whether or not they've ever heard of us. Artists can
+                claim their page to correct it, add a bio and photo, fix links, and see how their page is performing.
+              </P>
+              <P>When you claim a profile, you're telling us — and you need it to be true — that:</P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>You are that artist, or you're authorized by them to manage their presence.</li>
+                <li>The information you add is accurate and not misleading.</li>
+                <li>You have the rights to any bio, photo, artwork, or embed you upload or link.</li>
+              </ul>
+              <P>
+                Claiming a profile you have no right to is a serious misuse of the Service. We'll remove the claim, we
+                may suspend the account, and we may hand the profile to the rightful artist.
+              </P>
+              <P>
+                Verification is our best-effort check that a claim is genuine, using the evidence available to us. A
+                verified badge means we checked; it isn't a guarantee of identity, and it isn't an endorsement,
+                affiliation, or partnership. We may re-review or revoke verification if new information comes to light.
+              </P>
+              <P>
+                An artist can ask us to correct or remove their page whether or not they've claimed it. Email
+                support@unstream.stream from an address we can connect to the artist, and we'll sort it out.
+              </P>
+            </Section>
+
+            <Section n={8} title="Your content and the permissions you give us">
+              <P>
+                "Your Content" means anything you put into the Service: your bio, photo, links, location, username,
+                featured release, saved list, corrections, and anything you send us. You keep every right you already
+                had in it. We don't claim ownership.
+              </P>
+              <P>
+                To actually run the Service, we need your permission to handle it. By submitting Your Content, you give
+                us a worldwide, non-exclusive, royalty-free licence to host, store, reproduce, adapt for formatting and
+                display, and publish it — but only to operate, secure, and improve the Service, and only in the places
+                you've chosen to publish it. We don't sell Your Content, and we don't license it to anyone else for
+                their own purposes.
+              </P>
+              <P>
+                This licence ends when you delete the content or your account, apart from two ordinary exceptions:
+                backups take a short while to age out, and we may keep a record where the law requires it or where we
+                need it to resolve a dispute.
+              </P>
+              <P>
+                You're responsible for Your Content. Don't post anything unlawful, infringing, deceptive, hateful, or
+                designed to harass someone. We may remove content that breaks these Terms, and we may keep a copy for
+                the record when we do.
+              </P>
+              <P>
+                If you send us a suggestion or feature idea, we can use it freely and without obligation to you. That's
+                not us claiming your work — it's so we don't have to refuse good ideas out of caution.
+              </P>
+            </Section>
+
+            <Section n={9} title="Acceptable use">
+              <P>Please don't:</P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>Break the law with the Service, or use it to help anyone else do so.</li>
+                <li>
+                  Impersonate an artist, a label, another user, or us — including by claiming a profile that isn't
+                  yours, or picking a username designed to be mistaken for someone else.
+                </li>
+                <li>
+                  Scrape, crawl, or bulk-download the Service outside the public API and what our robots.txt allows.
+                  The API exists precisely so you don't have to; ask us if you need more than it gives you.
+                </li>
+                <li>
+                  Get around rate limits, quotas, or access controls — including by rotating accounts, keys, or IP
+                  addresses.
+                </li>
+                <li>
+                  Probe, scan, or test the security of the Service without asking first. If you find a vulnerability,
+                  please report it to support@unstream.stream; we'll take it seriously and we won't come after you for
+                  reporting it in good faith.
+                </li>
+                <li>
+                  Overload the Service, or aim automated traffic at it in a way that degrades it for other people.
+                </li>
+                <li>Upload malware, or use the Service to distribute it.</li>
+                <li>
+                  Use the Service to train a machine learning model on our content, or to build a substantially similar
+                  competing directory from our data. Many of the platforms we index have explicit policies against
+                  AI-generated music, and we're not going to be the pipe that undermines them.
+                </li>
+                <li>
+                  Misrepresent the payout percentages, verification status, or artist data you get from us when you
+                  republish it.
+                </li>
+              </ul>
+            </Section>
+
+            <Section n={10} title="API, apps, extension, and bot">
+              <P>
+                <strong>Public API.</strong> We offer a versioned REST API, documented on our{' '}
+                <Link to="/developers" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  developers page
+                </Link>
+                . API keys are issued to you, tied to your account, and not to be shared or resold. Requests are rate
+                limited. We may change, deprecate, or withdraw endpoints, and we may revoke a key that's being abused
+                or that's driving load we can't carry. Please don't present data from the API as if it were your own
+                research, and don't use it to rebuild the directory itself.
+              </P>
+              <P>
+                <strong>Browser extension.</strong> The extension reads the artist and track currently showing on the
+                streaming sites it supports, so it can search for alternatives. It doesn't read your credentials, your
+                listening history, or anything on other pages. Your browser's extension store adds its own terms on
+                top of these.
+              </P>
+              <P>
+                <strong>macOS and iOS apps.</strong> The apps read now-playing information from your device to do the
+                same thing, and sync your saved artists if you sign in. Apple's App Store terms apply alongside these
+                Terms, and Apple isn't responsible for the apps — we are. Optional scrobbling to ListenBrainz only
+                happens if you connect it, and is governed by ListenBrainz's own terms.
+              </P>
+              <P>
+                <strong>Discord bot.</strong> Adding the bot to a server means these Terms apply to that use too, along
+                with Discord's terms. Server admins are responsible for what happens in their server.
+              </P>
+              <P>
+                Where a component of the Service is also published as open source, the licence on that source code
+                governs the code. These Terms govern the hosted Service — running your own copy of the code doesn't put
+                you under these Terms, and using ours does.
+              </P>
+            </Section>
+
+            <Section n={11} title="Third-party platforms and links">
+              <P>
+                Almost everything Unstream shows you is a link somewhere else: Bandcamp, Mirlo, Ampwall, Subvert,
+                Faircamp sites, Jam.coop, Patreon, Qobuz, libraries, artists' own stores, and more. We also pull
+                metadata from sources like MusicBrainz, Wikidata, and Discogs.
+              </P>
+              <P>
+                Those platforms are not ours and we don't control them. We're not responsible for their content, their
+                pricing, their availability, their privacy practices, or how they treat you. When you follow a link,
+                you're leaving Unstream and entering someone else's agreement.
+              </P>
+              <P>
+                If a purchase goes wrong — the download fails, the artist never sees the money, the refund never
+                arrives — that's between you and that platform. We'll help you figure out who to talk to, but we can't
+                resolve it for you.
+              </P>
+            </Section>
+
+            <Section n={12} title="Copyright and takedowns">
+              <P>
+                We respect copyright, and we expect the same. If you believe something on Unstream infringes your
+                copyright, email support@unstream.stream with:
+              </P>
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>Enough detail to identify the work you say is infringed.</li>
+                <li>The URL of the material you want removed.</li>
+                <li>Your name, address, and email.</li>
+                <li>
+                  A statement that you believe in good faith the use isn't authorized by the rights holder, their
+                  agent, or the law.
+                </li>
+                <li>
+                  A statement, under penalty of perjury, that your notice is accurate and that you are the rights
+                  holder or authorized to act for them.
+                </li>
+                <li>Your physical or electronic signature.</li>
+              </ul>
+              <P>
+                We'll review it promptly and remove or disable material where the notice is valid. If your material was
+                removed and you think that was a mistake, send a counter-notice to the same address with the equivalent
+                detail, and we'll handle it under the same process.
+              </P>
+              <P>
+                We terminate the accounts of repeat infringers. Bear in mind we mostly host links and metadata rather
+                than recordings, so the fastest fix for infringing audio is usually a notice to the platform actually
+                hosting it — but tell us either way and we'll take our listing down.
+              </P>
+            </Section>
+
+            <Section n={13} title="Donations and support purchases">
+              <P>
+                Unstream is free. If you choose to support it, you can donate through Liberapay or make an in-app
+                support purchase in the Apple apps. Both are voluntary, and neither buys you a feature, a service
+                level, priority support, or influence over what we build.
+              </P>
+              <P>
+                We don't handle your payment details. Liberapay and Apple process those payments under their own terms,
+                and refunds go through them, not us. Donations are generally non-refundable, and Unstream is not a
+                charity — donations aren't tax-deductible.
+              </P>
+            </Section>
+
+            <Section n={14} title="Emails we send you">
+              <P>
+                We send transactional email you can't opt out of while you have an account: sign-in links, password
+                resets, and notices about your account or these Terms.
+              </P>
+              <P>
+                Everything else is opt-in. Our newsletter is double opt-in — you'll get a confirmation email before
+                you're subscribed to anything — and every issue has an unsubscribe link. Release alerts and feeds are
+                things you switch on yourself and can switch off the same way.
+              </P>
+            </Section>
+
+            <Section n={15} title="Availability and changes to the Service">
+              <P>
+                The Service is offered on a best-effort basis by a small independent project. There's no uptime
+                commitment and no support-response guarantee. Things break, upstream platforms change their pages, and
+                sometimes searches fail.
+              </P>
+              <P>
+                We may add, change, or remove features at any time. If we're removing something you rely on, we'll try
+                to give reasonable notice through the site or by email, and where a change materially reduces what your
+                account can do, we'll say so plainly rather than let you find out by accident.
+              </P>
+            </Section>
+
+            <Section n={16} title="Suspension and termination">
+              <P>
+                You can stop using the Service whenever you like, and delete your account by emailing
+                support@unstream.stream.
+              </P>
+              <P>
+                We may suspend or terminate your account, or remove content, if you break these Terms, if your use
+                puts the Service or other users at risk, or if we're required to by law. Where it's reasonable and
+                lawful to do so, we'll tell you why and give you a chance to put it right — an account is somebody's
+                music library, and we don't intend to delete one over a misunderstanding.
+              </P>
+              <P>
+                On termination, your public sharing page comes down and your account data is deleted, subject to the
+                backup and legal-record exceptions in section 8. Sections 8, 11, 17, 18, 19, 20, and 22 survive
+                termination.
+              </P>
+            </Section>
+
+            <Section n={17} title="Disclaimers">
+              <P>
+                The Service is provided "as is" and "as available", without warranties of any kind, whether express,
+                implied, or statutory. To the fullest extent the law allows, we disclaim the implied warranties of
+                merchantability, fitness for a particular purpose, title, and non-infringement.
+              </P>
+              <P>
+                We don't warrant that the Service will be uninterrupted, secure, or error-free; that search results,
+                artist matches, links, release information, or payout percentages are accurate, complete, or current;
+                or that any third-party platform will remain available or behave as described.
+              </P>
+              <P>
+                Some jurisdictions don't allow certain warranty exclusions, so parts of this section may not apply to
+                you. Nothing here limits rights you have as a consumer under mandatory local law.
+              </P>
+            </Section>
+
+            <Section n={18} title="Limitation of liability">
+              <P>
+                To the fullest extent permitted by law, Unstream and anyone operating it won't be liable for indirect,
+                incidental, special, consequential, exemplary, or punitive damages, or for lost profits, lost data,
+                lost goodwill, or the cost of substitute services, arising from or relating to your use of the Service
+                — even if we were told such damages were possible.
+              </P>
+              <P>
+                Our total liability for all claims relating to the Service is limited to the greater of (a) the total
+                amount you paid us in the twelve months before the claim, which for nearly everyone is zero, and (b)
+                fifty US dollars (US$50).
+              </P>
+              <P>
+                These limits don't apply to liability that can't be excluded by law — including, in many places,
+                liability for fraud, for death or personal injury caused by negligence, and consumer rights that can't
+                be waived. If you're a consumer in the EU, UK, or another jurisdiction with mandatory protections, you
+                keep those rights in full.
+              </P>
+              <P>
+                We're a free service run by one person. These limits are what make offering it at all reasonable, and
+                they're part of the basis on which we do.
+              </P>
+            </Section>
+
+            <Section n={19} title="Your responsibility for claims you cause">
+              <P>
+                If someone brings a claim against us because of Your Content, your use of the Service, or your breach
+                of these Terms — for example, a claim that a bio or photo you uploaded infringes their rights, or that
+                you claimed an artist profile you had no right to — you agree to defend us against it and to cover the
+                resulting damages, losses, and reasonable legal costs. We'll tell you promptly about any such claim and
+                won't settle it without talking to you.
+              </P>
+            </Section>
+
+            <Section n={20} title="Disputes and governing law">
+              <P>
+                <strong>Talk to us first.</strong> Before starting any formal proceeding, email
+                support@unstream.stream describing the problem and what you'd like done about it. Most things get
+                resolved this way. Please give us 30 days to respond.
+              </P>
+              <P>
+                These Terms are governed by the laws of the Commonwealth of Massachusetts, USA, without regard to its
+                conflict-of-laws rules. Any dispute that informal resolution doesn't settle will be brought in the
+                state or federal courts located in Massachusetts, and we each consent to that jurisdiction — except
+                that either of us can bring a qualifying claim in small claims court instead.
+              </P>
+              <P>
+                There's no mandatory arbitration here and no class-action waiver. If you're a consumer resident in the
+                EU, UK, or another jurisdiction whose law entitles you to the protection of your local courts, this
+                section doesn't take that away.
+              </P>
+            </Section>
+
+            <Section n={21} title="Changes to these Terms">
+              <P>
+                We may update these Terms as the Service changes. When we do, we'll update the "Last updated" date at
+                the top of this page.
+              </P>
+              <P>
+                For changes that materially affect your rights, we'll give notice before they take effect — through the
+                site and, if you have an account, by email — and we'll aim for at least 30 days' notice unless a
+                shorter period is needed for legal or security reasons. Continuing to use the Service after a change
+                takes effect means you accept it. If you'd rather not, you can delete your account.
+              </P>
+            </Section>
+
+            <Section n={22} title="Everything else">
+              <ul className="list-disc ml-5 text-text-primary/90 mb-3 space-y-1">
+                <li>
+                  <strong>Whole agreement.</strong> These Terms and the Privacy Policy are the entire agreement between
+                  us about the Service, and replace anything said earlier about it.
+                </li>
+                <li>
+                  <strong>If a clause fails.</strong> If any part of these Terms turns out to be unenforceable, the
+                  rest stays in force and the unenforceable part is narrowed only as far as needed.
+                </li>
+                <li>
+                  <strong>No waiver.</strong> If we don't enforce something straight away, we haven't given up the
+                  right to enforce it later.
+                </li>
+                <li>
+                  <strong>Assignment.</strong> You can't transfer your rights under these Terms without our consent. We
+                  may transfer ours to a successor who takes over the Service, and we'll tell you if that happens.
+                </li>
+                <li>
+                  <strong>Things outside our control.</strong> We're not liable for failures caused by events beyond
+                  our reasonable control, including outages at the platforms and infrastructure providers we depend on.
+                </li>
+                <li>
+                  <strong>No agency.</strong> These Terms don't make either of us the other's partner, employee, or
+                  agent, and they don't make us an agent of any artist or platform we list.
+                </li>
+              </ul>
+            </Section>
+
+            <Section n={23} title="Contact">
+              <P>
+                Questions, corrections, takedown notices, account deletion, or anything else about these Terms:{' '}
+                <a href="mailto:support@unstream.stream" className="text-accent-primary hover:text-accent-secondary transition-colors underline">
+                  support@unstream.stream
+                </a>
+                .
+              </P>
+            </Section>
+          </article>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+/** A numbered section, so support and email can point at "section 12" and mean it. */
+function Section({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-8">
+      <h3 id={`section-${n}`} className="font-display text-xl font-semibold text-text-primary mb-3">
+        {n}. {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return <p className="text-text-primary/90 leading-relaxed mb-3">{children}</p>;
+}

--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -167,6 +167,14 @@ export function initSentry(): void {
         return null
       }
 
+      // A search puts the artist name in the URL (/?q=artist), and Sentry attaches the page URL
+      // to every event. Strip the query string: the route is what makes an error diagnosable,
+      // and zero-result searches already report themselves server-side with a deduplicated
+      // `search_query` tag, which is a better signal than a stray URL on an unrelated crash.
+      if (event.request?.url) {
+        event.request.url = event.request.url.split('?')[0]
+      }
+
       const errorMessage = sentryErrorMessage(event, hint)
 
       // Classified BEFORE the dropped-request filter so a stale-build failure can

--- a/docs/specs/data-collection-audit.md
+++ b/docs/specs/data-collection-audit.md
@@ -41,8 +41,9 @@ dashboard, and it is genuinely anonymous.
 
 > The HMAC degrades to a plain SHA-256 if `SESSION_HASH_SECRET` is unset — and a plain SHA-256 of
 > an IP is reversible, because the input space is small enough to enumerate. The fallback logs a
-> warning. **Confirm the variable is set in the Netlify Functions environment**; the honesty of
-> this whole row depends on it.
+> warning. Confirmed 2026-08-08: the variable is set as a secret in Netlify's production
+> environment, so the keyed path is the live one. Re-check it if the environment is ever rebuilt;
+> the honesty of this whole row depends on it.
 
 **Rate-limit keys in Upstash** — `rl:standard:<ip>`, `rl:daily:strict:<ip>` and friends, holding
 raw IP addresses in sliding windows of up to 24 hours. An IP is personal data under GDPR. It is
@@ -79,29 +80,29 @@ all detached from any person:
    every artist who isn't on it. The migration says "No PII" and that's correct.
 3. **Netlify function logs** — cache keys are logged (`[Cache] SET: artist:mirlo:radiohead`), so
    artist names appear in short-lived operational logs.
-4. **GoatCounter page paths** — see below.
+4. ~~**GoatCounter page paths**~~ — no longer, see below.
 
-### GoatCounter records the search term
+### GoatCounter used to record the search term — fixed 2026-08-08
 
-`apps/web/index.html` loads `count.js` with no settings object. GoatCounter's default path is
+`count.js` was loaded with no settings object. GoatCounter's default path is
 `location.pathname + location.search`, and a search sets `/?q=artist+name` via `setSearchParams`
-in `App.tsx`. So every search is recorded by GoatCounter as a page view of a path containing the
-artist name.
+in `App.tsx`, so every search was recorded as a page view of a path containing the artist name —
+on a dashboard the README advertises as public.
 
-It sits against GoatCounter's daily-rotating visitor hash rather than against a person, so it
-isn't a search history. But the term does leave our servers, and if the dashboard at
-`unstream.goatcounter.com` is set to public — the README advertises it as "public metrics" — those
-paths are visible to anyone.
-
-Fixable in one line if we'd rather it didn't, by setting the path to `location.pathname` before
-`count.js` loads:
+`index.html` now sets the path explicitly before `count.js` loads:
 
 ```html
-<script>window.goatcounter = { path: function() { return location.pathname || '/' } }</script>
+<script>window.goatcounter = { path: function () { return location.pathname || '/' } }</script>
 ```
 
-The trade-off is losing per-query analytics, which is a product call, not a technical one. Until
-it's made, the privacy policy discloses the behaviour.
+Keep that script tag ahead of `count.js` — settings are read at load time, so ordering is what
+makes it work, and a silent revert to the default is the failure mode. Events fired from
+`services/analytics.ts` pass an explicit path and were never affected. Only the SPA loads
+GoatCounter; the edge-rendered pages don't include it at all.
+
+The deliberate exception is Sentry, which still receives the full page URL on an error. That is
+the point: a search that returns nothing useful is only diagnosable if you know what was searched
+for. Disclosed in the privacy policy rather than quietly stripped.
 
 ## Private by default — verified, not assumed
 
@@ -153,9 +154,10 @@ receive an artist name to search for and nothing about the person searching.
 
 ## Open items
 
-- [ ] Confirm `SESSION_HASH_SECRET` is set in Netlify Functions (production). Without it the
-      session hash is reversible.
-- [ ] Decide whether GoatCounter should stop receiving `?q=` search terms, and whether the
-      GoatCounter dashboard should be public.
+- [x] Confirm `SESSION_HASH_SECRET` is set in Netlify Functions (production) — confirmed
+      2026-08-08, set as a secret.
+- [x] Stop GoatCounter receiving `?q=` search terms — done 2026-08-08.
+- [ ] Purge the historical `/?q=…` paths already in GoatCounter (Settings → Manage pageviews).
+      The fix stops new ones; it doesn't touch what's already recorded.
 - [ ] Add a retention sweep for `app_events`. "Indefinite" is a weak answer for anything with a
       session identifier on it, even a daily-rotating one.

--- a/docs/specs/data-collection-audit.md
+++ b/docs/specs/data-collection-audit.md
@@ -1,0 +1,161 @@
+# Data collection audit
+
+Written 2026-08-08, by reading the migrations and the functions rather than the old privacy
+policy — which had drifted far enough that it was describing a different product.
+
+This is the working inventory the [privacy policy](../../apps/web/src/pages/PrivacyPolicyPage.tsx)
+is written from. **If a change alters what is collected, where it goes, or how long it's kept,
+update both in the same PR.** The policy is the promise; this file is the evidence for it.
+
+## The three categories
+
+The distinction that matters, and the one most privacy policies fudge:
+
+| | What it means | Can we trace it to a person? |
+|---|---|---|
+| **Anonymous** | No identifier of any kind | No, and never could |
+| **Pseudonymous** | An identifier exists, but no name or email attached | Not by us, but it isn't "nothing" |
+| **Identified** | Attached to an account | Yes |
+
+Calling pseudonymous data "anonymous" is the standard overclaim. A hashed session token is still
+an identifier. We put it in the middle column and say so.
+
+## Anonymous
+
+**`artist_analytics`** — daily counters per artist per metric (`search`, `view`,
+`click:<platform>`). `analytics-event.ts` resolves a slug to an artist ID and calls
+`increment_analytics(artist_id, date, metric)`. There is no user column, no session column, and
+the request IP is used for rate limiting and then discarded. This is the one thing on the artist
+dashboard, and it is genuinely anonymous.
+
+## Pseudonymous
+
+**`app_events`** — product usage events (`search`, `platform_click`, `extension_activated`,
+`page_view`, `release_alert`, `download`). Two things keep this clean:
+
+- `context` is filtered against an allowlist (`has_results`, `result_count`, `platform`,
+  `streaming_service`, `page`) and non-primitives are dropped, so a client cannot smuggle a field
+  in. `page` carries a label like `artist`, not a URL.
+- `session_hash` is `HMAC-SHA256(ip + user_agent + date)` keyed with `SESSION_HASH_SECRET`. Daily
+  rotation means no cross-day linkage, and the key means it can't be brute-forced back to an IP.
+
+> The HMAC degrades to a plain SHA-256 if `SESSION_HASH_SECRET` is unset — and a plain SHA-256 of
+> an IP is reversible, because the input space is small enough to enumerate. The fallback logs a
+> warning. **Confirm the variable is set in the Netlify Functions environment**; the honesty of
+> this whole row depends on it.
+
+**Rate-limit keys in Upstash** — `rl:standard:<ip>`, `rl:daily:strict:<ip>` and friends, holding
+raw IP addresses in sliding windows of up to 24 hours. An IP is personal data under GDPR. It is
+short-lived and used for nothing else, but it is not anonymous and the policy says so.
+
+**GoatCounter** — cookie-free, its own daily-rotating visitor hash.
+
+## Identified — tied to an account
+
+| Where | What |
+|---|---|
+| `auth.users` (Supabase) | Email, hashed password |
+| `saved_artists` | `user_id`, artist, `notes`, `supported`/`supported_at`, `device_id`, tombstones |
+| `usernames` | `user_id`, `username`, `location`, `saved_artists_public` |
+| `release_feed_tokens` | `user_id`, secret feed token |
+| `artist_profiles` | `user_id`, `email`, bio, image, website |
+| `verification_requests` | `user_id`, `email`, free-text `message` |
+| `api_keys` | `owner_email`, `owner_name`, `key_prefix`, `key_hash` (SHA-256 — the key itself is never stored) |
+| Buttondown | Newsletter email + a source tag (`changelog` / `guides` / `settings`) |
+
+`device_id` is a random UUID minted on first launch and kept in the keychain
+(`DeviceIDManager.swift`). Not a hardware identifier — it says nothing about the device.
+
+## Searches: not "not stored", but not linked to you either
+
+The intuition that we don't store searches is half right, and the half that's wrong is worth
+being precise about. **No search is ever written against a user account** — there is no search
+history table, and signing in doesn't create one. But the search *terms* persist in four places,
+all detached from any person:
+
+1. **Upstash results cache** — `artist:<platform>:<normalized query>`, 30-minute default TTL.
+2. **`bandcamp_slug_probes.query_norm`** — the normalized artist name is the primary key, stored
+   indefinitely. This is deliberate and load-bearing: it's what stops us re-probing Bandcamp for
+   every artist who isn't on it. The migration says "No PII" and that's correct.
+3. **Netlify function logs** — cache keys are logged (`[Cache] SET: artist:mirlo:radiohead`), so
+   artist names appear in short-lived operational logs.
+4. **GoatCounter page paths** — see below.
+
+### GoatCounter records the search term
+
+`apps/web/index.html` loads `count.js` with no settings object. GoatCounter's default path is
+`location.pathname + location.search`, and a search sets `/?q=artist+name` via `setSearchParams`
+in `App.tsx`. So every search is recorded by GoatCounter as a page view of a path containing the
+artist name.
+
+It sits against GoatCounter's daily-rotating visitor hash rather than against a person, so it
+isn't a search history. But the term does leave our servers, and if the dashboard at
+`unstream.goatcounter.com` is set to public — the README advertises it as "public metrics" — those
+paths are visible to anyone.
+
+Fixable in one line if we'd rather it didn't, by setting the path to `location.pathname` before
+`count.js` loads:
+
+```html
+<script>window.goatcounter = { path: function() { return location.pathname || '/' } }</script>
+```
+
+The trade-off is losing per-query analytics, which is a product call, not a technical one. Until
+it's made, the privacy policy discloses the behaviour.
+
+## Private by default — verified, not assumed
+
+- `usernames.saved_artists_public` is `BOOLEAN NOT NULL DEFAULT false` (migration 022). Sharing is
+  opt-in.
+- `usernames.location` is nullable with no default (migration 024), and renders only on
+  `/u/:handle`, which 404s unless sharing is on. Setting a username alone publishes nothing.
+- Migration 023 dropped the `USING (true)` anon SELECT policy on `usernames` that would otherwise
+  have exposed every user ID and handle. The reasoning in that file — *RLS is row-level, not
+  column-level* — is the single most useful sentence in the migration history. Apply it whenever
+  writing a policy.
+- `saved_artists` policies are all `auth.uid() = user_id`.
+- The public list endpoint returns username, saved artists, supported flags and location. Never
+  email, never notes.
+
+## Retention
+
+| Data | Kept for |
+|---|---|
+| Account data | Until deletion is requested |
+| `saved_artists` tombstones | 30 days, then hard-deleted by a scheduled sweep (migration 018) |
+| Search results cache | ~30 minutes |
+| Rate-limit keys | ≤ 24 hours |
+| `bandcamp_slug_probes` | Indefinite (no personal data) |
+| `artist_analytics` | Indefinite (anonymous) |
+| `app_events` | Indefinite — **no GC exists**; worth adding one |
+| Newsletter | Until unsubscribe |
+
+## Processors
+
+Netlify (hosting/functions), Supabase (database/auth), Upstash (cache/rate limits), GoatCounter
+(analytics), Sentry (errors), Buttondown (newsletter), Liberapay and Apple (payments — we never
+see card details), Discord (bot). All US-based, so UK/EEA users' data is transferred out of
+region.
+
+Sentry runs with `sendDefaultPii: false`, `tracesSampleRate: 0`, no Session Replay, and a
+`beforeSend` that drops noise. Note that error events still carry the page URL, which for a search
+includes the query string — the same caveat as GoatCounter.
+
+Upstream data sources (MusicBrainz, Wikidata, Wikipedia, Discogs, Bandcamp, Mirlo, and the rest)
+receive an artist name to search for and nothing about the person searching.
+
+## Client-side only
+
+- **Extension** — saved artists and a slug cache in `chrome.storage.local`; a notifications
+  preference in `chrome.storage.sync`. `lib/supabase.js` only ever calls `/auth/v1` endpoints.
+- **Apple apps** — saved artists on device; ListenBrainz and Plex tokens in the keychain.
+  Scrobbles go from the device straight to ListenBrainz; they never pass through us.
+
+## Open items
+
+- [ ] Confirm `SESSION_HASH_SECRET` is set in Netlify Functions (production). Without it the
+      session hash is reversible.
+- [ ] Decide whether GoatCounter should stop receiving `?q=` search terms, and whether the
+      GoatCounter dashboard should be public.
+- [ ] Add a retention sweep for `app_events`. "Indefinite" is a weak answer for anything with a
+      session identifier on it, even a daily-rotating one.

--- a/docs/specs/data-collection-audit.md
+++ b/docs/specs/data-collection-audit.md
@@ -78,9 +78,14 @@ all detached from any person:
 2. **`bandcamp_slug_probes.query_norm`** — the normalized artist name is the primary key, stored
    indefinitely. This is deliberate and load-bearing: it's what stops us re-probing Bandcamp for
    every artist who isn't on it. The migration says "No PII" and that's correct.
-3. **Netlify function logs** — cache keys are logged (`[Cache] SET: artist:mirlo:radiohead`), so
-   artist names appear in short-lived operational logs.
-4. ~~**GoatCounter page paths**~~ — no longer, see below.
+3. ~~**Netlify function logs**~~ — removed 2026-08-08. Cache keys were logged in full
+   (`[Cache] SET: artist:mirlo:radiohead`); `redactKey()` now trims them to
+   `artist:mirlo:…`, and the MusicBrainz, enrichment, probe and Sepia log lines no longer
+   interpolate the query. Which platform answered and how is the diagnostic value; the artist
+   name never was. The same redaction covers the Redis failure reports that reach Sentry.
+4. ~~**GoatCounter page paths**~~ — removed 2026-08-08, see below.
+5. **Sentry `search_query` tag on zero-result searches** — deliberate, and the one place a search
+   term is recorded on purpose. See below.
 
 ### GoatCounter used to record the search term — fixed 2026-08-08
 
@@ -100,9 +105,24 @@ makes it work, and a silent revert to the default is the failure mode. Events fi
 `services/analytics.ts` pass an explicit path and were never affected. Only the SPA loads
 GoatCounter; the edge-rendered pages don't include it at all.
 
-The deliberate exception is Sentry, which still receives the full page URL on an error. That is
-the point: a search that returns nothing useful is only diagnosable if you know what was searched
-for. Disclosed in the privacy policy rather than quietly stripped.
+The client-side Sentry `beforeSend` now strips the query string from `event.request.url` too, so
+an unrelated crash on a search page no longer carries the artist name along with it.
+
+### The one place a search term is recorded on purpose
+
+`search-sources.ts` reports zero-result searches to Sentry with the normalized query as a
+**tag** (`search_query:radiohead`), deduplicated to once per term per 24 hours.
+
+This is a product signal, not a diagnostic: it's the list of artists people want and Unstream
+can't find, which is the only direct evidence of where coverage is missing. The comment above it
+explains why it has to be a tag rather than an `extra` — every zero-result event shares one
+message, so Sentry folds them into a single issue where `extra` is readable one event at a time,
+while tags get an aggregated distribution on the issue page.
+
+It carries no identity, and the dedup means the record is "this term found nothing today", not
+"somebody searched this". Keep it in mind when editing the searches section of the privacy
+policy: it is the reason that section says "we record the term on its own" rather than "we don't
+keep searches at all". Removing it would cost the coverage signal and gain very little privacy.
 
 ## Private by default — verified, not assumed
 

--- a/docs/specs/data-collection-audit.md
+++ b/docs/specs/data-collection-audit.md
@@ -128,7 +128,7 @@ for. Disclosed in the privacy policy rather than quietly stripped.
 | Rate-limit keys | ≤ 24 hours |
 | `bandcamp_slug_probes` | Indefinite (no personal data) |
 | `artist_analytics` | Indefinite (anonymous) |
-| `app_events` | Indefinite — **no GC exists**; worth adding one |
+| `app_events` | Rows kept indefinitely; `session_hash` nulled after 90 days by a nightly sweep, after which the row is fully anonymous |
 | Newsletter | Until unsubscribe |
 
 ## Processors
@@ -159,5 +159,25 @@ receive an artist name to search for and nothing about the person searching.
 - [x] Stop GoatCounter receiving `?q=` search terms — done 2026-08-08.
 - [ ] Purge the historical `/?q=…` paths already in GoatCounter (Settings → Manage pageviews).
       The fix stops new ones; it doesn't touch what's already recorded.
-- [ ] Add a retention sweep for `app_events`. "Indefinite" is a weak answer for anything with a
-      session identifier on it, even a daily-rotating one.
+- [x] Add a retention sweep for `app_events` — done 2026-08-08. `session_hash` is nulled at 90
+      days rather than the row deleted, so every dashboard count survives and the row stops
+      being personal data. `session_hash` only ever deduplicated within a single day, so past 90
+      days it had no analytical value left.
+
+## A note on writing RLS policies here
+
+Two mistakes have now been made twice in this repo, and both are cheap to avoid:
+
+1. **RLS is row-level, not column-level.** A policy that exposes a row exposes every column in
+   it. Migration 023 learned this on `usernames.user_id`; `artist_profiles.email` was the same
+   bug, found in the 2026-08-08 audit.
+2. **`CREATE POLICY` with no `TO` clause applies to `PUBLIC`, which includes `anon`.** A policy
+   named "Service role full access" that omits `TO service_role` grants that access to anyone
+   holding the public anon key. The service role has `BYPASSRLS` and never needed a policy in
+   the first place — so the correct fix is to delete the policy, not re-scope it.
+
+The model to copy is in `20260731120000_releases.sql`: public reads via an explicit `SELECT`
+policy, writes left with no policy at all, and a comment saying the absence is deliberate.
+Supabase's `ALTER DEFAULT PRIVILEGES` also grants `anon`/`authenticated` full table privileges on
+every *new* table, so anything holding private data wants an explicit
+`REVOKE INSERT, UPDATE, DELETE … FROM anon, authenticated` too.

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -98,6 +98,7 @@ async function main() {
     { url: '/', changefreq: 'weekly', priority: '1.0' },
     { url: '/guides', changefreq: 'weekly', priority: '0.8' },
     { url: '/privacy-policy', changefreq: 'yearly', priority: '0.3' },
+    { url: '/terms', changefreq: 'yearly', priority: '0.3' },
   ];
 
   let urls = staticPages.map(page => `  <url>

--- a/supabase/migrations/20260808120000_scope-service-policies-to-service-role.sql
+++ b/supabase/migrations/20260808120000_scope-service-policies-to-service-role.sql
@@ -1,0 +1,91 @@
+-- Migration: stop "Service …" policies from granting access to anon
+--
+-- Several policies written early on are named for the service role but never say so. A
+-- CREATE POLICY with no TO clause applies to PUBLIC, and PUBLIC includes `anon` — the role a
+-- request carrying the public anon key runs as. The anon key ships in the client bundle, so
+-- every one of these policies was readable and writable by anyone.
+--
+-- Reproduced against a local Postgres with Supabase's role model before writing this:
+--   * read every verified artist's claim email from artist_profiles
+--   * read, update and delete verification_requests (email + free-text message)
+--   * set artist_profiles.verified_at — self-verification
+--   * rename or relink any artist in the catalogue
+--   * insert merge overrides, which steer search disambiguation
+--
+-- The fix is to delete the policies rather than rewrite them with `TO service_role`, because
+-- the service role has BYPASSRLS: it never consulted them in the first place. They granted
+-- nothing to the role they were named for and everything to the role they forgot to exclude.
+--
+-- 20260731120000_releases.sql already had this right, and says so:
+--   "Writes are service-role only. The service key bypasses RLS, so the absence of
+--    insert/update/delete policies is what keeps anon and authenticated clients read-only —
+--    deliberate, not an oversight."
+-- That is the model. This migration brings the older tables in line with it.
+--
+-- Safe to apply: nothing outside the server talks to PostgREST. The web app and the Apple apps
+-- go through api/functions/*, which use SUPABASE_SERVICE_KEY; the edge functions use the
+-- service key directly; the browser extension only ever calls /auth/v1. Every anon-key client
+-- in api/functions/ exists solely to call auth.getUser() and never touches a table.
+--
+-- Genuinely public reads are kept: the artist catalogue is the data the site renders anyway.
+
+-- ── artist_profiles ─────────────────────────────────────────────────────────
+-- RLS is row-level, not column-level (the lesson from migration 023), so a policy letting anon
+-- read verified profile rows exposed `email` along with the bio and links it was meant for. The
+-- public artist page is rendered server-side from the service-role client and never needed it.
+DROP POLICY IF EXISTS "Public read verified profiles" ON artist_profiles;
+DROP POLICY IF EXISTS "Service insert profiles" ON artist_profiles;
+DROP POLICY IF EXISTS "Service update profiles" ON artist_profiles;
+-- "Owner read own profile" (auth.uid() = user_id) stays: correctly scoped, and harmless.
+
+-- ── verification_requests ───────────────────────────────────────────────────
+-- The worst of them: FOR ALL USING (true) WITH CHECK (true) on a table of email addresses and
+-- free-text claim messages, so anon could read, alter, approve and delete every row.
+DROP POLICY IF EXISTS "Service role full access" ON verification_requests;
+-- "Users can read own verification requests" stays.
+
+-- ── artists / artist_links ──────────────────────────────────────────────────
+-- Not a disclosure — this data is public by design — but anon could rewrite or delete the
+-- catalogue. Reads stay open, writes go back to the service role.
+DROP POLICY IF EXISTS "Service insert" ON artists;
+DROP POLICY IF EXISTS "Service update" ON artists;
+DROP POLICY IF EXISTS "Service insert" ON artist_links;
+DROP POLICY IF EXISTS "Service update" ON artist_links;
+DROP POLICY IF EXISTS "Service delete" ON artist_links;
+
+-- ── artist_merge_overrides ──────────────────────────────────────────────────
+-- Migration 005's comment ("so the anon key, used by Netlify functions, can also read
+-- overrides") describes a wiring that no longer exists — the functions read with the service
+-- key. The read policy is harmless and stays; the insert policy let anyone corrupt search
+-- disambiguation by merging unrelated artists together.
+DROP POLICY IF EXISTS "Allow service role insert" ON artist_merge_overrides;
+
+-- ── app_events ──────────────────────────────────────────────────────────────
+-- analytics-app-event.ts records events with the service-role client, so the anon insert policy
+-- has no consumer; all it offered was a way to flood the product analytics with invented events.
+DROP POLICY IF EXISTS "Public insert app events" ON app_events;
+
+-- ── Defence in depth ────────────────────────────────────────────────────────
+-- Dropping the policies is the fix — an RLS-enabled table with no matching policy denies by
+-- default. Revoking the underlying grants means a future permissive policy, or RLS being
+-- switched off by accident, doesn't silently reopen write access. api_keys (migration 007) has
+-- always done this; these tables should have too.
+--
+-- Note Supabase sets ALTER DEFAULT PRIVILEGES … GRANT ALL ON TABLES TO anon, authenticated, so
+-- every new table starts life with these grants. New tables holding anything private want the
+-- same two lines.
+REVOKE INSERT, UPDATE, DELETE ON artist_profiles FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON verification_requests FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON artists FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON artist_links FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON artist_merge_overrides FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON app_events FROM anon, authenticated;
+
+-- SELECT grants are deliberately left in place: the remaining read policies (public catalogue
+-- data, and owner-scoped reads on artist_profiles and verification_requests) need them, and
+-- those policies are correctly scoped.
+
+COMMENT ON TABLE verification_requests IS
+  'Manual-review artist claims. Holds an email address and free-text message — service-role writes only; the sole policy is an owner-scoped read.';
+COMMENT ON TABLE artist_profiles IS
+  'Claimed artist profiles. Contains the claimant''s email, so there is deliberately no public read policy — public artist pages render server-side with the service-role client.';

--- a/supabase/migrations/20260808130000_app-events-session-hash-retention.sql
+++ b/supabase/migrations/20260808130000_app-events-session-hash-retention.sql
@@ -1,0 +1,56 @@
+-- Migration: expire app_events session hashes after 90 days
+--
+-- app_events has never had any retention. Every product event since the table shipped is still
+-- there, and each row carries session_hash — a keyed HMAC of (ip + user_agent + date). It can't
+-- be reversed and it rotates daily, which is why the privacy policy files it as pseudonymous
+-- rather than anonymous. But an identifier kept forever is an identifier kept longer than it's
+-- useful: session_hash exists to deduplicate visits *within a single day*, so after 90 days it
+-- has no analytical value left, only liability.
+--
+-- Nulling the column rather than deleting the row is the point. Every count the admin dashboard
+-- draws — events per type, per app, over time — is unaffected, because none of them group by
+-- session. The history stays complete and stops being personal data.
+--
+-- Deleting rows outright was the alternative and it costs year-over-year trends for no gain.
+--
+-- Follows the pg_cron pattern established by migration 018 (saved_artists tombstone GC).
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+CREATE OR REPLACE FUNCTION expire_app_event_session_hashes()
+RETURNS void AS $$
+BEGIN
+  -- `IS NOT NULL` keeps this cheap: once a row has been scrubbed it is never rewritten, so
+  -- each nightly run only touches the day that just aged past the window.
+  UPDATE app_events
+  SET session_hash = NULL
+  WHERE session_hash IS NOT NULL
+    AND created_at < now() - interval '90 days';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Partial index so the sweep finds the day's worth of expiring rows without scanning the whole
+-- table. It only covers unscrubbed rows, so it shrinks as the backlog is cleared.
+CREATE INDEX IF NOT EXISTS idx_app_events_unscrubbed
+  ON app_events (created_at)
+  WHERE session_hash IS NOT NULL;
+
+-- Idempotent: unschedule first so re-running the migration doesn't error.
+SELECT cron.unschedule('expire-app_event_session_hashes')
+  WHERE EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'expire-app_event_session_hashes'
+  );
+
+-- 3:20am UTC daily — a low-traffic window, offset from the 3am tombstone GC so the two single
+-- statement jobs don't land together.
+SELECT cron.schedule(
+  'expire-app_event_session_hashes',
+  '20 3 * * *',
+  $$SELECT expire_app_event_session_hashes();$$
+);
+
+-- The first run clears the whole backlog accumulated since the table shipped, which is the
+-- intent — everything older than 90 days should never have kept its hash this long.
+
+COMMENT ON COLUMN app_events.session_hash IS
+  'Keyed HMAC of (ip + user_agent + date) for same-day deduplication. Never a raw IP. Nulled after 90 days by expire_app_event_session_hashes(), after which the row is fully anonymous.';


### PR DESCRIPTION
Unstream had a privacy policy and nothing else. That was arguably fine when it was a search box, but people now create accounts, save artists to our servers, claim artist profiles on their own behalf, and publish a list with their username and location on it. Writing terms for that meant auditing what we actually collect — and the audit turned up more than a missing page.

## Terms of use (`/terms`)

23 numbered sections with a plain-language summary box at the top. Written around what the product does rather than a generic template, so the load-bearing parts are the honest ones:

- **§5** — we're a directory, not a shop; we're not party to your purchases; results can be wrong; payout percentages are estimates that don't account for processing fees, label splits, or deals we can't see.
- **§6** — exactly what goes public when you enable sharing, that email never does, and that turning it off can't retrieve copies already made.
- **§7** — what you're asserting when you claim a profile, and that verification is a best-effort check rather than an endorsement.
- **§8** — a narrow content licence: host and display to run the service, in the places you chose to publish. No sale, no sublicensing.
- **§12** — DMCA notice, counter-notice, repeat-infringer policy.

Consent lives in one `LegalConsent` component rather than three copies of a sentence. A magic link creates an account when there isn't one, so every sign-in form is also a sign-up form — all five carry the line: web login, the save-artist interstitial, the artist claim step, the extension popup, and the Apple sign-in sheet. The last two keep their own copy and are commented to point back at the component.

"Make public" in `SharingControls` now says what it publishes *before* you press it, rather than after.

Choices worth a second opinion: Massachusetts governing law, 13+ minimum age, courts and small claims rather than binding arbitration, and no named legal entity. If Unstream is ever incorporated, the name goes in §2 and §20 and nowhere else.

## Privacy policy rewrite

The old one had drifted badly enough to be a liability. It still said *"for listeners, all user preferences and saved artists are stored locally on your device"* — untrue since sync shipped — and predated public sharing, the newsletter, the release feeds and the public API. A policy that understates collection is worse than no policy, because it's a promise already being broken.

Every claim in the new one was checked against the migrations and the functions. The evidence is written down in `docs/specs/data-collection-audit.md` so it can be checked rather than trusted.

The substantive change is refusing to call pseudonymous data anonymous. Three categories, plainly labelled:

- **Anonymous** — the artist dashboard counters. Daily totals per artist per metric, no user, no session, no IP.
- **Pseudonymous** — product events carry a daily-rotating keyed session hash; rate limiting holds raw IPs for up to 24 hours. Not nothing, so not filed under "anonymous".
- **Account-linked** — email, saved artists, username/location, feed token, artist profile, verification messages, API key owner.

Searches get their own section, because "we don't store searches" was the comfortable answer and not the true one. We never record **who** searched for what — there's no search history and signing in doesn't create one — but the terms persist in the results cache, the Bandcamp probe table, and server logs, detached from any person. Disclosed rather than glossed.

Also adds what was simply missing: GDPR legal bases, per-item retention periods, international transfer disclosure, the processor list, and how to exercise your rights.

## Search terms no longer go to GoatCounter

GoatCounter's default path is `location.pathname + location.search`, `count.js` was loaded with no settings, and a search puts the artist name straight in the URL as `/?q=artist`. So every search was being recorded as a page path — on a dashboard advertised as public metrics.

Setting the path explicitly before `count.js` loads fixes it. Verified in a browser: the URL still reads `/?q=some+private+artist` while `goatcounter.path()` returns `/`. Events fired from `services/analytics.ts` pass an explicit path and were never affected; the edge-rendered pages don't load GoatCounter at all.

Sentry is deliberately left alone — a search that breaks is only diagnosable if you know what was searched for — and that exception is disclosed in the policy.

This stops new records. The `/?q=` paths already in GoatCounter need clearing by hand under Settings → Manage pageviews.

## Two migrations

**`20260808120000` — service policies that weren't.** A `CREATE POLICY` with no `TO` clause applies to `PUBLIC`, and `PUBLIC` includes `anon` — the role a request carrying the public anon key runs as. Several policies named "Service …" omit it, so they granted to everyone the access they were named for.

Reproduced by applying the deployed policies verbatim to a local Postgres with Supabase's role model. As `anon`, with no JWT: read every verified artist's claim email, read/approve/delete verification requests, set `verified_at` on any profile, rename catalogue artists, insert merge overrides. All seven denied after the migration.

They're deleted rather than re-scoped to `service_role`, because the service role has `BYPASSRLS` and never consulted them — they granted nothing to the role they named and everything to the role they forgot. `20260731120000_releases.sql` already had this right, and its comment is the model.

Nothing outside the server talks to PostgREST: functions and edge functions use the service key, the extension only calls `/auth/v1`, and every anon-key client in `api/functions/` exists solely to call `auth.getUser()`. Verified against the same database that `service_role` keeps full access, public catalogue reads still work, an owner still reads their own rows, and a different signed-in user still sees nothing.

**`20260808130000` — `app_events` retention.** The table had none, so every event since it shipped still carried its `session_hash`. That hash is a keyed HMAC that rotates daily and only ever deduplicated within a single day, so past 90 days it has no analytical value left — only liability. A nightly sweep nulls it at 90 days rather than deleting the row, keeping every dashboard count intact while ending the row's life as personal data. Boundary verified: 91 days scrubbed, 89 days kept, event context untouched. The first run clears the backlog.

Both migrations are re-runnable, and both RLS lessons — *row-level isn't column-level*, and *a policy with no `TO` clause means everyone* — are written into the audit doc, since this repo has now hit each of them twice.

## Deploy notes

- Migrations auto-apply via `supabase-migrate.yml` on merge to `main`. `pg_cron` is confirmed enabled, so the retention migration's `CREATE EXTENSION` is a no-op.
- The RLS migration describes the exposure it closes. Merge-to-deploy is under a minute, which keeps that window short.
- `/terms` is SPA-only and added to the sitemap; no `netlify.toml` changes.

## Testing

`npm run build` green, `npm run lint` unchanged (71 pre-existing problems before and after), 710 web unit tests and 1017 API tests passing. Both legal pages rendered in a browser; both migrations validated against a real Postgres, including idempotency and the regression checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVxipMUsXsnABZ51k21sZJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVxipMUsXsnABZ51k21sZJ)_