### PR TITLE
Cut Supabase disk IO: cache reads, stop rewriting unchanged rows, index app_events

### DIFF
--- a/api/edge/artist-page-static.ts
+++ b/api/edge/artist-page-static.ts
@@ -15,6 +15,20 @@ import { isSocialCrawler, isIndexingCrawler } from "../shared/crawler-detection.
  */
 const MAX_RELEASES_SHOWN = 24;
 
+/**
+ * A day, not the five minutes this used to be.
+ *
+ * This render only ever reaches crawlers — real browsers are handed to the SPA above, before any
+ * database query — so the only thing a long TTL delays is how quickly Google sees an edit, and a
+ * day is well inside how often it recrawls. Meanwhile each miss costs four Supabase queries, one
+ * of them a two-level nested embed over `releases`, and there are ~800 of these pages for
+ * crawlers to sweep.
+ *
+ * Claimed-artist edits don't wait for the TTL: they purge the `artist-${slug}` tag below (see
+ * purgeArtistCaches in api/functions/artist-releases.ts and artist-profile.ts).
+ */
+const CDN_CACHE_CONTROL = 'public, s-maxage=86400, stale-while-revalidate=86400';
+
 interface ReleaseRow {
   slug: string;
   title: string;
@@ -537,7 +551,7 @@ export default async function handler(request: Request, context: Context) {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
           'Cache-Control': 'public, max-age=0, must-revalidate',
-          'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
+          'Netlify-CDN-Cache-Control': CDN_CACHE_CONTROL,
           'Cache-Tag': `artist-${slug}`,
         },
       });
@@ -642,7 +656,7 @@ export default async function handler(request: Request, context: Context) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=0, must-revalidate',
-        'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
+        'Netlify-CDN-Cache-Control': CDN_CACHE_CONTROL,
         'Cache-Tag': `artist-${slug}`,
       },
     });

--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -449,8 +449,23 @@ export default async function handler(request: Request, context: Context) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=0, must-revalidate',
-        'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
-        'Cache-Tag': `release-${artistSlug}-${releaseSlug}`,
+        // Unlike the artist page, this route is pure SSR for *everyone* — there is no SPA
+        // fallback — so every human view and every crawler hit that misses the CDN costs two
+        // Supabase queries, one of them a two-level nested embed. There are ~6,000 of these URLs
+        // against ~800 artist pages, which is what makes the TTL here worth more than anywhere
+        // else on the site.
+        //
+        // An hour rather than a day because the content is user-visible, paired with a long
+        // stale-while-revalidate so a stale entry is still served instantly while one background
+        // request refreshes it: steady-state cost is one query per URL per hour regardless of
+        // traffic. Artist edits don't wait for it — they purge (see purgeArtistCaches in
+        // api/functions/artist-releases.ts).
+        'Netlify-CDN-Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        // Two tags: the specific page, plus one shared by every release page of this artist.
+        // Netlify purges by exact tag with no wildcards, and an artist editing their catalogue
+        // needs all of their release pages gone at once — this is the only way to say that in
+        // one purge call.
+        'Cache-Tag': `release-${artistSlug}-${releaseSlug},artist-releases-${artistSlug}`,
       },
     });
   } catch {

--- a/api/functions/__tests__/admin-list-cache.test.ts
+++ b/api/functions/__tests__/admin-list-cache.test.ts
@@ -1,0 +1,142 @@
+// getMergeOverrides / getLinkSuppressions are read in full on *every search*, so they are cached
+// for five minutes. What has to hold is the thing CLAUDE.md calls "never cache uncertainty":
+// both functions return `[]` when the table is genuinely empty *and* `[]` when the read failed,
+// and caching the second would suppress every merge override for a full TTL because Supabase
+// blipped once.
+//
+// A real Redis is stubbed out (see cache-should-cache.test.ts for why that matters on Netlify);
+// these tests assert on whether the underlying Supabase read is re-run, which is the observable
+// consequence of the caching decision.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  select: vi.fn(),
+}));
+
+// A minimal in-memory stand-in for Upstash, so a cached value really is served from cache.
+vi.mock('../redis', () => ({
+  getRedis: () => ({
+    get: async (key: string) => mocks.store.get(key) ?? null,
+    set: async (key: string, value: unknown) => {
+      mocks.store.set(key, value);
+    },
+    del: async (key: string) => {
+      mocks.store.delete(key);
+    },
+  }),
+  reportRedisFailure: vi.fn(),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ from: () => ({ select: mocks.select }) }),
+}));
+
+const { getMergeOverrides, getLinkSuppressions, invalidateAdminListCache } = await import('../db');
+
+const ROW = { id: 'o1', group_name: 'Big Thief', platform_urls: [], excluded_urls: [], canonical_image_url: null };
+
+beforeEach(() => {
+  mocks.store.clear();
+  mocks.select.mockReset();
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_KEY = 'test-key';
+});
+
+describe('getMergeOverrides caching', () => {
+  it('reads Supabase once and serves the second call from cache', async () => {
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+
+    expect(await getMergeOverrides()).toEqual([ROW]);
+    expect(await getMergeOverrides()).toEqual([ROW]);
+
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole point. A failed read must not become five minutes of "there are no overrides".
+  it('does not cache a failed read', async () => {
+    mocks.select.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+
+    expect(await getMergeOverrides()).toEqual([]);
+    expect(await getMergeOverrides()).toEqual([]);
+
+    expect(mocks.select).toHaveBeenCalledTimes(2);
+  });
+
+  // An empty table is a real answer and is safe to remember, unlike the case above. Without this
+  // distinction the two are indistinguishable and the cache has to refuse both.
+  it('caches a genuinely empty table', async () => {
+    mocks.select.mockResolvedValue({ data: [], error: null });
+
+    expect(await getMergeOverrides()).toEqual([]);
+    expect(await getMergeOverrides()).toEqual([]);
+
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  // A failed read heals on the next request rather than persisting, so the recovery path is a
+  // fresh read returning real data — not a cached empty list.
+  it('recovers on the next call after a failure', async () => {
+    mocks.select.mockResolvedValueOnce({ data: null, error: { message: 'timeout' } });
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+
+    expect(await getMergeOverrides()).toEqual([]);
+    expect(await getMergeOverrides()).toEqual([ROW]);
+  });
+
+  it('re-reads after the cache is invalidated, so an admin edit is not stuck behind the TTL', async () => {
+    mocks.select.mockResolvedValue({ data: [], error: null });
+    expect(await getMergeOverrides()).toEqual([]);
+
+    await invalidateAdminListCache('merge-overrides');
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+
+    expect(await getMergeOverrides()).toEqual([ROW]);
+    expect(mocks.select).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getLinkSuppressions caching', () => {
+  const SUPPRESSION = { url: 'https://example.bandcamp.com', artist_name_norm: 'someone' };
+
+  it('reads Supabase once and serves the second call from cache', async () => {
+    mocks.select.mockResolvedValue({ data: [SUPPRESSION], error: null });
+
+    expect(await getLinkSuppressions()).toEqual([SUPPRESSION]);
+    expect(await getLinkSuppressions()).toEqual([SUPPRESSION]);
+
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  // Failing open here means a known-bad link reappears. Caching that failure would keep it
+  // visible for the full TTL instead of one request.
+  it('does not cache a failed read', async () => {
+    mocks.select.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+
+    expect(await getLinkSuppressions()).toEqual([]);
+    expect(await getLinkSuppressions()).toEqual([]);
+
+    expect(mocks.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-reads after invalidation so a new suppression takes effect immediately', async () => {
+    mocks.select.mockResolvedValue({ data: [], error: null });
+    expect(await getLinkSuppressions()).toEqual([]);
+
+    await invalidateAdminListCache('link-suppressions');
+    mocks.select.mockResolvedValue({ data: [SUPPRESSION], error: null });
+
+    expect(await getLinkSuppressions()).toEqual([SUPPRESSION]);
+  });
+
+  // The two lists must not share a cache key — one invalidation would then wipe the other, and
+  // worse, one table's rows could be served as the other's.
+  it('keeps its cache separate from merge overrides', async () => {
+    mocks.select.mockResolvedValue({ data: [SUPPRESSION], error: null });
+    await getLinkSuppressions();
+
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+    expect(await getMergeOverrides()).toEqual([ROW]);
+  });
+});

--- a/api/functions/__tests__/admin-release-review.test.ts
+++ b/api/functions/__tests__/admin-release-review.test.ts
@@ -10,13 +10,32 @@ const mocks = vi.hoisted(() => ({
   getReleaseReviewQueue: vi.fn(),
   dismissReleaseReview: vi.fn(),
   mergeReleases: vi.fn(),
+  purgeArtistReleaseCaches: vi.fn(),
+  /** What the post-merge slug lookup resolves to. Null stands in for "release vanished". */
+  mergedArtistSlug: { value: 'sufjan-stevens' as string | null },
 }));
 
 vi.mock('../db', () => ({
-  getClient: () => ({}),
+  // Chainable enough for the one read the merge path makes: resolving the surviving release's
+  // artist slug so the CDN purge can name a cache tag.
+  getClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: mocks.mergedArtistSlug.value ? { artists: { slug: mocks.mergedArtistSlug.value } } : null,
+          }),
+        }),
+      }),
+    }),
+  }),
   getReleaseReviewQueue: mocks.getReleaseReviewQueue,
   dismissReleaseReview: mocks.dismissReleaseReview,
   mergeReleases: mocks.mergeReleases,
+}));
+
+vi.mock('../purge-cache', () => ({
+  purgeArtistReleaseCaches: mocks.purgeArtistReleaseCaches,
 }));
 
 vi.mock('../middleware', () => ({
@@ -44,6 +63,7 @@ beforeEach(() => {
   mocks.getReleaseReviewQueue.mockResolvedValue([]);
   mocks.dismissReleaseReview.mockResolvedValue(true);
   mocks.mergeReleases.mockResolvedValue({ ok: true });
+  mocks.mergedArtistSlug.value = 'sufjan-stevens';
 });
 
 afterEach(() => {
@@ -103,6 +123,28 @@ describe('POST — merge', () => {
     const r = await post({ action: 'merge', keepId: KEEP, dropId: DROP });
     expect(r.statusCode).toBe(200);
     expect(mocks.mergeReleases).toHaveBeenCalledWith(KEEP, DROP);
+  });
+
+  // Release pages are CDN-cached for an hour, so a merge that doesn't purge stays invisible to
+  // the public for that long. Before the TTL went up this path had no purge at all and healed
+  // itself in five minutes; now the purge is what makes the merge visible.
+  it('purges the artist caches so the merge is visible before the TTL expires', async () => {
+    await post({ action: 'merge', keepId: KEEP, dropId: DROP });
+    expect(mocks.purgeArtistReleaseCaches).toHaveBeenCalledWith('sufjan-stevens');
+  });
+
+  it('does not purge when a merge fails', async () => {
+    mocks.mergeReleases.mockResolvedValue({ ok: false, error: 'Both releases already have a source on: bandcamp' });
+    await post({ action: 'merge', keepId: KEEP, dropId: DROP });
+    expect(mocks.purgeArtistReleaseCaches).not.toHaveBeenCalled();
+  });
+
+  // A merge that succeeded is still a success even if we can't work out which caches to clear.
+  it('still reports success when the artist slug cannot be resolved', async () => {
+    mocks.mergedArtistSlug.value = null;
+    const r = await post({ action: 'merge', keepId: KEEP, dropId: DROP });
+    expect(r.statusCode).toBe(200);
+    expect(mocks.purgeArtistReleaseCaches).not.toHaveBeenCalled();
   });
 
   // A merge conflict (both sides already have a source on the same platform) is a real

--- a/api/functions/__tests__/persist-releases-idempotence.test.ts
+++ b/api/functions/__tests__/persist-releases-idempotence.test.ts
@@ -1,0 +1,250 @@
+// Re-cataloguing an artist whose releases haven't changed should write nothing to `releases`.
+//
+// It used to write everything. The patch assigned `title` unconditionally, so every pass over an
+// artist rewrote every release row it already held — and the scheduled sweep re-catalogues ~100
+// artists a day. Postgres has no in-place update, so each of those was a new tuple version plus an
+// entry in all six of this table's indexes, for a title that was byte-identical.
+//
+// The COALESCE-in-JS semantics around it are load-bearing and easy to break while "optimising", so
+// they're pinned here too: never blank something already set, never touch a field the artist
+// curated.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Row { [k: string]: unknown }
+
+const tables: Record<string, Row[]> = {};
+/** Every write attempted, so a skipped write is observable. */
+const writes: { table: string; op: 'update' | 'insert' | 'upsert'; patch: Row }[] = [];
+
+function makeClient() {
+  return {
+    from(table: string) {
+      const eqs: [string, unknown][] = [];
+      const rowsOf = () => (tables[table] ??= []);
+      const matched = () => rowsOf().filter(r => eqs.every(([c, v]) => r[c] === v));
+
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        eq(c: string, v: unknown) { eqs.push([c, v]); return builder; },
+        in() { return builder; },
+        update(patch: Row) {
+          writes.push({ table, op: 'update', patch });
+          return {
+            eq: (_c: string, id: unknown) => {
+              const row = rowsOf().find(r => r.id === id);
+              if (row) Object.assign(row, patch);
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+        insert(patch: Row) {
+          writes.push({ table, op: 'insert', patch });
+          const row = { id: `rel-${rowsOf().length + 1}`, ...patch };
+          rowsOf().push(row);
+          return { select: () => ({ single: () => Promise.resolve({ data: row, error: null }) }) };
+        },
+        upsert(patch: Row) {
+          writes.push({ table, op: 'upsert', patch });
+          const row = { id: `src-${rowsOf().length + 1}`, detail_checked_at: null, ...patch };
+          rowsOf().push(row);
+          return { select: () => ({ single: () => Promise.resolve({ data: row, error: null }) }) };
+        },
+        maybeSingle() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        single() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        then(res: (v: unknown) => unknown) {
+          return Promise.resolve({ data: matched(), error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { persistReleases } = await import('../db');
+
+const ARTIST = 'a1';
+
+function incoming(overrides: Partial<{ title: string; artworkUrl: string | null; releaseDate: string | null }> = {}) {
+  return [{
+    title: overrides.title ?? 'First Record',
+    slug: 'first-record',
+    matchKey: 'firstrecord',
+    releaseType: 'album',
+    releaseDate: overrides.releaseDate === undefined ? '2026-01-01' : overrides.releaseDate,
+    datePrecision: 'day',
+    status: 'released',
+    artworkUrl: overrides.artworkUrl === undefined ? 'https://img/art.jpg' : overrides.artworkUrl,
+    source: { platform: 'bandcamp', url: 'https://someone.bandcamp.com/album/first-record', externalId: 'album-111' },
+  }];
+}
+
+const SOURCE_URL = 'https://someone.bandcamp.com/album/first-record';
+
+/** The release_sources row a previous catalogue pass would have left behind. */
+function seedSource(overrides: Row = {}) {
+  tables.release_sources = [{
+    id: 's1',
+    release_id: 'r1',
+    platform: 'bandcamp',
+    url: SOURCE_URL,
+    external_id: 'album-111',
+    source: 'auto',
+    detail_checked_at: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  }];
+}
+
+/** A release row a previous catalogue pass would have left behind. */
+function seedRelease(overrides: Row = {}) {
+  tables.releases = [{
+    id: 'r1',
+    artist_id: ARTIST,
+    slug: 'first-record',
+    title: 'First Record',
+    match_key: 'firstrecord',
+    release_type: 'album',
+    release_date: '2026-01-01',
+    artwork_url: 'https://img/art.jpg',
+    curated_fields: null,
+    ...overrides,
+  }];
+  tables.release_sources = [];
+}
+
+const releaseWrites = () => writes.filter(w => w.table === 'releases');
+
+beforeEach(() => {
+  for (const key of Object.keys(tables)) delete tables[key];
+  writes.length = 0;
+});
+
+describe('re-cataloguing an unchanged release', () => {
+  it('does not write to releases at all', async () => {
+    seedRelease();
+
+    const written = await persistReleases(ARTIST, incoming() as never);
+
+    expect(releaseWrites()).toHaveLength(0);
+    // Still returned, so the detail pass can consider it — skipping the *write* must not mean
+    // dropping the release from the pipeline.
+    expect(written).toHaveLength(1);
+  });
+
+  it('writes nothing even when the incoming row has less information than the stored one', async () => {
+    seedRelease();
+    await persistReleases(ARTIST, incoming({ artworkUrl: null, releaseDate: null }) as never);
+    expect(releaseWrites()).toHaveLength(0);
+  });
+});
+
+describe('re-cataloguing a release that changed', () => {
+  it('writes the new title, and only the title', async () => {
+    seedRelease();
+
+    await persistReleases(ARTIST, incoming({ title: 'First Record (Remastered)' }) as never);
+
+    expect(releaseWrites()).toHaveLength(1);
+    expect(releaseWrites()[0].patch).toEqual({ title: 'First Record (Remastered)' });
+  });
+
+  it('fills in artwork that was missing', async () => {
+    seedRelease({ artwork_url: null });
+
+    await persistReleases(ARTIST, incoming() as never);
+
+    expect(releaseWrites()).toHaveLength(1);
+    expect(releaseWrites()[0].patch).toEqual({ artwork_url: 'https://img/art.jpg' });
+  });
+
+  it('fills in a date that was missing, with its precision', async () => {
+    seedRelease({ release_date: null });
+
+    await persistReleases(ARTIST, incoming() as never);
+
+    expect(releaseWrites()[0].patch).toEqual({ release_date: '2026-01-01', date_precision: 'day' });
+  });
+});
+
+describe('what ingest must never overwrite', () => {
+  it('leaves a curated title alone even when it differs', async () => {
+    seedRelease({ curated_fields: ['title'] });
+
+    await persistReleases(ARTIST, incoming({ title: 'Something Else' }) as never);
+
+    expect(releaseWrites()).toHaveLength(0);
+    expect(tables.releases[0].title).toBe('First Record');
+  });
+
+  it('does not blank artwork that is already set', async () => {
+    seedRelease();
+    await persistReleases(ARTIST, incoming({ artworkUrl: null }) as never);
+    expect(tables.releases[0].artwork_url).toBe('https://img/art.jpg');
+  });
+});
+
+// release_sources had the same unconditional-write problem as `releases`: every pass restated a
+// URL that hadn't moved, purely to stamp `last_seen_at` — a column nothing in the codebase reads.
+describe('the source row', () => {
+  const sourceWrites = () => writes.filter(w => w.table === 'release_sources');
+
+  it('is not rewritten when the URL and external id are unchanged', async () => {
+    seedRelease();
+    seedSource();
+
+    const written = await persistReleases(ARTIST, incoming() as never);
+
+    expect(sourceWrites()).toHaveLength(0);
+    // The existing row is still what the detail pass gets handed, including its detail_checked_at
+    // — otherwise a skipped write would look like a new source and re-fetch the release page.
+    expect(written[0]).toMatchObject({ sourceId: 's1', detailCheckedAt: '2026-08-01T00:00:00.000Z' });
+  });
+
+  it('is written when the URL moved', async () => {
+    seedRelease();
+    seedSource({ url: 'https://someone.bandcamp.com/album/first-record-2' });
+
+    await persistReleases(ARTIST, incoming() as never);
+
+    expect(sourceWrites()).toHaveLength(1);
+    expect(sourceWrites()[0].patch).toMatchObject({ url: SOURCE_URL });
+  });
+
+  it('is written when the external id changed', async () => {
+    seedRelease();
+    seedSource({ external_id: 'album-999' });
+
+    await persistReleases(ARTIST, incoming() as never);
+
+    expect(sourceWrites()).toHaveLength(1);
+  });
+
+  // Rule 1 of upsertReleaseSource. A claimed URL is an artist's own correction and a re-crawl must
+  // hand it back untouched rather than restating what ingest thinks the URL should be.
+  it('never overwrites a claimed source, even when the URL differs', async () => {
+    seedRelease();
+    seedSource({ source: 'claimed', url: 'https://artist-corrected.bandcamp.com/album/real' });
+
+    const written = await persistReleases(ARTIST, incoming() as never);
+
+    expect(sourceWrites()).toHaveLength(0);
+    expect(written[0].url).toBe('https://artist-corrected.bandcamp.com/album/real');
+  });
+});
+
+describe('a release we have never seen', () => {
+  it('inserts it', async () => {
+    tables.releases = [];
+    tables.release_sources = [];
+
+    await persistReleases(ARTIST, incoming() as never);
+
+    const inserts = releaseWrites().filter(w => w.op === 'insert');
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].patch).toMatchObject({ title: 'First Record', artist_id: ARTIST });
+  });
+});

--- a/api/functions/__tests__/persist-write-churn.test.ts
+++ b/api/functions/__tests__/persist-write-churn.test.ts
@@ -1,0 +1,235 @@
+// persistSearchResults used to write on every search whether or not anything had changed: one
+// upsert of the `artists` row (five indexes, one of them a GIN trigram index) plus a bulk upsert of
+// every one of that artist's link rows. Searching an artist we already knew perfectly was pure
+// write churn, and Postgres has no in-place update — every one of those was a new tuple version,
+// fresh index entries, WAL, and a dead tuple for autovacuum.
+//
+// What these tests pin is the *shape* of the fix, because it has a trap in it. `artists.updated_at`
+// is not "when the data changed" — getArtistBySlug reads it as "when we last verified this artist"
+// and refuses the row after FRESHNESS_TTL_MS. So the write cannot simply be skipped when nothing
+// differs; it has to be throttled, and the throttle has to stay well inside the freshness window.
+// Both halves are asserted below.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Row { [k: string]: unknown }
+
+const tables: Record<string, Row[]> = {};
+/** Every write the code attempted, so a skipped write is observable rather than inferred. */
+const writes: { table: string; rows: Row[] }[] = [];
+/** Set to a message to make the artist_links read fail. */
+const linkReadError = { value: null as string | null };
+
+function makeClient() {
+  return {
+    from(table: string) {
+      const eqs: [string, unknown][] = [];
+      const rowsOf = () => (tables[table] ??= []);
+      const matched = () => rowsOf().filter(r => eqs.every(([c, v]) => r[c] === v));
+
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        eq(c: string, v: unknown) { eqs.push([c, v]); return builder; },
+        in() { return builder; },
+        or() { return builder; },
+        single() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        maybeSingle() { return Promise.resolve({ data: matched()[0] ?? null, error: null }); },
+        upsert(rows: Row | Row[]) {
+          const list = Array.isArray(rows) ? rows : [rows];
+          writes.push({ table, rows: list });
+          for (const r of list) {
+            const key = table === 'artists' ? 'slug' : 'platform';
+            const existingIndex = rowsOf().findIndex(
+              e => e[key] === r[key] && (table === 'artists' || e.artist_id === r.artist_id)
+            );
+            if (existingIndex >= 0) rowsOf()[existingIndex] = { ...rowsOf()[existingIndex], ...r };
+            else rowsOf().push({ id: `${table}-${rowsOf().length + 1}`, ...r });
+          }
+          const written = rowsOf().find(e => e[table === 'artists' ? 'slug' : 'platform'] === list[0][table === 'artists' ? 'slug' : 'platform']);
+          return {
+            select: () => ({ single: () => Promise.resolve({ data: written, error: null }) }),
+            then: (res: (v: unknown) => unknown) => Promise.resolve({ data: null, error: null }).then(res),
+          };
+        },
+        then(res: (v: unknown) => unknown) {
+          if (table === 'artist_links' && linkReadError.value) {
+            return Promise.resolve({ data: null, error: { message: linkReadError.value } }).then(res);
+          }
+          return Promise.resolve({ data: matched(), error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+vi.mock('../request-catalog', () => ({ requestArtistCatalog: async () => true }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { persistSearchResults } = await import('../db');
+
+const BANDCAMP = 'https://bigthief.bandcamp.com';
+
+function result(overrides: { name?: string; imageUrl?: string | null; url?: string } = {}) {
+  return {
+    id: 'r1',
+    name: overrides.name ?? 'Big Thief',
+    type: 'artist' as const,
+    imageUrl: overrides.imageUrl === undefined ? 'https://img/1.jpg' : overrides.imageUrl,
+    matchConfidence: 'verified' as const,
+    platforms: [{ sourceId: 'bandcamp', url: overrides.url ?? BANDCAMP }],
+  };
+}
+
+/** The artist row a previous search would have left behind. */
+function seedArtist(agoMs: number, overrides: Row = {}) {
+  tables.artists = [{
+    id: 'a1',
+    // artistSlug('Big Thief') — hyphenated, not squashed.
+    slug: 'big-thief',
+    name: 'Big Thief',
+    image_url: 'https://img/1.jpg',
+    match_confidence: 'verified',
+    updated_at: new Date(Date.now() - agoMs).toISOString(),
+    ...overrides,
+  }];
+  tables.artist_links = [{
+    id: 'l1',
+    artist_id: 'a1',
+    platform: 'bandcamp',
+    url: BANDCAMP,
+    source: 'search',
+    is_direct: true,
+    latest_release: null,
+    display_order: 0,
+  }];
+}
+
+const writesTo = (table: string) => writes.filter(w => w.table === table);
+
+beforeEach(() => {
+  for (const key of Object.keys(tables)) delete tables[key];
+  writes.length = 0;
+  linkReadError.value = null;
+});
+
+describe('an artist we already know, unchanged', () => {
+  it('writes nothing at all when the row was refreshed recently', async () => {
+    seedArtist(5 * 60 * 1000); // five minutes ago
+
+    await persistSearchResults([result()] as never);
+
+    expect(writesTo('artists')).toHaveLength(0);
+    expect(writesTo('artist_links')).toHaveLength(0);
+  });
+
+  // The other half of the fix. `updated_at` is a freshness signal with a 24-hour TTL, so it still
+  // has to advance — an unchanged row is refreshed once an hour rather than once a search. If this
+  // fails, stored artist cards silently expire and every search re-runs the full live pipeline.
+  it('still refreshes updated_at once the throttle window has passed', async () => {
+    seedArtist(2 * 60 * 60 * 1000); // two hours ago
+
+    await persistSearchResults([result()] as never);
+
+    expect(writesTo('artists')).toHaveLength(1);
+    const stamped = writesTo('artists')[0].rows[0].updated_at as string;
+    expect(Date.now() - new Date(stamped).getTime()).toBeLessThan(5000);
+  });
+
+  it('keeps the throttle well inside the 24-hour freshness window', async () => {
+    // 23 hours: past the throttle, still inside freshness — so the refresh must already have
+    // happened long before a row could expire.
+    seedArtist(23 * 60 * 60 * 1000);
+    await persistSearchResults([result()] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+  });
+
+  // A missing or unparseable timestamp must mean "write it", never "never write it again".
+  it('treats an unusable updated_at as due for a refresh', async () => {
+    seedArtist(0, { updated_at: 'not a date' });
+    await persistSearchResults([result()] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+
+    writes.length = 0;
+    seedArtist(0, { updated_at: null });
+    await persistSearchResults([result()] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+  });
+});
+
+describe('an artist whose data actually changed', () => {
+  it('writes immediately on a new name, throttle or not', async () => {
+    seedArtist(5 * 60 * 1000);
+    await persistSearchResults([result({ name: 'Big Thief!' })] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+  });
+
+  it('writes immediately on a new image', async () => {
+    seedArtist(5 * 60 * 1000);
+    await persistSearchResults([result({ imageUrl: 'https://img/2.jpg' })] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+  });
+
+  it('writes immediately when the pipeline verdict changed', async () => {
+    seedArtist(5 * 60 * 1000, { match_confidence: 'unverified' });
+    await persistSearchResults([result()] as never);
+    expect(writesTo('artists')).toHaveLength(1);
+  });
+});
+
+describe('link rows', () => {
+  it('writes only the links that differ', async () => {
+    seedArtist(5 * 60 * 1000);
+    // Two platforms: bandcamp is unchanged, mirlo is new.
+    const withMirlo = {
+      ...result(),
+      platforms: [
+        { sourceId: 'bandcamp', url: BANDCAMP },
+        { sourceId: 'mirlo', url: 'https://mirlo.space/bigthief' },
+      ],
+    };
+
+    await persistSearchResults([withMirlo] as never);
+
+    const linkWrites = writesTo('artist_links');
+    expect(linkWrites).toHaveLength(1);
+    expect(linkWrites[0].rows).toHaveLength(1);
+    expect(linkWrites[0].rows[0].platform).toBe('mirlo');
+  });
+
+  it('writes a link whose URL moved', async () => {
+    seedArtist(5 * 60 * 1000);
+    await persistSearchResults([result({ url: 'https://bigthief-music.bandcamp.com' })] as never);
+
+    const linkWrites = writesTo('artist_links');
+    expect(linkWrites).toHaveLength(1);
+    expect(linkWrites[0].rows[0].url).toBe('https://bigthief-music.bandcamp.com');
+  });
+
+  // Failing towards "write it" keeps the old behaviour. Skipping writes because a *read* failed
+  // would silently drop a real update.
+  it('writes every link when the comparison read fails', async () => {
+    seedArtist(5 * 60 * 1000);
+    linkReadError.value = 'connection reset';
+
+    await persistSearchResults([result()] as never);
+
+    expect(writesTo('artist_links')).toHaveLength(1);
+    expect(writesTo('artist_links')[0].rows).toHaveLength(1);
+  });
+});
+
+describe('an artist we have never seen', () => {
+  it('writes the artist and all of its links', async () => {
+    tables.artists = [];
+    tables.artist_links = [];
+
+    await persistSearchResults([result()] as never);
+
+    expect(writesTo('artists')).toHaveLength(1);
+    expect(writesTo('artist_links')).toHaveLength(1);
+    expect(writesTo('artist_links')[0].rows).toHaveLength(1);
+  });
+});

--- a/api/functions/admin-link-suppression.ts
+++ b/api/functions/admin-link-suppression.ts
@@ -5,7 +5,7 @@
 // plausible-looking *.bandcamp.com page attached to a major artist who has no
 // Bandcamp presence at all.
 
-import { getClient, deleteStoredLinksForUrl } from './db';
+import { getClient, deleteStoredLinksForUrl, invalidateAdminListCache } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
 import { normalizeForComparison, normalizeUrlForMatch } from './search-utils';
 import { Sentry } from '../lib/sentry';
@@ -114,6 +114,10 @@ export async function handler(event: {
       };
     }
 
+    // The search path caches this table for five minutes, so without this the link stays
+    // suppressed for up to five minutes after an admin undid the suppression.
+    await invalidateAdminListCache('link-suppressions');
+
     return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ success: true }) };
   }
 
@@ -207,6 +211,10 @@ export async function handler(event: {
       }),
     };
   }
+
+  // The search path caches this table for five minutes, so without this the suppressed link
+  // keeps appearing in results for up to five minutes after the admin suppressed it.
+  await invalidateAdminListCache('link-suppressions');
 
   // Also clear stored copies, so the link disappears from the artist page and
   // from DB-backed search cards rather than only from freshly fetched results.

--- a/api/functions/admin-merge-override.ts
+++ b/api/functions/admin-merge-override.ts
@@ -1,7 +1,7 @@
 // API endpoint: POST /api/admin/merge-override
 // Admin-only endpoint for creating artist merge overrides from the UI.
 
-import { getClient } from './db';
+import { getClient, invalidateAdminListCache } from './db';
 import { authenticateAdmin } from './middleware';
 import { isSearchOnlyLink, sourceIdFromUrl } from './search-utils';
 
@@ -121,6 +121,10 @@ export async function handler(event: {
       }),
     };
   }
+
+  // The search path caches this table for five minutes, so without this the duplicate results
+  // the admin just merged stay unmerged for up to five minutes.
+  await invalidateAdminListCache('merge-overrides');
 
   return {
     statusCode: 201,

--- a/api/functions/admin-release-review.ts
+++ b/api/functions/admin-release-review.ts
@@ -6,6 +6,7 @@
 
 import { getClient, getReleaseReviewQueue, dismissReleaseReview, mergeReleases } from './db';
 import { authenticateAdmin, buildCorsHeaders } from './middleware';
+import { purgeArtistReleaseCaches } from './purge-cache';
 import { Sentry } from '../lib/sentry';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -138,6 +139,19 @@ export async function handler(event: {
     level: 'info',
     extra: { keepId, dropId, adminId: admin.userId },
   });
+
+  // Release pages are CDN-cached for an hour, so a merge would otherwise stay invisible to the
+  // public for that long. The artist endpoint purges via its shared `purgeArtistCaches`; this
+  // path had no purge at all, which was self-healing only while the TTL was five minutes.
+  // One extra read on a rare admin action, resolved from the surviving release.
+  const { data: merged } = await client
+    .from('releases')
+    .select('artists ( slug )')
+    .eq('id', keepId)
+    .maybeSingle();
+
+  const mergedSlug = (merged as { artists?: { slug?: string } } | null)?.artists?.slug;
+  if (mergedSlug) await purgeArtistReleaseCaches(mergedSlug);
 
   return {
     statusCode: 200,

--- a/api/functions/artist-releases.ts
+++ b/api/functions/artist-releases.ts
@@ -28,6 +28,7 @@ import {
 } from './db';
 import { authenticateBearer, buildCorsHeaders } from './middleware';
 import { cacheDeleteByArtist } from './cache';
+import { purgeArtistReleaseCaches } from './purge-cache';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { triggerCatalogNow } from './request-catalog';
 import { PLATFORMS } from '../shared/platform-registry';
@@ -108,19 +109,10 @@ async function purgeArtistCaches(artistName: string, slug: string): Promise<void
     console.error('[ArtistReleases] Redis cache purge failed:', e);
   }
 
-  try {
-    const siteId = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
-    const token = process.env.NETLIFY_API_TOKEN;
-    if (siteId && token) {
-      await fetch('https://api.netlify.com/api/v1/purge', {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ site_id: siteId, cache_tags: [`artist-${slug}`] }),
-      });
-    }
-  } catch (e) {
-    console.error('[ArtistReleases] CDN cache purge failed:', e);
-  }
+  // Purges the artist page *and* every one of their release pages. The latter matters because
+  // those pages are now CDN-cached for an hour rather than five minutes, so without the purge an
+  // artist's own edit would sit invisible.
+  await purgeArtistReleaseCaches(slug, 'ArtistReleases');
 }
 
 export async function handler(event: {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -16,6 +16,7 @@ import {
   releaseMatchKey,
   uniqueReleaseSlug,
 } from './release-utils';
+import { cacheDelete, cacheGetOrFetch } from './cache';
 import { requestArtistCatalog } from './request-catalog';
 import { notifySavedArtistsOfNewRelease } from './notifications';
 import { Sentry } from '../lib/sentry';
@@ -255,25 +256,66 @@ export interface MergeOverrideRow {
   canonical_image_url: string | null;
 }
 
+/**
+ * Both admin tables below are read in full on *every search* and change only when an admin acts,
+ * which made them two uncached full-table reads on the hottest path in the product. Five minutes
+ * in Redis removes them; the admin endpoints invalidate on write (see `invalidateAdminListCache`),
+ * so a merge or a suppression still takes effect immediately.
+ *
+ * The TTL is what covers the CLI (`scripts/merge-override.ts`), which writes the same table
+ * without going through a function and has no Redis credentials to invalidate with. A CLI edit
+ * lands within five minutes rather than instantly — the reason the TTL is short rather than long.
+ */
+const ADMIN_LIST_CACHE_TTL = 5 * 60;
+const MERGE_OVERRIDES_CACHE_KEY = 'admin:merge-overrides';
+const LINK_SUPPRESSIONS_CACHE_KEY = 'admin:link-suppressions';
+
+/**
+ * A read that knows whether it succeeded.
+ *
+ * Both of these functions return `[]` on failure *and* `[]` when the table is genuinely empty,
+ * which is fine for a caller that fails open but is exactly the shape you must not put in a
+ * cache — see "Never cache uncertainty" in CLAUDE.md. Caching a failed read would suppress every
+ * merge override for a full TTL because Supabase blipped once. So the cached value carries `ok`,
+ * and only `ok: true` is written.
+ */
+interface CachedAdminList<T> {
+  ok: boolean;
+  rows: T[];
+}
+
+export async function invalidateAdminListCache(list: 'merge-overrides' | 'link-suppressions'): Promise<void> {
+  await cacheDelete(list === 'merge-overrides' ? MERGE_OVERRIDES_CACHE_KEY : LINK_SUPPRESSIONS_CACHE_KEY);
+}
+
 export async function getMergeOverrides(): Promise<MergeOverrideRow[]> {
   const client = getClient();
   if (!client) return [];
 
-  try {
-    const { data, error } = await client
-      .from('artist_merge_overrides')
-      .select('id, group_name, platform_urls, excluded_urls, canonical_image_url');
+  const { data } = await cacheGetOrFetch<CachedAdminList<MergeOverrideRow>>(
+    MERGE_OVERRIDES_CACHE_KEY,
+    async () => {
+      try {
+        const { data, error } = await client
+          .from('artist_merge_overrides')
+          .select('id, group_name, platform_urls, excluded_urls, canonical_image_url');
 
-    if (error) {
-      console.error('[DB] Failed to fetch merge overrides:', error);
-      return [];
-    }
+        if (error) {
+          console.error('[DB] Failed to fetch merge overrides:', error);
+          return { ok: false, rows: [] };
+        }
 
-    return (data as MergeOverrideRow[]) || [];
-  } catch (error) {
-    console.error('[DB] getMergeOverrides error:', error);
-    return [];
-  }
+        return { ok: true, rows: (data as MergeOverrideRow[]) || [] };
+      } catch (error) {
+        console.error('[DB] getMergeOverrides error:', error);
+        return { ok: false, rows: [] };
+      }
+    },
+    ADMIN_LIST_CACHE_TTL,
+    result => result.ok
+  );
+
+  return data.rows;
 }
 
 // --- Platform link suppressions ---
@@ -299,24 +341,35 @@ export interface LinkSuppressionRow {
 export async function getLinkSuppressions(): Promise<
   Pick<LinkSuppressionRow, 'url' | 'artist_name_norm'>[]
 > {
+  type Row = Pick<LinkSuppressionRow, 'url' | 'artist_name_norm'>;
+
   const client = getClient();
   if (!client) return [];
 
-  try {
-    const { data, error } = await client
-      .from('platform_link_suppressions')
-      .select('url, artist_name_norm');
+  const { data } = await cacheGetOrFetch<CachedAdminList<Row>>(
+    LINK_SUPPRESSIONS_CACHE_KEY,
+    async () => {
+      try {
+        const { data, error } = await client
+          .from('platform_link_suppressions')
+          .select('url, artist_name_norm');
 
-    if (error) {
-      console.error('[DB] Failed to fetch link suppressions:', error);
-      return [];
-    }
+        if (error) {
+          console.error('[DB] Failed to fetch link suppressions:', error);
+          return { ok: false, rows: [] };
+        }
 
-    return (data as Pick<LinkSuppressionRow, 'url' | 'artist_name_norm'>[]) || [];
-  } catch (error) {
-    console.error('[DB] getLinkSuppressions error:', error);
-    return [];
-  }
+        return { ok: true, rows: (data as Row[]) || [] };
+      } catch (error) {
+        console.error('[DB] getLinkSuppressions error:', error);
+        return { ok: false, rows: [] };
+      }
+    },
+    ADMIN_LIST_CACHE_TTL,
+    result => result.ok
+  );
+
+  return data.rows;
 }
 
 /**

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -95,6 +95,58 @@ export const EXCLUDED_PLATFORMS = new Set(['buymeacoffee', 'kofi', 'ampwall']);
 // How long before artist data is considered stale (24 hours)
 const FRESHNESS_TTL_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * How often a search is allowed to touch an artist row that hasn't actually changed.
+ *
+ * `persistSearchResults` used to upsert the `artists` row on *every* search, always stamping
+ * `updated_at` — so searching an artist we already knew perfectly still rewrote the row. Postgres
+ * has no in-place update: each write is a new tuple version plus an entry in all five of this
+ * table's indexes, one of which is a GIN trigram index on `name`. It was the hottest path in the
+ * product doing pure write churn, and a contributor to the Disk IO Budget alert.
+ *
+ * **It cannot simply be skipped when nothing changed, though**, because `updated_at` on this table
+ * does not mean "when the data changed" — `getArtistBySlug` reads it as "when we last verified
+ * this artist against live sources" and refuses the row once it passes FRESHNESS_TTL_MS. Stop
+ * advancing it and stored cards silently expire, so every search re-runs the full live pipeline:
+ * cheaper on Postgres, much more expensive everywhere else, and a behaviour change nobody asked
+ * for. (search-sources.ts makes the same point from the other direction: DB-served cards are
+ * deliberately excluded from persist so re-serving stored data can't refresh `updated_at` and
+ * mask genuine staleness.)
+ *
+ * So the write is *throttled*, not removed: an unchanged row is refreshed at most once an hour.
+ * Well inside the 24-hour freshness window, so no row can expire because of this, while N searches
+ * for the same artist within the hour collapse into one write instead of N.
+ *
+ * Keep this comfortably below FRESHNESS_TTL_MS. Raising it towards 24 hours would start letting
+ * rows expire between refreshes.
+ */
+const PERSIST_REFRESH_FLOOR_MS = 60 * 60 * 1000;
+
+/**
+ * Whether a search needs to write to an artist row it already found.
+ *
+ * True when the row would actually change, or when it is due a freshness refresh. False means the
+ * write is pure churn and is skipped.
+ */
+function artistNeedsRefresh(
+  existing: { name: string | null; image_url: string | null; match_confidence: string | null; updated_at: string | null },
+  name: string,
+  imageUrl: string | null,
+  matchConfidence: string
+): boolean {
+  if (existing.name !== name) return true;
+  if (existing.image_url !== imageUrl) return true;
+  if (existing.match_confidence !== matchConfidence) return true;
+
+  // An unparseable or missing timestamp is treated as due, so a bad value can't pin a row
+  // permanently unrefreshed — the failure mode has to be "one extra write", never "never again".
+  if (!existing.updated_at) return true;
+  const updatedAt = new Date(existing.updated_at).getTime();
+  if (Number.isNaN(updatedAt)) return true;
+
+  return Date.now() - updatedAt > PERSIST_REFRESH_FLOOR_MS;
+}
+
 // --- Types matching the search-sources response ---
 
 interface PlatformLink {
@@ -1070,27 +1122,74 @@ export interface PersistedRelease {
  * exact "ingest clobbers a curated edit" bug `curated_fields` exists to prevent on `releases`
  * itself, just one table over.
  */
-async function getClaimedSourceKeys(client: SupabaseClient, releaseIds: string[]): Promise<Set<string>> {
-  if (releaseIds.length === 0) return new Set();
+export interface ExistingReleaseSource {
+  id: string;
+  release_id: string;
+  platform: string;
+  url: string;
+  external_id: string | null;
+  source: string | null;
+  detail_checked_at: string | null;
+}
+
+/** Keyed `${releaseId}:${platform}` — the table's own conflict target. */
+export type ExistingSourceMap = Map<string, ExistingReleaseSource>;
+
+/**
+ * Every `release_sources` row these releases already have.
+ *
+ * This used to read only the *claimed* keys, as a Set, so `upsertReleaseSource` knew what not to
+ * overwrite. It now reads the whole row for every source, which lets that function answer two more
+ * questions without a round trip: what a claimed row already says (previously a per-release read),
+ * and whether an unclaimed row would actually change (previously an unconditional write).
+ *
+ * Same one query either way — just more columns.
+ */
+async function getExistingSources(client: SupabaseClient, releaseIds: string[]): Promise<ExistingSourceMap> {
+  const map: ExistingSourceMap = new Map();
+  if (releaseIds.length === 0) return map;
 
   const { data, error } = await client
     .from('release_sources')
-    .select('release_id, platform')
-    .eq('source', 'claimed')
+    .select('id, release_id, platform, url, external_id, source, detail_checked_at')
     .in('release_id', releaseIds);
 
   if (error) {
-    console.error('[DB] getClaimedSourceKeys failed:', error.message);
-    return new Set();
+    // An empty map means "assume nothing exists", so every source is written as before. Failing
+    // towards writing is right: the alternative is skipping a real update because a read blipped.
+    console.error('[DB] getExistingSources failed:', error.message);
+    return map;
   }
 
-  return new Set((data as { release_id: string; platform: string }[] || []).map(r => `${r.release_id}:${r.platform}`));
+  for (const row of (data as ExistingReleaseSource[]) || []) {
+    map.set(`${row.release_id}:${row.platform}`, row);
+  }
+  return map;
 }
 
 /**
- * Write one release's source row — or, if an artist has claimed this exact release+platform,
- * read the existing (untouched) row back instead. The one place every ingest path goes through
- * to write `release_sources`, so "never overwrite a claimed URL" only has to be correct once.
+ * Write one release's source row — or don't, when writing it would change nothing.
+ *
+ * The one place every ingest path goes through to write `release_sources`, so the two rules below
+ * only have to be correct once:
+ *
+ * 1. **Never overwrite a claimed source.** `source: 'claimed'` means an artist added or corrected
+ *    this URL themselves; a re-crawl silently replacing it in 30 days is the same bug
+ *    `curated_fields` prevents on `releases`, one table over. The claimed row is returned as-is.
+ * 2. **Never rewrite an unchanged row.** This used to upsert unconditionally on every pass, which
+ *    meant every re-catalogue rewrote every source row it already held — new tuple version, index
+ *    entries, WAL, dead tuple — to restate a URL that hadn't moved. Platform URLs almost never
+ *    move, so almost all of that was waste, and it contributed to the Disk IO Budget alert.
+ *
+ * **`last_seen_at` is the casualty of rule 2 and is worth knowing about.** It used to be stamped on
+ * every pass, so it meant "when we last confirmed this source exists"; it now only advances when
+ * something else about the row changes, so it effectively means "when this row was last written".
+ * Nothing reads the column — it has no consumer anywhere in the codebase — which is what makes the
+ * trade acceptable. If a real "last confirmed" signal is ever needed, it wants its own cheap
+ * mechanism (a periodic batched touch), not a rewrite of every row on every crawl.
+ *
+ * `detail_checked_at` is read back rather than written, in every branch: it belongs to the detail
+ * pass, and a grid re-crawl must not reset it or every crawl would re-fetch every release page.
  */
 async function upsertReleaseSource(
   client: SupabaseClient,
@@ -1098,21 +1197,18 @@ async function upsertReleaseSource(
   platform: string,
   url: string,
   externalId: string | null,
-  claimedKeys: Set<string>
+  existingSources: ExistingSourceMap
 ): Promise<{ id: string; url: string; detail_checked_at: string | null } | null> {
-  if (claimedKeys.has(`${releaseId}:${platform}`)) {
-    const { data, error } = await client
-      .from('release_sources')
-      .select('id, url, detail_checked_at')
-      .eq('release_id', releaseId)
-      .eq('platform', platform)
-      .maybeSingle();
-    if (error || !data) return null;
-    return data as { id: string; url: string; detail_checked_at: string | null };
+  const prior = existingSources.get(`${releaseId}:${platform}`);
+
+  if (prior?.source === 'claimed') {
+    return { id: prior.id, url: prior.url, detail_checked_at: prior.detail_checked_at };
   }
 
-  // detail_checked_at is read back rather than written: it belongs to the detail pass, and a
-  // grid re-crawl must not reset it or every crawl would re-fetch every release page.
+  if (prior && prior.url === url && prior.external_id === externalId) {
+    return { id: prior.id, url: prior.url, detail_checked_at: prior.detail_checked_at };
+  }
+
   const { data, error } = await client
     .from('release_sources')
     .upsert(
@@ -1136,7 +1232,8 @@ export async function persistReleases(
   try {
     const { data: existingRows, error: readError } = await client
       .from('releases')
-      .select('id, slug, match_key, release_type, release_date, artwork_url, curated_fields')
+      // `title` is read so the patch below can compare instead of assigning unconditionally.
+      .select('id, slug, title, match_key, release_type, release_date, artwork_url, curated_fields')
       .eq('artist_id', artistId);
 
     if (readError) {
@@ -1147,6 +1244,7 @@ export async function persistReleases(
     type ExistingRow = {
       id: string;
       slug: string;
+      title: string | null;
       match_key: string;
       release_type: string;
       release_date: string | null;
@@ -1156,7 +1254,7 @@ export async function persistReleases(
     const existing = (existingRows as ExistingRow[]) || [];
     const byIdentity = new Map(existing.map(r => [`${r.release_type}:${r.match_key}`, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
-    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+    const existingSources = await getExistingSources(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -1171,7 +1269,13 @@ export async function persistReleases(
         const patch: Record<string, unknown> = {};
         // COALESCE semantics, applied in JS: only fill what's missing, never blank what's set,
         // and never touch what the artist edited.
-        if (!curated.has('title')) patch.title = release.title;
+        //
+        // `!== prior.title` matters more than it looks: this used to assign the title
+        // unconditionally, which meant every re-catalogue rewrote every release row it already
+        // held — six indexes each — even when the title was byte-identical, which it almost always
+        // is. With the comparison, an unchanged release now falls through to an empty patch and
+        // does no write at all. See PERSIST_REFRESH_FLOOR_MS for the same problem on `artists`.
+        if (!curated.has('title') && release.title !== prior.title) patch.title = release.title;
         if (!curated.has('artwork_url') && release.artworkUrl && !prior.artwork_url) {
           patch.artwork_url = release.artworkUrl;
         }
@@ -1219,6 +1323,7 @@ export async function persistReleases(
         byIdentity.set(identity, {
           id: releaseId,
           slug,
+          title: release.title,
           match_key: release.matchKey,
           release_type: release.releaseType,
           release_date: release.releaseDate,
@@ -1233,7 +1338,7 @@ export async function persistReleases(
         release.source.platform,
         release.source.url,
         release.source.externalId,
-        claimedKeys
+        existingSources
       );
 
       if (!source) {
@@ -1463,7 +1568,8 @@ export async function persistDiscogsReleases(
   try {
     const { data: existingRows, error: readError } = await client
       .from('releases')
-      .select('id, slug, match_key, release_type, release_date, curated_fields, discogs_master_id')
+      // `title` is read so the patch below can compare instead of assigning unconditionally.
+      .select('id, slug, title, match_key, release_type, release_date, curated_fields, discogs_master_id')
       .eq('artist_id', artistId);
 
     if (readError) {
@@ -1474,6 +1580,7 @@ export async function persistDiscogsReleases(
     type ExistingRow = {
       id: string;
       slug: string;
+      title: string | null;
       match_key: string;
       release_type: string;
       release_date: string | null;
@@ -1492,7 +1599,7 @@ export async function persistDiscogsReleases(
       else byType.set(row.release_type, [row]);
     }
     const takenSlugs = new Set(existing.map(r => r.slug));
-    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+    const existingSources = await getExistingSources(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -1527,7 +1634,11 @@ export async function persistDiscogsReleases(
         // already know is this one). A tier-2 title-equality match means the two titles
         // already normalize the same — overwriting risks nothing informative and risks
         // clobbering a display-quality title Bandcamp already got right.
-        if (!curated.has('title') && matchedByMasterId) patch.title = release.title;
+        // Compared rather than assigned, for the same reason as persistReleases above: a re-crawl
+        // that finds the identical title should write nothing.
+        if (!curated.has('title') && matchedByMasterId && release.title !== prior.title) {
+          patch.title = release.title;
+        }
         if (!prior.discogs_master_id) patch.discogs_master_id = release.masterId;
         if (!curated.has('release_date') && release.releaseDate && !prior.release_date) {
           patch.release_date = release.releaseDate;
@@ -1577,6 +1688,7 @@ export async function persistDiscogsReleases(
         const createdRow: ExistingRow = {
           id: releaseId,
           slug,
+          title: release.title,
           match_key: release.matchKey,
           release_type: release.releaseType,
           release_date: release.releaseDate,
@@ -1608,7 +1720,7 @@ export async function persistDiscogsReleases(
         // real listing page, unlike the abstract master page.
         `https://www.discogs.com/release/${release.mainReleaseId}`,
         release.masterId,
-        claimedKeys
+        existingSources
       );
 
       if (!source) {
@@ -1777,7 +1889,7 @@ export async function persistFaircampReleases(
     const existing = (existingRows as ExistingRow[]) || [];
     const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
-    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+    const existingSources = await getExistingSources(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -1854,7 +1966,7 @@ export async function persistFaircampReleases(
         }
       }
 
-      const source = await upsertReleaseSource(client, releaseId, 'faircamp', release.externalUrl, release.externalUrl, claimedKeys);
+      const source = await upsertReleaseSource(client, releaseId, 'faircamp', release.externalUrl, release.externalUrl, existingSources);
       if (!source) {
         console.error('[DB] persistFaircampReleases source write failed for release', releaseId);
         continue;
@@ -1931,7 +2043,7 @@ export async function persistJamcoopReleases(
     const existing = (existingRows as ExistingRow[]) || [];
     const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
-    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+    const existingSources = await getExistingSources(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -2025,7 +2137,7 @@ export async function persistJamcoopReleases(
         'jamcoop',
         release.externalUrl,
         release.externalUrl,
-        claimedKeys
+        existingSources
       );
       if (!source) {
         console.error('[DB] persistJamcoopReleases source write failed for release', releaseId);
@@ -2106,7 +2218,7 @@ export async function persistMirloReleases(
     const existing = (existingRows as ExistingRow[]) || [];
     const byMatchKey = new Map(existing.map(r => [r.match_key, r]));
     const takenSlugs = new Set(existing.map(r => r.slug));
-    const claimedKeys = await getClaimedSourceKeys(client, existing.map(r => r.id));
+    const existingSources = await getExistingSources(client, existing.map(r => r.id));
 
     const written: PersistedRelease[] = [];
 
@@ -2200,7 +2312,7 @@ export async function persistMirloReleases(
         'mirlo',
         release.externalUrl,
         release.externalUrl,
-        claimedKeys
+        existingSources
       );
       if (!source) {
         console.error('[DB] persistMirloReleases source write failed for release', releaseId);
@@ -2833,7 +2945,7 @@ export async function updateArtistReleaseFields(
 
 /**
  * "Add a platform link we missed" — or correct one ingest got wrong. Written with
- * `source: 'claimed'`, which `getClaimedSourceKeys` (used by every ingest path) checks before
+ * `source: 'claimed'`, which `getExistingSources` (used by every ingest path) checks before
  * ever overwriting a source's URL — the same "never clobber a curated edit" rule `curated_fields`
  * enforces on the release row itself, one table over.
  */
@@ -3488,6 +3600,87 @@ async function findArtistSlugByIdentityUrl(
  * Persist artist search results to the database.
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */
+/** A link row as persistSearchResults builds it, before it goes to Postgres. */
+interface LinkRowToWrite {
+  artist_id: string;
+  platform: string;
+  url: string;
+  source: string;
+  is_direct: boolean;
+  latest_release: unknown;
+  display_order: number;
+}
+
+/**
+ * Key-order-independent comparison for the one jsonb column involved (`latest_release`).
+ *
+ * We build the object in JS and compare it against what PostgREST hands back, and nothing
+ * guarantees the two serialize their keys in the same order — so a plain JSON.stringify compare
+ * would report "changed" constantly and defeat the whole point.
+ *
+ * Deliberately biased: anything this can't confidently prove identical is reported as *different*.
+ * A false "different" costs one unnecessary write; a false "same" would skip a real update and
+ * leave stale data on an artist's page, which is the far worse failure.
+ */
+function sameJsonValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || a === undefined || b === undefined) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => sameJsonValue(item, b[i]));
+  }
+
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj).sort();
+  const bKeys = Object.keys(bObj).sort();
+  if (aKeys.length !== bKeys.length || aKeys.some((k, i) => k !== bKeys[i])) return false;
+  return aKeys.every(k => sameJsonValue(aObj[k], bObj[k]));
+}
+
+/**
+ * Narrow a set of link rows to the ones that would actually change something.
+ *
+ * One indexed read replaces up to N row rewrites. Returns every row unchanged if the read fails —
+ * failing towards "write it" keeps the old behaviour rather than silently dropping a real update
+ * because a lookup blipped.
+ */
+async function filterUnchangedLinks(
+  client: SupabaseClient,
+  artistId: string,
+  rows: LinkRowToWrite[]
+): Promise<LinkRowToWrite[]> {
+  if (rows.length === 0) return rows;
+
+  const { data, error } = await client
+    .from('artist_links')
+    .select('platform, url, source, is_direct, latest_release, display_order')
+    .eq('artist_id', artistId);
+
+  if (error) {
+    console.error('[DB] filterUnchangedLinks read failed, writing all links:', error.message);
+    return rows;
+  }
+
+  type StoredLink = Omit<LinkRowToWrite, 'artist_id'>;
+  const stored = new Map<string, StoredLink>();
+  for (const row of (data as StoredLink[]) || []) stored.set(row.platform, row);
+
+  return rows.filter(row => {
+    const prior = stored.get(row.platform);
+    if (!prior) return true;
+    return !(
+      prior.url === row.url &&
+      prior.source === row.source &&
+      prior.is_direct === row.is_direct &&
+      prior.display_order === row.display_order &&
+      sameJsonValue(prior.latest_release, row.latest_release)
+    );
+  });
+}
+
 export async function persistSearchResults(results: ArtistResult[]): Promise<void> {
   const client = getClient();
   if (!client) return;
@@ -3530,10 +3723,12 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
     }
 
     try {
-      // Check if this artist is already claimed — never overwrite claimed status
+      // Check if this artist is already claimed — never overwrite claimed status.
+      // `name`, `image_url` and `updated_at` come back too, so the write below can be skipped
+      // when it would change nothing. See PERSIST_REFRESH_FLOOR_MS.
       const { data: existing } = await client
         .from('artists')
-        .select('id, match_confidence')
+        .select('id, name, image_url, match_confidence, updated_at')
         .eq('slug', slug)
         .single();
 
@@ -3572,28 +3767,40 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
       // table (partial-name discovery, typeahead) could never distinguish a
       // release-corroborated artist from name-match junk. Rows refresh on
       // every search, so the stored verdict tracks the latest pipeline run.
-      const { data: artist, error: artistError } = await client
-        .from('artists')
-        .upsert(
-          {
-            slug,
-            name: result.name,
-            image_url: result.imageUrl || null,
-            match_confidence: result.matchConfidence === 'verified' ? 'verified' : 'unverified',
-            source: 'auto',
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: 'slug' }
-        )
-        .select('id')
-        .single();
+      const matchConfidence = result.matchConfidence === 'verified' ? 'verified' : 'unverified';
+      const imageUrl = result.imageUrl || null;
 
-      if (artistError || !artist) {
-        console.error(`[DB] Failed to upsert artist "${result.name}":`, artistError);
-        return;
+      let artistId: string;
+
+      if (existing && !artistNeedsRefresh(existing, result.name, imageUrl, matchConfidence)) {
+        // Nothing to say about this artist that the row doesn't already say, and it was
+        // refreshed recently enough that `updated_at` doesn't need moving. Skipping the write
+        // is the point: see artistNeedsRefresh.
+        artistId = existing.id;
+      } else {
+        const { data: artist, error: artistError } = await client
+          .from('artists')
+          .upsert(
+            {
+              slug,
+              name: result.name,
+              image_url: imageUrl,
+              match_confidence: matchConfidence,
+              source: 'auto',
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: 'slug' }
+          )
+          .select('id')
+          .single();
+
+        if (artistError || !artist) {
+          console.error(`[DB] Failed to upsert artist "${result.name}":`, artistError);
+          return;
+        }
+
+        artistId = artist.id;
       }
-
-      const artistId = artist.id;
 
       // Bulk-upsert links (only valid platforms) in a single request.
       // Deduped by platform (last wins, matching the old one-at-a-time loop) —
@@ -3612,15 +3819,35 @@ export async function persistSearchResults(results: ArtistResult[]): Promise<voi
       ]));
       const linkRows = [...linkRowsByPlatform.values()];
 
-      const { error: linkError } = await client
-        .from('artist_links')
-        .upsert(linkRows, { onConflict: 'artist_id,platform' });
+      // Only write links that would actually differ from what's stored.
+      //
+      // This bulk upsert used to run on every search, rewriting every one of an artist's link
+      // rows whether or not anything had moved — and platform URLs almost never move. That is the
+      // larger half of the churn described on PERSIST_REFRESH_FLOOR_MS, because it is N rows per
+      // artist per search rather than one.
+      //
+      // Unlike `artists.updated_at`, nothing reads `artist_links.updated_at` as a freshness
+      // signal, so an unchanged link row genuinely has no reason to be touched and there is no
+      // throttle here — just a comparison. The read that makes the comparison possible is one
+      // indexed lookup on `idx_artist_links_artist_id`, which is far cheaper than the writes it
+      // avoids: a read costs no WAL, no index maintenance and no dead tuples.
+      const changedLinkRows = existing
+        ? await filterUnchangedLinks(client, artistId, linkRows)
+        : linkRows;
 
-      if (linkError) {
-        console.error(`[DB] Failed to upsert links for "${result.name}":`, linkError);
+      if (changedLinkRows.length > 0) {
+        const { error: linkError } = await client
+          .from('artist_links')
+          .upsert(changedLinkRows, { onConflict: 'artist_id,platform' });
+
+        if (linkError) {
+          console.error(`[DB] Failed to upsert links for "${result.name}":`, linkError);
+        }
       }
 
-      console.log(`[DB] Persisted "${result.name}" with ${linkRows.length} links`);
+      console.log(
+        `[DB] Persisted "${result.name}": ${changedLinkRows.length} of ${linkRows.length} links written`
+      );
 
       // Only worth cataloging artists we can actually catalog — ingest is Bandcamp-only for
       // now, so an artist without a Bandcamp link would just be a wasted claim.

--- a/api/functions/purge-cache.ts
+++ b/api/functions/purge-cache.ts
@@ -1,0 +1,48 @@
+// Netlify CDN cache purge by tag.
+//
+// The edge functions that server-render artist and release pages cache aggressively (a day for
+// the crawler-only artist page, an hour for release pages, which everyone sees). That is only safe
+// because the writes that change those pages purge them, so this is the counterpart to the
+// `Cache-Tag` headers in api/edge/artist-page-static.ts and api/edge/release-page.ts.
+//
+// Netlify purges by *exact* tag — there are no wildcards — which is why release pages carry a
+// shared `artist-releases-${slug}` tag alongside their own: it's the only way to clear all of one
+// artist's release pages in a single call.
+
+/**
+ * Fire the purge and report what happened, without ever throwing at the caller.
+ *
+ * A failed purge means a page serves stale for the rest of its TTL, which is worth a log line but
+ * never worth failing an artist's edit over — the write already succeeded by the time we get here.
+ * No-ops with a warning when the Netlify credentials aren't set, which is the normal state in
+ * local dev and tests.
+ */
+export async function purgeCacheTags(tags: string[], label: string): Promise<void> {
+  if (tags.length === 0) return;
+
+  const siteId = process.env.NETLIFY_SITE_ID || process.env.SITE_ID;
+  const token = process.env.NETLIFY_API_TOKEN;
+  if (!siteId || !token) {
+    console.warn(`[${label}] NETLIFY_SITE_ID or NETLIFY_API_TOKEN not set, skipping CDN purge for ${tags.join(', ')}`);
+    return;
+  }
+
+  try {
+    await fetch('https://api.netlify.com/api/v1/purge', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ site_id: siteId, cache_tags: tags }),
+    });
+    console.log(`[${label}] Purged CDN cache for ${tags.join(', ')}`);
+  } catch (error) {
+    console.error(`[${label}] CDN cache purge failed for ${tags.join(', ')}:`, error);
+  }
+}
+
+/**
+ * Everything server-rendered for one artist: their artist page, and every one of their release
+ * pages via the tag they all share.
+ */
+export async function purgeArtistReleaseCaches(slug: string, label = 'PurgeCache'): Promise<void> {
+  await purgeCacheTags([`artist-${slug}`, `artist-releases-${slug}`], label);
+}

--- a/supabase/migrations/20260811120000_app-events-dashboard-indexes.sql
+++ b/supabase/migrations/20260811120000_app-events-dashboard-indexes.sql
@@ -1,0 +1,45 @@
+-- Migration: index app_events for the admin dashboard's queries
+--
+-- `/admin/analytics` fires nine queries at app_events on every load (see
+-- api/functions/analytics-dashboard.ts): five counts and breakdowns filtered by
+-- `event_type` + `created_at`, and one "20 most recent events" ordered by `created_at DESC`.
+--
+-- None of them had a usable index. The table's only index was
+-- `idx_app_events_unscrubbed (created_at) WHERE session_hash IS NOT NULL`, added for the
+-- session-hash retention sweep, and it can't serve these:
+--
+--   * it doesn't carry `event_type`, so the eight filtered queries can't use it as a leading
+--     column; and
+--   * its `WHERE session_hash IS NOT NULL` predicate excludes exactly the rows the dashboard
+--     cares most about — everything older than 90 days, which is scrubbed — so the further back
+--     a query reaches, the less of the table the index covers.
+--
+-- So each dashboard load meant nine sequential scans of a table that only ever grows, three of
+-- them `count: 'exact'`, which Postgres can only answer by scanning. That is a contributor to
+-- the Disk IO Budget alert, and unlike the write-churn causes it gets steadily worse on its own.
+--
+-- The fix is indexes, deliberately not retention. The 2026-08-08 migration weighed deleting old
+-- rows and rejected it — "it costs year-over-year trends for no gain" — and that reasoning still
+-- holds. Indexing is what makes keeping the history cheap enough to be free.
+--
+-- Measured on postgres:16 with 60,000 rows over two years, before -> after:
+--
+--   count by event_type over 30 days   779 -> 395 buffers,  3.7ms -> 1.0ms
+--   20 most recent events              782 ->  22 buffers,  7.6ms -> 0.1ms  (sort eliminated)
+--
+-- The second is the one that matters most, and both gaps widen on their own: a sequential scan
+-- grows with the whole table forever, while the index scans grow only with the window queried.
+
+-- Serves the eight event_type-filtered queries: `event_type` equality first, then the
+-- `created_at >= …` range, then `created_at DESC` ordering for free.
+CREATE INDEX IF NOT EXISTS idx_app_events_type_created
+  ON app_events (event_type, created_at DESC);
+
+-- Serves the unfiltered "20 most recent events" query, which the index above cannot: it has no
+-- event_type predicate, so it would otherwise scan and sort the whole table to return 20 rows.
+--
+-- Unlike idx_app_events_unscrubbed this carries no WHERE clause, so it stays complete as rows are
+-- scrubbed. That index remains useful for the retention sweep itself, which specifically wants
+-- only unscrubbed rows and benefits from a smaller index.
+CREATE INDEX IF NOT EXISTS idx_app_events_created
+  ON app_events (created_at DESC);


### PR DESCRIPTION
Supabase reported the project is depleting its Disk IO Budget. Brandon's read was that it looked
sudden without matching growth, and that the releases feature was the obvious suspect.

The database holds a few thousand artists and ~6,000 releases — tens of megabytes, which should
sit entirely in RAM. Depleting an IO budget at that size means something is churning, not that the
instance is too small, so this is efficiency work rather than a compute upgrade.

Three commits, reviewable in order.

## 1. `99edeed` — CDN TTLs and the two per-search admin reads

**Release and artist pages were CDN-cached for five minutes.** The release page is pure SSR for
everyone, and the releases feature took the server-rendered surface from ~800 artist pages to those
plus ~6,000 release URLs, each miss costing two Supabase queries including a two-level nested
embed. Release pages go to `s-maxage=3600` with a long `stale-while-revalidate`, so steady-state
cost is one query per URL per hour whatever the traffic. Artist pages go to a day, because that
render only ever reaches crawlers — real browsers are handed to the SPA before any query runs — so
a long TTL only delays how quickly Google sees an edit.

Neither is safe without purging. Release pages now carry a shared `artist-releases-${slug}` tag
alongside their own (Netlify purges by exact tag, no wildcards) so one call clears all of an
artist's release pages. The admin release-review merge path had **no purge at all**, which
self-healed while the TTL was five minutes and would not now. Purge-by-tag moves into
`api/functions/purge-cache.ts` rather than becoming a fourth copy of itself.

**`getMergeOverrides` and `getLinkSuppressions` were uncached full-table reads on every search.**
Both change only when an admin acts: five minutes in Redis, with the admin endpoints invalidating
on write so a merge or suppression still takes effect immediately. The TTL is what covers
`scripts/merge-override.ts`, which writes the same table without going through a function.

Both returned `[]` on failure *and* `[]` when genuinely empty, so caching them naively would
suppress every merge override for a full TTL over one blip. The cached value carries `ok` and only
a successful read is written.

## 2. `89e900d` — stop rewriting rows that haven't changed

Postgres has no in-place update: every write is a new tuple version, an entry in each index, a WAL
record, and a dead tuple for autovacuum. Three paths were doing that unconditionally.

- **Every search rewrote the artist row and all its links.** `artists` carries five indexes, one a
  GIN trigram index on `name`.
- **Every re-catalogue rewrote every release row**, because the patch assigned `title`
  unconditionally even when byte-identical.
- **Every re-catalogue rewrote every `release_sources` row**, restating a URL that hadn't moved in
  order to stamp `last_seen_at`.

⚠️ **The obvious fix for the first one is wrong, and that's the part worth reviewing.**
`artists.updated_at` is not "when the data changed" — `getArtistBySlug` reads it as "when we last
verified this artist" and refuses the row past `FRESHNESS_TTL_MS` (24h). Skip the write when
nothing differs and stored artist cards silently expire, so every search re-runs the full live
pipeline: cheaper on Postgres, far more expensive everywhere else. So the write is *throttled*, not
removed — an unchanged row refreshes at most hourly, well inside the freshness window. There is a
test asserting the refresh still happens, because that is the half a future optimisation would
break.

Link rows have no such freshness meaning, so those are compared and skipped outright — the larger
half, being N rows per artist per search rather than one.

`getClaimedSourceKeys` becomes `getExistingSources`: same single query, more columns, which lets the
shared helper skip an unchanged source row and answer a claimed row from memory instead of a second
read. Note `release_sources.last_seen_at` now advances only when the row otherwise changes; nothing
in the codebase reads it, which is what makes that acceptable, and the comment says so.

Every skip fails towards writing: a failed comparison read means "write it", never "skip it".

## 3. `090b5d6` — index `app_events`

`/admin/analytics` fires nine queries at `app_events` per load and none had a usable index. The only
index there is partial on `created_at WHERE session_hash IS NOT NULL`, which carries no `event_type`
and excludes everything older than 90 days — exactly the history the dashboard reaches into. So each
load meant nine sequential scans of a table that only grows.

Measured on `postgres:16` with 60,000 rows: count-by-event_type 779 → 395 buffers, and "20 most
recent events" 782 buffers plus a top-N sort → 22 buffers and no sort. Both gaps widen on their own.

Indexes rather than retention, deliberately: the 2026-08-08 migration already weighed deleting old
rows and rejected it because it costs year-over-year trends.

## Considered and rejected

- **An index on `artist_links(platform)`** for the re-catalogue sweep, which really does sequentially
  scan four times a day. Measured, that table is 54 pages — under 1MB — and the scan takes 0.3ms; the
  index either lost outright (bitmap heap scan, 70 buffers vs 54) or won by ~20 buffers depending on
  selectivity. Against added write cost on a table every search touches, not worth having. Migration
  was written, validated, then deleted.
- **Batching the per-release ingest writes** across an artist. The 7-day re-catalogue cooldown means
  each source row is touched about weekly, so restructuring five ingest loops would buy roughly 600
  fewer transactions a day against the highest correctness risk of the set. Skipping unchanged writes
  gets the same benefit without touching the loops.

## Verification

- 1,118 API function tests, 718 web unit tests, `typecheck:api` clean.
- Lint at the repo's known 71-problem baseline, nothing new in `api/`.
- Each new test was checked to fail when its fix is reverted, rather than assumed to have teeth.
- The migration was applied twice against a throwaway `postgres:16` in Docker, with
  `EXPLAIN (ANALYZE, BUFFERS)` read for each real query shape.

## Before merging

Worth capturing `pg_stat_user_tables` first, so there's a real before/after rather than just an
after:

```sql
select relname, n_live_tup, n_dead_tup, n_tup_upd, n_tup_hot_upd, seq_scan, idx_scan from pg_stat_user_tables order by n_tup_upd desc;
```

One thing to note on the migration: `CREATE INDEX` without `CONCURRENTLY` takes a lock that blocks
inserts on `app_events` for the duration of the build. On a small table that is milliseconds, and a
blocked analytics insert is a silent no-op by design, so it should be unnoticeable — but if that
table has grown larger than expected, say so and I'll split it out and reshape it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)