### PR TITLE
Update desktop update-checker to 3.5.0

### DIFF
--- a/api/functions/desktop-version.ts
+++ b/api/functions/desktop-version.ts
@@ -7,9 +7,9 @@ import type { Handler } from '@netlify/functions';
 // v3.3.0 it runs at launch, so a stale value here means users are told they're up to
 // date when they aren't. Keep it in step with Info-macOS.plist.
 const VERSION_INFO = {
-  latestVersion: '3.3.1',
+  latestVersion: '3.5.0',
   downloadUrl: 'https://github.com/brandonlucasgreen/unstream/releases/latest',
-  releaseNotes: 'Fixes saved artists not loading after signing in',
+  releaseNotes: 'Fixes release alerts: cross-device dismissal sync, missing platforms, and alerts lost after time away',
 };
 
 export const handler: Handler = async (event) => {


### PR DESCRIPTION
## Summary
- `api/functions/desktop-version.ts` still had `latestVersion: '3.3.1'` even though #422 bumped the app itself to 3.5.0 (build 15) across all four version files. Left as-is, the in-app update check (live since v3.3.0) would tell users on 3.3.1 they're already current.
- Bumps `latestVersion` to `3.5.0` and updates `releaseNotes` to describe the release-alert fixes from #422.

## Timing note
This should merge around the same time the actual `v3.5.0` GitHub release is published, not well before it — `downloadUrl` points at `releases/latest`, which will still resolve to `v3.3.1` until that release goes live. Merging this alone first would tell users a 3.5.0 download is ready when the asset doesn't exist yet.

## Test plan
- [x] No behavior change to request handling, just the static version string/notes.