### PR TITLE
Only alert on releases that are actually new

### DIFF
--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -104,6 +104,7 @@ interface ReleaseRow {
   slug: string;
   release_date: string | null;
   date_precision: string | null;
+  status: string;
   created_at: string;
 }
 
@@ -113,14 +114,15 @@ interface ReleaseRow {
  * `saved_artists`, `artists`, `releases`, `release_sources`, `email_log`,
  * `notification_preferences`, and `auth.admin.getUserById` all in one client.
  *
- * The `releases` update is modelled as a real claim: it hands back the rows that are still
- * unclaimed and empties the pool, so a second call to the same client sees what production
- * would see on the next catalog run — nothing.
+ * `releases` is modelled as the real two-step claim: a select of everything still unclaimed,
+ * then an update over the ids the caller chose, which marks exactly those and reports back which
+ * it won. A second call sees what the next catalog run would see, so anything the caller declines
+ * to claim — an undated release — stays pending exactly as it does in the database.
  */
 function makeFanoutClient(opts: {
   savedArtists?: { data: { user_id: string }[] | null; error?: unknown };
   artistRow?: { data: { name: string; slug: string } | null; error?: unknown };
-  releases?: { data: ReleaseRow[] | null; error?: unknown };
+  releases?: { data: ReleaseRow[] | null; error?: unknown; claimError?: unknown; stolenIds?: string[] };
   releaseSources?: { data: { release_id: string; platform: string }[] | null; error?: unknown };
   emails?: Record<string, string>;
   optedOut?: Record<string, boolean>;
@@ -133,10 +135,17 @@ function makeFanoutClient(opts: {
   const optedOut = opts.optedOut ?? {};
 
   let unclaimed = releasesResult.data;
-  const claimReleases = vi.fn(() => {
-    const claimed = unclaimed;
-    unclaimed = unclaimed ? [] : null;
-    return Promise.resolve({ data: claimed, error: releasesResult.error ?? null });
+  const readUnclaimed = vi.fn(() =>
+    Promise.resolve({ data: unclaimed, error: releasesResult.error ?? null }),
+  );
+  const claimByIds = vi.fn((_col: string, ids: string[]) => {
+    // `stolenIds` stand in for rows a concurrent catalog run claimed between our read and our
+    // write: still asked for, but not won.
+    const stolen = opts.releases?.stolenIds ?? [];
+    const won = (unclaimed || []).filter(row => ids.includes(row.id) && !stolen.includes(row.id));
+    unclaimed = unclaimed ? unclaimed.filter(row => !ids.includes(row.id)) : null;
+    const result = { data: won.map(row => ({ id: row.id })), error: releasesResult.claimError ?? null };
+    return { is: () => ({ select: () => Promise.resolve(result) }) };
   });
 
   const from = vi.fn((table: string) => {
@@ -147,7 +156,10 @@ function makeFanoutClient(opts: {
       return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve(artistRowResult) }) }) };
     }
     if (table === 'releases') {
-      return { update: () => ({ eq: () => ({ eq: () => ({ is: () => ({ select: claimReleases }) }) }) }) };
+      return {
+        select: () => ({ eq: () => ({ eq: () => ({ is: readUnclaimed }) }) }),
+        update: () => ({ in: claimByIds }),
+      };
     }
     if (table === 'release_sources') {
       return { select: () => ({ in: () => Promise.resolve(releaseSourcesResult) }) };
@@ -183,7 +195,7 @@ function makeFanoutClient(opts: {
   return { from, auth: { admin: { getUserById } } } as never;
 }
 
-/** Two savers and one newly discovered release — the shape most of these tests need. */
+/** Two savers and one release out two days ago — the shape most of these tests need. */
 function releaseClient(overrides: Parameters<typeof makeFanoutClient>[0] = {}) {
   return makeFanoutClient({
     savedArtists: { data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null },
@@ -194,13 +206,19 @@ function releaseClient(overrides: Parameters<typeof makeFanoutClient>[0] = {}) {
   });
 }
 
+/** An ISO date `offsetDays` from today — negative for the past. Relative, so no clock stubbing. */
+function isoDate(offsetDays: number): string {
+  return new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10);
+}
+
 function release(id: string, title: string, overrides: Partial<ReleaseRow> = {}): ReleaseRow {
   return {
     id,
     title,
     slug: title.toLowerCase().replace(/ /g, '-'),
-    release_date: '2026-08-12',
+    release_date: isoDate(-2),
     date_precision: 'day',
+    status: 'released',
     created_at: '2026-08-12T00:00:00Z',
     ...overrides,
   };
@@ -215,7 +233,7 @@ describe('notifySavedArtistsOfNewRelease', () => {
   it('sends nothing when no release is unaccounted for', async () => {
     const client = releaseClient({ releases: { data: [], error: null } });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
   });
@@ -224,32 +242,85 @@ describe('notifySavedArtistsOfNewRelease', () => {
     const client = releaseClient();
 
     // One email per saver on the first run, and not one more on the second.
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
   });
 
-  it('claims an artist’s first catalogue without announcing it as new', async () => {
+  it('says nothing about a release that came out years ago', async () => {
     const client = releaseClient({
-      releases: { data: [release('r1', 'Old Album'), release('r2', 'Older Album')], error: null },
+      releases: { data: [release('r1', 'Old Album', { release_date: '2019-04-01' })], error: null },
     });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 0 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+  });
 
-    // The back catalogue was claimed all the same, so a later run can't announce it either —
-    // the next genuinely new release is the first thing anyone hears about.
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 2 });
+  it('counts a release from exactly a week ago as news, and one from the day before as not', async () => {
+    const onTheEdge = releaseClient({
+      releases: { data: [release('r1', 'Just Inside', { release_date: isoDate(-7) })], error: null },
+    });
+    await notifySavedArtistsOfNewRelease({ client: onTheEdge, artistId: 'artist-1' });
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
+
+    mocks.sendTransactionalEmail.mockClear();
+
+    const justOutside = releaseClient({
+      releases: { data: [release('r2', 'Just Outside', { release_date: isoDate(-8) })], error: null },
+    });
+    await notifySavedArtistsOfNewRelease({ client: justOutside, artistId: 'artist-1' });
     expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+  });
+
+  it('announces a release that has not come out yet', async () => {
+    const client = releaseClient({
+      releases: { data: [release('r1', 'Next Month', { release_date: isoDate(30), status: 'announced' })], error: null },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('Next Month');
+  });
+
+  it('announces a pre-order that reached us without a date', async () => {
+    const client = releaseClient({
+      releases: {
+        data: [release('r1', 'Pre Order', { release_date: null, date_precision: null, status: 'announced' })],
+        error: null,
+      },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
+    // Nothing is invented about when it lands — we say we don't know.
+    expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('Release date not listed');
+  });
+
+  it('leaves an undated release pending, and announces it once a date arrives', async () => {
+    const pending = release('r1', 'No Date Yet', { release_date: null, date_precision: null });
+    const client = releaseClient({ releases: { data: [pending], error: null } });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+
+    // A later run's detail pass fills the date in. Because the row was never claimed, it is still
+    // there to be judged — an unknown date was not cached as a permanent "not news".
+    pending.release_date = isoDate(-1);
+    pending.date_precision = 'day';
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+    expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
   });
 
   it('does nothing when nobody saved the artist', async () => {
     const client = releaseClient({ savedArtists: { data: [], error: null } });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
   });
@@ -257,7 +328,7 @@ describe('notifySavedArtistsOfNewRelease', () => {
   it('emails every saver about the artist by name, linking to their profile', async () => {
     const client = releaseClient();
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
     const recipients = mocks.sendTransactionalEmail.mock.calls.map(([params]) => params.to);
@@ -267,6 +338,7 @@ describe('notifySavedArtistsOfNewRelease', () => {
 
   it('names the release, its date, and the platforms it can be bought on', async () => {
     const client = releaseClient({
+      releases: { data: [release('r1', 'Fine Motor Control', { release_date: '2026-08-12' })], error: null },
       releaseSources: {
         // Deliberately lowest-payout-first, to prove the artist-paying-first ordering is applied.
         data: [{ release_id: 'r1', platform: 'discogs' }, { release_id: 'r1', platform: 'bandcamp' }],
@@ -274,7 +346,7 @@ describe('notifySavedArtistsOfNewRelease', () => {
       },
     });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     const sent = mocks.sendTransactionalEmail.mock.calls[0][0];
     expect(sent.subject).toBe('New release from Test Artist: Fine Motor Control');
@@ -284,63 +356,81 @@ describe('notifySavedArtistsOfNewRelease', () => {
     expect(sent.text).toContain('12 August 2026 · Available on Bandcamp, Discogs');
   });
 
-  it('says the date is not listed rather than inventing one', async () => {
-    const client = releaseClient({
-      releases: { data: [release('r1', 'Untitled', { release_date: null, date_precision: null })], error: null },
-    });
-
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
-
-    expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('Release date not listed');
-  });
-
   it('still names the releases when the platform lookup fails', async () => {
     const client = releaseClient({ releaseSources: { data: null, error: { message: 'boom' } } });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(2);
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('Fine Motor Control');
     expect(mocks.captureException).toHaveBeenCalled();
   });
 
-  it('sends nothing when the claim itself fails, so nothing is announced twice later', async () => {
+  it('sends nothing when the read fails, so nothing is announced twice later', async () => {
     const client = releaseClient({ releases: { data: null, error: { message: 'boom' } } });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
     expect(mocks.captureException).toHaveBeenCalled();
   });
 
-  it('lists newest first, caps the list at five, and counts the rest', async () => {
+  it('sends nothing when the claim write fails, rather than announcing unclaimed releases', async () => {
+    const client = releaseClient({
+      releases: { data: [release('r1', 'Fine Motor Control')], claimError: { message: 'boom' } },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+
+    expect(mocks.sendTransactionalEmail).not.toHaveBeenCalled();
+    expect(mocks.captureException).toHaveBeenCalled();
+  });
+
+  it('announces only the releases it won, when a concurrent run claims some first', async () => {
+    const client = releaseClient({
+      releases: {
+        data: [release('mine', 'Mine'), release('theirs', 'Theirs')],
+        stolenIds: ['theirs'],
+        error: null,
+      },
+    });
+
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
+
+    const sent = mocks.sendTransactionalEmail.mock.calls[0][0];
+    expect(sent.subject).toBe('New release from Test Artist: Mine');
+    expect(sent.html).not.toContain('Theirs');
+  });
+
+  it('counts and lists only the newsworthy releases, newest first, capped at five', async () => {
     const client = releaseClient({
       releases: {
         data: [
-          release('r1', 'Oldest', { release_date: '2020-01-01' }),
-          release('r2', 'Undated', { release_date: null, date_precision: null }),
+          release('old', 'Old Album', { release_date: '2019-04-01' }),
+          release('undated', 'No Date Yet', { release_date: null, date_precision: null }),
           ...Array.from({ length: 6 }, (_, i) =>
-            release(`n${i}`, `Recent ${i}`, { release_date: `2026-0${i + 1}-01` }),
+            release(`n${i}`, `Recent ${i}`, { release_date: isoDate(-(i + 1)) }),
           ),
         ],
         error: null,
       },
     });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     const sent = mocks.sendTransactionalEmail.mock.calls[0][0];
-    expect(sent.subject).toBe('8 new releases from Test Artist');
-    expect(sent.html.indexOf('Recent 5')).toBeLessThan(sent.html.indexOf('Recent 4'));
-    expect(sent.html).not.toContain('Undated');
-    expect(sent.html).not.toContain('Oldest');
-    expect(sent.html).toContain('…and 3 more.');
+    expect(sent.subject).toBe('6 new releases from Test Artist');
+    expect(sent.html.indexOf('Recent 0')).toBeLessThan(sent.html.indexOf('Recent 1'));
+    expect(sent.html).not.toContain('Recent 5');
+    expect(sent.html).not.toContain('Old Album');
+    expect(sent.html).not.toContain('No Date Yet');
+    expect(sent.html).toContain('…and 1 more.');
   });
 
   it('carries the opt-out footer and a List-Unsubscribe header', async () => {
     const client = releaseClient();
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     const sent = mocks.sendTransactionalEmail.mock.calls[0][0];
     expect(sent.html).toContain('https://unstream.stream/settings#notifications');
@@ -352,7 +442,7 @@ describe('notifySavedArtistsOfNewRelease', () => {
   it('does not email a saver who turned new-release alerts off', async () => {
     const client = releaseClient({ optedOut: { u1: true } });
 
-    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1', previousReleasesFound: 4 });
+    await notifySavedArtistsOfNewRelease({ client, artistId: 'artist-1' });
 
     expect(mocks.sendTransactionalEmail).toHaveBeenCalledTimes(1);
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].to).toBe('fan2@example.com');

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -605,15 +605,11 @@ export async function recordCatalogOutcome(
         });
       } else if (outcome.releasesFound > previous) {
         // Fire-and-forget: notifySavedArtistsOfNewRelease decides for itself whether there is
-        // anything to say (it sends nothing unless this run added releases no alert has covered
-        // yet) and logs its own failures to Sentry — a notification email must never affect
-        // cataloging's own success/failure. The count comparison here is only a cheap gate:
-        // a total that didn't go up can't have added rows worth claiming.
-        void notifySavedArtistsOfNewRelease({
-          client,
-          artistId,
-          previousReleasesFound: previous,
-        }).catch(err => {
+        // anything to say (it sends nothing unless this run turned up a release that is both
+        // unannounced and actually recent) and logs its own failures to Sentry — a notification
+        // email must never affect cataloging's own success/failure. The count comparison here is
+        // only a cheap gate: a total that didn't go up can't have added rows worth claiming.
+        void notifySavedArtistsOfNewRelease({ client, artistId }).catch(err => {
           Sentry.captureException(err, { extra: { context: 'notifySavedArtistsOfNewRelease', artistId } });
         });
       }

--- a/api/functions/notifications.ts
+++ b/api/functions/notifications.ts
@@ -200,22 +200,22 @@ export async function filterByPreference(
 interface NewReleaseParams {
   client: SupabaseClient;
   artistId: string;
-  /**
-   * `release_catalog_state.releases_found` as it stood *before* this catalog run. Zero means
-   * this is the first run that has ever found anything for this artist, which is a backfill
-   * rather than news — see notifySavedArtistsOfNewRelease.
-   */
-  previousReleasesFound: number;
 }
 
 /** How many of the new releases get named in the email before it falls back to "and N more". */
 const MAX_LISTED_RELEASES = 5;
 
+/**
+ * How recently a release must have come out for the alert to treat it as news. Anything older is
+ * a catalogue gap we have only just filled, not something that happened.
+ */
+const RECENT_RELEASE_WINDOW_DAYS = 7;
+
 interface NewReleaseSummary {
   id: string;
   title: string;
   slug: string;
-  /** "12 August 2026", "August 2026", "2026" — or '' when the upstream never gave us a date. */
+  /** "12 August 2026", "August 2026", "2026" — or '' for an upcoming release with no date yet. */
   dateText: string;
   /** Display names, artist-paying platforms first. */
   platforms: string[];
@@ -227,6 +227,7 @@ interface ClaimedRow {
   slug: string;
   release_date: string | null;
   date_precision: string | null;
+  status: string;
   created_at: string;
 }
 
@@ -241,45 +242,109 @@ function byNewest(a: ClaimedRow, b: ClaimedRow): number {
 }
 
 /**
- * Takes ownership of every release for this artist that no alert has accounted for yet, and
- * returns them. An empty result means there is nothing new to say — the caller sends no email
- * at all rather than repeating itself.
+ * Whether a release is worth emailing about: out in the last week, or still to come.
+ *
+ * Cataloguing discovers records, it doesn't witness them being released. A parser improvement, a
+ * newly linked platform or a Discogs pass can surface an album from 1998 for the first time, and
+ * to this code that looks exactly like an album published this morning. Telling somebody
+ * "new release from X" about a record they may well have owned for twenty years is noise, and
+ * noise in the first alerts anybody receives is the expensive kind.
+ *
+ * Dates are compared as ISO strings, which sort chronologically, so this needs no date parsing.
+ * A future date passes on the same comparison, which is what makes an upcoming release news.
+ */
+function isNewsworthy(row: ClaimedRow, now: Date): boolean {
+  // 'announced' means dated in the future or flagged as a pre-order upstream, and a pre-order can
+  // reach us with no date at all — still the most newsworthy thing an artist does.
+  if (row.status === 'announced') return true;
+  if (!row.release_date) return false;
+
+  const cutoff = new Date(now.getTime() - RECENT_RELEASE_WINDOW_DAYS * 86_400_000);
+  return row.release_date >= cutoff.toISOString().slice(0, 10);
+}
+
+/**
+ * Whether we know enough about a release's age to rule on it at all. An undated release could
+ * be from this morning or from 1998, and the detail pass that would settle it is budgeted — so a
+ * release can arrive dateless in one run and dated in the next.
+ */
+function canJudgeAge(row: ClaimedRow): boolean {
+  return row.release_date !== null || row.status === 'announced';
+}
+
+/**
+ * Takes ownership of every release for this artist that no alert has accounted for yet *and whose
+ * age we can actually judge*, and returns them. The caller decides which of them are worth an
+ * email; claiming is about never saying the same thing twice, not about what gets said.
  *
  * This is what stops a release being announced twice. The alert used to infer "what's new" from
  * releases_found before and after a run, and a count can't express which records those are: a run
  * that drops one release and adds two leaves the total up by one and re-announces something
- * already sent. `alert_sent_at` states it directly, and the UPDATE ... RETURNING is atomic, so
- * two catalog runs racing on the same artist split the new releases between them instead of both
- * claiming the lot.
+ * already sent. `alert_sent_at` states it directly.
+ *
+ * Read first, then claim by id. The obvious version is one UPDATE with the age filter inlined,
+ * but that puts the rule in a PostgREST filter string used nowhere else in this codebase, where a
+ * mistake wouldn't fail — it would quietly match the wrong rows and mail them out. The decision
+ * lives in canJudgeAge instead, where it is typechecked and unit-tested, and the UPDATE only has
+ * to handle ids. Atomicity is unaffected: `alert_sent_at IS NULL` is still on the write, and its
+ * RETURNING is still the authority, so two catalog runs racing on the same artist split the rows
+ * between them rather than both claiming the lot.
+ *
+ * Undated releases are deliberately left unclaimed. "We don't know when this came out" is not
+ * "this is old", and marking it accounted-for would cache that uncertainty as a permanent no —
+ * the single most repeated bug in this codebase. It stays pending until a date settles it in
+ * either direction. A release that never gets a date is therefore never announced, which is the
+ * honest outcome: we have nothing to tell anyone about when it happened.
  *
  * Claiming *before* checking who (if anyone) is going to be emailed is deliberate. Releases
  * discovered while nobody was saving the artist are marked seen and never announced, so somebody
  * saving that artist a year later gets alerts from that point forward rather than a mail-out of
  * everything they missed.
  */
-async function claimUnalertedReleases(
+async function claimDatedReleases(
   client: SupabaseClient,
   artistId: string,
-): Promise<NewReleaseSummary[]> {
+): Promise<ClaimedRow[]> {
   const { data, error } = await client
     .from('releases')
-    .update({ alert_sent_at: new Date().toISOString() })
+    .select('id, title, slug, release_date, date_precision, status, created_at')
     .eq('artist_id', artistId)
     .eq('is_hidden', false)
-    .is('alert_sent_at', null)
-    .select('id, title, slug, release_date, date_precision, created_at');
+    .is('alert_sent_at', null);
 
   if (error) {
     // Nothing was claimed, so nothing is lost: report it and let the next catalog run retry.
     // Sending a vaguer email instead would be guessing at exactly the thing this claim exists
     // to know for certain.
-    Sentry.captureException(error, { extra: { context: 'claimUnalertedReleases', artistId } });
+    Sentry.captureException(error, { extra: { context: 'claimDatedReleases.read', artistId } });
     return [];
   }
 
-  const rows = ((data as ClaimedRow[]) || []).sort(byNewest);
-  if (rows.length === 0) return [];
+  const candidates = ((data as ClaimedRow[]) || []).filter(canJudgeAge);
+  if (candidates.length === 0) return [];
 
+  const { data: claimed, error: claimError } = await client
+    .from('releases')
+    .update({ alert_sent_at: new Date().toISOString() })
+    .in('id', candidates.map(row => row.id))
+    .is('alert_sent_at', null)
+    .select('id');
+
+  if (claimError) {
+    Sentry.captureException(claimError, { extra: { context: 'claimDatedReleases.claim', artistId } });
+    return [];
+  }
+
+  // Only the rows this call actually won — a concurrent run may have taken some of them.
+  const won = new Set(((claimed as { id: string }[]) || []).map(row => row.id));
+  return candidates.filter(row => won.has(row.id)).sort(byNewest);
+}
+
+/** Adds the display detail — formatted date, platform names — to the releases being announced. */
+async function toSummaries(
+  client: SupabaseClient,
+  rows: ClaimedRow[],
+): Promise<NewReleaseSummary[]> {
   const platformsByRelease = await getPlatformsByRelease(client, rows.map(row => row.id));
 
   return rows.map(row => ({
@@ -333,24 +398,27 @@ function releaseDetailLine(release: NewReleaseSummary): string {
 }
 
 /**
- * Tells everyone who saved this artist about the releases they haven't been told about yet.
- * Called from recordCatalogOutcome whenever releases_found increases.
+ * Tells everyone who saved this artist about their genuinely new releases — out in the last week,
+ * or still to come. Called from recordCatalogOutcome whenever releases_found increases.
  *
- * Every release is announced at most once, and only ever in one email: claimUnalertedReleases
- * is the authority on what counts as new, and an empty claim means no email is sent at all.
+ * Two independent guarantees, and both have to hold for an email to go out. claimDatedReleases
+ * makes sure nothing is ever announced twice; isNewsworthy makes sure nothing is announced that
+ * isn't news. Everything else this run turned up is claimed and quietly filed, so it can't
+ * resurface later either. Nothing to announce means no email at all.
+ *
+ * The date window also stands in for what used to be a separate first-catalogue special case. An
+ * artist's opening crawl arrives as their entire discography, and "34 new releases" was wrong
+ * about every record in it — but that is only ever true of *old* records, which the window now
+ * excludes on their own merits. A first crawl that happens to include last week's single is real
+ * news, and no longer suppressed for being first.
  */
 export async function notifySavedArtistsOfNewRelease(params: NewReleaseParams): Promise<void> {
-  const { client, artistId, previousReleasesFound } = params;
+  const { client, artistId } = params;
 
-  const releases = await claimUnalertedReleases(client, artistId);
-  if (releases.length === 0) return;
-
-  // An artist's first successful catalogue arrives as their whole discography at once, which is
-  // a backfill and not news — "Test Artist has 34 new releases" is wrong about every record in
-  // the list. Those releases are claimed above and deliberately not announced, so the next
-  // genuinely new one is the first thing anybody hears about. Zero also covers a catalogue that
-  // previously found nothing at all (a broken parser, since recovered), which is the same story.
-  if (previousReleasesFound === 0) return;
+  const claimed = await claimDatedReleases(client, artistId);
+  const now = new Date();
+  const newsworthy = claimed.filter(row => isNewsworthy(row, now));
+  if (newsworthy.length === 0) return;
 
   let userIds = await getActiveSavers(client, artistId);
   if (userIds.length === 0) return;
@@ -371,6 +439,7 @@ export async function notifySavedArtistsOfNewRelease(params: NewReleaseParams): 
   const emails = await resolveEmails(client, userIds);
   if (emails.length === 0) return;
 
+  const releases = await toSummaries(client, newsworthy);
   const listed = releases.slice(0, MAX_LISTED_RELEASES);
   const undisclosed = releases.length - listed.length;
 

--- a/supabase/migrations/20260810180000_alert-sent-at-comment.sql
+++ b/supabase/migrations/20260810180000_alert-sent-at-comment.sql
@@ -1,0 +1,19 @@
+-- Migration: restate what releases.alert_sent_at means
+--
+-- Comment only — no schema change. 20260810120000 introduced the column on the assumption that
+-- every release would be accounted for within one catalog run of being inserted, which is what
+-- the partial index on the unalerted rows was sized for. That is no longer true, and the column
+-- comment (and the index's expected size) should say so rather than quietly drift.
+--
+-- The alert now only announces releases that came out in the last week or are still to come, so
+-- api/functions/notifications.ts claims the rows whose age it can judge and leaves undated ones
+-- pending. "We don't know when this came out" is not "this is old" — the detail pass is budgeted,
+-- so a release can arrive dateless in one run and dated in the next — and writing alert_sent_at
+-- on the strength of a missing date would cache that uncertainty as a permanent no.
+--
+-- The practical consequence: rows can now stay NULL indefinitely, so idx_releases_unalerted holds
+-- a standing population of undated releases rather than briefly-pending ones. It is still a small
+-- per-artist lookup and needs no change; it is simply no longer near-empty.
+
+COMMENT ON COLUMN releases.alert_sent_at IS
+  'When the new-release alert accounted for this release, whether or not it was worth emailing about. NULL means undecided — either not yet catalogued into an alert, or undated, since an unknown release date is not evidence a release is old. Set once and never cleared, which is what stops a release being announced twice. Ingest must never write it — see api/functions/notifications.ts.';


### PR DESCRIPTION
Follow-up to #440.

Cataloguing discovers records, it doesn't witness them being released. A parser improvement, a newly linked platform or a Discogs pass can surface an album from 1998 for the first time, and to the alert that looked exactly like an album published this morning. "New release from X" about a record somebody may have owned for twenty years is noise, and noise in the first alerts anyone receives is the expensive kind.

## The rule

An alert now only names releases that **came out in the last week, or are still to come**. Everything else the run turned up is still claimed, so it can't resurface in a later email either, and an artist with nothing recent produces no email at all.

"Still to come" covers both a future release date and an upstream pre-order flag (`status = 'announced'`), which can reach us without a date — that one still gets announced, saying plainly that the date isn't listed rather than inventing one.

## Undated releases stay pending, they aren't written off

An undated release is deliberately left **unclaimed**. "We don't know when this came out" is not "this is old" — the Bandcamp detail pass is budgeted, so a release can arrive dateless in one run and dated in the next — and writing `alert_sent_at` on the strength of a missing date would cache that uncertainty as a permanent no, which is the single most repeated bug class in this codebase.

So an undated release stays pending until a date settles it in either direction. One that never gets a date is never announced, which is the honest outcome: we have nothing to tell anyone about when it happened.

The practical consequence is that `idx_releases_unalerted` now holds a standing population of undated rows rather than briefly-pending ones. It's still a small per-artist lookup and needs no change, but #440's column comment said otherwise, so `20260810180000` restates it. That migration is **comment-only — no schema change**.

## The first-catalogue special case is gone

#440 suppressed an artist's opening crawl wholesale, because it arrives as a whole discography and "34 new releases" was wrong about every record in it. That was only ever true because the records were *old*, which the date window now excludes on their own merits. Keeping both rules would mean a first crawl containing last week's single gets silently dropped — a real alert lost. One honest rule ("is this release actually new") replaces two overlapping heuristics, and `previousReleasesFound` disappears from the call.

## Why the claim reads before it writes

The obvious implementation is a single `UPDATE` with the age rule inlined as `.or('release_date.not.is.null,status.eq.announced')`. That puts the rule in a PostgREST filter string used nowhere else in this repo, and a mistake there wouldn't fail — it would quietly match the wrong rows and mail them out.

So the claim reads the unaccounted-for rows, decides in `canJudgeAge` (typechecked, unit-tested), and writes by id. Atomicity is unchanged: `alert_sent_at IS NULL` is still on the write, and its `RETURNING` is still what decides who won when two catalog runs race on the same artist. The cost is one extra query on a path that only runs when a crawl found something new.

## Verification

`npm run build` passes — 1083 API tests, 717 web unit tests. New coverage for the age window (including the exact 7-day boundary in both directions), upcoming releases, dateless pre-orders, an undated release becoming announceable once its date arrives, mixed batches where only the recent entries are named *and counted*, the claim-write failure path, and losing a race to a concurrent run.

Both migrations were applied in order against a throwaway Postgres 16 to confirm the comment-only change lands cleanly on top of #440's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VwExcipCeoGtPHFXx3wqk

---
_Generated by [Claude Code](https://claude.ai/code/session_012VwExcipCeoGtPHFXx3wqk)_