### PR TITLE
Pause the weekly analytics recap

### DIFF
--- a/.github/workflows/weekly-analytics-recap.yml
+++ b/.github/workflows/weekly-analytics-recap.yml
@@ -8,19 +8,36 @@ name: Weekly analytics recap
 # Netlify functions in this repo — same precedent as recatalog-sweep.yml,
 # schedule-social-posts.yml, and upstash-keepalive.yml.
 #
-# ## Cadence: once a week, Monday mornings US time
+# ## PAUSED — no schedule, manual dispatch only
 #
-# '0 13 * * 1' is 13:00 UTC Monday — 6am PT / 9am ET, so the recap lands at the start of an
-# artist's work week rather than overnight. Every run recomputes the "last 7 days" window from
-# when it actually fires, so this is safe to reschedule without a backfill.
+# The weekly cron ('0 13 * * 1' — 13:00 UTC Monday, 6am PT / 9am ET) is deliberately removed,
+# for two reasons that both need to stop being true before it goes back.
 #
-# Safe to over-run: the function's own idempotency guard (email_log, keyed on artistId + the
-# Monday date of that week) means a duplicate invocation the same week sends nothing twice.
+# 1. Volume. This is the only email that fans out to the whole roster at once: one send per
+#    verified claimed profile, all in the same minute. On Resend's free plan (100/day) a single
+#    Monday run exhausts the entire day's allowance and starves the saved-artist alerts, which
+#    are the ones a fan is actually waiting on. Nothing here throttles or spreads the batch.
+#
+# 2. Content. Most claimed artists don't yet get enough searches, views or clicks in a week for
+#    the recap to say anything worth reading. "3 views, 0 clicks" is an honest number and a
+#    discouraging email, and it makes Unstream look smaller than it is to exactly the people
+#    we most want to convince.
+#
+# Turning it back on means: enough traffic that a typical recap reports numbers worth sending
+# (and/or a floor below which an artist is skipped), plus either a paid Resend plan or a send
+# budget that can't crowd out the release alerts. A monthly cadence would ease both at once.
+#
+# The function, its tests and the /settings toggle all stay — this is a pause, not a removal.
+# The toggle is hidden while it's paused (see TOGGLES in NotificationPreferences.tsx); restore
+# it in the same change that restores the schedule.
+#
+# Manual dispatch is kept on purpose: running it by hand is a deliberate act by somebody who
+# can see the day's remaining allowance. Safe to over-run — the function's idempotency guard
+# (email_log, keyed on artistId + the Monday date of that week) means a second invocation in
+# the same week sends nothing twice.
 
 on:
-  schedule:
-    - cron: '0 13 * * 1'
-  workflow_dispatch: # Manual trigger from the GitHub UI
+  workflow_dispatch: # Manual trigger from the GitHub UI. No schedule — see above.
 
 jobs:
   recap:

--- a/apps/web/src/components/NotificationPreferences.tsx
+++ b/apps/web/src/components/NotificationPreferences.tsx
@@ -8,6 +8,13 @@ interface Preferences {
   weeklyAnalyticsRecap: boolean;
 }
 
+/**
+ * The weekly analytics recap is deliberately absent: it is paused at the sender
+ * (.github/workflows/weekly-analytics-recap.yml has no schedule), and a switch for an email
+ * nobody receives is a promise the product doesn't keep. The preference itself is untouched —
+ * still stored, still returned by the API, still honored — so restoring this entry alongside
+ * the schedule brings back whatever each artist had already chosen.
+ */
 const TOGGLES: { key: keyof Preferences; label: string; description: string }[] = [
   {
     key: 'newRelease',
@@ -18,11 +25,6 @@ const TOGGLES: { key: keyof Preferences; label: string; description: string }[] 
     key: 'newPlatformLink',
     label: 'New places to support',
     description: 'When an artist you saved adds a link to a new platform.',
-  },
-  {
-    key: 'weeklyAnalyticsRecap',
-    label: 'Weekly analytics recap',
-    description: 'A weekly summary of searches, views, and clicks for artists you\'ve claimed.',
   },
 ];
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -112,7 +112,7 @@ export function SettingsPage() {
           <section id="notifications" className="scroll-mt-24 p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
             <h2 className="text-lg font-semibold">Notifications</h2>
             <p className="text-sm text-text-muted">
-              Emails about artists you've saved and, if you've claimed a profile, your own stats.
+              Emails about the artists you've saved.
             </p>
             <NotificationPreferences />
           </section>

--- a/apps/web/tests/unit/NotificationPreferences.test.tsx
+++ b/apps/web/tests/unit/NotificationPreferences.test.tsx
@@ -22,7 +22,7 @@ describe('NotificationPreferences', () => {
     cleanup();
   });
 
-  it('renders all three toggles reflecting the fetched state', async () => {
+  it('renders the saved-artist toggles reflecting the fetched state', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ newRelease: true, newPlatformLink: false, weeklyAnalyticsRecap: true }),
@@ -34,11 +34,23 @@ describe('NotificationPreferences', () => {
       expect(screen.getByText('New releases')).not.toBeNull();
     });
     expect(screen.getByText('New places to support')).not.toBeNull();
-    expect(screen.getByText('Weekly analytics recap')).not.toBeNull();
 
     expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByRole('switch', { name: 'New places to support' }).getAttribute('aria-checked')).toBe('false');
-    expect(screen.getByRole('switch', { name: 'Weekly analytics recap' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('offers no switch for the paused weekly recap, even though the preference still exists', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ newRelease: true, newPlatformLink: true, weeklyAnalyticsRecap: true }),
+    });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByText('New releases')).not.toBeNull();
+    });
+    expect(screen.queryByText('Weekly analytics recap')).toBeNull();
   });
 
   it('toggles a preference off and reflects the server response', async () => {


### PR DESCRIPTION
Follow-up to #440 / #441. The recap, not the release alerts, is what exhausted the day's Resend allowance.

## Why

**Volume.** It's the only email that fans out to the whole roster at once — one send per verified claimed profile, all in the same minute — with nothing throttling or spreading the batch. On Resend's free plan (100/day) a single Monday run can consume the entire day's allowance and starve the saved-artist alerts, which are the ones a fan is actually waiting on. The release alerts are bounded by savers and, after #441, by whether anything was genuinely released; the recap is bounded only by how many artists have claimed a profile, which is the number we want to grow.

**Content.** Most claimed artists don't yet get enough searches, views or clicks in a week for the recap to say anything worth reading. "3 views, 0 clicks" is an honest number and a discouraging email, and it makes Unstream look smaller than it is to exactly the people we most want to convince.

## What changes

The weekly cron comes off `weekly-analytics-recap.yml`. `workflow_dispatch` stays, so it can still be run by hand — a deliberate act by somebody who can see the day's remaining allowance, and safe to over-run because the function's `email_log` guard (artist + that week's Monday) won't send twice.

The `/settings` toggle is hidden while it's paused, for the same reason the saved-artist toggles were hidden while those were admin-only: a switch for an email nobody receives is a promise the product doesn't keep. The stored preference is untouched — still written, still returned by the API, still honored — so restoring the toggle alongside the schedule brings back whatever each artist had already chosen.

**This is a pause, not a removal.** The function, its tests, the `notification_preferences.weekly_analytics_recap` column and the email body all stay exactly as they are.

## What has to be true to turn it back on

Recorded in the workflow header so it doesn't get restored by reflex:

- Enough traffic that a typical recap reports numbers worth reading — and/or a floor below which an artist is skipped rather than sent a discouraging one.
- Either a paid Resend plan, or a send budget that can't crowd out the release alerts.
- A monthly cadence would ease both at once: fewer sends, and numbers with more in them.

## Verification

`npm run build` passes — 1083 API tests, 718 web unit tests. The workflow YAML parses with `workflow_dispatch` as its only trigger. A new UI test asserts the recap offers no switch while the underlying preference still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VwExcipCeoGtPHFXx3wqk

---
_Generated by [Claude Code](https://claude.ai/code/session_012VwExcipCeoGtPHFXx3wqk)_