### PR TITLE
Remove the Codebase link from the site footer

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -14,15 +14,6 @@ export function Footer() {
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/changelog" className="hover:text-text-primary transition-colors">Changelog</Link>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
-          <a
-            href="https://github.com/brandonlucasgreen/unstream"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-text-primary transition-colors"
-          >
-            Codebase
-          </a>
-          <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/support" className="hover:text-text-primary transition-colors">Donate</Link>
           <span className="text-text-muted/40 text-xs">&#x2022;</span>
           <Link to="/faq" className="hover:text-text-primary transition-colors">FAQ</Link>


### PR DESCRIPTION
## Summary
- Removes the "Codebase" link (pointing to the GitHub repo) and its separator from the site footer.

## Test plan
- [x] Verified in the local dev preview that the footer no longer shows the Codebase link and the remaining links render correctly.