### PR TITLE
Add Guides, FAQ, and Contact links to the logged-out header

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -119,7 +119,12 @@ export function Header() {
         { to: '/dashboard', label: 'Dashboard', emphasis: true },
         { to: '/settings', label: 'Settings' },
       ]
-    : [{ to: '/login', label: 'Login', button: true }];
+    : [
+        { to: '/guides', label: 'Guides' },
+        { to: '/faq', label: 'FAQ' },
+        { to: 'https://letterbird.co/hi-d2078591', label: 'Contact', external: true },
+        { to: '/login', label: 'Login', button: true },
+      ];
 
   // The sticky header keeps a solid background rather than a blurred one: a
   // backdrop-filter would become the containing block for MobileNav's fixed
@@ -169,6 +174,16 @@ export function Header() {
           <nav className="hidden sm:flex items-center gap-3 text-sm">
             {navItems.map(entry => isNavGroup(entry) ? (
               <NavDropdown key={entry.label} group={entry} />
+            ) : entry.external ? (
+              <a
+                key={entry.to}
+                href={entry.to}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-text-muted hover:text-text-primary transition-colors"
+              >
+                {entry.label}
+              </a>
             ) : (
               <Link
                 key={entry.to}

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -12,6 +12,8 @@ export type NavItem = {
    * colour, so a button inside the list would only add noise.
    */
   button?: boolean;
+  /** `to` is a full URL to an outside site (e.g. Contact) — render a plain `<a>`, not a router `Link`. */
+  external?: boolean;
 };
 
 /** A labelled set of links — a dropdown on desktop, an indented block here. */
@@ -159,6 +161,19 @@ export function MobileNav({
                   </Link>
                 ))}
               </div>
+            ) : entry.external ? (
+              <a
+                key={entry.to}
+                href={entry.to}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={close}
+                className={`border-b border-border px-6 py-4 text-base hover:bg-bg-hover transition-colors ${
+                  entry.emphasis ? 'text-accent-primary font-medium' : 'text-text-primary'
+                }`}
+              >
+                {entry.label}
+              </a>
             ) : (
               <Link
                 key={entry.to}


### PR DESCRIPTION
## Summary
- The logged-out header only had a Login link. Adds Guides, FAQ, and Contact to its left, matching what the footer already links to.
- Responsive: same shared `navItems` array feeds both the desktop inline nav and the existing mobile hamburger drawer, so at narrow widths it collapses automatically — no new responsive logic needed.
- Contact points offsite to the same Letterbird address used in the footer. Since `MobileNav`'s `NavItem`/render loop only supported internal router `Link`s, added an `external` flag so both the desktop nav and drawer render it as a plain `<a target="_blank" rel="noopener noreferrer">` instead.

## Test plan
- [x] `npx tsc -b apps/web --noEmit` — clean
- [x] `npm run lint` — no new errors (pre-existing baseline noise unchanged)
- [x] `npm run test:unit` — 717 passing
- [x] Verified in browser at desktop width: Guides / FAQ / Contact / Login render inline, correct hrefs, Contact opens in a new tab
- [x] Verified in browser at mobile width (375px): hamburger opens a drawer with Guides / FAQ / Contact / Login stacked in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)