### PR TITLE
Support Loop, web half: Bandcamp collection import, auto-supported, collection pages (Steps 1 + 3)

### DIFF
--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -123,7 +123,7 @@ export default async function handler(request: Request, context: Context) {
       // keeps the page honest (Support Loop Step 3).
       const { data: collectionData } = await supabase
         .from('collection_items')
-        .select('title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
+        .select('id, title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
         .eq('user_id', unameData.user_id)
         .eq('provenance', 'purchased')
         .eq('hidden', false)
@@ -151,10 +151,10 @@ export default async function handler(request: Request, context: Context) {
       const artistSlug = release?.artists?.slug || '';
       const title = escapeHtml(row.title || '');
       const artistName = escapeHtml(row.artist_name || '');
-      const artUrl = row.art_url || release?.artwork_url || '';
-      const artHtml = artUrl
-        ? `<img src="${escapeHtml(artUrl)}" alt="${title} by ${artistName}" class="collection-art" loading="lazy">`
-        : `<span class="collection-art-fallback">${title}</span>`;
+      // Unmatched items fall back to the art proxy, which fetches the cover from Bandcamp
+      // server-side — most of a real collection has no matched release to borrow art from.
+      const artUrl = row.art_url || release?.artwork_url || `/api/collection/art/${row.id}`;
+      const artHtml = `<img src="${escapeHtml(artUrl)}" alt="${title} by ${artistName}" class="collection-art" loading="lazy">`;
       const caption = `<div class="collection-caption">${title}</div><div class="collection-caption caption-artist">${artistName}</div>`;
       const releaseUrl = release?.slug && artistSlug
         ? `https://unstream.stream/a/${escapeHtml(artistSlug)}/${escapeHtml(release.slug)}`

--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -43,7 +43,17 @@ const CSS = `
   .copy-btn { display: inline-flex; align-items: center; gap: 8px; padding: 8px 16px; border-radius: 8px; border: 1px solid var(--border); background: var(--bg2); color: var(--text); font-size: 14px; cursor: pointer; transition: background 0.15s; }
   .copy-btn:hover { background: var(--border); }
   .copy-btn.copied { color: #22c55e; border-color: rgba(34,197,94,0.3); }
+  .collection-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+  @media (max-width: 640px) { .collection-grid { grid-template-columns: repeat(3, 1fr); } }
+  .collection-tile { display: block; text-decoration: none; color: var(--text); min-width: 0; }
+  .collection-art { width: 100%; aspect-ratio: 1; object-fit: cover; border-radius: 8px; background: var(--border); display: block; }
+  .collection-art-fallback { width: 100%; aspect-ratio: 1; border-radius: 8px; background: var(--border); display: flex; align-items: center; justify-content: center; padding: 8px; font-size: 11px; color: var(--muted); text-align: center; overflow: hidden; }
+  .collection-caption { margin-top: 6px; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .collection-caption .caption-artist { color: var(--muted); }
 `;
+
+/** Tiles on the crawler render. A deliberate cap for page weight — the SPA shows everything. */
+const CRAWLER_COLLECTION_LIMIT = 60;
 
 export default async function handler(request: Request, context: Context) {
   try {
@@ -69,6 +79,7 @@ export default async function handler(request: Request, context: Context) {
 
     let usernameRow: any;
     let savedArtists: any[];
+    let collectionItems: any[] = [];
 
     try {
       // Look up the username row to check sharing flag + get user_id + location
@@ -107,6 +118,21 @@ export default async function handler(request: Request, context: Context) {
         .abortSignal(controller.signal);
 
       savedArtists = savedData || [];
+
+      // Public collection: purchased and not hidden only — the provenance gate is what
+      // keeps the page honest (Support Loop Step 3).
+      const { data: collectionData } = await supabase
+        .from('collection_items')
+        .select('title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
+        .eq('user_id', unameData.user_id)
+        .eq('provenance', 'purchased')
+        .eq('hidden', false)
+        .order('acquired_at', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false })
+        .limit(CRAWLER_COLLECTION_LIMIT)
+        .abortSignal(controller.signal);
+
+      collectionItems = collectionData || [];
     } catch {
       clearTimeout(timeoutId);
       return context.next();
@@ -117,6 +143,35 @@ export default async function handler(request: Request, context: Context) {
     const ownerName = escapeHtml(usernameRow.username);
     const ownerLocation = usernameRow.location ? escapeHtml(usernameRow.location) : null;
     const pageUrl = `https://unstream.stream/u/${handle}`;
+
+    // Collection tiles — matched items link to the release page so a viewer can buy the
+    // same record. Everything interpolated is escaped.
+    const collectionTilesHtml = collectionItems.map((row: any) => {
+      const release = row.releases;
+      const artistSlug = release?.artists?.slug || '';
+      const title = escapeHtml(row.title || '');
+      const artistName = escapeHtml(row.artist_name || '');
+      const artUrl = row.art_url || release?.artwork_url || '';
+      const artHtml = artUrl
+        ? `<img src="${escapeHtml(artUrl)}" alt="${title} by ${artistName}" class="collection-art" loading="lazy">`
+        : `<span class="collection-art-fallback">${title}</span>`;
+      const caption = `<div class="collection-caption">${title}</div><div class="collection-caption caption-artist">${artistName}</div>`;
+      const releaseUrl = release?.slug && artistSlug
+        ? `https://unstream.stream/a/${escapeHtml(artistSlug)}/${escapeHtml(release.slug)}`
+        : null;
+      return releaseUrl
+        ? `<a href="${releaseUrl}" class="collection-tile">${artHtml}${caption}</a>`
+        : `<div class="collection-tile">${artHtml}${caption}</div>`;
+    }).join('');
+
+    const supportedCount = savedArtists.filter((row: any) => row.supported === true).length;
+    const countParts: string[] = [];
+    if (collectionItems.length > 0) {
+      countParts.push(`${collectionItems.length} release${collectionItems.length === 1 ? '' : 's'} collected`);
+    }
+    if (supportedCount > 0) {
+      countParts.push(`${supportedCount} artist${supportedCount === 1 ? '' : 's'} supported`);
+    }
 
     // Build artist cards HTML
     const artistCardsHtml = savedArtists.length > 0
@@ -136,15 +191,15 @@ export default async function handler(request: Request, context: Context) {
 
           return `<a href="${profileUrl}" class="artist-card">${avatarHtml}<div style="flex:1;min-width:0"><div class="artist-name">${escapeHtml(name)}</div>${supportedBadge}</div></a>`;
         }).join('')
-      : '<p style="color:var(--muted);text-align:center;padding:48px 0">No saved artists yet.</p>';
+      : (collectionTilesHtml ? '' : '<p style="color:var(--muted);text-align:center;padding:48px 0">No saved artists yet.</p>');
 
     // JSON-LD structured data
     const jsonLd = {
       '@context': 'https://schema.org',
       '@type': 'CollectionPage',
-      name: `${usernameRow.username}'s saved artists on Unstream`,
+      name: `${usernameRow.username}'s collection on Unstream`,
       url: pageUrl,
-      description: `Artists saved by ${usernameRow.username} on Unstream — platforms that pay artists fairly.`,
+      description: `Music ${usernameRow.username} has bought and artists they support on Unstream — platforms that pay artists fairly.`,
     };
 
     const html = `<!DOCTYPE html>
@@ -152,16 +207,16 @@ export default async function handler(request: Request, context: Context) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${ownerName}'s saved artists - Unstream</title>
-  <meta name="description" content="Artists saved by ${ownerName} on Unstream — platforms that pay artists fairly.">
-  <meta property="og:title" content="${ownerName}'s saved artists - Unstream">
-  <meta property="og:description" content="Artists saved by ${ownerName} on Unstream — platforms that pay artists fairly.">
+  <title>${ownerName}'s collection - Unstream</title>
+  <meta name="description" content="Music ${ownerName} has bought and artists they support on Unstream — platforms that pay artists fairly.">
+  <meta property="og:title" content="${ownerName}'s collection - Unstream">
+  <meta property="og:description" content="Music ${ownerName} has bought and artists they support on Unstream — platforms that pay artists fairly.">
   <meta property="og:url" content="${pageUrl}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Unstream">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="${ownerName}'s saved artists - Unstream">
-  <meta name="twitter:description" content="Artists saved by ${ownerName} on Unstream — platforms that pay artists fairly.">
+  <meta name="twitter:title" content="${ownerName}'s collection - Unstream">
+  <meta name="twitter:description" content="Music ${ownerName} has bought and artists they support on Unstream — platforms that pay artists fairly.">
   <link rel="canonical" href="${pageUrl}">
   <script type="application/ld+json">${JSON.stringify(jsonLd).replace(/</g, '\\u003c')}</script>
   <link href="https://fonts.googleapis.com/css2?family=Darker+Grotesque:wght@300..900&family=Stack+Sans+Headline:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -182,8 +237,9 @@ export default async function handler(request: Request, context: Context) {
 
   <div class="page-content">
     <div class="container" style="padding-top:48px;padding-bottom:16px;text-align:center">
-      <h1 style="font-size:24px;font-weight:700">${ownerName}'s saved artists</h1>
+      <h1 style="font-size:24px;font-weight:700">${ownerName}'s collection</h1>
       ${ownerLocation ? `<p style="color:var(--text);font-size:14px;margin-top:4px">${ownerLocation}</p>` : ''}
+      ${countParts.length > 0 ? `<p style="color:var(--muted);font-size:14px;margin-top:4px">${countParts.join(' &#x2022; ')}</p>` : ''}
       <div data-share-mount style="margin-top:24px">
         <button class="copy-btn" id="copy-url-btn" data-url="${pageUrl}">
           <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
@@ -192,7 +248,14 @@ export default async function handler(request: Request, context: Context) {
       </div>
     </div>
 
+    ${collectionTilesHtml ? `<div class="container" style="padding-bottom:40px">
+      <div class="collection-grid">
+        ${collectionTilesHtml}
+      </div>
+    </div>` : ''}
+
     <div class="container" style="padding-bottom:48px">
+      ${collectionTilesHtml && savedArtists.length > 0 ? '<h2 style="font-size:18px;font-weight:600;margin-bottom:12px">Artists</h2>' : ''}
       <div style="display:grid;gap:8px">
         ${artistCardsHtml}
       </div>

--- a/api/functions/__tests__/bandcamp-subsonic.test.ts
+++ b/api/functions/__tests__/bandcamp-subsonic.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'crypto';
+import {
+  deriveSubsonicToken,
+  subsonicPing,
+  subsonicArtistCount,
+  subsonicFetchAllAlbums,
+  SubsonicError,
+  SUBSONIC_SERVER,
+} from '../bandcamp-subsonic';
+
+const CRED = { username: 'fan', t: 'deadbeef', s: 'salt1234' };
+
+function okEnvelope(extra: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ 'subsonic-response': { status: 'ok', version: '1.16.1', ...extra } }),
+  } as Response;
+}
+
+describe('bandcamp-subsonic', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('deriveSubsonicToken', () => {
+    it('derives t = md5(password + s) with a fresh salt each time', () => {
+      const a = deriveSubsonicToken('hunter2');
+      const b = deriveSubsonicToken('hunter2');
+      expect(a.s).not.toBe(b.s);
+      expect(a.t).toBe(createHash('md5').update('hunter2' + a.s).digest('hex'));
+      expect(b.t).toBe(createHash('md5').update('hunter2' + b.s).digest('hex'));
+    });
+
+    it('never embeds the password in the token pair', () => {
+      const { t, s } = deriveSubsonicToken('supersecret');
+      expect(t).not.toContain('supersecret');
+      expect(s).not.toContain('supersecret');
+    });
+  });
+
+  describe('subsonicPing', () => {
+    it('resolves on an ok envelope and targets the Bandcamp server', async () => {
+      fetchMock.mockResolvedValue(okEnvelope());
+      await subsonicPing(CRED);
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.origin + url.pathname).toBe(`${SUBSONIC_SERVER}/rest/ping.view`);
+      expect(url.searchParams.get('u')).toBe('fan');
+      expect(url.searchParams.get('t')).toBe('deadbeef');
+      expect(url.searchParams.get('s')).toBe('salt1234');
+      expect(url.searchParams.get('f')).toBe('json');
+    });
+
+    it('throws an auth-flagged SubsonicError on error code 40', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          'subsonic-response': {
+            status: 'failed',
+            error: { code: 40, message: 'Wrong username or password' },
+          },
+        }),
+      } as Response);
+      const err = await subsonicPing(CRED).catch(e => e);
+      expect(err).toBeInstanceOf(SubsonicError);
+      expect(err.isAuthFailure).toBe(true);
+    });
+
+    it('throws on HTTP failure without leaking the URL', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 503 } as Response);
+      const err = await subsonicPing(CRED).catch(e => e);
+      expect(err).toBeInstanceOf(SubsonicError);
+      expect(err.message).not.toContain('deadbeef');
+      expect(err.message).not.toContain('salt1234');
+      expect(err.message).not.toContain('bandcamp.com');
+    });
+
+    it('throws on a non-JSON response (bot challenge lookalike)', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('not json');
+        },
+      } as unknown as Response);
+      await expect(subsonicPing(CRED)).rejects.toThrow('non-JSON response');
+    });
+  });
+
+  describe('subsonicArtistCount', () => {
+    it('sums artists across index buckets', async () => {
+      fetchMock.mockResolvedValue(
+        okEnvelope({
+          artists: {
+            index: [
+              { name: 'A', artist: [{ id: '1' }, { id: '2' }] },
+              { name: 'B', artist: [{ id: '3' }] },
+            ],
+          },
+        })
+      );
+      expect(await subsonicArtistCount(CRED)).toBe(3);
+    });
+  });
+
+  describe('subsonicFetchAllAlbums', () => {
+    const album = (id: number) => ({
+      id: `al-${id}`,
+      name: `Album ${id}`,
+      artist: `Artist ${id}`,
+      coverArt: `ar-${id}`,
+      year: 2020,
+      created: '2026-01-02T03:04:05.000Z',
+    });
+
+    it('collects albums and stops on a short page', async () => {
+      const fullPage = Array.from({ length: 500 }, (_, i) => album(i));
+      const shortPage = [album(500), album(501)];
+      fetchMock
+        .mockResolvedValueOnce(okEnvelope({ albumList2: { album: fullPage } }))
+        .mockResolvedValueOnce(okEnvelope({ albumList2: { album: shortPage } }));
+
+      const albums = await subsonicFetchAllAlbums(CRED);
+      expect(albums).toHaveLength(502);
+      expect(albums[0]).toMatchObject({ id: 'al-0', name: 'Album 0', artist: 'Artist 0' });
+
+      const second = new URL(fetchMock.mock.calls[1][0] as string);
+      expect(second.searchParams.get('offset')).toBe('500');
+      expect(second.searchParams.get('type')).toBe('alphabeticalByArtist');
+    });
+
+    it('handles an empty collection', async () => {
+      fetchMock.mockResolvedValue(okEnvelope({ albumList2: { album: [] } }));
+      expect(await subsonicFetchAllAlbums(CRED)).toEqual([]);
+    });
+
+    it('skips malformed album entries rather than crashing', async () => {
+      fetchMock.mockResolvedValue(
+        okEnvelope({ albumList2: { album: [album(1), { id: 42 }, null, 'junk'] } })
+      );
+      const albums = await subsonicFetchAllAlbums(CRED);
+      expect(albums).toHaveLength(1);
+    });
+
+    it('throws mid-pagination instead of returning a partial collection', async () => {
+      const fullPage = Array.from({ length: 500 }, (_, i) => album(i));
+      fetchMock
+        .mockResolvedValueOnce(okEnvelope({ albumList2: { album: fullPage } }))
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+      await expect(subsonicFetchAllAlbums(CRED)).rejects.toThrow(SubsonicError);
+    });
+  });
+});

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -31,12 +31,16 @@ function internalEvent(body: unknown) {
 interface TableMocks {
   connectionRow?: Record<string, unknown> | null;
   releases?: Record<string, unknown>[];
+  savedRows?: Record<string, unknown>[];
 }
 
-// Routes supabase table calls; records connection updates and item upserts.
-function setupDb({ connectionRow = null, releases = [] }: TableMocks) {
+// Routes supabase table calls; records connection updates, item upserts, and
+// saved_artists writes (the auto-mark-supported side effect).
+function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableMocks) {
   const connectionUpdates: Record<string, unknown>[] = [];
   const upsertBatches: Record<string, unknown>[][] = [];
+  const savedInserts: Record<string, unknown>[][] = [];
+  const savedUpdates: { patch: Record<string, unknown>; slugs: unknown }[] = [];
 
   mocks.mockFrom.mockImplementation((table: string) => {
     if (table === 'bandcamp_connections') {
@@ -69,11 +73,34 @@ function setupDb({ connectionRow = null, releases = [] }: TableMocks) {
         })),
       };
     }
+    if (table === 'saved_artists') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(() => Promise.resolve({ data: savedRows, error: null })),
+          })),
+        })),
+        upsert: vi.fn((rows: Record<string, unknown>[]) => {
+          savedInserts.push(rows);
+          return Promise.resolve({ error: null });
+        }),
+        update: vi.fn((patch: Record<string, unknown>) => ({
+          eq: vi.fn(() => ({
+            in: vi.fn((_col: string, slugs: unknown) => {
+              savedUpdates.push({ patch, slugs });
+              return Promise.resolve({ error: null });
+            }),
+          })),
+        })),
+      };
+    }
     throw new Error(`unexpected table ${table}`);
   });
 
-  return { connectionUpdates, upsertBatches };
+  return { connectionUpdates, upsertBatches, savedInserts, savedUpdates };
 }
+
+const SUFJAN = { id: 'artist-1', slug: 'sufjan-stevens', name: 'Sufjan Stevens', image_url: 'https://img/s.jpg' };
 
 describe('bandcamp-sync-background handler', () => {
   beforeEach(() => {
@@ -149,9 +176,9 @@ describe('bandcamp-sync-background handler', () => {
     mocks.mockReadAllPages.mockResolvedValue({
       ok: true,
       rows: [
-        { id: 'artist-1', name: 'Sufjan Stevens' },
-        { id: 'artist-2', name: 'Ambiguous' },
-        { id: 'artist-3', name: 'ambiguous' }, // normalizes identically → no matching
+        SUFJAN,
+        { id: 'artist-2', slug: 'ambiguous', name: 'Ambiguous', image_url: null },
+        { id: 'artist-3', slug: 'ambiguous-2', name: 'ambiguous', image_url: null }, // normalizes identically → no matching
       ],
     });
     mocks.mockFetchAllAlbums.mockResolvedValue([
@@ -166,6 +193,95 @@ describe('bandcamp-sync-background handler', () => {
     expect(byExternal['al-1']).toMatchObject({ release_id: 'rel-1', art_url: 'https://f4.bcbits.com/a.jpg' });
     expect(byExternal['al-2'].release_id).toBeNull();
     expect(byExternal['al-3'].release_id).toBeNull();
+  });
+
+  describe('auto-mark supported (spec OQ6: buying is supporting)', () => {
+    const ciphertext = () => encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const albums = [{ id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }];
+
+    function withArtists() {
+      mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
+      mocks.mockFetchAllAlbums.mockResolvedValue(albums);
+    }
+
+    it('saves a matched artist as supported when they have no saved row', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      const inserted = savedInserts.flat();
+      expect(inserted).toHaveLength(1);
+      expect(inserted[0]).toMatchObject({
+        user_id: 'user-1',
+        artist_id: 'artist-1',
+        artist_slug: 'sufjan-stevens',
+        artist_name: 'Sufjan Stevens',
+        supported: true,
+      });
+      expect(inserted[0].supported_at).toBeTruthy();
+      expect(inserted[0].last_modified).toBeTruthy();
+      expect(savedUpdates).toHaveLength(0);
+    });
+
+    it('upgrades an existing unsupported row instead of inserting', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [{ artist_slug: 'sufjan-stevens', supported: false, deleted: false }],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(1);
+      expect(savedUpdates[0].patch).toMatchObject({ supported: true });
+      expect(savedUpdates[0].slugs).toEqual(['sufjan-stevens']);
+    });
+
+    it('leaves an already-supported row untouched (original supported_at preserved)', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [{ artist_slug: 'sufjan-stevens', supported: true, deleted: false }],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(0);
+    });
+
+    it('never resurrects a tombstoned row — permanent dismissal sticks across re-syncs', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [{ artist_slug: 'sufjan-stevens', supported: false, deleted: true }],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(0);
+    });
+
+    it('marks nothing for unmatched artists', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
+      mocks.mockFetchAllAlbums.mockResolvedValue([
+        { id: 'al-9', name: 'Some Album', artist: 'Nobody We Know' },
+      ]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(0);
+    });
   });
 
   it('records an error — not a partial success — when the fetch dies mid-sync', async () => {

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockReadAllPages: vi.fn(),
+  mockFetchAllAlbums: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({ from: mocks.mockFrom }),
+  readAllPages: mocks.mockReadAllPages,
+}));
+vi.mock('../bandcamp-subsonic', async importOriginal => {
+  const original = await importOriginal<typeof import('../bandcamp-subsonic')>();
+  return { ...original, subsonicFetchAllAlbums: mocks.mockFetchAllAlbums };
+});
+
+import { handler } from '../bandcamp-sync-background';
+import { SubsonicError } from '../bandcamp-subsonic';
+import { encryptCredential } from '../credential-crypto';
+
+function internalEvent(body: unknown) {
+  return {
+    httpMethod: 'POST',
+    headers: { authorization: 'Bearer internal-secret' },
+    body: JSON.stringify(body),
+  };
+}
+
+interface TableMocks {
+  connectionRow?: Record<string, unknown> | null;
+  releases?: Record<string, unknown>[];
+}
+
+// Routes supabase table calls; records connection updates and item upserts.
+function setupDb({ connectionRow = null, releases = [] }: TableMocks) {
+  const connectionUpdates: Record<string, unknown>[] = [];
+  const upsertBatches: Record<string, unknown>[][] = [];
+
+  mocks.mockFrom.mockImplementation((table: string) => {
+    if (table === 'bandcamp_connections') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: connectionRow, error: null })),
+          })),
+        })),
+        update: vi.fn((patch: Record<string, unknown>) => {
+          connectionUpdates.push(patch);
+          return { eq: vi.fn(() => Promise.resolve({ error: null })) };
+        }),
+      };
+    }
+    if (table === 'collection_items') {
+      return {
+        upsert: vi.fn((rows: Record<string, unknown>[]) => {
+          upsertBatches.push(rows);
+          return Promise.resolve({ error: null });
+        }),
+      };
+    }
+    if (table === 'releases') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ data: releases, error: null })),
+          })),
+        })),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return { connectionUpdates, upsertBatches };
+}
+
+describe('bandcamp-sync-background handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.INTERNAL_FUNCTION_SECRET = 'internal-secret';
+    process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
+    mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [] });
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    delete process.env.BANDCAMP_CREDENTIAL_KEY;
+  });
+
+  it('refuses requests without the internal secret', async () => {
+    const res = await handler({
+      httpMethod: 'POST',
+      headers: { authorization: 'Bearer wrong' },
+      body: JSON.stringify({ userId: 'user-1' }),
+    });
+    expect(res.statusCode).toBe(401);
+    expect(mocks.mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('skips quietly when the user disconnected before the run', async () => {
+    setupDb({ connectionRow: null });
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ skipped: true });
+  });
+
+  it('imports albums as purchased items and completes the connection row', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates, upsertBatches } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockResolvedValue([
+      { id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens', created: '2026-01-01T00:00:00Z' },
+      { id: 'al-2', name: 'Carrie & Lowell', artist: 'Sufjan Stevens' },
+      { id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }, // duplicate id from source
+    ]);
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ imported: 2 });
+
+    // The credential was decrypted and used.
+    expect(mocks.mockFetchAllAlbums).toHaveBeenCalledWith({ username: 'fan', t: 'tok', s: 'salt' });
+
+    // Deduplicated rows, all purchased, never touching `hidden`.
+    const rows = upsertBatches.flat();
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toMatchObject({ user_id: 'user-1', source: 'bandcamp', provenance: 'purchased' });
+      expect(row).not.toHaveProperty('hidden');
+    }
+    expect(rows[0]).toMatchObject({ external_id: 'al-1', title: 'Illinois', acquired_at: '2026-01-01T00:00:00Z' });
+
+    // Success recorded: idle, count, timestamp, no lingering error.
+    const done = connectionUpdates.at(-1)!;
+    expect(done).toMatchObject({ sync_status: 'idle', sync_error: null, item_count: 2 });
+    expect(done.last_synced_at).toBeTruthy();
+  });
+
+  it('matches releases by normalized artist name + title, skipping ambiguous artists', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { upsertBatches } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+      releases: [
+        { id: 'rel-1', artist_id: 'artist-1', match_key: 'illinois', artwork_url: 'https://f4.bcbits.com/a.jpg' },
+      ],
+    });
+    mocks.mockReadAllPages.mockResolvedValue({
+      ok: true,
+      rows: [
+        { id: 'artist-1', name: 'Sufjan Stevens' },
+        { id: 'artist-2', name: 'Ambiguous' },
+        { id: 'artist-3', name: 'ambiguous' }, // normalizes identically → no matching
+      ],
+    });
+    mocks.mockFetchAllAlbums.mockResolvedValue([
+      { id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' },
+      { id: 'al-2', name: 'Some Album', artist: 'Ambiguous' },
+      { id: 'al-3', name: 'Unknown Album', artist: 'Nobody We Know' },
+    ]);
+
+    await handler(internalEvent({ userId: 'user-1' }));
+    const rows = upsertBatches.flat() as Record<string, unknown>[];
+    const byExternal = Object.fromEntries(rows.map(r => [r.external_id as string, r]));
+    expect(byExternal['al-1']).toMatchObject({ release_id: 'rel-1', art_url: 'https://f4.bcbits.com/a.jpg' });
+    expect(byExternal['al-2'].release_id).toBeNull();
+    expect(byExternal['al-3'].release_id).toBeNull();
+  });
+
+  it('records an error — not a partial success — when the fetch dies mid-sync', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates, upsertBatches } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockRejectedValue(new SubsonicError('getAlbumList2: HTTP 500'));
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    expect(res.statusCode).toBe(500);
+    expect(upsertBatches).toHaveLength(0);
+    expect(connectionUpdates.at(-1)).toMatchObject({
+      sync_status: 'error',
+      sync_error: expect.stringContaining('Re-sync'),
+    });
+  });
+
+  it('tells the user to reconnect when the stored credential is rejected', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockRejectedValue(new SubsonicError('getAlbumList2: bad creds', 40));
+
+    await handler(internalEvent({ userId: 'user-1' }));
+    expect(connectionUpdates.at(-1)).toMatchObject({
+      sync_status: 'error',
+      sync_error: expect.stringContaining('reconnect'),
+    });
+  });
+
+  it('marks the credential unusable when decryption fails, without calling Bandcamp', async () => {
+    const { connectionUpdates } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: 'not.a.blob' },
+    });
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    expect(res.statusCode).toBe(500);
+    expect(mocks.mockFetchAllAlbums).not.toHaveBeenCalled();
+    expect(connectionUpdates.at(-1)).toMatchObject({
+      sync_status: 'error',
+      sync_error: expect.stringContaining('reconnect'),
+    });
+  });
+});

--- a/api/functions/__tests__/collection-art.test.ts
+++ b/api/functions/__tests__/collection-art.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  mockCoverArtId: vi.fn(),
+  mockFetchCoverArt: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+vi.mock('../bandcamp-subsonic', async importOriginal => {
+  const original = await importOriginal<typeof import('../bandcamp-subsonic')>();
+  return {
+    ...original,
+    subsonicAlbumCoverArtId: mocks.mockCoverArtId,
+    subsonicFetchCoverArt: mocks.mockFetchCoverArt,
+  };
+});
+
+import { handler } from '../collection-art';
+import { encryptCredential } from '../credential-crypto';
+
+const ITEM_ID = '11111111-1111-4111-8111-111111111111';
+const OWNER = 'user-owner';
+
+interface Setup {
+  item?: Record<string, unknown> | null;
+  sharingPublic?: boolean;
+  hasConnection?: boolean;
+}
+
+function setupDb({ item, sharingPublic = false, hasConnection = true }: Setup) {
+  mocks.mockFrom.mockImplementation((table: string) => {
+    if (table === 'collection_items') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle: vi.fn(() => Promise.resolve({ data: item ?? null, error: null })) })),
+        })),
+      };
+    }
+    if (table === 'usernames') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: { saved_artists_public: sharingPublic }, error: null })),
+          })),
+        })),
+      };
+    }
+    if (table === 'bandcamp_connections') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({
+                data: hasConnection
+                  ? {
+                      bandcamp_username: 'fan',
+                      credential_ciphertext: encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' })),
+                    }
+                  : null,
+                error: null,
+              })
+            ),
+          })),
+        })),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+}
+
+const PUBLIC_ITEM = { user_id: OWNER, external_id: 'al-1', provenance: 'purchased', hidden: false };
+
+function get(headers: Record<string, string | undefined> = {}) {
+  return handler({ httpMethod: 'GET', headers, pathParameters: { id: ITEM_ID } });
+}
+
+function signedInAs(userId: string | null) {
+  mocks.mockCreateClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue(
+        userId ? { data: { user: { id: userId } }, error: null } : { data: { user: null }, error: 'bad token' }
+      ),
+    },
+  });
+}
+
+describe('collection-art handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    signedInAs(null);
+    mocks.mockCoverArtId.mockResolvedValue('art-1');
+    mocks.mockFetchCoverArt.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]).buffer,
+      contentType: 'image/jpeg',
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.BANDCAMP_CREDENTIAL_KEY;
+  });
+
+  it('rejects a malformed item id without touching the database', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: {}, pathParameters: { id: '../secrets' } });
+    expect(res.statusCode).toBe(400);
+    expect(mocks.mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('serves art for a public item on a shared page', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true });
+    const res = await get();
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('image/jpeg');
+    expect(res.isBase64Encoded).toBe(true);
+    // Cached hard at the CDN so one page view doesn't re-hit Bandcamp per tile.
+    expect(res.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=2592000');
+  });
+
+  it('refuses a public request when the owner has not shared their page', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: false });
+    const res = await get();
+    expect(res.statusCode).toBe(404);
+    expect(mocks.mockFetchCoverArt).not.toHaveBeenCalled();
+  });
+
+  it('refuses a public request for a hidden item, matching the page it appears on', async () => {
+    setupDb({ item: { ...PUBLIC_ITEM, hidden: true }, sharingPublic: true });
+    const res = await get();
+    expect(res.statusCode).toBe(404);
+    expect(mocks.mockFetchCoverArt).not.toHaveBeenCalled();
+  });
+
+  it('refuses a public request for a non-purchased item', async () => {
+    setupDb({ item: { ...PUBLIC_ITEM, provenance: 'listened' }, sharingPublic: true });
+    expect((await get()).statusCode).toBe(404);
+  });
+
+  it('serves the owner their own hidden item even with sharing off', async () => {
+    setupDb({ item: { ...PUBLIC_ITEM, hidden: true }, sharingPublic: false });
+    signedInAs(OWNER);
+    const res = await get({ authorization: 'Bearer owner-token' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('does not let one signed-in user read another user\'s private art', async () => {
+    setupDb({ item: { ...PUBLIC_ITEM, hidden: true }, sharingPublic: false });
+    signedInAs('someone-else');
+    const res = await get({ authorization: 'Bearer other-token' });
+    expect(res.statusCode).toBe(404);
+    expect(mocks.mockFetchCoverArt).not.toHaveBeenCalled();
+  });
+
+  it('404s briefly — not permanently — when Bandcamp has no art', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true });
+    mocks.mockCoverArtId.mockResolvedValue(null);
+    const res = await get();
+    expect(res.statusCode).toBe(404);
+    // A month-long cache would freeze a transient upstream failure into a permanent gap.
+    expect(res.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
+  });
+
+  it('404s rather than throwing when Bandcamp errors', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true });
+    mocks.mockFetchCoverArt.mockRejectedValue(new Error('upstream exploded'));
+    const res = await get();
+    expect(res.statusCode).toBe(404);
+    expect(res.headers['Netlify-CDN-Cache-Control']).toContain('s-maxage=300');
+  });
+
+  it('404s when the owner has disconnected Bandcamp', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true, hasConnection: false });
+    expect((await get()).statusCode).toBe(404);
+  });
+
+  it('never returns credential material in a response body', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true, hasConnection: false });
+    const res = await get();
+    expect(res.body).not.toContain('tok');
+    expect(res.body).not.toContain('salt');
+    expect(res.body).not.toContain('ciphertext');
+  });
+});

--- a/api/functions/__tests__/credential-crypto.test.ts
+++ b/api/functions/__tests__/credential-crypto.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+import {
+  encryptCredential,
+  decryptCredential,
+  isCredentialKeyConfigured,
+} from '../credential-crypto';
+
+const TEST_KEY = randomBytes(32).toString('base64');
+
+describe('credential-crypto', () => {
+  const originalKey = process.env.BANDCAMP_CREDENTIAL_KEY;
+
+  beforeEach(() => {
+    process.env.BANDCAMP_CREDENTIAL_KEY = TEST_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.BANDCAMP_CREDENTIAL_KEY;
+    else process.env.BANDCAMP_CREDENTIAL_KEY = originalKey;
+  });
+
+  it('round-trips a credential payload', () => {
+    const payload = JSON.stringify({ t: 'abcdef0123456789', s: 'somesalt' });
+    const blob = encryptCredential(payload);
+    expect(decryptCredential(blob)).toBe(payload);
+  });
+
+  it('produces a different blob each time (fresh IV), both decryptable', () => {
+    const a = encryptCredential('secret');
+    const b = encryptCredential('secret');
+    expect(a).not.toBe(b);
+    expect(decryptCredential(a)).toBe('secret');
+    expect(decryptCredential(b)).toBe('secret');
+  });
+
+  it('never contains the plaintext in the stored blob', () => {
+    const blob = encryptCredential('supersecretpassword');
+    expect(blob).not.toContain('supersecretpassword');
+    expect(Buffer.from(blob.split('.')[2], 'base64').toString('utf8')).not.toContain(
+      'supersecretpassword'
+    );
+  });
+
+  it('throws on decryption with a different key', () => {
+    const blob = encryptCredential('secret');
+    process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
+    expect(() => decryptCredential(blob)).toThrow();
+  });
+
+  it('throws on a tampered blob (GCM auth)', () => {
+    const blob = encryptCredential('secret');
+    const parts = blob.split('.');
+    const ct = Buffer.from(parts[2], 'base64');
+    ct[0] = ct[0] ^ 0xff;
+    const tampered = `${parts[0]}.${parts[1]}.${ct.toString('base64')}`;
+    expect(() => decryptCredential(tampered)).toThrow();
+  });
+
+  it('throws on a malformed blob', () => {
+    expect(() => decryptCredential('not-a-real-blob')).toThrow('Malformed credential ciphertext');
+  });
+
+  it('throws when the key is missing', () => {
+    delete process.env.BANDCAMP_CREDENTIAL_KEY;
+    expect(() => encryptCredential('secret')).toThrow('BANDCAMP_CREDENTIAL_KEY is not configured');
+    expect(isCredentialKeyConfigured()).toBe(false);
+  });
+
+  it('throws when the key is the wrong length', () => {
+    process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(16).toString('base64');
+    expect(() => encryptCredential('secret')).toThrow('32 bytes');
+    expect(isCredentialKeyConfigured()).toBe(false);
+  });
+
+  it('reports configured with a valid key', () => {
+    expect(isCredentialKeyConfigured()).toBe(true);
+  });
+});

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -190,6 +190,24 @@ describe('me-bandcamp handler', () => {
       );
     });
 
+    it('treats a non-202 dispatch (e.g. 404 on a deploy preview) as sync-start failure', async () => {
+      mocks.mockPing.mockResolvedValue(undefined);
+      mocks.mockArtistCount.mockResolvedValue(1);
+      // The background function isn't deployed at the target URL — Netlify answers 404,
+      // which fetch does NOT throw on. Claiming "syncing" here would spin forever.
+      fetchMock.mockResolvedValue({ ok: false, status: 404 });
+      const upsert = vi.fn((..._args: unknown[]) => Promise.resolve({ error: null }));
+      const updateEq = vi.fn(() => Promise.resolve({ error: null }));
+      const update = vi.fn(() => ({ eq: updateEq }));
+      mocks.mockFrom.mockReturnValue({ upsert, update });
+
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(JSON.parse(res!.body).syncStatus).toBe('error');
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({ sync_status: 'error', sync_error: expect.stringContaining('Re-sync') })
+      );
+    });
+
     it('validates the body', async () => {
       const res = await handler(authedEvent('POST', { username: '', password: PASSWORD }));
       expect(res!.statusCode).toBe(400);

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -25,9 +25,41 @@ vi.mock('../bandcamp-subsonic', async importOriginal => {
   };
 });
 
-import { handler } from '../me-bandcamp';
+import { handler, selfDispatchOrigin } from '../me-bandcamp';
 import { SubsonicError } from '../bandcamp-subsonic';
 import { decryptCredential } from '../credential-crypto';
+
+// The dispatch target carries INTERNAL_FUNCTION_SECRET, and Host is client-supplied, so
+// this allowlist is a security boundary, not a convenience.
+describe('selfDispatchOrigin', () => {
+  it('accepts this site\'s own production and Netlify deploy hostnames', () => {
+    expect(selfDispatchOrigin('unstream.stream')).toBe('https://unstream.stream');
+    expect(selfDispatchOrigin('www.unstream.stream')).toBe('https://www.unstream.stream');
+    expect(selfDispatchOrigin('unstream.netlify.app')).toBe('https://unstream.netlify.app');
+    expect(selfDispatchOrigin('deploy-preview-438--unstream.netlify.app')).toBe(
+      'https://deploy-preview-438--unstream.netlify.app'
+    );
+    // Case and port are normalised away before matching.
+    expect(selfDispatchOrigin('Unstream.Stream:443')).toBe('https://unstream.stream');
+  });
+
+  it('refuses any hostname that is not ours, so the secret cannot be redirected', () => {
+    for (const host of [
+      'evil.com',
+      'unstream.stream.evil.com',
+      'unstream.netlify.app.evil.com',
+      'evil.com--unstream.netlify.app',
+      'deploy-preview-438--unstream.netlify.app.evil.com',
+      'notunstream.stream',
+      '169.254.169.254',
+      'localhost',
+      '',
+      undefined,
+    ]) {
+      expect(selfDispatchOrigin(host)).toBeNull();
+    }
+  });
+});
 
 const PASSWORD = 'bandcamp-generated-credential';
 
@@ -206,6 +238,46 @@ describe('me-bandcamp handler', () => {
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({ sync_status: 'error', sync_error: expect.stringContaining('Re-sync') })
       );
+    });
+
+    it('dispatches to the deploy that served the request, not always production', async () => {
+      // The bug this fixes: a deploy preview handed its sync to production, where the
+      // branch's background function 404s.
+      mocks.mockPing.mockResolvedValue(undefined);
+      mocks.mockArtistCount.mockResolvedValue(1);
+      const upsert = vi.fn((..._args: unknown[]) => Promise.resolve({ error: null }));
+      mocks.mockFrom.mockReturnValue({ upsert });
+
+      await handler({
+        httpMethod: 'POST',
+        headers: {
+          authorization: 'Bearer valid-token',
+          host: 'deploy-preview-438--unstream.netlify.app',
+        },
+        body: JSON.stringify({ username: 'fan', password: PASSWORD }),
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://deploy-preview-438--unstream.netlify.app/.netlify/functions/bandcamp-sync-background',
+        expect.anything()
+      );
+    });
+
+    it('ignores a spoofed Host, so the internal secret never leaves our own deploys', async () => {
+      mocks.mockPing.mockResolvedValue(undefined);
+      mocks.mockArtistCount.mockResolvedValue(1);
+      const upsert = vi.fn((..._args: unknown[]) => Promise.resolve({ error: null }));
+      mocks.mockFrom.mockReturnValue({ upsert });
+
+      await handler({
+        httpMethod: 'POST',
+        headers: { authorization: 'Bearer valid-token', host: 'evil.example.com' },
+        body: JSON.stringify({ username: 'fan', password: PASSWORD }),
+      });
+
+      const dispatched = fetchMock.mock.calls[0][0] as string;
+      expect(dispatched).toBe('https://unstream.stream/.netlify/functions/bandcamp-sync-background');
+      expect(dispatched).not.toContain('evil.example.com');
     });
 
     it('validates the body', async () => {

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  mockPing: vi.fn(),
+  mockArtistCount: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+vi.mock('../bandcamp-subsonic', async importOriginal => {
+  const original = await importOriginal<typeof import('../bandcamp-subsonic')>();
+  return {
+    ...original,
+    subsonicPing: mocks.mockPing,
+    subsonicArtistCount: mocks.mockArtistCount,
+  };
+});
+
+import { handler } from '../me-bandcamp';
+import { SubsonicError } from '../bandcamp-subsonic';
+import { decryptCredential } from '../credential-crypto';
+
+const PASSWORD = 'bandcamp-generated-credential';
+
+function authedEvent(method: string, body: unknown = null) {
+  return {
+    httpMethod: method,
+    headers: { authorization: 'Bearer valid-token' },
+    body: body === null ? null : JSON.stringify(body),
+  };
+}
+
+describe('me-bandcamp handler', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
+    process.env.INTERNAL_FUNCTION_SECRET = 'internal-secret';
+    process.env.URL = 'https://unstream.stream';
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        }),
+      },
+    });
+    fetchMock.mockResolvedValue({ ok: true, status: 202 });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.BANDCAMP_CREDENTIAL_KEY;
+    delete process.env.INTERNAL_FUNCTION_SECRET;
+    delete process.env.URL;
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: {}, body: null });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('GET reports not connected when there is no row', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+        })),
+      })),
+    });
+    const res = await handler(authedEvent('GET'));
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ connected: false });
+  });
+
+  it('GET returns connection status without any credential material', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() =>
+            Promise.resolve({
+              data: {
+                bandcamp_username: 'fan',
+                sync_status: 'idle',
+                sync_error: null,
+                item_count: 42,
+                last_synced_at: '2026-08-09T00:00:00Z',
+              },
+              error: null,
+            })
+          ),
+        })),
+      })),
+    });
+    const res = await handler(authedEvent('GET'));
+    const body = JSON.parse(res!.body);
+    expect(body).toMatchObject({ connected: true, username: 'fan', itemCount: 42, syncStatus: 'idle' });
+    expect(res!.body).not.toContain('ciphertext');
+  });
+
+  describe('POST connect', () => {
+    it('rejects a bad credential inline (Subsonic error 40) and stores nothing', async () => {
+      mocks.mockPing.mockRejectedValue(new SubsonicError('ping: wrong credentials', 40));
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(res!.statusCode).toBe(400);
+      expect(JSON.parse(res!.body).error).toContain('rejected');
+      expect(mocks.mockFrom).not.toHaveBeenCalled();
+      expect(res!.body).not.toContain(PASSWORD);
+    });
+
+    it('returns 502 when Bandcamp is unreachable, storing nothing', async () => {
+      mocks.mockPing.mockRejectedValue(new SubsonicError('ping: timed out'));
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(res!.statusCode).toBe(502);
+      expect(mocks.mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when the encryption key is not configured', async () => {
+      delete process.env.BANDCAMP_CREDENTIAL_KEY;
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(res!.statusCode).toBe(500);
+      expect(mocks.mockPing).not.toHaveBeenCalled();
+    });
+
+    it('stores an encrypted, decryptable token pair — never the password — and starts a sync', async () => {
+      mocks.mockPing.mockResolvedValue(undefined);
+      mocks.mockArtistCount.mockResolvedValue(37);
+      const upsert = vi.fn((..._args: unknown[]) => Promise.resolve({ error: null }));
+      mocks.mockFrom.mockReturnValue({ upsert });
+
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(res!.statusCode).toBe(200);
+      expect(JSON.parse(res!.body)).toMatchObject({
+        connected: true,
+        username: 'fan',
+        syncStatus: 'syncing',
+        artistCount: 37,
+      });
+
+      const stored = upsert.mock.calls[0]![0] as Record<string, string>;
+      expect(stored.sync_status).toBe('syncing');
+      expect(stored.credential_ciphertext).not.toContain(PASSWORD);
+      const decrypted = JSON.parse(decryptCredential(stored.credential_ciphertext));
+      expect(decrypted).toHaveProperty('t');
+      expect(decrypted).toHaveProperty('s');
+      expect(decrypted.t).not.toContain(PASSWORD);
+
+      // The ping was made with the same derived pair that was stored.
+      const pinged = mocks.mockPing.mock.calls[0][0];
+      expect(pinged).toMatchObject({ username: 'fan', t: decrypted.t, s: decrypted.s });
+
+      // The background sync was requested with the internal secret, after the upsert.
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://unstream.stream/.netlify/functions/bandcamp-sync-background',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: 'Bearer internal-secret' }),
+          body: JSON.stringify({ userId: 'user-1' }),
+        })
+      );
+    });
+
+    it('records a sync-start failure on the row instead of claiming a sync is running', async () => {
+      mocks.mockPing.mockResolvedValue(undefined);
+      mocks.mockArtistCount.mockResolvedValue(1);
+      delete process.env.INTERNAL_FUNCTION_SECRET; // sync can't be requested
+      const upsert = vi.fn(() => Promise.resolve({ error: null }));
+      const updateEq = vi.fn(() => Promise.resolve({ error: null }));
+      const update = vi.fn(() => ({ eq: updateEq }));
+      mocks.mockFrom.mockReturnValue({ upsert, update });
+
+      const res = await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+      expect(JSON.parse(res!.body).syncStatus).toBe('error');
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({ sync_status: 'error', sync_error: expect.stringContaining('Re-sync') })
+      );
+    });
+
+    it('validates the body', async () => {
+      const res = await handler(authedEvent('POST', { username: '', password: PASSWORD }));
+      expect(res!.statusCode).toBe(400);
+      const res2 = await handler(authedEvent('POST', { username: 'fan' }));
+      expect(res2!.statusCode).toBe(400);
+    });
+  });
+
+  describe('POST resync', () => {
+    it('404s when there is no connection', async () => {
+      mocks.mockFrom.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+          })),
+        })),
+      });
+      const res = await handler(authedEvent('POST', { resync: true }));
+      expect(res!.statusCode).toBe(404);
+    });
+
+    it('409s when a sync is already running', async () => {
+      mocks.mockFrom.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: { sync_status: 'syncing' }, error: null })),
+          })),
+        })),
+      });
+      const res = await handler(authedEvent('POST', { resync: true }));
+      expect(res!.statusCode).toBe(409);
+    });
+  });
+
+  describe('DELETE', () => {
+    it('deletes the connection, leaving items by default', async () => {
+      const deleteEq = vi.fn(() => Promise.resolve({ error: null }));
+      mocks.mockFrom.mockReturnValue({ delete: vi.fn(() => ({ eq: deleteEq })) });
+
+      const res = await handler(authedEvent('DELETE', {}));
+      expect(res!.statusCode).toBe(200);
+      expect(JSON.parse(res!.body)).toEqual({ connected: false, itemsDeleted: 0 });
+      expect(mocks.mockFrom).toHaveBeenCalledWith('bandcamp_connections');
+      expect(mocks.mockFrom).not.toHaveBeenCalledWith('collection_items');
+    });
+
+    it('deletes imported items when asked, scoped to source=bandcamp', async () => {
+      const connectionEq = vi.fn(() => Promise.resolve({ error: null }));
+      const sourceEq = vi.fn(() => Promise.resolve({ count: 12, error: null }));
+      const userEq = vi.fn(() => ({ eq: sourceEq }));
+      mocks.mockFrom.mockImplementation((table: string) =>
+        table === 'bandcamp_connections'
+          ? { delete: vi.fn(() => ({ eq: connectionEq })) }
+          : { delete: vi.fn(() => ({ eq: userEq })) }
+      );
+
+      const res = await handler(authedEvent('DELETE', { deleteItems: true }));
+      expect(res!.statusCode).toBe(200);
+      expect(JSON.parse(res!.body)).toEqual({ connected: false, itemsDeleted: 12 });
+      expect(userEq).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(sourceEq).toHaveBeenCalledWith('source', 'bandcamp');
+    });
+  });
+});

--- a/api/functions/__tests__/me-collection.test.ts
+++ b/api/functions/__tests__/me-collection.test.ts
@@ -8,10 +8,15 @@ const mocks = vi.hoisted(() => ({
   mockGetClientIp: vi.fn(() => '127.0.0.1'),
 }));
 
-vi.mock('../db', () => ({
-  getClient: () => ({ from: mocks.mockFrom }),
-  readAllPages: mocks.mockReadAllPages,
-}));
+// Real artistSlug — see the note in public-saved-artists.test.ts.
+vi.mock('../db', async importOriginal => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    getClient: () => ({ from: mocks.mockFrom }),
+    readAllPages: mocks.mockReadAllPages,
+    artistSlug: actual.artistSlug,
+  };
+});
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -50,15 +55,54 @@ describe('me-collection handler', () => {
   });
 
   it('GET returns the owner view including hidden items, via paged reads', async () => {
-    const items = [
-      { id: 'i-1', title: 'Illinois', hidden: false, provenance: 'purchased' },
-      { id: 'i-2', title: 'Secret Album', hidden: true, provenance: 'purchased' },
-    ];
-    mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: items });
+    mocks.mockReadAllPages.mockResolvedValue({
+      ok: true,
+      rows: [
+        {
+          id: 'i-1',
+          title: 'Illinois',
+          artist_name: 'Sufjan Stevens',
+          art_url: null,
+          hidden: false,
+          provenance: 'purchased',
+          releases: { slug: 'illinois', artwork_url: 'https://f4.bcbits.com/a.jpg', artists: { slug: 'sufjan-stevens' } },
+        },
+        {
+          id: 'i-2',
+          title: 'Secret Album',
+          artist_name: 'Nobody We Know',
+          art_url: null,
+          hidden: true,
+          provenance: 'purchased',
+          releases: null,
+        },
+      ],
+    });
+    // No artist rows exist for the unmatched item's artist.
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({ in: vi.fn(() => Promise.resolve({ data: [], error: null })) })),
+    });
 
     const res = await handler(authedEvent('GET'));
     expect(res!.statusCode).toBe(200);
-    expect(JSON.parse(res!.body)).toEqual({ items, total: 2 });
+    const body = JSON.parse(res!.body);
+    expect(body.total).toBe(2);
+    // Hidden items belong in the owner's view — the public page is what filters them.
+    expect(body.items.map((i: { hidden: boolean }) => i.hidden)).toEqual([false, true]);
+    // Matched item: art and links from the joined release.
+    expect(body.items[0]).toMatchObject({
+      art_url: 'https://f4.bcbits.com/a.jpg',
+      url: '/a/sufjan-stevens/illinois',
+      artist_url: '/a/sufjan-stevens',
+    });
+    // Unmatched item: art falls back to the proxy, and nothing is linked.
+    expect(body.items[1]).toMatchObject({
+      art_url: '/api/collection/art/i-2',
+      url: null,
+      artist_url: null,
+    });
+    // The join column is dropped rather than echoed back to the client.
+    expect(body.items[0].releases).toBeUndefined();
     // The paged reader is what guards PostgREST's silent 1,000-row cap.
     expect(mocks.mockReadAllPages).toHaveBeenCalled();
   });

--- a/api/functions/__tests__/me-collection.test.ts
+++ b/api/functions/__tests__/me-collection.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockReadAllPages: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({ from: mocks.mockFrom }),
+  readAllPages: mocks.mockReadAllPages,
+}));
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+
+import { handler } from '../me-collection';
+
+function authedEvent(method: string, body: unknown = null) {
+  return {
+    httpMethod: method,
+    headers: { authorization: 'Bearer valid-token' },
+    body: body === null ? null : JSON.stringify(body),
+  };
+}
+
+describe('me-collection handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        }),
+      },
+    });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: {}, body: null });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('GET returns the owner view including hidden items, via paged reads', async () => {
+    const items = [
+      { id: 'i-1', title: 'Illinois', hidden: false, provenance: 'purchased' },
+      { id: 'i-2', title: 'Secret Album', hidden: true, provenance: 'purchased' },
+    ];
+    mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: items });
+
+    const res = await handler(authedEvent('GET'));
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ items, total: 2 });
+    // The paged reader is what guards PostgREST's silent 1,000-row cap.
+    expect(mocks.mockReadAllPages).toHaveBeenCalled();
+  });
+
+  it('GET surfaces a failed read as an error, not an empty collection', async () => {
+    mocks.mockReadAllPages.mockResolvedValue({ ok: false, reason: 'boom' });
+    const res = await handler(authedEvent('GET'));
+    expect(res!.statusCode).toBe(500);
+  });
+
+  it('POST validates the body', async () => {
+    expect((await handler(authedEvent('POST', { hidden: true })))!.statusCode).toBe(400);
+    expect((await handler(authedEvent('POST', { id: 'i-1', hidden: 'yes' })))!.statusCode).toBe(400);
+  });
+
+  it('POST scopes the hide toggle to the owner', async () => {
+    const maybeSingle = vi.fn(() =>
+      Promise.resolve({ data: { id: 'i-1', hidden: true }, error: null })
+    );
+    const select = vi.fn(() => ({ maybeSingle }));
+    const userEq = vi.fn(() => ({ select }));
+    const idEq = vi.fn(() => ({ eq: userEq }));
+    const update = vi.fn(() => ({ eq: idEq }));
+    mocks.mockFrom.mockReturnValue({ update });
+
+    const res = await handler(authedEvent('POST', { id: 'i-1', hidden: true }));
+    expect(res!.statusCode).toBe(200);
+    expect(update).toHaveBeenCalledWith({ hidden: true });
+    expect(idEq).toHaveBeenCalledWith('id', 'i-1');
+    expect(userEq).toHaveBeenCalledWith('user_id', 'user-1');
+  });
+
+  it('POST 404s for an item the user does not own', async () => {
+    const maybeSingle = vi.fn(() => Promise.resolve({ data: null, error: null }));
+    mocks.mockFrom.mockReturnValue({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({ select: vi.fn(() => ({ maybeSingle })) })),
+        })),
+      })),
+    });
+    const res = await handler(authedEvent('POST', { id: 'i-nope', hidden: true }));
+    expect(res!.statusCode).toBe(404);
+  });
+});

--- a/api/functions/__tests__/public-saved-artists.test.ts
+++ b/api/functions/__tests__/public-saved-artists.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const mocks = vi.hoisted(() => {
   return {
     mockFrom: vi.fn(),
+    mockReadAllPages: vi.fn(),
     mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
     mockGetClientIp: vi.fn(() => '127.0.0.1'),
   };
@@ -13,6 +14,7 @@ vi.mock('../db', () => ({
   getClient: () => ({
     from: mocks.mockFrom,
   }),
+  readAllPages: mocks.mockReadAllPages,
 }));
 vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -34,6 +36,8 @@ describe('public-saved-artists handler', () => {
     process.env.SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_KEY = 'service-key';
     mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    // Collection read defaults to empty; individual tests override.
+    mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [] });
   });
 
   afterEach(() => {
@@ -129,6 +133,85 @@ describe('public-saved-artists handler', () => {
     expect(body.user_id).toBeUndefined();
     expect(body.email).toBeUndefined();
     expect(body.saved_artists[0].user_id).toBeUndefined();
+  });
+
+  describe('public collection (Support Loop Step 3)', () => {
+    // usernames lookup + empty saved_artists; collection comes from mockReadAllPages.
+    function setupPublicUser() {
+      mocks.mockFrom.mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({
+              data: { user_id: 'user-1', username: 'testuser', saved_artists_public: true, location: null },
+              error: null,
+            })),
+          })),
+        })),
+      }).mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ data: [], error: null })),
+          })),
+        })),
+      });
+    }
+
+    it('includes purchased items, linking matched ones to their release page', async () => {
+      setupPublicUser();
+      mocks.mockReadAllPages.mockResolvedValue({
+        ok: true,
+        rows: [
+          {
+            title: 'Illinois',
+            artist_name: 'Sufjan Stevens',
+            art_url: null,
+            acquired_at: '2026-01-01T00:00:00Z',
+            releases: { slug: 'illinois', artwork_url: 'https://f4.bcbits.com/a.jpg', artists: { slug: 'sufjan-stevens' } },
+          },
+          {
+            title: 'Obscure Tape',
+            artist_name: 'Nobody We Know',
+            art_url: null,
+            acquired_at: null,
+            releases: null,
+          },
+        ],
+      });
+
+      const res = await handler(validEvent);
+      expect(res!.statusCode).toBe(200);
+      const body = JSON.parse(res!.body);
+      expect(body.collection).toHaveLength(2);
+      // Matched: release-page link and artwork fallback from the joined release.
+      expect(body.collection[0]).toEqual({
+        title: 'Illinois',
+        artist_name: 'Sufjan Stevens',
+        art_url: 'https://f4.bcbits.com/a.jpg',
+        acquired_at: '2026-01-01T00:00:00Z',
+        url: '/a/sufjan-stevens/illinois',
+      });
+      // Unmatched items still appear — they just don't link anywhere.
+      expect(body.collection[1].url).toBeNull();
+      expect(body.collection[1].title).toBe('Obscure Tape');
+    });
+
+    it('never exposes account metadata alongside the collection', async () => {
+      setupPublicUser();
+      mocks.mockReadAllPages.mockResolvedValue({
+        ok: true,
+        rows: [{ title: 'X', artist_name: 'Y', art_url: null, acquired_at: null, releases: null }],
+      });
+      const res = await handler(validEvent);
+      expect(res!.body).not.toContain('user-1');
+      expect(res!.body).not.toContain('user_id');
+    });
+
+    it('reports a failed collection read as an error, not an empty collection', async () => {
+      setupPublicUser();
+      mocks.mockReadAllPages.mockResolvedValue({ ok: false, reason: 'boom' });
+      const res = await handler(validEvent);
+      expect(res!.statusCode).toBe(500);
+    });
   });
 
   it('returns 200 with empty array when user has no saved artists', async () => {

--- a/api/functions/__tests__/public-saved-artists.test.ts
+++ b/api/functions/__tests__/public-saved-artists.test.ts
@@ -10,12 +10,17 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('../db', () => ({
-  getClient: () => ({
-    from: mocks.mockFrom,
-  }),
-  readAllPages: mocks.mockReadAllPages,
-}));
+// artistSlug is the REAL one: artist links are derived by slugging the Bandcamp name, and a
+// stub here would let this test pass while the derived slug drifted from what the artists
+// table actually stores.
+vi.mock('../db', async importOriginal => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    getClient: () => ({ from: mocks.mockFrom }),
+    readAllPages: mocks.mockReadAllPages,
+    artistSlug: actual.artistSlug,
+  };
+});
 vi.mock('../ratelimit', () => ({
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
@@ -162,6 +167,7 @@ describe('public-saved-artists handler', () => {
         ok: true,
         rows: [
           {
+            id: 'i-1',
             title: 'Illinois',
             artist_name: 'Sufjan Stevens',
             art_url: null,
@@ -169,6 +175,7 @@ describe('public-saved-artists handler', () => {
             releases: { slug: 'illinois', artwork_url: 'https://f4.bcbits.com/a.jpg', artists: { slug: 'sufjan-stevens' } },
           },
           {
+            id: 'i-2',
             title: 'Obscure Tape',
             artist_name: 'Nobody We Know',
             art_url: null,
@@ -177,22 +184,61 @@ describe('public-saved-artists handler', () => {
           },
         ],
       });
+      // Neither unmatched artist has a page.
+      mocks.mockFrom.mockReturnValue({
+        select: vi.fn(() => ({ in: vi.fn(() => Promise.resolve({ data: [], error: null })) })),
+      });
 
       const res = await handler(validEvent);
       expect(res!.statusCode).toBe(200);
       const body = JSON.parse(res!.body);
       expect(body.collection).toHaveLength(2);
-      // Matched: release-page link and artwork fallback from the joined release.
+      // Matched: release-page link, artist link, and artwork from the joined release.
       expect(body.collection[0]).toEqual({
+        id: 'i-1',
         title: 'Illinois',
         artist_name: 'Sufjan Stevens',
         art_url: 'https://f4.bcbits.com/a.jpg',
         acquired_at: '2026-01-01T00:00:00Z',
         url: '/a/sufjan-stevens/illinois',
+        artist_url: '/a/sufjan-stevens',
       });
-      // Unmatched items still appear — they just don't link anywhere.
-      expect(body.collection[1].url).toBeNull();
-      expect(body.collection[1].title).toBe('Obscure Tape');
+      // Unmatched items still appear: art comes from the proxy, and nothing is linked.
+      expect(body.collection[1]).toMatchObject({
+        title: 'Obscure Tape',
+        art_url: '/api/collection/art/i-2',
+        url: null,
+        artist_url: null,
+      });
+    });
+
+    it('links the artist when their page exists, even with no matched release', async () => {
+      setupPublicUser();
+      mocks.mockReadAllPages.mockResolvedValue({
+        ok: true,
+        rows: [
+          {
+            id: 'i-3',
+            title: 'under the blankets',
+            artist_name: 'Anne Sulikowski',
+            art_url: null,
+            acquired_at: null,
+            releases: null,
+          },
+        ],
+      });
+      // The artists table has the slug derived from that name.
+      mocks.mockFrom.mockReturnValue({
+        select: vi.fn(() => ({
+          in: vi.fn(() => Promise.resolve({ data: [{ slug: 'anne-sulikowski' }], error: null })),
+        })),
+      });
+
+      const res = await handler(validEvent);
+      const body = JSON.parse(res!.body);
+      expect(body.collection[0].artist_url).toBe('/a/anne-sulikowski');
+      // The release still isn't linked — only the artist page exists.
+      expect(body.collection[0].url).toBeNull();
     });
 
     it('never exposes account metadata alongside the collection', async () => {

--- a/api/functions/bandcamp-subsonic.ts
+++ b/api/functions/bandcamp-subsonic.ts
@@ -1,0 +1,203 @@
+// Subsonic client for Bandcamp's collection API (open beta, shipped 2026-07-16).
+//
+// Bandcamp speaks the Subsonic protocol at one known host, so this is a Subsonic client
+// pointed at one server. Kept Subsonic-shaped rather than Bandcamp-hardcoded on purpose:
+// if generic servers (Funkwhale, Navidrome, Airsonic, Jellyfin) ever come back into scope
+// they arrive as a group by making SUBSONIC_SERVER a parameter — see support-loop-spec.md
+// Step 1, "Deferred, not discarded". Until then the host is a constant, which is what keeps
+// this free of the SSRF surface a user-supplied server URL would open.
+//
+// Uses the ID3 endpoints (getArtists, getAlbumList2) rather than the folder-based ones —
+// better-structured data for a library import.
+//
+// SECURITY: Subsonic authentication travels in the query string (u, t, s). Request URLs
+// must therefore NEVER be logged, thrown, or attached to Sentry events. Errors carry the
+// method name and an error code only.
+
+import { createHash, randomBytes } from 'crypto';
+
+export const SUBSONIC_SERVER = 'https://bandcamp.com/api/subsonic';
+
+const SUBSONIC_VERSION = '1.16.1';
+const CLIENT_NAME = 'unstream';
+
+// Max page size the Subsonic spec allows for getAlbumList2.
+const PAGE_SIZE = 500;
+
+// Backstop against a server that never returns a short page (40 pages = 20,000 albums —
+// far past any real collection). Hitting it is reported as a failure, not a truncation:
+// a sync that silently stopped early would record a partial collection as complete.
+const MAX_PAGES = 40;
+
+// Bandcamp warns large libraries are slow in the beta; be generous per request.
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/** The stored credential: t = md5(password + s). The password itself is never stored. */
+export interface SubsonicCredential {
+  username: string;
+  t: string;
+  s: string;
+}
+
+export interface SubsonicAlbum {
+  id: string;
+  name: string;
+  artist: string;
+  coverArt?: string;
+  year?: number;
+  genre?: string;
+  /** ISO timestamp the server reports for the album entering the library. */
+  created?: string;
+}
+
+/** Subsonic error code 40 is "wrong username or password". */
+export class SubsonicError extends Error {
+  readonly code: number | null;
+
+  constructor(message: string, code: number | null = null) {
+    super(message);
+    this.name = 'SubsonicError';
+    this.code = code;
+  }
+  get isAuthFailure(): boolean {
+    return this.code === 40 || this.code === 41;
+  }
+}
+
+/**
+ * Derive the salted-token pair from a password, per the Subsonic spec:
+ * t = md5(password + salt). This is what gets encrypted and stored; the password is
+ * discarded by the caller immediately after. MD5 here is protocol-mandated, not a choice.
+ */
+export function deriveSubsonicToken(password: string): { t: string; s: string } {
+  const s = randomBytes(8).toString('hex');
+  const t = createHash('md5').update(password + s).digest('hex');
+  return { t, s };
+}
+
+function buildUrl(credential: SubsonicCredential, method: string, params: Record<string, string> = {}): string {
+  const query = new URLSearchParams({
+    u: credential.username,
+    t: credential.t,
+    s: credential.s,
+    v: SUBSONIC_VERSION,
+    c: CLIENT_NAME,
+    f: 'json',
+    ...params,
+  });
+  return `${SUBSONIC_SERVER}/rest/${method}.view?${query.toString()}`;
+}
+
+interface SubsonicResponseBody {
+  'subsonic-response'?: {
+    status?: string;
+    error?: { code?: number; message?: string };
+    artists?: { index?: { artist?: unknown[] }[] };
+    albumList2?: { album?: unknown[] };
+  };
+}
+
+/**
+ * One Subsonic call. Throws SubsonicError on transport failure, non-JSON, or a
+ * status:"failed" envelope. Never includes the URL in any error.
+ */
+async function subsonicRequest(
+  credential: SubsonicCredential,
+  method: string,
+  params: Record<string, string> = {}
+): Promise<NonNullable<SubsonicResponseBody['subsonic-response']>> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(buildUrl(credential, method, params), {
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new SubsonicError(`${method}: ${aborted ? 'timed out' : 'request failed'}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    throw new SubsonicError(`${method}: HTTP ${response.status}`);
+  }
+
+  let body: SubsonicResponseBody;
+  try {
+    body = (await response.json()) as SubsonicResponseBody;
+  } catch {
+    throw new SubsonicError(`${method}: non-JSON response`);
+  }
+
+  const envelope = body['subsonic-response'];
+  if (!envelope) {
+    throw new SubsonicError(`${method}: missing subsonic-response envelope`);
+  }
+  if (envelope.status !== 'ok') {
+    const code = envelope.error?.code ?? null;
+    throw new SubsonicError(
+      `${method}: ${envelope.error?.message || 'server reported failure'}`,
+      code
+    );
+  }
+  return envelope;
+}
+
+/** Verify a credential works. Throws SubsonicError (isAuthFailure for bad credentials). */
+export async function subsonicPing(credential: SubsonicCredential): Promise<void> {
+  await subsonicRequest(credential, 'ping');
+}
+
+/** Number of artists in the collection — the "it worked" confirmation on connect. */
+export async function subsonicArtistCount(credential: SubsonicCredential): Promise<number> {
+  const envelope = await subsonicRequest(credential, 'getArtists');
+  const indexes = envelope.artists?.index ?? [];
+  return indexes.reduce((sum, idx) => sum + (idx.artist?.length ?? 0), 0);
+}
+
+function toAlbum(raw: unknown): SubsonicAlbum | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  const id = record.id;
+  const name = record.name;
+  const artist = record.artist;
+  if (typeof id !== 'string' || typeof name !== 'string' || typeof artist !== 'string') {
+    return null;
+  }
+  return {
+    id,
+    name,
+    artist,
+    coverArt: typeof record.coverArt === 'string' ? record.coverArt : undefined,
+    year: typeof record.year === 'number' ? record.year : undefined,
+    genre: typeof record.genre === 'string' ? record.genre : undefined,
+    created: typeof record.created === 'string' ? record.created : undefined,
+  };
+}
+
+/**
+ * Fetch the whole collection via paginated getAlbumList2. Throws mid-pagination rather
+ * than returning what it has: a partial result recorded as a complete sync would be a
+ * silently wrong collection, which is the "never cache uncertainty" bug class.
+ */
+export async function subsonicFetchAllAlbums(
+  credential: SubsonicCredential
+): Promise<SubsonicAlbum[]> {
+  const albums: SubsonicAlbum[] = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const envelope = await subsonicRequest(credential, 'getAlbumList2', {
+      type: 'alphabeticalByArtist',
+      size: String(PAGE_SIZE),
+      offset: String(page * PAGE_SIZE),
+    });
+    const rawAlbums = envelope.albumList2?.album ?? [];
+    for (const raw of rawAlbums) {
+      const album = toAlbum(raw);
+      if (album) albums.push(album);
+    }
+    if (rawAlbums.length < PAGE_SIZE) return albums;
+  }
+  throw new SubsonicError('getAlbumList2: exceeded maximum page count');
+}

--- a/api/functions/bandcamp-subsonic.ts
+++ b/api/functions/bandcamp-subsonic.ts
@@ -178,6 +178,62 @@ function toAlbum(raw: unknown): SubsonicAlbum | null {
 }
 
 /**
+ * The `coverArt` id for one album, read from getAlbum.
+ *
+ * Needed because Subsonic's cover-art id is not required to equal the album id, and we
+ * don't store it — collection rows keep only the album id. Returns null when the server
+ * reports no art rather than throwing: a missing cover is an ordinary answer, not a fault.
+ */
+export async function subsonicAlbumCoverArtId(
+  credential: SubsonicCredential,
+  albumId: string
+): Promise<string | null> {
+  const envelope = await subsonicRequest(credential, 'getAlbum', { id: albumId });
+  const album = (envelope as Record<string, unknown>).album;
+  if (typeof album !== 'object' || album === null) return null;
+  const coverArt = (album as Record<string, unknown>).coverArt;
+  return typeof coverArt === 'string' && coverArt ? coverArt : null;
+}
+
+/**
+ * Fetch cover-art bytes. Unlike every other call here, a successful response is an image,
+ * not JSON — so a JSON body means the server is reporting an error (no art, bad id) and is
+ * returned as null. Callers must treat null as "no art", never as a failure worth caching
+ * as permanent.
+ */
+export async function subsonicFetchCoverArt(
+  credential: SubsonicCredential,
+  coverArtId: string,
+  size?: number
+): Promise<{ bytes: ArrayBuffer; contentType: string } | null> {
+  const params: Record<string, string> = { id: coverArtId };
+  if (size) params.size = String(size);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(buildUrl(credential, 'getCoverArt', params), {
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new SubsonicError(`getCoverArt: ${aborted ? 'timed out' : 'request failed'}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    throw new SubsonicError(`getCoverArt: HTTP ${response.status}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.startsWith('image/')) return null;
+
+  return { bytes: await response.arrayBuffer(), contentType };
+}
+
+/**
  * Fetch the whole collection via paginated getAlbumList2. Throws mid-pagination rather
  * than returning what it has: a partial result recorded as a complete sync would be a
  * silently wrong collection, which is the "never cache uncertainty" bug class.

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -39,23 +39,36 @@ interface MatchedRelease {
   artwork_url: string | null;
 }
 
+interface MatchedArtist {
+  id: string;
+  slug: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+interface LibraryMatches {
+  /** Subsonic album id → Unstream release, where title + artist matched exactly. */
+  releases: Map<string, MatchedRelease>;
+  /** Unstream artist id → artist, for every album whose artist matched unambiguously. */
+  artists: Map<string, MatchedArtist>;
+}
+
 /**
- * Match imported albums to Unstream releases by normalized artist name + normalized title
- * (releases.match_key is already normalizeForComparison output). Conservative on purpose:
- * an ambiguous artist name — two artist rows normalizing identically — matches nothing,
- * because a wrong release_id asserts the wrong record on a public page.
+ * Match imported albums to Unstream artists (by normalized name) and releases (by
+ * normalized artist name + normalized title — releases.match_key is already
+ * normalizeForComparison output). Conservative on purpose: an ambiguous artist name — two
+ * artist rows normalizing identically — matches nothing, because a wrong release_id or a
+ * wrong "supported" mark asserts the wrong fact about a user's support.
  */
-async function matchReleases(
-  albums: SubsonicAlbum[]
-): Promise<Map<string, MatchedRelease>> {
+async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   const client = getClient();
-  const matches = new Map<string, MatchedRelease>();
+  const matches: LibraryMatches = { releases: new Map(), artists: new Map() };
   if (!client || albums.length === 0) return matches;
 
   // The artists table is a few thousand rows; normalization has to happen in JS, so read
   // it once and match in memory rather than issuing a query per imported artist name.
-  const artistRead = await readAllPages<{ id: string; name: string }>(
-    (from, to) => client.from('artists').select('id, name').order('id').range(from, to),
+  const artistRead = await readAllPages<{ id: string; slug: string; name: string; image_url: string | null }>(
+    (from, to) => client.from('artists').select('id, slug, name, image_url').order('id').range(from, to),
     'artists (bandcamp-sync matching)'
   );
   if (!artistRead.ok) {
@@ -64,26 +77,30 @@ async function matchReleases(
     return matches;
   }
 
-  const artistsByNorm = new Map<string, string | 'ambiguous'>();
+  const artistsByNorm = new Map<string, MatchedArtist | 'ambiguous'>();
   for (const row of artistRead.rows) {
     const norm = normalizeForComparison(row.name);
     if (!norm) continue;
-    artistsByNorm.set(norm, artistsByNorm.has(norm) ? 'ambiguous' : row.id);
+    artistsByNorm.set(
+      norm,
+      artistsByNorm.has(norm)
+        ? 'ambiguous'
+        : { id: row.id, slug: row.slug, name: row.name, imageUrl: row.image_url }
+    );
   }
 
-  // Album -> candidate artist id, and the set of artist ids whose releases we need.
-  const albumArtistId = new Map<string, string>();
-  const neededArtistIds = new Set<string>();
+  // Album -> candidate artist, and the set of artist ids whose releases we need.
+  const albumArtist = new Map<string, MatchedArtist>();
   for (const album of albums) {
-    const artistId = artistsByNorm.get(normalizeForComparison(album.artist));
-    if (!artistId || artistId === 'ambiguous') continue;
-    albumArtistId.set(album.id, artistId);
-    neededArtistIds.add(artistId);
+    const artist = artistsByNorm.get(normalizeForComparison(album.artist));
+    if (!artist || artist === 'ambiguous') continue;
+    albumArtist.set(album.id, artist);
+    matches.artists.set(artist.id, artist);
   }
-  if (neededArtistIds.size === 0) return matches;
+  if (matches.artists.size === 0) return matches;
 
   const releaseByKey = new Map<string, MatchedRelease>();
-  const ids = [...neededArtistIds];
+  const ids = [...matches.artists.keys()];
   for (let i = 0; i < ids.length; i += RELEASE_LOOKUP_CHUNK) {
     const chunk = ids.slice(i, i + RELEASE_LOOKUP_CHUNK);
     const { data, error } = await client
@@ -106,12 +123,116 @@ async function matchReleases(
   }
 
   for (const album of albums) {
-    const artistId = albumArtistId.get(album.id);
-    if (!artistId) continue;
-    const release = releaseByKey.get(`${artistId}:${normalizeForComparison(album.name)}`);
-    if (release) matches.set(album.id, release);
+    const artist = albumArtist.get(album.id);
+    if (!artist) continue;
+    const release = releaseByKey.get(`${artist.id}:${normalizeForComparison(album.name)}`);
+    if (release) matches.releases.set(album.id, release);
   }
   return matches;
+}
+
+/** Slugs per saved_artists read — stays far below PostgREST's 1,000-row response cap. */
+const SAVED_LOOKUP_CHUNK = 100;
+
+/**
+ * Buying an artist's record IS supporting them, so a Bandcamp import marks every matched
+ * artist as saved + supported (Brandon, 2026-08-09, spec open question 6). Collection and
+ * saved list are two views of the same relationship.
+ *
+ * Three rules keep this from fighting the user:
+ *   - a row the user tombstoned (deleted=true) is left completely alone — permanent
+ *     dismissal is a locked spec decision and a re-sync must never resurrect it;
+ *   - an already-supported row keeps its original supported_at;
+ *   - only supported goes true; nothing here can ever un-support or overwrite notes.
+ *
+ * Failure here degrades, not fails: items are the sync's primary artifact, and the mark
+ * is derived state the next re-sync recomputes.
+ */
+async function markArtistsSupported(userId: string, artists: MatchedArtist[]): Promise<void> {
+  const client = getClient();
+  if (!client || artists.length === 0) return;
+
+  const bySlug = new Map(artists.map(a => [a.slug, a]));
+  const slugs = [...bySlug.keys()];
+  const existing = new Map<string, { supported: boolean; deleted: boolean }>();
+
+  for (let i = 0; i < slugs.length; i += SAVED_LOOKUP_CHUNK) {
+    const chunk = slugs.slice(i, i + SAVED_LOOKUP_CHUNK);
+    const { data, error } = await client
+      .from('saved_artists')
+      .select('artist_slug, supported, deleted')
+      .eq('user_id', userId)
+      .in('artist_slug', chunk);
+    if (error) {
+      // Without a reliable view of existing rows we can't insert safely (we might
+      // resurrect a tombstone), so skip this chunk's artists entirely.
+      console.warn('[bandcamp-sync] saved_artists read failed:', error.message);
+      Sentry.captureException(new Error(`saved_artists read failed: ${error.message}`), {
+        tags: { function: 'bandcamp-sync' },
+        extra: { stage: 'mark-supported' },
+      });
+      for (const slug of chunk) bySlug.delete(slug);
+      continue;
+    }
+    for (const row of data ?? []) {
+      existing.set(row.artist_slug, { supported: row.supported, deleted: row.deleted === true });
+    }
+  }
+
+  const serverNow = new Date().toISOString();
+  const toInsert = [...bySlug.values()]
+    .filter(a => !existing.has(a.slug))
+    .map(a => ({
+      user_id: userId,
+      artist_id: a.id,
+      artist_slug: a.slug,
+      artist_name: a.name,
+      artist_image_url: a.imageUrl,
+      supported: true,
+      supported_at: serverNow,
+      // Stamped server-side on insert so the row is immediately visible to the Apple
+      // app's ?since= incremental pulls — same reasoning as saved-artists.ts.
+      last_modified: serverNow,
+    }));
+
+  const toSupport = [...bySlug.values()]
+    .filter(a => {
+      const row = existing.get(a.slug);
+      return row !== undefined && !row.deleted && !row.supported;
+    })
+    .map(a => a.slug);
+
+  for (let i = 0; i < toInsert.length; i += SAVED_LOOKUP_CHUNK) {
+    const { error } = await client
+      .from('saved_artists')
+      .upsert(toInsert.slice(i, i + SAVED_LOOKUP_CHUNK), { onConflict: 'user_id,artist_slug' });
+    if (error) {
+      console.warn('[bandcamp-sync] saved_artists insert failed:', error.message);
+      Sentry.captureException(new Error(`saved_artists insert failed: ${error.message}`), {
+        tags: { function: 'bandcamp-sync' },
+        extra: { stage: 'mark-supported' },
+      });
+    }
+  }
+
+  for (let i = 0; i < toSupport.length; i += SAVED_LOOKUP_CHUNK) {
+    const { error } = await client
+      .from('saved_artists')
+      .update({ supported: true, supported_at: serverNow, last_modified: serverNow })
+      .eq('user_id', userId)
+      .in('artist_slug', toSupport.slice(i, i + SAVED_LOOKUP_CHUNK));
+    if (error) {
+      console.warn('[bandcamp-sync] saved_artists support update failed:', error.message);
+      Sentry.captureException(new Error(`saved_artists support update failed: ${error.message}`), {
+        tags: { function: 'bandcamp-sync' },
+        extra: { stage: 'mark-supported' },
+      });
+    }
+  }
+
+  if (toInsert.length > 0 || toSupport.length > 0) {
+    console.log(`[bandcamp-sync] marked supported: ${toInsert.length} new, ${toSupport.length} upgraded`);
+  }
 }
 
 export async function handler(event: {
@@ -189,7 +310,7 @@ export async function handler(event: {
     }
     const uniqueAlbums = [...byId.values()];
 
-    const releaseMatches = await matchReleases(uniqueAlbums);
+    const matches = await matchLibrary(uniqueAlbums);
 
     const rows = uniqueAlbums.map(album => ({
       user_id: userId,
@@ -197,11 +318,11 @@ export async function handler(event: {
       external_id: album.id,
       title: album.name,
       artist_name: album.artist,
-      art_url: releaseMatches.get(album.id)?.artwork_url ?? null,
+      art_url: matches.releases.get(album.id)?.artwork_url ?? null,
       acquired_at: album.created ?? null,
       provenance: 'purchased', // a Bandcamp collection is proof of purchase — spec §5
       acquisition: 'unknown',
-      release_id: releaseMatches.get(album.id)?.id ?? null,
+      release_id: matches.releases.get(album.id)?.id ?? null,
       // `hidden` deliberately omitted: re-syncs must not un-hide items the user hid.
     }));
 
@@ -214,6 +335,10 @@ export async function handler(event: {
         throw new Error(`collection_items upsert failed: ${error.message}`);
       }
     }
+
+    // Buying is supporting: mark every matched artist saved + supported. After the items
+    // land — the mark is derived state, and a failure inside degrades rather than throwing.
+    await markArtistsSupported(userId, [...matches.artists.values()]);
 
     const { error: doneError } = await client
       .from('bandcamp_connections')
@@ -228,11 +353,15 @@ export async function handler(event: {
       throw new Error(`connection status update failed: ${doneError.message}`);
     }
 
-    console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${releaseMatches.size} matched to releases)`);
+    console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${matches.releases.size} matched to releases, ${matches.artists.size} artists)`);
     return {
       statusCode: 200,
       headers: RESPONSE_HEADERS,
-      body: JSON.stringify({ imported: uniqueAlbums.length, matched: releaseMatches.size }),
+      body: JSON.stringify({
+        imported: uniqueAlbums.length,
+        matched: matches.releases.size,
+        artistsMarked: matches.artists.size,
+      }),
     };
   } catch (error) {
     const isAuth = error instanceof SubsonicError && error.isAuthFailure;

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -1,0 +1,248 @@
+// Netlify Background Function: import a user's Bandcamp collection into collection_items.
+//
+// Invoked by me-bandcamp.ts on connect and re-sync. A `-background` function returns 202
+// to its caller immediately and then runs for up to 15 minutes — Bandcamp warns that large
+// libraries sync slowly in the beta, so this must be off the request path.
+//
+// Authenticated with the shared internal secret (isInternalRequest), same as
+// catalog-artist-background.ts: an open endpoint that makes Unstream hit Bandcamp with a
+// stored credential on demand would be both an amplifier and a credential oracle.
+//
+// Failure semantics — the "never cache uncertainty" rule applied to a sync: a fetch that
+// dies mid-pagination throws (see subsonicFetchAllAlbums) and lands in the catch block,
+// which records sync_status='error' on the connection row. It must never record a partial
+// import as a completed sync — that would show a user a quietly wrong collection.
+
+import { Sentry } from '../lib/sentry';
+import { getClient, readAllPages } from './db';
+import { isInternalRequest } from './middleware';
+import { decryptCredential } from './credential-crypto';
+import {
+  subsonicFetchAllAlbums,
+  SubsonicError,
+  type SubsonicAlbum,
+  type SubsonicCredential,
+} from './bandcamp-subsonic';
+import { normalizeForComparison } from './search-utils';
+
+const RESPONSE_HEADERS = { 'Content-Type': 'application/json' };
+
+/** Rows per upsert batch — keeps each PostgREST request comfortably sized. */
+const UPSERT_CHUNK = 500;
+
+/** Artist ids per releases lookup. Small enough that even prolific artists stay far
+ *  under PostgREST's silent 1,000-row response cap. */
+const RELEASE_LOOKUP_CHUNK = 50;
+
+interface MatchedRelease {
+  id: string;
+  artwork_url: string | null;
+}
+
+/**
+ * Match imported albums to Unstream releases by normalized artist name + normalized title
+ * (releases.match_key is already normalizeForComparison output). Conservative on purpose:
+ * an ambiguous artist name — two artist rows normalizing identically — matches nothing,
+ * because a wrong release_id asserts the wrong record on a public page.
+ */
+async function matchReleases(
+  albums: SubsonicAlbum[]
+): Promise<Map<string, MatchedRelease>> {
+  const client = getClient();
+  const matches = new Map<string, MatchedRelease>();
+  if (!client || albums.length === 0) return matches;
+
+  // The artists table is a few thousand rows; normalization has to happen in JS, so read
+  // it once and match in memory rather than issuing a query per imported artist name.
+  const artistRead = await readAllPages<{ id: string; name: string }>(
+    (from, to) => client.from('artists').select('id, name').order('id').range(from, to),
+    'artists (bandcamp-sync matching)'
+  );
+  if (!artistRead.ok) {
+    // Matching is enrichment: a failed read degrades to an unmatched import, not a failed sync.
+    console.warn('[bandcamp-sync] artist read failed, importing unmatched:', artistRead.reason);
+    return matches;
+  }
+
+  const artistsByNorm = new Map<string, string | 'ambiguous'>();
+  for (const row of artistRead.rows) {
+    const norm = normalizeForComparison(row.name);
+    if (!norm) continue;
+    artistsByNorm.set(norm, artistsByNorm.has(norm) ? 'ambiguous' : row.id);
+  }
+
+  // Album -> candidate artist id, and the set of artist ids whose releases we need.
+  const albumArtistId = new Map<string, string>();
+  const neededArtistIds = new Set<string>();
+  for (const album of albums) {
+    const artistId = artistsByNorm.get(normalizeForComparison(album.artist));
+    if (!artistId || artistId === 'ambiguous') continue;
+    albumArtistId.set(album.id, artistId);
+    neededArtistIds.add(artistId);
+  }
+  if (neededArtistIds.size === 0) return matches;
+
+  const releaseByKey = new Map<string, MatchedRelease>();
+  const ids = [...neededArtistIds];
+  for (let i = 0; i < ids.length; i += RELEASE_LOOKUP_CHUNK) {
+    const chunk = ids.slice(i, i + RELEASE_LOOKUP_CHUNK);
+    const { data, error } = await client
+      .from('releases')
+      .select('id, artist_id, match_key, artwork_url')
+      .in('artist_id', chunk)
+      .eq('is_hidden', false);
+    if (error) {
+      // Matching is best-effort enrichment; a failed lookup degrades to unmatched items,
+      // it doesn't fail the sync. Log so a systematic failure is visible.
+      console.warn('[bandcamp-sync] release lookup failed:', error.message);
+      continue;
+    }
+    for (const row of data ?? []) {
+      releaseByKey.set(`${row.artist_id}:${row.match_key}`, {
+        id: row.id,
+        artwork_url: row.artwork_url,
+      });
+    }
+  }
+
+  for (const album of albums) {
+    const artistId = albumArtistId.get(album.id);
+    if (!artistId) continue;
+    const release = releaseByKey.get(`${artistId}:${normalizeForComparison(album.name)}`);
+    if (release) matches.set(album.id, release);
+  }
+  return matches;
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+  if (!isInternalRequest(event.headers.authorization)) {
+    return { statusCode: 401, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  let userId: string;
+  try {
+    const body = JSON.parse(event.body || '{}');
+    userId = typeof body.userId === 'string' ? body.userId : '';
+  } catch {
+    return { statusCode: 400, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  }
+  if (!userId) {
+    return { statusCode: 400, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'userId is required' }) };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const { data: connection, error: connectionError } = await client
+    .from('bandcamp_connections')
+    .select('bandcamp_username, credential_ciphertext')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (connectionError) {
+    console.error('[bandcamp-sync] Error loading connection:', connectionError.message);
+    return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Failed to load connection' }) };
+  }
+  if (!connection) {
+    // Disconnected between request and run — nothing to do, and no row to mark.
+    console.log('[bandcamp-sync] no connection row for user — skipping');
+    return { statusCode: 200, headers: RESPONSE_HEADERS, body: JSON.stringify({ skipped: true }) };
+  }
+
+  async function recordFailure(message: string) {
+    await client!
+      .from('bandcamp_connections')
+      .update({ sync_status: 'error', sync_error: message })
+      .eq('user_id', userId);
+  }
+
+  try {
+    let credential: SubsonicCredential;
+    try {
+      const { t, s } = JSON.parse(decryptCredential(connection.credential_ciphertext));
+      credential = { username: connection.bandcamp_username, t, s };
+    } catch (error) {
+      // Undecryptable means unusable (key rotated, blob corrupted) — the user has to
+      // reconnect; retrying can never succeed.
+      console.error('[bandcamp-sync] credential decrypt failed');
+      Sentry.captureException(error, { tags: { function: 'bandcamp-sync' }, extra: { stage: 'decrypt' } });
+      await recordFailure('The stored credential is no longer readable. Disconnect and reconnect Bandcamp.');
+      return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Credential unusable' }) };
+    }
+
+    const albums = await subsonicFetchAllAlbums(credential);
+
+    // Dedupe by Subsonic id — a duplicate in one upsert batch is a Postgres error
+    // ("cannot affect row a second time"), not a harmless overwrite.
+    const byId = new Map<string, SubsonicAlbum>();
+    for (const album of albums) {
+      if (!byId.has(album.id)) byId.set(album.id, album);
+    }
+    const uniqueAlbums = [...byId.values()];
+
+    const releaseMatches = await matchReleases(uniqueAlbums);
+
+    const rows = uniqueAlbums.map(album => ({
+      user_id: userId,
+      source: 'bandcamp',
+      external_id: album.id,
+      title: album.name,
+      artist_name: album.artist,
+      art_url: releaseMatches.get(album.id)?.artwork_url ?? null,
+      acquired_at: album.created ?? null,
+      provenance: 'purchased', // a Bandcamp collection is proof of purchase — spec §5
+      acquisition: 'unknown',
+      release_id: releaseMatches.get(album.id)?.id ?? null,
+      // `hidden` deliberately omitted: re-syncs must not un-hide items the user hid.
+    }));
+
+    for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
+      const chunk = rows.slice(i, i + UPSERT_CHUNK);
+      const { error } = await client
+        .from('collection_items')
+        .upsert(chunk, { onConflict: 'user_id,source,external_id' });
+      if (error) {
+        throw new Error(`collection_items upsert failed: ${error.message}`);
+      }
+    }
+
+    const { error: doneError } = await client
+      .from('bandcamp_connections')
+      .update({
+        sync_status: 'idle',
+        sync_error: null,
+        item_count: uniqueAlbums.length,
+        last_synced_at: new Date().toISOString(),
+      })
+      .eq('user_id', userId);
+    if (doneError) {
+      throw new Error(`connection status update failed: ${doneError.message}`);
+    }
+
+    console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${releaseMatches.size} matched to releases)`);
+    return {
+      statusCode: 200,
+      headers: RESPONSE_HEADERS,
+      body: JSON.stringify({ imported: uniqueAlbums.length, matched: releaseMatches.size }),
+    };
+  } catch (error) {
+    const isAuth = error instanceof SubsonicError && error.isAuthFailure;
+    console.error('[bandcamp-sync] sync failed:', error instanceof Error ? error.message : String(error));
+    Sentry.captureException(error, { tags: { function: 'bandcamp-sync' }, extra: { stage: 'sync' } });
+    await recordFailure(
+      isAuth
+        ? 'Bandcamp rejected the stored credential. Disconnect and reconnect with a fresh credential from Fan Settings → Subsonic.'
+        : 'The sync failed partway through. Bandcamp’s Subsonic support is in beta — use Re-sync to try again.'
+    );
+    return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Sync failed' }) };
+  }
+}

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -291,11 +291,20 @@ export async function handler(event: {
     try {
       const { t, s } = JSON.parse(decryptCredential(connection.credential_ciphertext));
       credential = { username: connection.bandcamp_username, t, s };
-    } catch (error) {
+    } catch {
       // Undecryptable means unusable (key rotated, blob corrupted) — the user has to
       // reconnect; retrying can never succeed.
+      //
+      // The caught error is deliberately NOT forwarded. If decryption succeeded but
+      // JSON.parse rejected the result, V8 embeds a snippet of the parsed string in the
+      // SyntaxError message — and that string is the decrypted credential. Reporting a
+      // synthetic error keeps the rule absolute: the credential never reaches Sentry, even
+      // inside an exception message.
       console.error('[bandcamp-sync] credential decrypt failed');
-      Sentry.captureException(error, { tags: { function: 'bandcamp-sync' }, extra: { stage: 'decrypt' } });
+      Sentry.captureException(new Error('bandcamp credential could not be decrypted or parsed'), {
+        tags: { function: 'bandcamp-sync' },
+        extra: { stage: 'decrypt' },
+      });
       await recordFailure('The stored credential is no longer readable. Disconnect and reconnect Bandcamp.');
       return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Credential unusable' }) };
     }

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -369,7 +369,7 @@ export async function handler(event: {
     Sentry.captureException(error, { tags: { function: 'bandcamp-sync' }, extra: { stage: 'sync' } });
     await recordFailure(
       isAuth
-        ? 'Bandcamp rejected the stored credential. Disconnect and reconnect with a fresh credential from Fan Settings → Subsonic.'
+        ? 'Bandcamp rejected the stored login. Disconnect and reconnect with a fresh username and password from Fan Settings → Subsonic.'
         : 'The sync failed partway through. Bandcamp’s Subsonic support is in beta — use Re-sync to try again.'
     );
     return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Sync failed' }) };

--- a/api/functions/collection-art.ts
+++ b/api/functions/collection-art.ts
@@ -1,0 +1,191 @@
+// API endpoint: /api/collection/art/{collectionItemId}
+// GET — the cover art for one collection item, fetched from Bandcamp server-side.
+//
+// Why a proxy rather than a stored URL: Subsonic serves cover art from an authenticated
+// endpoint (`getCoverArt`), and its credentials travel in the query string. Putting that URL
+// in an <img src> would publish the user's Bandcamp credential to every viewer and every
+// referrer log. So the image is fetched here, with the credential decrypted server-side, and
+// only the bytes go out.
+//
+// This is what fills the gap left by release matching: art_url is populated only for items
+// matched to an Unstream release (28% of a real 190-item collection when measured
+// 2026-08-13), and a grid that is three-quarters empty boxes reads as broken.
+//
+// Cached hard at the CDN — one Bandcamp request per image per edge per month — because
+// otherwise every page view would re-fetch every tile. Pagination (15 tiles a page) bounds
+// the burst on a cold cache.
+
+import { createClient } from '@supabase/supabase-js';
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { decryptCredential } from './credential-crypto';
+import {
+  subsonicAlbumCoverArtId,
+  subsonicFetchCoverArt,
+  type SubsonicCredential,
+} from './bandcamp-subsonic';
+
+const BASE_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+const JSON_HEADERS = { ...BASE_HEADERS, 'Content-Type': 'application/json' };
+
+/** A month at the CDN, a day in the browser. Album art for a bought record doesn't change. */
+const IMAGE_CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=86400',
+  'Netlify-CDN-Cache-Control': 'public, s-maxage=2592000, stale-while-revalidate=86400',
+};
+
+/**
+ * A negative answer is cached far more briefly than an image. "No art" is usually permanent,
+ * but this path also returns 404 when Bandcamp is unreachable, and caching *that* for a month
+ * would turn a blip into a lasting hole in someone's collection page.
+ */
+const MISS_CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=300',
+  'Netlify-CDN-Cache-Control': 'public, s-maxage=300',
+};
+
+interface ItemRow {
+  user_id: string;
+  external_id: string | null;
+  provenance: string;
+  hidden: boolean;
+}
+
+/** Declared so header lookups stay typed — this handler returns images as well as JSON. */
+interface FunctionResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  isBase64Encoded?: boolean;
+}
+
+async function authenticatedUserId(authHeader: string | undefined): Promise<string | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+  const { data, error } = await createClient(url, anonKey).auth.getUser(authHeader.slice(7));
+  if (error || !data.user) return null;
+  return data.user.id;
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  path?: string;
+  pathParameters?: Record<string, string | undefined>;
+}): Promise<FunctionResponse> {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: BASE_HEADERS, body: '' };
+  }
+  if (event.httpMethod !== 'GET') {
+    return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+  }
+
+  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', JSON_HEADERS);
+  // `response` is optional on the rate-limit result, so returning it bare can hand Netlify
+  // `undefined`. Substitute a plain 429 rather than relying on the caller's shape.
+  if (rl.limited) {
+    return rl.response ?? { statusCode: 429, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Rate limited' }) };
+  }
+
+  const itemId = (event.pathParameters?.id || event.path?.split('/').pop() || '').replace(/\/$/, '');
+  if (!/^[0-9a-f-]{36}$/i.test(itemId)) {
+    return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Invalid item id' }) };
+  }
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const { data: item, error: itemError } = await client
+    .from('collection_items')
+    .select('user_id, external_id, provenance, hidden')
+    .eq('id', itemId)
+    .maybeSingle<ItemRow>();
+
+  if (itemError) {
+    console.error('[collection-art] item lookup failed:', itemError.message);
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+  }
+  if (!item || !item.external_id) {
+    return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'Not found' }) };
+  }
+
+  // Two ways to be allowed to see this: you own it, or it is on a page anyone can see.
+  // The public test mirrors the public page exactly — purchased, not hidden, sharing on —
+  // so this endpoint can never expose a tile the page itself would withhold.
+  const viewerId = await authenticatedUserId(event.headers.authorization);
+  let allowed = viewerId === item.user_id;
+
+  if (!allowed) {
+    if (item.provenance !== 'purchased' || item.hidden) {
+      return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+    }
+    const { data: owner } = await client
+      .from('usernames')
+      .select('saved_artists_public')
+      .eq('user_id', item.user_id)
+      .maybeSingle();
+    allowed = owner?.saved_artists_public === true;
+  }
+
+  if (!allowed) {
+    // 404 rather than 403, matching the public page: don't confirm the item exists.
+    return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+  }
+
+  const { data: connection } = await client
+    .from('bandcamp_connections')
+    .select('bandcamp_username, credential_ciphertext')
+    .eq('user_id', item.user_id)
+    .maybeSingle();
+
+  if (!connection) {
+    return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'No art available' }) };
+  }
+
+  let credential: SubsonicCredential;
+  try {
+    const { t, s } = JSON.parse(decryptCredential(connection.credential_ciphertext));
+    credential = { username: connection.bandcamp_username, t, s };
+  } catch {
+    // Never forward the caught error: a JSON.parse failure would carry a snippet of the
+    // decrypted credential in its message. Same rule as bandcamp-sync-background.
+    console.error('[collection-art] credential decrypt failed');
+    return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'No art available' }) };
+  }
+
+  try {
+    // The album id is not guaranteed to be the cover-art id, so ask the album for it.
+    const coverArtId = await subsonicAlbumCoverArtId(credential, item.external_id);
+    const art = coverArtId ? await subsonicFetchCoverArt(credential, coverArtId, 600) : null;
+
+    if (!art) {
+      return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'No art available' }) };
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        ...BASE_HEADERS,
+        ...IMAGE_CACHE_HEADERS,
+        'Content-Type': art.contentType,
+      },
+      body: Buffer.from(art.bytes).toString('base64'),
+      isBase64Encoded: true,
+    };
+  } catch (error) {
+    // Bandcamp unreachable or erroring. A short-cached 404 so the tile falls back to its
+    // title placeholder now and can recover on the next request — never a long cache, which
+    // would freeze a transient failure into a permanent gap.
+    console.warn('[collection-art] art fetch failed:', error instanceof Error ? error.message : String(error));
+    return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'No art available' }) };
+  }
+}

--- a/api/functions/collection-utils.ts
+++ b/api/functions/collection-utils.ts
@@ -1,0 +1,83 @@
+// Shared shaping for collection reads — used by the owner's view (me-collection) and the
+// public page (public-saved-artists), so the two can't drift in what they link to.
+
+import { artistSlug, getClient } from './db';
+
+/** Slugs per lookup. A 190-item collection is ~96 artists, so this is one query in practice. */
+const ARTIST_LOOKUP_CHUNK = 100;
+
+export interface CollectionRowWithRelease {
+  title: string;
+  artist_name: string;
+  art_url: string | null;
+  releases?: { slug: string; artwork_url: string | null; artists: { slug: string } | null } | null;
+}
+
+/**
+ * Which of these artist names have a page on Unstream, by name → slug.
+ *
+ * The Bandcamp import stores the artist's name as Bandcamp spells it, not a foreign key, so
+ * "does this artist have a page?" is answered by deriving the slug the same way every other
+ * writer does — `artistSlug()` — and asking whether that row exists. Deriving it here rather
+ * than storing a column keeps a rename in the artists table from stranding a dead link, and
+ * avoids a migration on a table whose last one is still waiting to merge.
+ *
+ * Artists with no page are simply absent from the map: the caller renders their name as
+ * plain text rather than a link to a 404.
+ */
+export async function resolveArtistPages(names: string[]): Promise<Map<string, string>> {
+  const resolved = new Map<string, string>();
+  const client = getClient();
+  if (!client || names.length === 0) return resolved;
+
+  // slug → the names that derive it (several spellings can collapse to one slug).
+  const namesBySlug = new Map<string, string[]>();
+  for (const name of new Set(names)) {
+    const slug = artistSlug(name);
+    if (!slug) continue;
+    const existing = namesBySlug.get(slug);
+    if (existing) existing.push(name);
+    else namesBySlug.set(slug, [name]);
+  }
+
+  const slugs = [...namesBySlug.keys()];
+  for (let i = 0; i < slugs.length; i += ARTIST_LOOKUP_CHUNK) {
+    const chunk = slugs.slice(i, i + ARTIST_LOOKUP_CHUNK);
+    const { data, error } = await client.from('artists').select('slug').in('slug', chunk);
+    if (error) {
+      // Links are an enhancement; a failed lookup degrades to unlinked names, it doesn't
+      // fail the page.
+      console.warn('[collection] artist page lookup failed:', error.message);
+      continue;
+    }
+    for (const row of data ?? []) {
+      for (const name of namesBySlug.get(row.slug) ?? []) resolved.set(name, row.slug);
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * The release page for a collection item, when we matched it to one. Null otherwise — an
+ * unmatched item still renders, it just isn't a link.
+ */
+export function releaseUrlFor(row: CollectionRowWithRelease): string | null {
+  const release = row.releases;
+  const artist = release?.artists?.slug;
+  return release?.slug && artist ? `/a/${artist}/${release.slug}` : null;
+}
+
+/**
+ * The artist page for a collection item. Prefers the artist the matched release actually
+ * belongs to — that one is a verified relationship — and falls back to the name lookup.
+ */
+export function artistUrlFor(
+  row: CollectionRowWithRelease,
+  artistPages: Map<string, string>
+): string | null {
+  const fromRelease = row.releases?.artists?.slug;
+  if (fromRelease) return `/a/${fromRelease}`;
+  const bySlug = artistPages.get(row.artist_name);
+  return bySlug ? `/a/${bySlug}` : null;
+}

--- a/api/functions/credential-crypto.ts
+++ b/api/functions/credential-crypto.ts
@@ -1,0 +1,78 @@
+// Encryption for stored third-party credentials (bandcamp_connections.credential_ciphertext).
+//
+// This is the repo's first at-rest encryption, so the choice is deliberate rather than an
+// implementation detail. Three options were on the table:
+//
+//   - pgcrypto: the key is passed inside SQL text, so it lands in Postgres logs and
+//     pg_stat_statements. Rejected.
+//   - Supabase Vault: key and ciphertext live in the same trust domain (the database), and
+//     decryption can't be unit-tested without a live DB. Rejected.
+//   - App-level AES-256-GCM with the key in a Netlify env var (this file): the ciphertext
+//     lives in Supabase, the key lives in Netlify — a leak of either store alone reveals
+//     nothing. Same handling as BUTTONDOWN_API_KEY. Chosen.
+//
+// Node's crypto module, not crypto.subtle — Netlify's Node runtime has had gaps in
+// crypto.subtle support before (see me-feed-token.ts history).
+//
+// Key: BANDCAMP_CREDENTIAL_KEY, 32 bytes, base64-encoded. Generate one with:
+//   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+//
+// Rotating the key invalidates every stored credential; users would reconnect. That is the
+// accepted trade-off for never writing the key anywhere but the env.
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // NIST-recommended nonce size for GCM
+
+function getKey(): Buffer {
+  const raw = process.env.BANDCAMP_CREDENTIAL_KEY;
+  if (!raw) {
+    throw new Error('BANDCAMP_CREDENTIAL_KEY is not configured');
+  }
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== 32) {
+    throw new Error('BANDCAMP_CREDENTIAL_KEY must be 32 bytes, base64-encoded');
+  }
+  return key;
+}
+
+/** True when the env carries a usable key. Callers use this to fail fast with a clear 500. */
+export function isCredentialKeyConfigured(): boolean {
+  try {
+    getKey();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Encrypt a plaintext string. Returns `base64(iv).base64(authTag).base64(ciphertext)` —
+ * dot-separated so it stores as one opaque text column.
+ */
+export function encryptCredential(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('base64')}.${authTag.toString('base64')}.${ciphertext.toString('base64')}`;
+}
+
+/**
+ * Decrypt a value produced by encryptCredential. Throws on a malformed blob, a wrong key,
+ * or any tampering (GCM authenticates) — callers treat a throw as "credential unusable,
+ * user must reconnect", never as an empty credential.
+ */
+export function decryptCredential(blob: string): string {
+  const key = getKey();
+  const parts = blob.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Malformed credential ciphertext');
+  }
+  const [iv, authTag, ciphertext] = parts.map(p => Buffer.from(p, 'base64'));
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -213,10 +213,10 @@ export async function handler(event: {
     const username = typeof body.username === 'string' ? body.username.trim() : '';
     const password = typeof body.password === 'string' ? body.password : '';
     if (!username || username.length > 200) {
-      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'A Bandcamp username is required' }) };
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'The username Bandcamp generated is required' }) };
     }
     if (!password || password.length > 500) {
-      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'The credential from Bandcamp’s Fan Settings is required' }) };
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'The password Bandcamp generated is required' }) };
     }
 
     if (!isCredentialKeyConfigured()) {
@@ -240,7 +240,7 @@ export async function handler(event: {
         return {
           statusCode: 400,
           headers: CORS_HEADERS,
-          body: JSON.stringify({ error: 'Bandcamp rejected that username or credential. Check both in Bandcamp’s Fan Settings → Subsonic.' }),
+          body: JSON.stringify({ error: 'Bandcamp rejected that username or password. Check both against Fan Settings → Subsonic on Bandcamp.' }),
         };
       }
       console.warn('[me-bandcamp] Bandcamp ping failed:', error instanceof Error ? error.message : String(error));

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -1,0 +1,336 @@
+// API endpoint: /api/me/bandcamp
+// GET    — connection status: connected, username, sync state, item count, last sync.
+// POST   — { username, password }: connect. Verifies against Bandcamp's Subsonic API,
+//          stores the encrypted salted-token pair (never the password), starts a sync.
+//          { resync: true }: re-run the import for an existing connection.
+// DELETE — { deleteItems? }: disconnect. Deletes the credential row; optionally deletes
+//          imported collection items too.
+//
+// Support Loop Step 1 (support-loop-spec.md). Credential rules from collection-spec.md §4:
+// the password exists only inside the POST request — it is converted to the Subsonic
+// (t, s) pair, encrypted (credential-crypto.ts), and discarded. It must never be logged,
+// stored, echoed back, or attached to a Sentry event.
+
+import { createClient } from '@supabase/supabase-js';
+import { Sentry } from '../lib/sentry';
+import { getClient } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { encryptCredential, isCredentialKeyConfigured } from './credential-crypto';
+import {
+  deriveSubsonicToken,
+  subsonicPing,
+  subsonicArtistCount,
+  SubsonicError,
+} from './bandcamp-subsonic';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+};
+
+interface ConnectionRow {
+  bandcamp_username: string;
+  sync_status: string;
+  sync_error: string | null;
+  item_count: number | null;
+  last_synced_at: string | null;
+}
+
+function toStatusShape(row: ConnectionRow | null) {
+  if (!row) return { connected: false as const };
+  return {
+    connected: true as const,
+    username: row.bandcamp_username,
+    syncStatus: row.sync_status,
+    syncError: row.sync_error,
+    itemCount: row.item_count,
+    lastSyncedAt: row.last_synced_at,
+  };
+}
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { userId: data.user.id };
+}
+
+/**
+ * Ask the background function to run the import. Returns false when it couldn't be asked
+ * (missing config, network) — the caller records that as a sync error rather than leaving
+ * the row claiming a sync that will never happen. Same handshake as request-catalog.ts:
+ * Netlify answers 202 immediately, so there is no result to read back.
+ */
+async function requestSync(userId: string): Promise<boolean> {
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+  // `URL` and not `DEPLOY_PRIME_URL`: only URL, SITE_NAME and SITE_ID reach a function at
+  // runtime — see request-catalog.ts.
+  const siteUrl = process.env.URL;
+  if (!secret || !siteUrl) {
+    console.log('[me-bandcamp] sync not requested — INTERNAL_FUNCTION_SECRET or site URL not configured');
+    return false;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 3_000);
+    try {
+      await fetch(`${siteUrl}/.netlify/functions/bandcamp-sync-background`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${secret}`,
+        },
+        body: JSON.stringify({ userId }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+    return true;
+  } catch (error) {
+    console.warn('[me-bandcamp] sync request failed:', error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+const SYNC_START_FAILED = 'Sync could not be started. Use Re-sync to try again.';
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    const { data: row, error } = await client
+      .from('bandcamp_connections')
+      .select('bandcamp_username, sync_status, sync_error, item_count, last_synced_at')
+      .eq('user_id', user.userId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[me-bandcamp] Error fetching connection:', error.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load connection status' }) };
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(toStatusShape(row)) };
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    // Re-sync an existing connection.
+    if (body.resync === true) {
+      const { data: existing, error } = await client
+        .from('bandcamp_connections')
+        .select('sync_status')
+        .eq('user_id', user.userId)
+        .maybeSingle();
+      if (error) {
+        console.error('[me-bandcamp] Error checking connection for resync:', error.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to start sync' }) };
+      }
+      if (!existing) {
+        return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'No Bandcamp connection to sync' }) };
+      }
+      if (existing.sync_status === 'syncing') {
+        return { statusCode: 409, headers: CORS_HEADERS, body: JSON.stringify({ error: 'A sync is already running' }) };
+      }
+
+      // Mark syncing before asking: the background function reads this row, so the
+      // status write must land first (same ordering as connect below).
+      const { error: markError } = await client
+        .from('bandcamp_connections')
+        .update({ sync_status: 'syncing', sync_error: null })
+        .eq('user_id', user.userId);
+      if (markError) {
+        console.error('[me-bandcamp] Error updating sync status:', markError.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to start sync' }) };
+      }
+
+      const started = await requestSync(user.userId);
+      if (!started) {
+        await client
+          .from('bandcamp_connections')
+          .update({ sync_status: 'error', sync_error: SYNC_START_FAILED })
+          .eq('user_id', user.userId);
+      }
+
+      const { data: row, error: readError } = await client
+        .from('bandcamp_connections')
+        .select('bandcamp_username, sync_status, sync_error, item_count, last_synced_at')
+        .eq('user_id', user.userId)
+        .single();
+      if (readError) {
+        console.error('[me-bandcamp] Error reading connection after resync:', readError.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to start sync' }) };
+      }
+      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(toStatusShape(row)) };
+    }
+
+    // Connect.
+    const username = typeof body.username === 'string' ? body.username.trim() : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+    if (!username || username.length > 200) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'A Bandcamp username is required' }) };
+    }
+    if (!password || password.length > 500) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'The credential from Bandcamp’s Fan Settings is required' }) };
+    }
+
+    if (!isCredentialKeyConfigured()) {
+      // Configuration, not user error — and worth a Sentry event because the feature is
+      // silently unusable until the env var lands.
+      console.error('[me-bandcamp] BANDCAMP_CREDENTIAL_KEY is not configured');
+      Sentry.captureMessage('me-bandcamp: BANDCAMP_CREDENTIAL_KEY not configured', 'error');
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Bandcamp connections are not available right now' }) };
+    }
+
+    // Derive the salted token; the password is not referenced again after this line.
+    const { t, s } = deriveSubsonicToken(password);
+    const credential = { username, t, s };
+
+    // Verify before storing: a stored credential that never worked would surface as a
+    // confusing background sync failure instead of an inline "check your credential".
+    try {
+      await subsonicPing(credential);
+    } catch (error) {
+      if (error instanceof SubsonicError && error.isAuthFailure) {
+        return {
+          statusCode: 400,
+          headers: CORS_HEADERS,
+          body: JSON.stringify({ error: 'Bandcamp rejected that username or credential. Check both in Bandcamp’s Fan Settings → Subsonic.' }),
+        };
+      }
+      console.warn('[me-bandcamp] Bandcamp ping failed:', error instanceof Error ? error.message : String(error));
+      return {
+        statusCode: 502,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Bandcamp didn’t respond. Their Subsonic support is in beta — try again in a minute.' }),
+      };
+    }
+
+    // A nice-to-have confirmation number; a failure here shouldn't block the connect.
+    let artistCount: number | null = null;
+    try {
+      artistCount = await subsonicArtistCount(credential);
+    } catch {
+      // The sync will establish real counts.
+    }
+
+    const ciphertext = encryptCredential(JSON.stringify({ t, s }));
+
+    // Store first, then ask for the sync: the background function reads this row, so
+    // requesting before the upsert lands would race it into "no connection found".
+    const { error: upsertError } = await client
+      .from('bandcamp_connections')
+      .upsert(
+        {
+          user_id: user.userId,
+          bandcamp_username: username,
+          credential_ciphertext: ciphertext,
+          sync_status: 'syncing',
+          sync_error: null,
+        },
+        { onConflict: 'user_id' }
+      );
+
+    if (upsertError) {
+      console.error('[me-bandcamp] Error storing connection:', upsertError.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to save the connection' }) };
+    }
+
+    const started = await requestSync(user.userId);
+    if (!started) {
+      await client
+        .from('bandcamp_connections')
+        .update({ sync_status: 'error', sync_error: SYNC_START_FAILED })
+        .eq('user_id', user.userId);
+    }
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        connected: true,
+        username,
+        syncStatus: started ? 'syncing' : 'error',
+        syncError: started ? null : SYNC_START_FAILED,
+        artistCount,
+      }),
+    };
+  }
+
+  if (event.httpMethod === 'DELETE') {
+    let body: Record<string, unknown> = {};
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    const { error: deleteError } = await client
+      .from('bandcamp_connections')
+      .delete()
+      .eq('user_id', user.userId);
+
+    if (deleteError) {
+      console.error('[me-bandcamp] Error deleting connection:', deleteError.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to disconnect' }) };
+    }
+
+    let itemsDeleted = 0;
+    if (body.deleteItems === true) {
+      const { count, error: itemsError } = await client
+        .from('collection_items')
+        .delete({ count: 'exact' })
+        .eq('user_id', user.userId)
+        .eq('source', 'bandcamp');
+      if (itemsError) {
+        console.error('[me-bandcamp] Error deleting collection items:', itemsError.message);
+        return {
+          statusCode: 500,
+          headers: CORS_HEADERS,
+          body: JSON.stringify({ error: 'Disconnected, but deleting imported items failed. Try again from Settings.' }),
+        };
+      }
+      itemsDeleted = count ?? 0;
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ connected: false, itemsDeleted }) };
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -83,8 +83,9 @@ async function requestSync(userId: string): Promise<boolean> {
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 3_000);
+    let response: Response;
     try {
-      await fetch(`${siteUrl}/.netlify/functions/bandcamp-sync-background`, {
+      response = await fetch(`${siteUrl}/.netlify/functions/bandcamp-sync-background`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -95,6 +96,14 @@ async function requestSync(userId: string): Promise<boolean> {
       });
     } finally {
       clearTimeout(timeoutId);
+    }
+    // Netlify's dispatcher answers 202 when it accepts a background invocation. Anything
+    // else means the sync will never run — notably a 404 when this code runs on a deploy
+    // preview, whose `URL` points at production before the function has shipped there.
+    // Claiming "syncing" on that response would spin forever.
+    if (!response.ok) {
+      console.warn(`[me-bandcamp] sync dispatch refused: HTTP ${response.status}`);
+      return false;
     }
     return true;
   } catch (error) {

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -65,16 +65,46 @@ async function authenticateRequest(authHeader: string | undefined): Promise<{ us
 }
 
 /**
- * Ask the background function to run the import. Returns false when it couldn't be asked
- * (missing config, network) — the caller records that as a sync error rather than leaving
- * the row claiming a sync that will never happen. Same handshake as request-catalog.ts:
- * Netlify answers 202 immediately, so there is no result to read back.
+ * The origin to dispatch the background job to: the deploy that is actually serving this
+ * request, when we can prove it's one of ours.
+ *
+ * Netlify exposes only `URL`, `SITE_NAME` and `SITE_ID` to a function at runtime, and `URL`
+ * always names *production* — so a deploy preview would hand its work to production, which
+ * on a branch-only function is a 404 and on a shipped one is the wrong deploy running it.
+ * The `Host` header does name the current deploy.
+ *
+ * But `Host` is client-supplied, and dispatching to it unchecked would POST
+ * INTERNAL_FUNCTION_SECRET to whatever hostname an attacker sent. So it is honoured only
+ * when it is one of this site's own Netlify hostnames; anything else falls back to `URL`,
+ * which is the safe (if less useful) old behaviour.
+ *
+ * Unlike catalog dispatch — which writes shared artist data and spends a shared crawl
+ * budget, and so stays pinned behind request-catalog.ts's production gate — a Bandcamp sync
+ * writes only the rows of the user who asked for it, so letting a preview run its own is
+ * both safe and the point.
  */
-async function requestSync(userId: string): Promise<boolean> {
+export function selfDispatchOrigin(host: string | undefined): string | null {
+  if (!host) return null;
+  const hostname = host.split(':')[0].trim().toLowerCase();
+  if (hostname === 'unstream.stream' || hostname === 'www.unstream.stream') {
+    return `https://${hostname}`;
+  }
+  // Deploy previews and branch deploys: <deploy-name>--unstream.netlify.app
+  if (hostname === 'unstream.netlify.app' || /^[a-z0-9-]+--unstream\.netlify\.app$/.test(hostname)) {
+    return `https://${hostname}`;
+  }
+  return null;
+}
+
+/**
+ * Ask the background function to run the import. Returns false when it couldn't be asked
+ * (missing config, network, a non-202 answer) — the caller records that as a sync error
+ * rather than leaving the row claiming a sync that will never happen. Same handshake as
+ * request-catalog.ts: Netlify answers 202 immediately, so there is no result to read back.
+ */
+async function requestSync(userId: string, host: string | undefined): Promise<boolean> {
   const secret = process.env.INTERNAL_FUNCTION_SECRET;
-  // `URL` and not `DEPLOY_PRIME_URL`: only URL, SITE_NAME and SITE_ID reach a function at
-  // runtime — see request-catalog.ts.
-  const siteUrl = process.env.URL;
+  const siteUrl = selfDispatchOrigin(host) ?? process.env.URL;
   if (!secret || !siteUrl) {
     console.log('[me-bandcamp] sync not requested — INTERNAL_FUNCTION_SECRET or site URL not configured');
     return false;
@@ -189,7 +219,7 @@ export async function handler(event: {
         return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to start sync' }) };
       }
 
-      const started = await requestSync(user.userId);
+      const started = await requestSync(user.userId, event.headers.host);
       if (!started) {
         await client
           .from('bandcamp_connections')
@@ -281,7 +311,7 @@ export async function handler(event: {
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to save the connection' }) };
     }
 
-    const started = await requestSync(user.userId);
+    const started = await requestSync(user.userId, event.headers.host);
     if (!started) {
       await client
         .from('bandcamp_connections')

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -10,6 +10,12 @@
 import { createClient } from '@supabase/supabase-js';
 import { getClient, readAllPages } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
+import {
+  artistUrlFor,
+  releaseUrlFor,
+  resolveArtistPages,
+  type CollectionRowWithRelease,
+} from './collection-utils';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -20,6 +26,9 @@ const CORS_HEADERS = {
 
 const ITEM_COLUMNS =
   'id, source, title, artist_name, art_url, acquired_at, provenance, acquisition, hidden, release_id';
+
+/** The same columns plus the joins the grid needs to build release and artist links. */
+const ITEM_COLUMNS_WITH_LINKS = `${ITEM_COLUMNS}, releases!left (slug, artwork_url, artists (slug))`;
 
 async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
   if (!authHeader?.startsWith('Bearer ')) return null;
@@ -60,11 +69,11 @@ export async function handler(event: {
 
   if (event.httpMethod === 'GET') {
     // Paged read: a real Bandcamp collection can exceed PostgREST's silent 1,000-row cap.
-    const read = await readAllPages<Record<string, unknown>>(
+    const read = await readAllPages<Record<string, unknown> & CollectionRowWithRelease & { id: string }>(
       (from, to) =>
         client
           .from('collection_items')
-          .select(ITEM_COLUMNS)
+          .select(ITEM_COLUMNS_WITH_LINKS)
           .eq('user_id', user.userId)
           .order('acquired_at', { ascending: false, nullsFirst: false })
           .order('created_at', { ascending: false })
@@ -77,10 +86,21 @@ export async function handler(event: {
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load collection' }) };
     }
 
+    const artistPages = await resolveArtistPages(read.rows.map(r => r.artist_name));
+
+    const items = read.rows.map(({ releases, ...row }) => ({
+      ...row,
+      // Same art fallback as the public page: unmatched items get their cover from Bandcamp
+      // via the proxy rather than rendering an empty box.
+      art_url: row.art_url || releases?.artwork_url || `/api/collection/art/${row.id}`,
+      url: releaseUrlFor({ ...row, releases }),
+      artist_url: artistUrlFor({ ...row, releases }, artistPages),
+    }));
+
     return {
       statusCode: 200,
       headers: CORS_HEADERS,
-      body: JSON.stringify({ items: read.rows, total: read.rows.length }),
+      body: JSON.stringify({ items, total: items.length }),
     };
   }
 

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -1,0 +1,125 @@
+// API endpoint: /api/me/collection
+// GET  — the signed-in user's collection items (including hidden ones — this is the
+//        owner's view; the public page filters to provenance='purchased' AND NOT hidden).
+// POST — { id, hidden }: hide or unhide one of the user's own items on the public page.
+//
+// Support Loop Step 1 (support-loop-spec.md); the collection page rebuild (Step 3) renders
+// from this. Writes to collection_items happen only in sync code (bandcamp-sync-background)
+// — this endpoint can flip `hidden` and nothing else, so provenance stays server-asserted.
+
+import { createClient } from '@supabase/supabase-js';
+import { getClient, readAllPages } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+const ITEM_COLUMNS =
+  'id, source, title, artist_name, art_url, acquired_at, provenance, acquisition, hidden, release_id';
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+
+  const anonClient = createClient(url, anonKey);
+  const { data, error } = await anonClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { userId: data.user.id };
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    // Paged read: a real Bandcamp collection can exceed PostgREST's silent 1,000-row cap.
+    const read = await readAllPages<Record<string, unknown>>(
+      (from, to) =>
+        client
+          .from('collection_items')
+          .select(ITEM_COLUMNS)
+          .eq('user_id', user.userId)
+          .order('acquired_at', { ascending: false, nullsFirst: false })
+          .order('created_at', { ascending: false })
+          .range(from, to),
+      'collection_items'
+    );
+
+    if (!read.ok) {
+      console.error('[me-collection] Error fetching items:', read.reason);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load collection' }) };
+    }
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ items: read.rows, total: read.rows.length }),
+    };
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    const id = typeof body.id === 'string' ? body.id : '';
+    if (!id) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'id is required' }) };
+    }
+    if (typeof body.hidden !== 'boolean') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'hidden must be a boolean' }) };
+    }
+
+    // The user_id filter is the ownership check — the service-role client bypasses RLS,
+    // so it has to be in the query, not assumed from it.
+    const { data: row, error } = await client
+      .from('collection_items')
+      .update({ hidden: body.hidden })
+      .eq('id', id)
+      .eq('user_id', user.userId)
+      .select(ITEM_COLUMNS)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[me-collection] Error updating item:', error.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to update item' }) };
+    }
+    if (!row) {
+      return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Item not found' }) };
+    }
+
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(row) };
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/functions/public-saved-artists.ts
+++ b/api/functions/public-saved-artists.ts
@@ -1,9 +1,14 @@
 // API endpoint: /api/public/saved-artists/:handle
-// GET — public, anonymous-accessible. Returns a user's saved artists list if sharing is enabled.
-// 404 on private, unknown handle, or missing username.
+// GET — public, anonymous-accessible. Returns a user's saved artists list and public
+// collection if sharing is enabled. 404 on private, unknown handle, or missing username.
 // Rate limited at 'standard' tier (30/min/IP) per amendment 1.
+//
+// The collection and the saved list are two views of the same relationship — artists you
+// support, and the releases you bought to support them (Support Loop Step 3). Only
+// provenance='purchased', non-hidden items are ever public: a page that counted anything
+// else as support would be lying, and the whole value of the artifact is that it isn't.
 
-import { getClient } from './db';
+import { getClient, readAllPages } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
@@ -89,6 +94,47 @@ export async function handler(event: {
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
     }
 
+    // Public collection: purchased and not hidden, most recently acquired first. Paged read
+    // because a real Bandcamp collection can exceed PostgREST's silent 1,000-row cap.
+    const collectionRead = await readAllPages<{
+      title: string;
+      artist_name: string;
+      art_url: string | null;
+      acquired_at: string | null;
+      releases: { slug: string; artwork_url: string | null; artists: { slug: string } | null } | null;
+    }>(
+      (from, to) =>
+        client
+          .from('collection_items')
+          .select('title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
+          .eq('user_id', userId)
+          .eq('provenance', 'purchased')
+          .eq('hidden', false)
+          .order('acquired_at', { ascending: false, nullsFirst: false })
+          .order('created_at', { ascending: false })
+          .range(from, to),
+      'collection_items (public page)'
+    );
+
+    if (!collectionRead.ok) {
+      console.error('[public-saved-artists] Error fetching collection:', collectionRead.reason);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+    }
+
+    const collection = collectionRead.rows.map(row => {
+      const release = row.releases;
+      const artistSlug = release?.artists?.slug || null;
+      return {
+        title: row.title,
+        artist_name: row.artist_name,
+        art_url: row.art_url || release?.artwork_url || null,
+        acquired_at: row.acquired_at,
+        // Matched items link to the release page, so a viewer can buy the same record —
+        // the loop closes. Unmatched items still render, just without a link.
+        url: release?.slug && artistSlug ? `/a/${artistSlug}/${release.slug}` : null,
+      };
+    });
+
     // Shape the response — NEVER include email, user_id, or account metadata
     const savedArtists = (saved || []).map((row: any) => {
       const artistRow = row.artists;
@@ -107,6 +153,7 @@ export async function handler(event: {
         owner_display_name: ownerDisplayName,
         owner_location: ownerLocation,
         saved_artists: savedArtists,
+        collection,
       }),
     };
   } catch (error) {

--- a/api/functions/public-saved-artists.ts
+++ b/api/functions/public-saved-artists.ts
@@ -9,6 +9,7 @@
 // else as support would be lying, and the whole value of the artifact is that it isn't.
 
 import { getClient, readAllPages } from './db';
+import { artistUrlFor, releaseUrlFor, resolveArtistPages } from './collection-utils';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
@@ -97,6 +98,7 @@ export async function handler(event: {
     // Public collection: purchased and not hidden, most recently acquired first. Paged read
     // because a real Bandcamp collection can exceed PostgREST's silent 1,000-row cap.
     const collectionRead = await readAllPages<{
+      id: string;
       title: string;
       artist_name: string;
       art_url: string | null;
@@ -106,7 +108,7 @@ export async function handler(event: {
       (from, to) =>
         client
           .from('collection_items')
-          .select('title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
+          .select('id, title, artist_name, art_url, acquired_at, releases!left (slug, artwork_url, artists (slug))')
           .eq('user_id', userId)
           .eq('provenance', 'purchased')
           .eq('hidden', false)
@@ -121,19 +123,21 @@ export async function handler(event: {
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
     }
 
-    const collection = collectionRead.rows.map(row => {
-      const release = row.releases;
-      const artistSlug = release?.artists?.slug || null;
-      return {
-        title: row.title,
-        artist_name: row.artist_name,
-        art_url: row.art_url || release?.artwork_url || null,
-        acquired_at: row.acquired_at,
-        // Matched items link to the release page, so a viewer can buy the same record —
-        // the loop closes. Unmatched items still render, just without a link.
-        url: release?.slug && artistSlug ? `/a/${artistSlug}/${release.slug}` : null,
-      };
-    });
+    const artistPages = await resolveArtistPages(collectionRead.rows.map(r => r.artist_name));
+
+    const collection = collectionRead.rows.map(row => ({
+      id: row.id,
+      title: row.title,
+      artist_name: row.artist_name,
+      // Falls back to the art proxy, which fetches from Bandcamp server-side. Only ~28% of a
+      // real collection matches an Unstream release, so without this most tiles are blank.
+      art_url: row.art_url || row.releases?.artwork_url || `/api/collection/art/${row.id}`,
+      acquired_at: row.acquired_at,
+      // Matched items link to the release page, so a viewer can buy the same record —
+      // the loop closes. Unmatched items still render, just without a link.
+      url: releaseUrlFor(row),
+      artist_url: artistUrlFor(row, artistPages),
+    }));
 
     // Shape the response — NEVER include email, user_id, or account metadata
     const savedArtists = (saved || []).map((row: any) => {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -71,6 +71,16 @@
     "functions/weekly-analytics-recap.ts",
     "functions/__tests__/weekly-analytics-recap.test.ts",
     "functions/me-notifications.ts",
-    "functions/__tests__/me-notifications.test.ts"
+    "functions/__tests__/me-notifications.test.ts",
+    "functions/me-bandcamp.ts",
+    "functions/me-collection.ts",
+    "functions/bandcamp-sync-background.ts",
+    "functions/credential-crypto.ts",
+    "functions/bandcamp-subsonic.ts",
+    "functions/__tests__/me-bandcamp.test.ts",
+    "functions/__tests__/me-collection.test.ts",
+    "functions/__tests__/bandcamp-sync.test.ts",
+    "functions/__tests__/credential-crypto.test.ts",
+    "functions/__tests__/bandcamp-subsonic.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -81,6 +81,8 @@
     "functions/__tests__/me-collection.test.ts",
     "functions/__tests__/bandcamp-sync.test.ts",
     "functions/__tests__/credential-crypto.test.ts",
-    "functions/__tests__/bandcamp-subsonic.test.ts"
+    "functions/__tests__/bandcamp-subsonic.test.ts",
+    "functions/public-saved-artists.ts",
+    "functions/__tests__/public-saved-artists.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -83,6 +83,9 @@
     "functions/__tests__/credential-crypto.test.ts",
     "functions/__tests__/bandcamp-subsonic.test.ts",
     "functions/public-saved-artists.ts",
-    "functions/__tests__/public-saved-artists.test.ts"
+    "functions/__tests__/public-saved-artists.test.ts",
+    "functions/collection-art.ts",
+    "functions/collection-utils.ts",
+    "functions/__tests__/collection-art.test.ts"
   ]
 }

--- a/apps/web/src/components/BandcampConnect.tsx
+++ b/apps/web/src/components/BandcampConnect.tsx
@@ -1,0 +1,305 @@
+import { useState, useEffect, useCallback } from 'react';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+
+// Settings section for connecting a Bandcamp collection via Bandcamp's Subsonic API
+// (open beta). The credential goes straight to /api/me/bandcamp over one POST and is never
+// kept in client state longer than the request — see api/functions/me-bandcamp.ts for the
+// server-side handling.
+
+interface ConnectionStatus {
+  connected: boolean;
+  username?: string;
+  syncStatus?: 'idle' | 'syncing' | 'error';
+  syncError?: string | null;
+  itemCount?: number | null;
+  lastSyncedAt?: string | null;
+}
+
+const SYNC_POLL_MS = 5_000;
+
+export function BandcampConnect() {
+  const { session } = useAuth();
+  const [status, setStatus] = useState<ConnectionStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [username, setUsername] = useState('');
+  const [credential, setCredential] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    if (!session) return;
+    try {
+      const res = await fetch('/api/me/bandcamp', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to fetch Bandcamp connection status');
+      setStatus(await res.json());
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'BandcampConnect.fetchStatus' } });
+      setError('Failed to load Bandcamp connection status.');
+    } finally {
+      setLoading(false);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // While a sync runs in the background, keep the status fresh.
+  useEffect(() => {
+    if (status?.syncStatus !== 'syncing') return;
+    const id = setInterval(fetchStatus, SYNC_POLL_MS);
+    return () => clearInterval(id);
+  }, [status?.syncStatus, fetchStatus]);
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/me/bandcamp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ username: username.trim(), password: credential }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to connect Bandcamp');
+      }
+      setCredential('');
+      setUsername('');
+      setStatus({
+        connected: true,
+        username: data.username,
+        syncStatus: data.syncStatus,
+        syncError: data.syncError,
+        itemCount: null,
+        lastSyncedAt: null,
+      });
+    } catch (e) {
+      // Deliberately no Sentry here: a connect failure message is expected user-facing
+      // feedback (bad credential, Bandcamp down), and the exception path must never risk
+      // carrying form contents.
+      setError(e instanceof Error ? e.message : 'Failed to connect Bandcamp.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleResync = async () => {
+    if (!session || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/me/bandcamp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ resync: true }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to start sync');
+      setStatus(data);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'BandcampConnect.resync' } });
+      setError(e instanceof Error ? e.message : 'Failed to start sync.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDisconnect = async (deleteItems: boolean) => {
+    if (!session || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/me/bandcamp', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ deleteItems }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to disconnect');
+      setStatus({ connected: false });
+      setConfirmingDisconnect(false);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'BandcampConnect.disconnect' } });
+      setError(e instanceof Error ? e.message : 'Failed to disconnect.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <p className="text-sm text-text-muted">Loading Bandcamp connection…</p>;
+  }
+
+  if (!status) {
+    return error ? <p className="text-sm text-red-400">{error}</p> : null;
+  }
+
+  if (!status.connected) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-text-muted">
+          Import the music you've bought on Bandcamp into your collection. This reads your
+          collection and never changes anything on Bandcamp.
+        </p>
+        <ol className="list-decimal list-inside text-sm text-text-muted space-y-1">
+          <li>
+            Open{' '}
+            <a
+              href="https://bandcamp.com/settings"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-primary hover:underline"
+            >
+              Bandcamp's Fan Settings
+            </a>{' '}
+            and generate credentials under <strong className="text-text-primary">Subsonic</strong>.
+          </li>
+          <li>Paste your Bandcamp username and the generated credential below.</li>
+        </ol>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <form onSubmit={handleConnect} className="space-y-3">
+          <div>
+            <label htmlFor="bandcamp-username" className="block text-sm text-text-primary mb-1">
+              Bandcamp username
+            </label>
+            <input
+              id="bandcamp-username"
+              type="text"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              autoComplete="off"
+              className="w-full max-w-sm px-3 py-2 rounded-lg bg-bg-primary border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary"
+            />
+          </div>
+          <div>
+            <label htmlFor="bandcamp-credential" className="block text-sm text-text-primary mb-1">
+              Subsonic credential
+            </label>
+            <input
+              id="bandcamp-credential"
+              type="password"
+              value={credential}
+              onChange={e => setCredential(e.target.value)}
+              autoComplete="off"
+              className="w-full max-w-sm px-3 py-2 rounded-lg bg-bg-primary border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={submitting || !username.trim() || !credential}
+            className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? 'Connecting…' : 'Connect Bandcamp'}
+          </button>
+        </form>
+        <p className="text-xs text-text-muted">
+          Bandcamp's Subsonic support is in beta and may change or break. Your credential is
+          stored encrypted, and you can disconnect — and delete everything imported — at any time.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-text-muted">
+        Connected as <strong className="text-text-primary">{status.username}</strong>
+      </p>
+
+      {status.syncStatus === 'syncing' && (
+        <p className="text-sm text-text-muted" role="status">
+          Importing your collection… Large collections can take a while in Bandcamp's beta.
+          You can leave this page.
+        </p>
+      )}
+
+      {status.syncStatus === 'error' && status.syncError && (
+        <p className="text-sm text-red-400">{status.syncError}</p>
+      )}
+
+      {status.syncStatus === 'idle' && (
+        <p className="text-sm text-text-muted">
+          {status.itemCount != null ? `${status.itemCount} releases imported` : 'Imported'}
+          {status.lastSyncedAt
+            ? ` · last synced ${new Date(status.lastSyncedAt).toLocaleDateString()}`
+            : ''}
+        </p>
+      )}
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {!confirmingDisconnect ? (
+        <div className="flex gap-3">
+          {status.syncStatus !== 'syncing' && (
+            <button
+              type="button"
+              onClick={handleResync}
+              disabled={submitting}
+              className="px-3 py-1.5 rounded-lg border border-border text-sm text-text-primary hover:bg-bg-primary disabled:opacity-50"
+            >
+              Re-sync
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setConfirmingDisconnect(true)}
+            disabled={submitting}
+            className="px-3 py-1.5 rounded-lg border border-border text-sm text-red-400 hover:bg-bg-primary disabled:opacity-50"
+          >
+            Disconnect
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-text-primary">
+            Disconnect Bandcamp? Your stored credential is deleted either way — choose what
+            happens to the releases already imported.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => handleDisconnect(false)}
+              disabled={submitting}
+              className="px-3 py-1.5 rounded-lg border border-border text-sm text-text-primary hover:bg-bg-primary disabled:opacity-50"
+            >
+              Disconnect, keep items
+            </button>
+            <button
+              type="button"
+              onClick={() => handleDisconnect(true)}
+              disabled={submitting}
+              className="px-3 py-1.5 rounded-lg border border-border text-sm text-red-400 hover:bg-bg-primary disabled:opacity-50"
+            >
+              Disconnect and delete items
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingDisconnect(false)}
+              disabled={submitting}
+              className="px-3 py-1.5 rounded-lg text-sm text-text-muted hover:text-text-primary disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/BandcampConnect.tsx
+++ b/apps/web/src/components/BandcampConnect.tsx
@@ -162,22 +162,26 @@ export function BandcampConnect() {
           <li>
             Open{' '}
             <a
-              href="https://bandcamp.com/settings"
+              href="https://bandcamp.com/settings?pane=fan"
               target="_blank"
               rel="noopener noreferrer"
               className="text-accent-primary hover:underline"
             >
               Bandcamp's Fan Settings
             </a>{' '}
-            and generate credentials under <strong className="text-text-primary">Subsonic</strong>.
+            and turn on <strong className="text-text-primary">Subsonic</strong>. Bandcamp shows
+            you a server address, a username, and a password.
           </li>
-          <li>Paste your Bandcamp username and the generated credential below.</li>
+          <li>
+            Paste the username and password below. Skip the server address — it's always the
+            same, and Unstream fills it in.
+          </li>
         </ol>
         {error && <p className="text-sm text-red-400">{error}</p>}
         <form onSubmit={handleConnect} className="space-y-3">
           <div>
             <label htmlFor="bandcamp-username" className="block text-sm text-text-primary mb-1">
-              Bandcamp username
+              Username (from Bandcamp)
             </label>
             <input
               id="bandcamp-username"
@@ -190,7 +194,7 @@ export function BandcampConnect() {
           </div>
           <div>
             <label htmlFor="bandcamp-credential" className="block text-sm text-text-primary mb-1">
-              Subsonic credential
+              Password (from Bandcamp)
             </label>
             <input
               id="bandcamp-credential"

--- a/apps/web/src/components/CollectionGrid.tsx
+++ b/apps/web/src/components/CollectionGrid.tsx
@@ -1,0 +1,172 @@
+import { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  COLLECTION_PAGE_SIZE,
+  COLLECTION_SORTS,
+  pageWindow,
+  sortItems,
+  type CollectionGridItem,
+  type CollectionSortKey,
+} from '../utils/collection-grid';
+
+// The album-art grid shared by the public collection page and the owner's dashboard, so the
+// two can't drift in sorting, paging or what's clickable. Paging and sorting logic lives in
+// utils/collection-grid.ts.
+
+function Tile({ item }: { item: CollectionGridItem }) {
+  // Which URL failed, rather than a boolean: a boolean would need resetting whenever the
+  // item's art changed, and comparing URLs makes that fall out for free.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const showArt = item.artUrl && failedUrl !== item.artUrl;
+
+  return (
+    <div className={`relative group ${item.dimmed ? 'opacity-40' : ''}`}>
+      {showArt ? (
+        <img
+          src={item.artUrl!}
+          alt={`${item.title} by ${item.artistName}`}
+          loading="lazy"
+          // The art proxy answers 404 when Bandcamp has no cover, so a broken image is an
+          // expected outcome here, not an error.
+          onError={() => setFailedUrl(item.artUrl)}
+          className="w-full aspect-square object-cover rounded-lg bg-bg-hover"
+        />
+      ) : (
+        // A mark, not the title: the caption directly below already carries the title and
+        // artist, and repeating it inside the square just reads as a rendering fault.
+        <div className="w-full aspect-square rounded-lg bg-bg-hover flex items-center justify-center">
+          <svg
+            className="w-6 h-6 text-text-muted opacity-50"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z"
+            />
+          </svg>
+        </div>
+      )}
+
+      <div className="mt-1.5 min-w-0">
+        {item.releaseUrl ? (
+          <Link to={item.releaseUrl} className="block text-xs font-medium truncate hover:underline">
+            {item.title}
+          </Link>
+        ) : (
+          <p className="text-xs font-medium truncate">{item.title}</p>
+        )}
+        {item.artistUrl ? (
+          <Link
+            to={item.artistUrl}
+            className="block text-xs text-text-muted truncate hover:text-text-primary hover:underline"
+          >
+            {item.artistName}
+          </Link>
+        ) : (
+          <p className="text-xs text-text-muted truncate">{item.artistName}</p>
+        )}
+      </div>
+
+      {item.overlay}
+    </div>
+  );
+}
+
+export function CollectionGrid({ items }: { items: CollectionGridItem[] }) {
+  const [sort, setSort] = useState<CollectionSortKey>('added');
+  const [page, setPage] = useState(1);
+
+  const sorted = useMemo(() => sortItems(items, sort), [items, sort]);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / COLLECTION_PAGE_SIZE));
+
+  // Clamped during render rather than corrected in an effect: a collection that shrinks
+  // (an item deleted, a filter applied) can leave `page` past the end, and deriving the
+  // safe value avoids a second render pass to fix it.
+  const safePage = Math.min(page, totalPages);
+  const start = (safePage - 1) * COLLECTION_PAGE_SIZE;
+  const visible = sorted.slice(start, start + COLLECTION_PAGE_SIZE);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-sm text-text-muted">
+          {sorted.length} release{sorted.length === 1 ? '' : 's'}
+        </p>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-text-muted">Sort</span>
+          <select
+            value={sort}
+            onChange={e => {
+              setSort(e.target.value as CollectionSortKey);
+              // Page 1 of the new order — staying on page 7 of a resorted list shows the
+              // viewer somewhere arbitrary.
+              setPage(1);
+            }}
+            aria-label="Sort collection"
+            className="px-2 py-1 rounded-lg bg-bg-primary border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary"
+          >
+            {COLLECTION_SORTS.map(({ key, label }) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+        {visible.map(item => (
+          <Tile key={item.key} item={item} />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <nav className="flex flex-wrap items-center justify-center gap-1" aria-label="Collection pages">
+          <button
+            type="button"
+            onClick={() => setPage(p => Math.max(1, Math.min(p, totalPages) - 1))}
+            disabled={safePage === 1}
+            className="px-2 py-1 rounded text-sm text-text-muted hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Previous
+          </button>
+          {pageWindow(safePage, totalPages).map((n, i) =>
+            n === null ? (
+              <span key={`gap-${i}`} className="px-1 text-text-muted">
+                …
+              </span>
+            ) : (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setPage(n)}
+                aria-label={`Page ${n}`}
+                aria-current={n === safePage ? 'page' : undefined}
+                className={`min-w-8 px-2 py-1 rounded text-sm ${
+                  n === safePage
+                    ? 'bg-accent-primary text-white'
+                    : 'text-text-muted hover:text-text-primary hover:bg-bg-hover'
+                }`}
+              >
+                {n}
+              </button>
+            )
+          )}
+          <button
+            type="button"
+            onClick={() => setPage(p => Math.min(totalPages, Math.min(p, totalPages) + 1))}
+            disabled={safePage === totalPages}
+            className="px-2 py-1 rounded text-sm text-text-muted hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/CollectionSection.tsx
+++ b/apps/web/src/components/CollectionSection.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+
+// Dashboard section: the owner's view of their collection (Support Loop Step 3).
+// The public page (/u/:handle) shows only purchased, non-hidden items; here the owner
+// sees everything, including hidden items (marked), and can hide/unhide each one.
+// The empty state points at the import — that's the action that fills this in.
+
+interface CollectionItem {
+  id: string;
+  source: string;
+  title: string;
+  artist_name: string;
+  art_url: string | null;
+  acquired_at: string | null;
+  provenance: string;
+  hidden: boolean;
+  release_id: string | null;
+}
+
+export function CollectionSection() {
+  const { session } = useAuth();
+  const [items, setItems] = useState<CollectionItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const fetchCollection = useCallback(async () => {
+    if (!session) return;
+    try {
+      const res = await fetch('/api/me/collection', {
+        headers: { 'Authorization': `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to load collection');
+      const data = await res.json();
+      setItems(data.items || []);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'CollectionSection.fetch' } });
+      setError('Failed to load your collection.');
+    }
+  }, [session]);
+
+  useEffect(() => {
+    fetchCollection();
+  }, [fetchCollection]);
+
+  const handleToggleHidden = async (item: CollectionItem) => {
+    if (!session || togglingId) return;
+    setTogglingId(item.id);
+    setError(null);
+    try {
+      const res = await fetch('/api/me/collection', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ id: item.id, hidden: !item.hidden }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update item');
+      }
+      const updated = await res.json();
+      setItems(prev => prev ? prev.map(i => (i.id === updated.id ? { ...i, hidden: updated.hidden } : i)) : prev);
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'CollectionSection.toggleHidden' } });
+      setError(e instanceof Error ? e.message : 'Failed to update item.');
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+        <svg className="w-5 h-5 text-accent-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+        </svg>
+        Your Collection
+      </h2>
+
+      {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+
+      {items === null ? (
+        !error && <p className="text-sm text-text-muted">Loading your collection…</p>
+      ) : items.length === 0 ? (
+        <div className="text-center py-12 rounded-lg border border-border border-dashed">
+          <p className="text-text-muted">No releases in your collection yet.</p>
+          <p className="text-text-muted text-sm mt-1">
+            Bought music on Bandcamp?{' '}
+            <Link to="/settings" className="text-accent-primary hover:underline">
+              Connect your collection in Settings
+            </Link>{' '}
+            and it fills in from what you've actually bought.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+          {items.map(item => (
+            <div key={item.id} className="relative group">
+              {item.art_url ? (
+                <img
+                  src={item.art_url}
+                  alt={`${item.title} by ${item.artist_name}`}
+                  loading="lazy"
+                  className={`w-full aspect-square object-cover rounded-lg bg-bg-hover ${item.hidden ? 'opacity-40' : ''}`}
+                />
+              ) : (
+                <div className={`w-full aspect-square rounded-lg bg-bg-hover flex items-center justify-center p-2 ${item.hidden ? 'opacity-40' : ''}`}>
+                  <span className="text-text-muted text-xs text-center line-clamp-4">{item.title}</span>
+                </div>
+              )}
+              <div className="mt-1.5 min-w-0">
+                <p className={`text-xs font-medium truncate ${item.hidden ? 'text-text-muted' : ''}`}>{item.title}</p>
+                <p className="text-xs text-text-muted truncate">{item.artist_name}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleToggleHidden(item)}
+                disabled={togglingId === item.id}
+                aria-label={item.hidden ? `Show ${item.title} on your public page` : `Hide ${item.title} from your public page`}
+                title={item.hidden ? 'Hidden from your public page — click to show' : 'Hide from your public page'}
+                className={`absolute top-1.5 right-1.5 p-1.5 rounded-md bg-black/60 text-white transition-opacity disabled:opacity-50 ${
+                  item.hidden ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
+                }`}
+              >
+                {item.hidden ? (
+                  <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/CollectionSection.tsx
+++ b/apps/web/src/components/CollectionSection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { CollectionGrid } from './CollectionGrid';
 
 // Dashboard section: the owner's view of their collection (Support Loop Step 3).
 // The public page (/u/:handle) shows only purchased, non-hidden items; here the owner
@@ -18,6 +19,8 @@ interface CollectionItem {
   provenance: string;
   hidden: boolean;
   release_id: string | null;
+  url: string | null;
+  artist_url: string | null;
 }
 
 export function CollectionSection() {
@@ -97,25 +100,17 @@ export function CollectionSection() {
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
-          {items.map(item => (
-            <div key={item.id} className="relative group">
-              {item.art_url ? (
-                <img
-                  src={item.art_url}
-                  alt={`${item.title} by ${item.artist_name}`}
-                  loading="lazy"
-                  className={`w-full aspect-square object-cover rounded-lg bg-bg-hover ${item.hidden ? 'opacity-40' : ''}`}
-                />
-              ) : (
-                <div className={`w-full aspect-square rounded-lg bg-bg-hover flex items-center justify-center p-2 ${item.hidden ? 'opacity-40' : ''}`}>
-                  <span className="text-text-muted text-xs text-center line-clamp-4">{item.title}</span>
-                </div>
-              )}
-              <div className="mt-1.5 min-w-0">
-                <p className={`text-xs font-medium truncate ${item.hidden ? 'text-text-muted' : ''}`}>{item.title}</p>
-                <p className="text-xs text-text-muted truncate">{item.artist_name}</p>
-              </div>
+        <CollectionGrid
+          items={items.map(item => ({
+            key: item.id,
+            title: item.title,
+            artistName: item.artist_name,
+            artUrl: item.art_url,
+            acquiredAt: item.acquired_at,
+            releaseUrl: item.url,
+            artistUrl: item.artist_url,
+            dimmed: item.hidden,
+            overlay: (
               <button
                 type="button"
                 onClick={() => handleToggleHidden(item)}
@@ -137,9 +132,9 @@ export function CollectionSection() {
                   </svg>
                 )}
               </button>
-            </div>
-          ))}
-        </div>
+            ),
+          }))}
+        />
       )}
     </section>
   );

--- a/apps/web/src/components/SharingControls.tsx
+++ b/apps/web/src/components/SharingControls.tsx
@@ -102,7 +102,7 @@ export function SharingControls() {
     return (
       <div className="rounded-lg border border-border p-4 bg-bg-secondary">
         <p className="text-sm text-text-primary">
-          Set a username to share your saved artists.
+          Set a username to publish your public profile.
         </p>
         <Link
           to="/settings"
@@ -118,11 +118,12 @@ export function SharingControls() {
   if (!sharing.public) {
     return (
       <div className="rounded-lg border border-border p-4 bg-bg-secondary">
-        <p className="text-sm text-text-primary">Your saved artists are private.</p>
+        <p className="text-sm text-text-primary">Your profile is private.</p>
         <p className="text-xs text-text-muted mt-1">
-          Making them public publishes your username, the artists you've saved, and your location
-          if you've set one, at a link anyone can open and search engines can index. Your email
-          address is never published. See the{' '}
+          Making it public publishes your username, the releases in your collection, the artists
+          you've saved, and your location if you've set one, at a link anyone can open and search
+          engines can index. Hidden items stay private, and your email address is never published.
+          See the{' '}
           <Link to="/terms#section-6" className="text-accent-primary hover:underline">Terms of Use</Link>.
         </p>
         {error && <p className="text-sm text-red-400 mt-2">{error}</p>}
@@ -140,12 +141,24 @@ export function SharingControls() {
   // State 3: Public (sharing on)
   return (
     <div className="rounded-lg border border-border p-4 bg-bg-secondary">
-      <p className="text-sm text-text-primary">Your saved artists are public.</p>
+      <p className="text-sm text-text-primary">Your profile is public.</p>
+      <p className="text-xs text-text-muted mt-1">
+        Anyone with the link can see the releases in your collection and the artists you've
+        saved. Items you've hidden stay private.
+      </p>
       {error && <p className="text-sm text-red-400 mt-2">{error}</p>}
       <div className="flex items-center gap-2 mt-2 flex-wrap">
         <span className="text-sm text-text-muted font-mono truncate max-w-xs">
           {sharing.public_url}
         </span>
+        <a
+          href={sharing.public_url ?? '#'}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm font-medium hover:text-text-primary hover:border-border-hover transition-colors"
+        >
+          View profile
+        </a>
         <button
           onClick={handleCopy}
           className={`px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors ${

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { Footer } from '../components/Footer';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { DashboardSkeleton } from '../components/LoadingSkeletons';
 import { RecentReleasesSection, type RecentRelease } from '../components/RecentReleasesSection';
+import { CollectionSection } from '../components/CollectionSection';
 import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
 
 interface ClaimedProfile {
@@ -363,6 +364,13 @@ export function DashboardPage() {
               subscribePanel={<ReleaseFeedControls />}
             />
           )}
+
+          {/*
+            The collection — releases actually bought (Support Loop Step 3). Its empty state
+            points at the Bandcamp import, a different action from the saved-artists empty
+            state below, so the two never say the same thing twice.
+          */}
+          <CollectionSection />
 
           {/* Saved Artists Section */}
           <section>

--- a/apps/web/src/pages/PublicSavedArtistsPage.tsx
+++ b/apps/web/src/pages/PublicSavedArtistsPage.tsx
@@ -13,10 +13,58 @@ interface SavedArtistPublic {
   supported: boolean;
 }
 
+interface CollectionItemPublic {
+  title: string;
+  artist_name: string;
+  art_url: string | null;
+  acquired_at: string | null;
+  url: string | null;
+}
+
 interface PublicSharingData {
   owner_display_name: string;
   owner_location: string | null;
   saved_artists: SavedArtistPublic[];
+  collection?: CollectionItemPublic[];
+}
+
+// One collection tile: album art (or a titled placeholder), caption underneath. Matched
+// items link to the release page so a viewer can buy the same record — the loop closes.
+function CollectionTile({ item }: { item: CollectionItemPublic }) {
+  const art = item.art_url ? (
+    <img
+      src={item.art_url}
+      alt={`${item.title} by ${item.artist_name}`}
+      loading="lazy"
+      className="w-full aspect-square object-cover rounded-lg bg-bg-hover"
+    />
+  ) : (
+    <div className="w-full aspect-square rounded-lg bg-bg-hover flex items-center justify-center p-3">
+      <span className="text-text-muted text-xs text-center line-clamp-4">{item.title}</span>
+    </div>
+  );
+
+  const caption = (
+    <div className="mt-1.5 min-w-0">
+      <p className="text-xs font-medium truncate">{item.title}</p>
+      <p className="text-xs text-text-muted truncate">{item.artist_name}</p>
+    </div>
+  );
+
+  if (item.url) {
+    return (
+      <Link to={item.url} className="block group">
+        <div className="group-hover:opacity-90 transition-opacity">{art}</div>
+        {caption}
+      </Link>
+    );
+  }
+  return (
+    <div>
+      {art}
+      {caption}
+    </div>
+  );
 }
 
 export function PublicSavedArtistsPage() {
@@ -98,15 +146,28 @@ export function PublicSavedArtistsPage() {
     );
   }
 
+  const collection = data.collection ?? [];
+  const supportedCount = data.saved_artists.filter(a => a.supported).length;
+  const countParts: string[] = [];
+  if (collection.length > 0) {
+    countParts.push(`${collection.length} release${collection.length === 1 ? '' : 's'} collected`);
+  }
+  if (supportedCount > 0) {
+    countParts.push(`${supportedCount} artist${supportedCount === 1 ? '' : 's'} supported`);
+  }
+
   return (
     <div className="min-h-screen bg-bg-primary text-text-primary flex flex-col">
       <Header />
       <main className="flex-1 p-6">
         <div className="max-w-2xl mx-auto">
           <div className="text-center mb-8">
-            <h1 className="text-2xl font-bold">{data.owner_display_name}'s saved artists</h1>
+            <h1 className="text-2xl font-bold">{data.owner_display_name}'s collection</h1>
             {data.owner_location && (
               <p className="text-text-primary text-sm mt-2">{data.owner_location}</p>
+            )}
+            {countParts.length > 0 && (
+              <p className="text-text-muted text-sm mt-2">{countParts.join(' · ')}</p>
             )}
             <button
               onClick={handleCopy}
@@ -123,9 +184,25 @@ export function PublicSavedArtistsPage() {
             </button>
           </div>
 
-          {data.saved_artists.length === 0 ? (
+          {/* The collection — evidence, not intent. Album art is what makes the page
+              worth screenshotting; omitted entirely when empty. */}
+          {collection.length > 0 && (
+            <section className="mb-10">
+              <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+                {collection.map((item, i) => (
+                  <CollectionTile key={`${item.artist_name}:${item.title}:${i}`} item={item} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {collection.length > 0 && data.saved_artists.length > 0 && (
+            <h2 className="text-lg font-semibold mb-4">Artists</h2>
+          )}
+
+          {data.saved_artists.length === 0 && collection.length === 0 ? (
             <div className="text-center py-12 rounded-lg border border-border border-dashed">
-              <p className="text-text-muted">No saved artists yet.</p>
+              <p className="text-text-muted">Nothing here yet.</p>
             </div>
           ) : (
             <div className="grid gap-3">

--- a/apps/web/src/pages/PublicSavedArtistsPage.tsx
+++ b/apps/web/src/pages/PublicSavedArtistsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
+import { CollectionGrid } from '../components/CollectionGrid';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { ArtistRowsSkeleton } from '../components/LoadingSkeletons';
 import { Skeleton } from '../components/Skeleton';
@@ -14,11 +15,13 @@ interface SavedArtistPublic {
 }
 
 interface CollectionItemPublic {
+  id: string;
   title: string;
   artist_name: string;
   art_url: string | null;
   acquired_at: string | null;
   url: string | null;
+  artist_url: string | null;
 }
 
 interface PublicSharingData {
@@ -26,45 +29,6 @@ interface PublicSharingData {
   owner_location: string | null;
   saved_artists: SavedArtistPublic[];
   collection?: CollectionItemPublic[];
-}
-
-// One collection tile: album art (or a titled placeholder), caption underneath. Matched
-// items link to the release page so a viewer can buy the same record — the loop closes.
-function CollectionTile({ item }: { item: CollectionItemPublic }) {
-  const art = item.art_url ? (
-    <img
-      src={item.art_url}
-      alt={`${item.title} by ${item.artist_name}`}
-      loading="lazy"
-      className="w-full aspect-square object-cover rounded-lg bg-bg-hover"
-    />
-  ) : (
-    <div className="w-full aspect-square rounded-lg bg-bg-hover flex items-center justify-center p-3">
-      <span className="text-text-muted text-xs text-center line-clamp-4">{item.title}</span>
-    </div>
-  );
-
-  const caption = (
-    <div className="mt-1.5 min-w-0">
-      <p className="text-xs font-medium truncate">{item.title}</p>
-      <p className="text-xs text-text-muted truncate">{item.artist_name}</p>
-    </div>
-  );
-
-  if (item.url) {
-    return (
-      <Link to={item.url} className="block group">
-        <div className="group-hover:opacity-90 transition-opacity">{art}</div>
-        {caption}
-      </Link>
-    );
-  }
-  return (
-    <div>
-      {art}
-      {caption}
-    </div>
-  );
 }
 
 export function PublicSavedArtistsPage() {
@@ -188,11 +152,17 @@ export function PublicSavedArtistsPage() {
               worth screenshotting; omitted entirely when empty. */}
           {collection.length > 0 && (
             <section className="mb-10">
-              <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
-                {collection.map((item, i) => (
-                  <CollectionTile key={`${item.artist_name}:${item.title}:${i}`} item={item} />
-                ))}
-              </div>
+              <CollectionGrid
+                items={collection.map(item => ({
+                  key: item.id,
+                  title: item.title,
+                  artistName: item.artist_name,
+                  artUrl: item.art_url,
+                  acquiredAt: item.acquired_at,
+                  releaseUrl: item.url,
+                  artistUrl: item.artist_url,
+                }))}
+              />
             </section>
           )}
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -96,9 +96,9 @@ export function SettingsPage() {
             />
           </section>
 
-          {/* Sharing section */}
+          {/* Public profile section */}
           <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
-            <h2 className="text-lg font-semibold">Sharing</h2>
+            <h2 className="text-lg font-semibold">Public profile</h2>
             <SharingControls />
           </section>
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { PasswordChangeForm } from '../components/PasswordChangeForm';
 import { SharingControls } from '../components/SharingControls';
 import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
 import { NotificationPreferences } from '../components/NotificationPreferences';
+import { BandcampConnect } from '../components/BandcampConnect';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
 
@@ -99,6 +100,12 @@ export function SettingsPage() {
           <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
             <h2 className="text-lg font-semibold">Sharing</h2>
             <SharingControls />
+          </section>
+
+          {/* Bandcamp collection section */}
+          <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
+            <h2 className="text-lg font-semibold">Bandcamp collection</h2>
+            <BandcampConnect />
           </section>
 
           {/* Release feed section */}

--- a/apps/web/src/utils/collection-grid.ts
+++ b/apps/web/src/utils/collection-grid.ts
@@ -1,0 +1,88 @@
+// Pure paging and sorting logic for the collection grid. Separate from the component so it
+// can be unit-tested directly, and so the component file exports only a component.
+
+export interface CollectionGridItem {
+  key: string;
+  title: string;
+  artistName: string;
+  artUrl: string | null;
+  acquiredAt: string | null;
+  /** Release page, when the item matched one. Null renders the title as plain text. */
+  releaseUrl: string | null;
+  /** Artist page, when that artist exists on Unstream. Null renders the name as plain text. */
+  artistUrl: string | null;
+  /** Owner view: hidden-from-public items are shown, dimmed. */
+  dimmed?: boolean;
+  /** Owner view: the per-tile hide/show control. */
+  overlay?: React.ReactNode;
+}
+
+export type CollectionSortKey = 'added' | 'album' | 'artist';
+
+export const COLLECTION_SORTS: { key: CollectionSortKey; label: string }[] = [
+  { key: 'added', label: 'Date added' },
+  { key: 'album', label: 'Album name (A–Z)' },
+  { key: 'artist', label: 'Artist name (A–Z)' },
+];
+
+/**
+ * 15 a page, in three rows of five. A real collection is ~190 items, and rendering all of
+ * them is both unnavigable and — now that unmatched covers are fetched from Bandcamp on
+ * demand — 190 upstream image requests on a single page load.
+ */
+export const COLLECTION_PAGE_SIZE = 15;
+
+/** How many consecutive page numbers to show around the current one. */
+const PAGE_RUN = 5;
+
+/**
+ * Page numbers to render, with nulls standing in for gaps: 1 … 5 6 [7] 8 9 … 13
+ *
+ * The run stays PAGE_RUN wide even at the ends — a window of just current±1 technically
+ * paginates but leaves most pages unreachable in one click, which defeats the point of
+ * numbering them.
+ */
+export function pageWindow(current: number, total: number): (number | null)[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  let start = Math.max(1, current - Math.floor(PAGE_RUN / 2));
+  const end = Math.min(total, start + PAGE_RUN - 1);
+  start = Math.max(1, end - PAGE_RUN + 1);
+
+  const pages = new Set<number>([1, total]);
+  for (let n = start; n <= end; n++) pages.add(n);
+
+  const ordered = [...pages].sort((a, b) => a - b);
+  const out: (number | null)[] = [];
+  for (let i = 0; i < ordered.length; i++) {
+    if (i > 0 && ordered[i] - ordered[i - 1] > 1) out.push(null);
+    out.push(ordered[i]);
+  }
+  return out;
+}
+
+export function sortItems(
+  items: CollectionGridItem[],
+  sort: CollectionSortKey
+): CollectionGridItem[] {
+  const sorted = [...items];
+  if (sort === 'album') {
+    sorted.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+  } else if (sort === 'artist') {
+    sorted.sort(
+      (a, b) =>
+        a.artistName.localeCompare(b.artistName, undefined, { sensitivity: 'base' }) ||
+        a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+    );
+  } else {
+    // Newest acquisition first. Items with no date sort last rather than to the top, where
+    // an unknown date would masquerade as the most recent purchase.
+    sorted.sort((a, b) => {
+      if (!a.acquiredAt && !b.acquiredAt) return 0;
+      if (!a.acquiredAt) return 1;
+      if (!b.acquiredAt) return -1;
+      return b.acquiredAt.localeCompare(a.acquiredAt);
+    });
+  }
+  return sorted;
+}

--- a/apps/web/tests/unit/BandcampConnect.test.tsx
+++ b/apps/web/tests/unit/BandcampConnect.test.tsx
@@ -32,11 +32,11 @@ describe('BandcampConnect', () => {
     render(<BandcampConnect />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+      expect(screen.getByLabelText('Username (from Bandcamp)')).not.toBeNull();
     });
-    expect(screen.getByLabelText('Subsonic credential')).not.toBeNull();
+    expect(screen.getByLabelText('Password (from Bandcamp)')).not.toBeNull();
     const link = screen.getByRole('link', { name: /Fan Settings/ }) as HTMLAnchorElement;
-    expect(link.href).toBe('https://bandcamp.com/settings');
+    expect(link.href).toBe('https://bandcamp.com/settings?pane=fan');
     // The beta caveat is part of the honesty contract in the spec.
     expect(screen.getByText(/beta/)).not.toBeNull();
   });
@@ -49,11 +49,11 @@ describe('BandcampConnect', () => {
 
     render(<BandcampConnect />);
     await waitFor(() => {
-      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+      expect(screen.getByLabelText('Username (from Bandcamp)')).not.toBeNull();
     });
 
-    fireEvent.change(screen.getByLabelText('Bandcamp username'), { target: { value: 'fan' } });
-    fireEvent.change(screen.getByLabelText('Subsonic credential'), { target: { value: 'sekrit' } });
+    fireEvent.change(screen.getByLabelText('Username (from Bandcamp)'), { target: { value: 'fan' } });
+    fireEvent.change(screen.getByLabelText('Password (from Bandcamp)'), { target: { value: 'sekrit' } });
     fireEvent.click(screen.getByRole('button', { name: 'Connect Bandcamp' }));
 
     await waitFor(() => {
@@ -78,18 +78,18 @@ describe('BandcampConnect', () => {
 
     render(<BandcampConnect />);
     await waitFor(() => {
-      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+      expect(screen.getByLabelText('Username (from Bandcamp)')).not.toBeNull();
     });
 
-    fireEvent.change(screen.getByLabelText('Bandcamp username'), { target: { value: 'fan' } });
-    fireEvent.change(screen.getByLabelText('Subsonic credential'), { target: { value: 'wrong' } });
+    fireEvent.change(screen.getByLabelText('Username (from Bandcamp)'), { target: { value: 'fan' } });
+    fireEvent.change(screen.getByLabelText('Password (from Bandcamp)'), { target: { value: 'wrong' } });
     fireEvent.click(screen.getByRole('button', { name: 'Connect Bandcamp' }));
 
     await waitFor(() => {
       expect(screen.getByText(/rejected that username or credential/)).not.toBeNull();
     });
     // Still on the form so the user can retry.
-    expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+    expect(screen.getByLabelText('Username (from Bandcamp)')).not.toBeNull();
   });
 
   it('shows sync results and offers re-sync when connected and idle', async () => {
@@ -130,7 +130,7 @@ describe('BandcampConnect', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Disconnect and delete items' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+      expect(screen.getByLabelText('Username (from Bandcamp)')).not.toBeNull();
     });
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/me/bandcamp',

--- a/apps/web/tests/unit/BandcampConnect.test.tsx
+++ b/apps/web/tests/unit/BandcampConnect.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { BandcampConnect } from '../../src/components/BandcampConnect';
+
+function statusResponse(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+describe('BandcampConnect', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ session: { access_token: 'test-token' } });
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the connect form with the Bandcamp settings link when not connected', async () => {
+    mockFetch.mockResolvedValueOnce(statusResponse({ connected: false }));
+
+    render(<BandcampConnect />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+    });
+    expect(screen.getByLabelText('Subsonic credential')).not.toBeNull();
+    const link = screen.getByRole('link', { name: /Fan Settings/ }) as HTMLAnchorElement;
+    expect(link.href).toBe('https://bandcamp.com/settings');
+    // The beta caveat is part of the honesty contract in the spec.
+    expect(screen.getByText(/beta/)).not.toBeNull();
+  });
+
+  it('submits the credential once and clears the form fields on success', async () => {
+    mockFetch.mockResolvedValueOnce(statusResponse({ connected: false }));
+    mockFetch.mockResolvedValueOnce(
+      statusResponse({ connected: true, username: 'fan', syncStatus: 'syncing', syncError: null })
+    );
+
+    render(<BandcampConnect />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+    });
+
+    fireEvent.change(screen.getByLabelText('Bandcamp username'), { target: { value: 'fan' } });
+    fireEvent.change(screen.getByLabelText('Subsonic credential'), { target: { value: 'sekrit' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Bandcamp' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Importing your collection/)).not.toBeNull();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/me/bandcamp',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ username: 'fan', password: 'sekrit' }),
+      })
+    );
+  });
+
+  it('surfaces the server error message on a rejected credential', async () => {
+    mockFetch.mockResolvedValueOnce(statusResponse({ connected: false }));
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Bandcamp rejected that username or credential.' }),
+    });
+
+    render(<BandcampConnect />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+    });
+
+    fireEvent.change(screen.getByLabelText('Bandcamp username'), { target: { value: 'fan' } });
+    fireEvent.change(screen.getByLabelText('Subsonic credential'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Bandcamp' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/rejected that username or credential/)).not.toBeNull();
+    });
+    // Still on the form so the user can retry.
+    expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+  });
+
+  it('shows sync results and offers re-sync when connected and idle', async () => {
+    mockFetch.mockResolvedValueOnce(
+      statusResponse({
+        connected: true,
+        username: 'fan',
+        syncStatus: 'idle',
+        syncError: null,
+        itemCount: 128,
+        lastSyncedAt: '2026-08-09T12:00:00Z',
+      })
+    );
+
+    render(<BandcampConnect />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fan')).not.toBeNull();
+    });
+    expect(screen.getByText(/128 releases imported/)).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Re-sync' })).not.toBeNull();
+  });
+
+  it('disconnecting asks what to do with imported items', async () => {
+    mockFetch.mockResolvedValueOnce(
+      statusResponse({ connected: true, username: 'fan', syncStatus: 'idle', itemCount: 5 })
+    );
+    mockFetch.mockResolvedValueOnce(statusResponse({ connected: false, itemsDeleted: 5 }));
+
+    render(<BandcampConnect />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Disconnect' })).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    expect(screen.getByRole('button', { name: 'Disconnect, keep items' })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect and delete items' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bandcamp username')).not.toBeNull();
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/me/bandcamp',
+      expect.objectContaining({
+        method: 'DELETE',
+        body: JSON.stringify({ deleteItems: true }),
+      })
+    );
+  });
+
+  it('shows the sync error with a re-sync path when the import failed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      statusResponse({
+        connected: true,
+        username: 'fan',
+        syncStatus: 'error',
+        syncError: 'The sync failed partway through.',
+      })
+    );
+
+    render(<BandcampConnect />);
+
+    await waitFor(() => {
+      expect(screen.getByText('The sync failed partway through.')).not.toBeNull();
+    });
+    expect(screen.getByRole('button', { name: 'Re-sync' })).not.toBeNull();
+  });
+});

--- a/apps/web/tests/unit/CollectionGrid.test.tsx
+++ b/apps/web/tests/unit/CollectionGrid.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CollectionGrid } from '../../src/components/CollectionGrid';
+import {
+  COLLECTION_PAGE_SIZE,
+  pageWindow,
+  sortItems,
+  type CollectionGridItem,
+} from '../../src/utils/collection-grid';
+
+function item(over: Partial<CollectionGridItem> & { key: string }): CollectionGridItem {
+  return {
+    title: 'A Title',
+    artistName: 'An Artist',
+    artUrl: null,
+    acquiredAt: null,
+    releaseUrl: null,
+    artistUrl: null,
+    ...over,
+  };
+}
+
+function manyItems(n: number) {
+  return Array.from({ length: n }, (_, i) =>
+    item({ key: `k${i}`, title: `Album ${String(i).padStart(3, '0')}` })
+  );
+}
+
+function renderGrid(items: CollectionGridItem[]) {
+  return render(
+    <MemoryRouter>
+      <CollectionGrid items={items} />
+    </MemoryRouter>
+  );
+}
+
+describe('pageWindow', () => {
+  it('lists every page when there are few', () => {
+    expect(pageWindow(1, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('always keeps the first and last page reachable', () => {
+    const w = pageWindow(7, 13);
+    expect(w[0]).toBe(1);
+    expect(w[w.length - 1]).toBe(13);
+    expect(w).toContain(7);
+  });
+
+  it('marks gaps with nulls rather than dropping them silently', () => {
+    expect(pageWindow(7, 13)).toEqual([1, null, 5, 6, 7, 8, 9, null, 13]);
+  });
+
+  it('keeps a full run of pages reachable at either end', () => {
+    expect(pageWindow(1, 13)).toEqual([1, 2, 3, 4, 5, null, 13]);
+    expect(pageWindow(13, 13)).toEqual([1, null, 9, 10, 11, 12, 13]);
+  });
+});
+
+describe('sortItems', () => {
+  const unsorted = [
+    item({ key: 'b', title: 'Bravo', artistName: 'Zed', acquiredAt: '2024-01-01T00:00:00Z' }),
+    item({ key: 'a', title: 'alpha', artistName: 'Ada', acquiredAt: '2026-01-01T00:00:00Z' }),
+    item({ key: 'c', title: 'Charlie', artistName: 'Moe', acquiredAt: null }),
+  ];
+
+  it('sorts by album name case-insensitively', () => {
+    expect(sortItems(unsorted, 'album').map(i => i.key)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts by artist name', () => {
+    expect(sortItems(unsorted, 'artist').map(i => i.key)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('sorts newest acquisition first, with undated items last', () => {
+    // An unknown date must not masquerade as the most recent purchase.
+    expect(sortItems(unsorted, 'added').map(i => i.key)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [...unsorted];
+    sortItems(input, 'album');
+    expect(input.map(i => i.key)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('CollectionGrid', () => {
+  afterEach(cleanup);
+
+  it('shows only one page of tiles and reports the full count', () => {
+    renderGrid(manyItems(190));
+    expect(screen.getByText('190 releases')).not.toBeNull();
+    expect(screen.getByText('Album 000')).not.toBeNull();
+    expect(screen.getByText(`Album ${String(COLLECTION_PAGE_SIZE - 1).padStart(3, '0')}`)).not.toBeNull();
+    // The 16th item belongs to page 2.
+    expect(screen.queryByText(`Album ${String(COLLECTION_PAGE_SIZE).padStart(3, '0')}`)).toBeNull();
+  });
+
+  it('jumps to a numbered page', () => {
+    renderGrid(manyItems(190));
+    fireEvent.click(screen.getByRole('button', { name: 'Page 3' }));
+    // Page 3 starts at index 30.
+    expect(screen.getByText('Album 030')).not.toBeNull();
+    expect(screen.queryByText('Album 000')).toBeNull();
+  });
+
+  it('renders no pagination for a single page', () => {
+    renderGrid(manyItems(5));
+    expect(screen.queryByRole('navigation', { name: 'Collection pages' })).toBeNull();
+  });
+
+  it('returns to page 1 when the sort changes, so the view is never stranded', () => {
+    renderGrid(manyItems(190));
+    fireEvent.click(screen.getByRole('button', { name: 'Page 3' }));
+    expect(screen.queryByText('Album 000')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Sort collection'), { target: { value: 'album' } });
+    expect(screen.getByText('Album 000')).not.toBeNull();
+  });
+
+  it('links the release and the artist only when a page exists for them', () => {
+    renderGrid([
+      item({
+        key: 'linked',
+        title: 'Illinois',
+        artistName: 'Sufjan Stevens',
+        releaseUrl: '/a/sufjan-stevens/illinois',
+        artistUrl: '/a/sufjan-stevens',
+      }),
+      item({ key: 'plain', title: 'Obscure Tape', artistName: 'Nobody We Know' }),
+    ]);
+
+    expect(screen.getByRole('link', { name: 'Illinois' }).getAttribute('href')).toBe('/a/sufjan-stevens/illinois');
+    expect(screen.getByRole('link', { name: 'Sufjan Stevens' }).getAttribute('href')).toBe('/a/sufjan-stevens');
+    // Unlinkable ones render as text, not as links to a 404.
+    expect(screen.queryByRole('link', { name: 'Obscure Tape' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Nobody We Know' })).toBeNull();
+    expect(screen.getByText('Obscure Tape')).not.toBeNull();
+  });
+
+  it('drops to the placeholder, keeping the caption, when cover art fails to load', () => {
+    renderGrid([item({ key: 'a', title: 'Missing Art', artUrl: '/api/collection/art/a' })]);
+
+    const img = screen.getByAltText('Missing Art by An Artist');
+    // The art proxy 404s when Bandcamp has no cover — an expected outcome, not an error.
+    fireEvent.error(img);
+    expect(screen.queryByAltText('Missing Art by An Artist')).toBeNull();
+    expect(screen.getByText('Missing Art')).not.toBeNull();
+  });
+});

--- a/apps/web/tests/unit/CollectionSection.test.tsx
+++ b/apps/web/tests/unit/CollectionSection.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { CollectionSection } from '../../src/components/CollectionSection';
+
+const ITEM = {
+  id: 'i-1',
+  source: 'bandcamp',
+  title: 'Illinois',
+  artist_name: 'Sufjan Stevens',
+  art_url: 'https://f4.bcbits.com/a.jpg',
+  acquired_at: '2026-01-01T00:00:00Z',
+  provenance: 'purchased',
+  hidden: false,
+  release_id: 'rel-1',
+};
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <CollectionSection />
+    </MemoryRouter>
+  );
+}
+
+describe('CollectionSection', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ session: { access_token: 'test-token' } });
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('empty state points at the Bandcamp import, not at search', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], total: 0 }) });
+    renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText(/No releases in your collection yet/)).not.toBeNull();
+    });
+    const link = screen.getByRole('link', { name: /Connect your collection in Settings/ }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/settings');
+  });
+
+  it('renders items as an art grid with a hide control', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ items: [ITEM], total: 1 }) });
+    renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Illinois')).not.toBeNull();
+    });
+    expect(screen.getByAltText('Illinois by Sufjan Stevens')).not.toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Hide Illinois from your public page' })
+    ).not.toBeNull();
+  });
+
+  it('toggles hidden via POST and reflects the server response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ items: [ITEM], total: 1 }) });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ ...ITEM, hidden: true }) });
+    renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Illinois')).not.toBeNull();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Hide Illinois from your public page' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Show Illinois on your public page' })).not.toBeNull();
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/me/collection',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: 'i-1', hidden: true }),
+      })
+    );
+  });
+});

--- a/apps/web/tests/unit/SharingControls.test.tsx
+++ b/apps/web/tests/unit/SharingControls.test.tsx
@@ -40,7 +40,7 @@ describe('SharingControls', () => {
 
     renderWithRouter();
     await waitFor(() => {
-      expect(screen.getByText('Set a username to share your saved artists.')).not.toBeNull();
+      expect(screen.getByText('Set a username to publish your public profile.')).not.toBeNull();
     });
     expect(screen.getByText('Set username').getAttribute('href')).toBe('/settings');
   });
@@ -53,7 +53,7 @@ describe('SharingControls', () => {
 
     renderWithRouter();
     await waitFor(() => {
-      expect(screen.getByText('Your saved artists are private.')).not.toBeNull();
+      expect(screen.getByText('Your profile is private.')).not.toBeNull();
     });
     expect(screen.getByText('Make public')).not.toBeNull();
   });
@@ -70,11 +70,50 @@ describe('SharingControls', () => {
 
     renderWithRouter();
     await waitFor(() => {
-      expect(screen.getByText('Your saved artists are public.')).not.toBeNull();
+      expect(screen.getByText('Your profile is public.')).not.toBeNull();
     });
     expect(screen.getByText('https://unstream.stream/u/testuser')).not.toBeNull();
     expect(screen.getByText('Copy')).not.toBeNull();
     expect(screen.getByText('Make private')).not.toBeNull();
+  });
+
+  it('offers a View profile link that opens the public page in a new tab', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        public: true,
+        public_handle: 'testuser',
+        public_url: 'https://unstream.stream/u/testuser',
+      }),
+    });
+
+    renderWithRouter();
+    await waitFor(() => {
+      expect(screen.getByText('Your profile is public.')).not.toBeNull();
+    });
+
+    const view = screen.getByRole('link', { name: 'View profile' });
+    expect(view.getAttribute('href')).toBe('https://unstream.stream/u/testuser');
+    expect(view.getAttribute('target')).toBe('_blank');
+    // rel is not optional on a target=_blank link: without it the opened page gets
+    // window.opener and can navigate this tab.
+    expect(view.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('says the collection is published, not just saved artists', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ public: false, public_handle: 'testuser', public_url: null }),
+    });
+
+    renderWithRouter();
+    await waitFor(() => {
+      expect(screen.getByText('Your profile is private.')).not.toBeNull();
+    });
+    // The collection is the bigger disclosure of the two — it must be named before someone
+    // opts in, not discovered afterwards.
+    expect(screen.getByText(/releases in your collection/)).not.toBeNull();
+    expect(screen.getByText(/Hidden items stay private/)).not.toBeNull();
   });
 
   it('calls API to enable sharing when Make public is clicked', async () => {
@@ -99,7 +138,7 @@ describe('SharingControls', () => {
     fireEvent.click(screen.getByText('Make public'));
 
     await waitFor(() => {
-      expect(screen.getByText('Your saved artists are public.')).not.toBeNull();
+      expect(screen.getByText('Your profile is public.')).not.toBeNull();
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -133,7 +172,7 @@ describe('SharingControls', () => {
     fireEvent.click(screen.getByText('Make private'));
 
     await waitFor(() => {
-      expect(screen.getByText('Your saved artists are private.')).not.toBeNull();
+      expect(screen.getByText('Your profile is private.')).not.toBeNull();
     });
 
     expect(mockFetch).toHaveBeenCalledWith(

--- a/netlify.toml
+++ b/netlify.toml
@@ -144,6 +144,19 @@
   to = "/.netlify/functions/me-password"
   status = 200
 
+# Bandcamp collection connection (Subsonic beta). The connect POST carries a credential,
+# which is why it's proxied server-side and stored encrypted — requires
+# BANDCAMP_CREDENTIAL_KEY (see api/functions/credential-crypto.ts).
+[[redirects]]
+  from = "/api/me/bandcamp"
+  to = "/.netlify/functions/me-bandcamp"
+  status = 200
+
+[[redirects]]
+  from = "/api/me/collection"
+  to = "/.netlify/functions/me-collection"
+  status = 200
+
 # Newsletter signup. Proxies to Buttondown server-side so the API key stays out of the
 # browser and the CSP doesn't need a third-party script host. Requires BUTTONDOWN_API_KEY.
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -157,6 +157,14 @@
   to = "/.netlify/functions/me-collection"
   status = 200
 
+# Cover art for a collection item, proxied from Bandcamp. Subsonic serves art from an
+# authenticated endpoint whose credentials ride the query string, so the image cannot be
+# linked directly from a page — see api/functions/collection-art.ts.
+[[redirects]]
+  from = "/api/collection/art/*"
+  to = "/.netlify/functions/collection-art"
+  status = 200
+
 # Newsletter signup. Proxies to Buttondown server-side so the API key stays out of the
 # browser and the CSP doesn't need a third-party script host. Requires BUTTONDOWN_API_KEY.
 [[redirects]]

--- a/supabase/migrations/20260809120000_bandcamp-collection.sql
+++ b/supabase/migrations/20260809120000_bandcamp-collection.sql
@@ -1,5 +1,10 @@
 -- Migration: bandcamp_connections, collection_items, listening_signals
 --
+-- Applied to production ahead of the PR merge (workflow_dispatch, 2026-08-09) so the
+-- deploy preview — which shares the production database — could exercise the connect
+-- flow. Purely additive, so the early application is the safe side of the
+-- migration/deploy race.
+--
 -- The Support Loop, Step 1 (docs: support-loop-spec.md, collection-spec.md §4–5).
 -- Three tables:
 --

--- a/supabase/migrations/20260809120000_bandcamp-collection.sql
+++ b/supabase/migrations/20260809120000_bandcamp-collection.sql
@@ -1,0 +1,192 @@
+-- Migration: bandcamp_connections, collection_items, listening_signals
+--
+-- The Support Loop, Step 1 (docs: support-loop-spec.md, collection-spec.md §4–5).
+-- Three tables:
+--
+--   bandcamp_connections  one row per user who connected their Bandcamp collection via
+--                         Bandcamp's Subsonic API (open beta, shipped 2026-07-16)
+--   collection_items      releases a user actually acquired — the public collection
+--   listening_signals     streaming-side play counts (Apple Music, Last.fm, the Mac app's
+--                         now-playing monitor). Feeds the private "gap" report. Schema lands
+--                         now so Steps 2 and 5 have a landing zone; nothing writes it yet.
+--
+-- The gap itself (artists you play a lot and never paid) is DERIVED at read time from
+-- listening_signals minus collection_items minus supported_artists — deliberately not
+-- stored, so it can't go stale.
+
+-- ---------------------------------------------------------------------------
+-- bandcamp_connections
+-- ---------------------------------------------------------------------------
+
+-- Credential handling: Subsonic auth is username + token, not OAuth, so this table holds
+-- the keys to someone's Bandcamp account. What is stored is the salted-token form
+-- (t = md5(password + salt), plus the salt) — the plaintext password is derived from and
+-- discarded during the connect request and never persisted. The (t, s) pair is encrypted
+-- with AES-256-GCM before it reaches this table; the key lives ONLY in the Netlify env var
+-- BANDCAMP_CREDENTIAL_KEY (see api/functions/credential-crypto.ts for why app-level
+-- encryption was chosen over pgcrypto and Supabase Vault: the key must never appear in SQL
+-- text or share a trust domain with the ciphertext). A leak of this table alone reveals
+-- nothing usable.
+
+CREATE TABLE IF NOT EXISTS bandcamp_connections (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  bandcamp_username text NOT NULL,
+
+  -- base64(iv) || '.' || base64(authTag) || '.' || base64(ciphertext); ciphertext is the
+  -- JSON {"t": ..., "s": ...}. Encrypted/decrypted only in api/functions/credential-crypto.ts.
+  credential_ciphertext text NOT NULL,
+
+  sync_status text NOT NULL DEFAULT 'idle'
+    CHECK (sync_status IN ('idle', 'syncing', 'error')),
+
+  -- Human-readable failure summary for the settings page. Never contains credentials.
+  sync_error text,
+
+  -- Items imported by the last successful sync. NULL until one completes.
+  item_count integer CHECK (item_count IS NULL OR item_count >= 0),
+  last_synced_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS trg_bandcamp_connections_updated_at ON bandcamp_connections;
+CREATE TRIGGER trg_bandcamp_connections_updated_at
+  BEFORE UPDATE ON bandcamp_connections
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- Server-only table: RLS enabled with NO policies, deliberately (same shape as
+-- bandcamp_slug_probes). Even the owner's own session must not read the ciphertext through
+-- PostgREST — all access goes through me-bandcamp.ts / bandcamp-sync-background.ts using
+-- the service-role client, which return status fields but never the credential.
+ALTER TABLE bandcamp_connections ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE bandcamp_connections IS
+  'One row per user with a connected Bandcamp collection (Subsonic beta). Credential is AES-256-GCM-encrypted with a key held only in Netlify env. Server-only: RLS with no policies is deliberate.';
+
+-- ---------------------------------------------------------------------------
+-- collection_items
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS collection_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Matched Unstream release where one exists. Nullable on purpose: an unmatched import
+  -- still appears in the collection rather than vanishing, rendered from the denormalised
+  -- fields below.
+  release_id uuid REFERENCES releases(id) ON DELETE SET NULL,
+
+  source text NOT NULL CHECK (source IN ('bandcamp', 'discogs', 'manual')),
+
+  -- The source's own stable id (Subsonic album id for Bandcamp). What makes re-sync
+  -- idempotent: upserts key on (user_id, source, external_id) instead of minting duplicates.
+  external_id text,
+
+  -- Denormalised so an unmatched item still renders.
+  title text NOT NULL,
+  artist_name text NOT NULL,
+  art_url text,
+
+  acquired_at timestamptz,
+
+  -- The load-bearing distinction (collection-spec.md §5). Only 'purchased' ever appears on
+  -- the public collection page; 'owned' and 'listened' feed the private gap report.
+  -- Conflating these would make the page lie about support. Everything from the Bandcamp
+  -- import is 'purchased' — a Bandcamp collection is proof of purchase.
+  provenance text NOT NULL CHECK (provenance IN ('purchased', 'owned', 'listened')),
+
+  -- Paid vs free-download vs unknown. Bandcamp's Subsonic API doesn't say, so imports are
+  -- 'unknown' until a source can tell us.
+  acquisition text NOT NULL DEFAULT 'unknown'
+    CHECK (acquisition IN ('purchased', 'free', 'unknown')),
+
+  -- Per-item hide from the public page. The owner still sees hidden items.
+  hidden boolean NOT NULL DEFAULT false,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Re-sync updates rather than duplicates: imports upsert on these three columns.
+  -- A plain constraint, not a partial index, because PostgREST's upsert emits
+  -- ON CONFLICT (cols) without a WHERE clause and so can't target a partial index.
+  -- Manual items (external_id NULL) never collide — Postgres treats NULLs as distinct.
+  UNIQUE (user_id, source, external_id)
+);
+
+DROP TRIGGER IF EXISTS trg_collection_items_updated_at ON collection_items;
+CREATE TRIGGER trg_collection_items_updated_at
+  BEFORE UPDATE ON collection_items
+  FOR EACH ROW
+  EXECUTE FUNCTION set_releases_updated_at();
+
+-- The page read: one user's collection, most recently acquired first.
+CREATE INDEX IF NOT EXISTS idx_collection_items_user_chrono
+  ON collection_items (user_id, acquired_at DESC NULLS LAST, created_at DESC);
+
+ALTER TABLE collection_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own collection items" ON collection_items;
+DROP POLICY IF EXISTS "Users can update own collection items" ON collection_items;
+DROP POLICY IF EXISTS "Users can delete own collection items" ON collection_items;
+
+CREATE POLICY "Users can view own collection items"
+  ON collection_items FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own collection items"
+  ON collection_items FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own collection items"
+  ON collection_items FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- No INSERT policy, deliberately: rows are written only by server code (imports, and later
+-- a manual-add endpoint) through the service-role client, which is what keeps provenance
+-- honest — a client that could insert its own rows could mark anything 'purchased'.
+
+COMMENT ON TABLE collection_items IS
+  'Releases a user actually acquired. provenance gates the public page: only purchased is ever public. Inserts are service-role only so provenance stays honest.';
+
+-- ---------------------------------------------------------------------------
+-- listening_signals
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS listening_signals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  artist_name text NOT NULL,
+
+  source text NOT NULL CHECK (source IN ('apple_music', 'lastfm', 'mac_app')),
+
+  play_count integer NOT NULL DEFAULT 0 CHECK (play_count >= 0),
+  last_played timestamptz,
+  synced_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (user_id, source, artist_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_listening_signals_user
+  ON listening_signals (user_id, play_count DESC);
+
+ALTER TABLE listening_signals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own listening signals" ON listening_signals;
+DROP POLICY IF EXISTS "Users can delete own listening signals" ON listening_signals;
+
+CREATE POLICY "Users can view own listening signals"
+  ON listening_signals FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own listening signals"
+  ON listening_signals FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- No INSERT/UPDATE policies: writes come from server sync endpoints via the service-role
+-- client. The gap report derived from this table is private to the owner — nothing here is
+-- ever rendered publicly.
+
+COMMENT ON TABLE listening_signals IS
+  'Streaming-side play counts per (user, source, artist). Feeds the private gap report; never public. Written by server sync code only.';


### PR DESCRIPTION
## What this is

Steps 1 and 3 of the Support Loop (`support-loop-spec.md`), plus Brandon's answers to open questions 5 and 6: the full web half of the loop, from connecting a Bandcamp collection to a shareable collection page.

## Step 1 — Bandcamp collection import

1. `/settings` → **Bandcamp collection** → generate a Subsonic credential in Bandcamp's Fan Settings, paste username + credential.
2. `me-bandcamp` verifies the credential against Bandcamp inline (`ping`), converts it to the Subsonic salted-token pair, encrypts it, stores it, and kicks off `bandcamp-sync-background`.
3. The background function pages through `getAlbumList2`, upserts items into the new `collection_items` table as `provenance: purchased` (idempotent on `user_id, source, external_id`), and matches albums to Unstream artists/releases by normalized name — skipping ambiguous names rather than guessing.
4. The settings section polls while syncing, then offers Re-sync and Disconnect (with an explicit keep-or-delete-items choice).

## OQ6 — buying is supporting

The import marks every unambiguously matched artist as **saved + supported**. Guardrails: tombstoned rows are never resurrected (permanent dismissal is a locked spec decision), an already-supported row keeps its original `supported_at`, and nothing can ever un-support or touch notes. Newly saved artists get catalogued by the six-hourly sweep (saved artists sort first) rather than an immediate crawl burst.

## Step 3 — the collection page (OQ5: two views of the same data)

`/u/:handle` now leads with an **album-art grid** of purchased, non-hidden items — counts in the header ("N releases collected · M artists supported"), matched items linking to their release page so a viewer can buy the same record — with the artists list below. Same content on the crawler render (capped at 60 tiles). `/dashboard` gains a **Your Collection** section: the owner's full grid including hidden items, per-item hide/unhide, and an empty state that points at the import.

## Decisions worth reviewing

- **Credential encryption (spec OQ1):** app-level AES-256-GCM via `node:crypto`, key in Netlify env `BANDCAMP_CREDENTIAL_KEY`. pgcrypto puts the key in SQL text (Postgres logs); Vault keeps key and ciphertext in one trust domain. With this split, a leak of either store alone reveals nothing.
- **`bandcamp_connections` is server-only** (RLS, no policies): even the owner's session can't read the ciphertext.
- **`collection_items` INSERT is service-role only** so nothing client-side can mark itself `purchased` — the provenance gate is what keeps the public page honest.
- **Never cache uncertainty, sync edition:** a mid-pagination failure records `sync_status='error'`; a partial import is never recorded as a completed sync. Likewise a failed collection read on the public page is a 500, not an empty collection.
- **`listening_signals` ships now** (schema only) as the landing zone for Steps 2/5.

## Verification

- 50 new tests across crypto, the Subsonic client, connect/disconnect, sync + auto-mark rules, collection endpoints, and both UIs; full suites pass (1,120 API + 726 web) and `npm run build` is green. Lint at the pre-existing 71-problem baseline.
- Migration validated against a throwaway Postgres 16: clean apply, idempotent re-apply, upsert dedup, NULL-distinct manual items, CHECK rejections, RLS shape.

## Before this works in production

1. Set `BANDCAMP_CREDENTIAL_KEY` in Netlify (Functions scope): `node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`
2. `INTERNAL_FUNCTION_SECRET` is already set for the catalog functions and is reused here.

Not testable end-to-end until a real Bandcamp account connects — spec OQ2 (what the beta actually returns) still needs that.

Pairs with #439 (Apple Music library import, Step 2). Independent code paths; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)