### PR TITLE
Stop the Bandcamp import duplicating artists a fan already saved

### DIFF
--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -40,7 +40,7 @@ function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableM
   const connectionUpdates: Record<string, unknown>[] = [];
   const upsertBatches: Record<string, unknown>[][] = [];
   const savedInserts: Record<string, unknown>[][] = [];
-  const savedUpdates: { patch: Record<string, unknown>; slugs: unknown }[] = [];
+  const savedUpdates: { patch: Record<string, unknown>; column: string; values: unknown }[] = [];
 
   mocks.mockFrom.mockImplementation((table: string) => {
     if (table === 'bandcamp_connections') {
@@ -77,7 +77,16 @@ function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableM
       return {
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
-            in: vi.fn(() => Promise.resolve({ data: savedRows, error: null })),
+            // Honours the column actually queried. Without this the mock answers the
+            // artist_id read and the artist_slug read identically, and a row filed under a
+            // synthetic slug would look findable by slug when in production it isn't — the
+            // exact blindness the dedup fix exists to close.
+            in: vi.fn((column: string, values: unknown[]) =>
+              Promise.resolve({
+                data: savedRows.filter(row => values.includes(row[column])),
+                error: null,
+              })
+            ),
           })),
         })),
         upsert: vi.fn((rows: Record<string, unknown>[]) => {
@@ -86,8 +95,8 @@ function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableM
         }),
         update: vi.fn((patch: Record<string, unknown>) => ({
           eq: vi.fn(() => ({
-            in: vi.fn((_col: string, slugs: unknown) => {
-              savedUpdates.push({ patch, slugs });
+            in: vi.fn((column: string, values: unknown) => {
+              savedUpdates.push({ patch, column, values });
               return Promise.resolve({ error: null });
             }),
           })),
@@ -230,7 +239,8 @@ describe('bandcamp-sync-background handler', () => {
     it('upgrades an existing unsupported row instead of inserting', async () => {
       const { savedInserts, savedUpdates } = setupDb({
         connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ artist_slug: 'sufjan-stevens', supported: false, deleted: false }],
+        // No artist_id: the legacy shape, where only the slug identifies the artist.
+        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false }],
       });
       withArtists();
 
@@ -239,13 +249,14 @@ describe('bandcamp-sync-background handler', () => {
       expect(savedInserts).toHaveLength(0);
       expect(savedUpdates).toHaveLength(1);
       expect(savedUpdates[0].patch).toMatchObject({ supported: true });
-      expect(savedUpdates[0].slugs).toEqual(['sufjan-stevens']);
+      expect(savedUpdates[0].column).toBe('id');
+      expect(savedUpdates[0].values).toEqual(['row-1']);
     });
 
     it('leaves an already-supported row untouched (original supported_at preserved)', async () => {
       const { savedInserts, savedUpdates } = setupDb({
         connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ artist_slug: 'sufjan-stevens', supported: true, deleted: false }],
+        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: true, deleted: false }],
       });
       withArtists();
 
@@ -258,7 +269,7 @@ describe('bandcamp-sync-background handler', () => {
     it('never resurrects a tombstoned row — permanent dismissal sticks across re-syncs', async () => {
       const { savedInserts, savedUpdates } = setupDb({
         connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ artist_slug: 'sufjan-stevens', supported: false, deleted: true }],
+        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: true }],
       });
       withArtists();
 
@@ -266,6 +277,64 @@ describe('bandcamp-sync-background handler', () => {
 
       expect(savedInserts).toHaveLength(0);
       expect(savedUpdates).toHaveLength(0);
+    });
+
+    // The two cases the slug-only lookup got wrong. A row saved from a search result is filed
+    // under a synthetic slug (`sufjanstevens`), which the canonical slug never equals, so only
+    // artist_id finds it — measured on production 2026-08-14, one import duplicated three of
+    // Brandon's saved artists this way.
+    it('upgrades a row saved under a synthetic slug rather than duplicating the artist', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [
+          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: false },
+        ],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(1);
+      expect(savedUpdates[0].column).toBe('id');
+      expect(savedUpdates[0].values).toEqual(['row-1']);
+    });
+
+    it('never resurrects a tombstone filed under a synthetic slug', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [
+          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
+        ],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(0);
+    });
+
+    // The shape deduplicating an account leaves behind: the superseded row tombstoned, the
+    // canonical one live. The tombstone must not be read as "artist dismissed" — that would
+    // strand the live row unsupported through every future re-sync — and neither row may be
+    // duplicated by a fresh insert.
+    it('supports the live row when a tombstone for the same artist sits beside it', async () => {
+      const { savedInserts, savedUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        savedRows: [
+          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
+          { id: 'row-2', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false },
+        ],
+      });
+      withArtists();
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(savedInserts).toHaveLength(0);
+      expect(savedUpdates).toHaveLength(1);
+      expect(savedUpdates[0].column).toBe('id');
+      expect(savedUpdates[0].values).toEqual(['row-2']);
     });
 
     it('marks nothing for unmatched artists', async () => {

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -131,8 +131,19 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   return matches;
 }
 
-/** Slugs per saved_artists read — stays far below PostgREST's 1,000-row response cap. */
+/** Artists per saved_artists read — stays far below PostgREST's 1,000-row response cap. */
 const SAVED_LOOKUP_CHUNK = 100;
+
+/** The saved_artists columns needed to decide insert vs. upgrade vs. leave alone. */
+const SAVED_SELECT = 'id, artist_id, artist_slug, supported, deleted';
+
+interface SavedRow {
+  id: string;
+  artist_id: string | null;
+  artist_slug: string | null;
+  supported: boolean;
+  deleted: boolean;
+}
 
 /**
  * Buying an artist's record IS supporting them, so a Bandcamp import marks every matched
@@ -145,6 +156,16 @@ const SAVED_LOOKUP_CHUNK = 100;
  *   - an already-supported row keeps its original supported_at;
  *   - only supported goes true; nothing here can ever un-support or overwrite notes.
  *
+ * **An existing row is looked up by `artist_id` as well as by slug, and matching on the slug
+ * alone broke the first of those rules.** `(user_id, artist_slug)` is the table's natural key
+ * (migration 014), but a row saved from a search result carries a *synthetic* slug —
+ * `modelactriz`, `seoulmetro`, `qobuz-robertlogan` — that the canonical slug never equals, and
+ * `artist_id` is then the only thing identifying the artist. So the slug-only check found
+ * nothing and inserted a **second live row for an artist already saved** (measured on
+ * production 2026-08-14: Model/Actriz, Rodney Owl and Seoul Metro each duplicated by one
+ * import), and it equally missed a **tombstone** filed under the other slug, resurrecting a
+ * dismissal this function promises is permanent.
+ *
  * Failure here degrades, not fails: items are the sync's primary artifact, and the mark
  * is derived state the next re-sync recomputes.
  */
@@ -152,55 +173,76 @@ async function markArtistsSupported(userId: string, artists: MatchedArtist[]): P
   const client = getClient();
   if (!client || artists.length === 0) return;
 
-  const bySlug = new Map(artists.map(a => [a.slug, a]));
-  const slugs = [...bySlug.keys()];
-  const existing = new Map<string, { supported: boolean; deleted: boolean }>();
+  const serverNow = new Date().toISOString();
+  const toInsert: Record<string, unknown>[] = [];
+  /** Row ids, not slugs: a row matched by `artist_id` may be filed under a different slug. */
+  const toSupport: string[] = [];
 
-  for (let i = 0; i < slugs.length; i += SAVED_LOOKUP_CHUNK) {
-    const chunk = slugs.slice(i, i + SAVED_LOOKUP_CHUNK);
-    const { data, error } = await client
-      .from('saved_artists')
-      .select('artist_slug, supported, deleted')
-      .eq('user_id', userId)
-      .in('artist_slug', chunk);
-    if (error) {
+  for (let i = 0; i < artists.length; i += SAVED_LOOKUP_CHUNK) {
+    const chunk = artists.slice(i, i + SAVED_LOOKUP_CHUNK);
+
+    // Two reads rather than one, because a saved row can name this artist either way and
+    // neither column alone finds both (see the doc comment above).
+    const [byId, bySlug] = await Promise.all([
+      client
+        .from('saved_artists')
+        .select(SAVED_SELECT)
+        .eq('user_id', userId)
+        .in('artist_id', chunk.map(a => a.id)),
+      client
+        .from('saved_artists')
+        .select(SAVED_SELECT)
+        .eq('user_id', userId)
+        .in('artist_slug', chunk.map(a => a.slug)),
+    ]);
+
+    const failure = byId.error || bySlug.error;
+    if (failure) {
       // Without a reliable view of existing rows we can't insert safely (we might
       // resurrect a tombstone), so skip this chunk's artists entirely.
-      console.warn('[bandcamp-sync] saved_artists read failed:', error.message);
-      Sentry.captureException(new Error(`saved_artists read failed: ${error.message}`), {
+      console.warn('[bandcamp-sync] saved_artists read failed:', failure.message);
+      Sentry.captureException(new Error(`saved_artists read failed: ${failure.message}`), {
         tags: { function: 'bandcamp-sync' },
         extra: { stage: 'mark-supported' },
       });
-      for (const slug of chunk) bySlug.delete(slug);
       continue;
     }
-    for (const row of data ?? []) {
-      existing.set(row.artist_slug, { supported: row.supported, deleted: row.deleted === true });
+
+    const rows = [...(byId.data ?? []), ...(bySlug.data ?? [])] as SavedRow[];
+
+    for (const artist of chunk) {
+      // Both reads can return the same row, and an already-duplicated artist returns two — so
+      // decide over every candidate rather than picking one.
+      const candidates = rows.filter(
+        row => (row.artist_id && row.artist_id === artist.id) || row.artist_slug === artist.slug
+      );
+
+      if (candidates.length === 0) {
+        toInsert.push({
+          user_id: userId,
+          artist_id: artist.id,
+          artist_slug: artist.slug,
+          artist_name: artist.name,
+          artist_image_url: artist.imageUrl,
+          supported: true,
+          supported_at: serverNow,
+          // Stamped server-side on insert so the row is immediately visible to the Apple
+          // app's ?since= incremental pulls — same reasoning as saved-artists.ts.
+          last_modified: serverNow,
+        });
+        continue;
+      }
+
+      // A tombstone wins only when nothing live is left for this artist — then the dismissal
+      // is untouchable, and no row is inserted either. A tombstone sitting *beside* a live row
+      // means that row was superseded, not the artist dismissed (deduplicating an account
+      // leaves exactly that shape), and skipping there would strand the live row unsupported.
+      const live = candidates.filter(row => !row.deleted);
+      for (const row of live) {
+        if (!row.supported && !toSupport.includes(row.id)) toSupport.push(row.id);
+      }
     }
   }
-
-  const serverNow = new Date().toISOString();
-  const toInsert = [...bySlug.values()]
-    .filter(a => !existing.has(a.slug))
-    .map(a => ({
-      user_id: userId,
-      artist_id: a.id,
-      artist_slug: a.slug,
-      artist_name: a.name,
-      artist_image_url: a.imageUrl,
-      supported: true,
-      supported_at: serverNow,
-      // Stamped server-side on insert so the row is immediately visible to the Apple
-      // app's ?since= incremental pulls — same reasoning as saved-artists.ts.
-      last_modified: serverNow,
-    }));
-
-  const toSupport = [...bySlug.values()]
-    .filter(a => {
-      const row = existing.get(a.slug);
-      return row !== undefined && !row.deleted && !row.supported;
-    })
-    .map(a => a.slug);
 
   for (let i = 0; i < toInsert.length; i += SAVED_LOOKUP_CHUNK) {
     const { error } = await client
@@ -220,7 +262,7 @@ async function markArtistsSupported(userId: string, artists: MatchedArtist[]): P
       .from('saved_artists')
       .update({ supported: true, supported_at: serverNow, last_modified: serverNow })
       .eq('user_id', userId)
-      .in('artist_slug', toSupport.slice(i, i + SAVED_LOOKUP_CHUNK));
+      .in('id', toSupport.slice(i, i + SAVED_LOOKUP_CHUNK));
     if (error) {
       console.warn('[bandcamp-sync] saved_artists support update failed:', error.message);
       Sentry.captureException(new Error(`saved_artists support update failed: ${error.message}`), {

--- a/supabase/migrations/20260814170000_dedupe-saved-artists.sql
+++ b/supabase/migrations/20260814170000_dedupe-saved-artists.sql
@@ -1,0 +1,64 @@
+-- Collapse duplicate saved_artists rows that name the same artist twice.
+--
+-- `(user_id, artist_slug)` is the table's natural key (migration 014, which dropped the
+-- original `(user_id, artist_id)` constraint so a fan could save an artist with no `artists`
+-- row). The cost of that is real: a save made from a search result stores a *synthetic* slug
+-- (`modelactriz`, `seoulmetro`, `rodneyowl`, `qobuz-robertlogan`), so a later write using the
+-- canonical slug looks like a different artist and inserts a second live row.
+--
+-- The Bandcamp collection import did exactly that on 2026-08-14 — it checked for an existing
+-- row by slug only — duplicating Model/Actriz, Rodney Owl and Seoul Metro in one run. That
+-- code now matches on `artist_id` too (bandcamp-sync-background.ts), so this cleans up the
+-- rows already written rather than a recurring condition. One pair predates the import
+-- (Bird Streets, two saves 19 seconds apart) and is fixed by the same statement.
+--
+-- Deliberately no unique constraint on `(user_id, artist_id)`: `artist_id` is nullable, so it
+-- would exempt exactly the legacy rows most likely to duplicate, and a hard constraint would
+-- turn a duplicate save into a failed one for the fan rather than a no-op.
+--
+-- The losing rows are **tombstoned, not deleted**. saved_artists is synced to the Apple app by
+-- `?since=` incremental pulls (migration 017), which learn about removals only from
+-- `deleted = true`; a hard delete would leave the duplicate on every device forever. Both the
+-- keeper and the tombstone get a fresh `last_modified` so that pull picks up both changes.
+
+WITH grouped AS (
+  SELECT
+    sa.id,
+    -- The truest values across the pair, not whichever row happens to win: `added_at` is when
+    -- this fan first saved the artist, and `supported_at` when they first supported them.
+    MIN(sa.added_at) OVER dupe AS first_added_at,
+    MIN(sa.supported_at) OVER dupe AS first_supported_at,
+    BOOL_OR(sa.supported) OVER dupe AS ever_supported,
+    COUNT(*) OVER dupe AS group_size,
+    ROW_NUMBER() OVER (
+      PARTITION BY sa.user_id, sa.artist_id
+      -- Keep the row whose slug matches the artists table: it is the slug every link and every
+      -- later write derives, so keeping the synthetic one would just re-open the same gap.
+      -- Failing that, keep the earliest save.
+      ORDER BY (a.slug IS NOT NULL AND sa.artist_slug = a.slug) DESC, sa.added_at ASC, sa.id ASC
+    ) AS rn
+  FROM saved_artists sa
+  LEFT JOIN artists a ON a.id = sa.artist_id
+  WHERE sa.deleted = false
+    AND sa.artist_id IS NOT NULL
+  WINDOW dupe AS (PARTITION BY sa.user_id, sa.artist_id)
+),
+dupes AS (
+  SELECT * FROM grouped WHERE group_size > 1
+),
+keepers AS (
+  UPDATE saved_artists sa
+  SET added_at = d.first_added_at,
+      supported = d.ever_supported,
+      supported_at = CASE WHEN d.ever_supported THEN d.first_supported_at ELSE NULL END,
+      last_modified = now()
+  FROM dupes d
+  WHERE sa.id = d.id AND d.rn = 1
+  RETURNING sa.id
+)
+UPDATE saved_artists sa
+SET deleted = true,
+    deleted_at = now(),
+    last_modified = now()
+FROM dupes d
+WHERE sa.id = d.id AND d.rn > 1;


### PR DESCRIPTION
Started from a report that `/dashboard`'s Recent Releases was showing "recent releases from *any artist* whose releases we've captured." **It wasn't** — the endpoint is correctly scoped, verified against production for all 16 accounts that have saved artists: no artist appears in anyone's feed who isn't in their own `saved_artists`. The unfamiliar names were 27 rows the Bandcamp collection import wrote at `2026-08-14 12:43:04`, matched from 190 albums in `collection_items` and marked saved + supported by design (spec OQ6, "buying is supporting"). That behaviour stays; the collection surface simply wasn't live yet, which is what made it look like a leak.

The dig did turn up two real defects in the import, both from one cause.

## The bug

`markArtistsSupported` asked "does this user already have this artist?" by `artist_slug` alone. That *is* the table's natural key — migration 014 dropped `UNIQUE(user_id, artist_id)` so a fan could save an artist with no `artists` row — but a save made from a search result stores a **synthetic** slug (`modelactriz`, `seoulmetro`, `rodneyowl`, `qobuz-robertlogan`) that the canonical slug never equals. So the check answered "no" for artists already saved, and:

1. **It inserted a second live row.** Measured on production: one import duplicated Model/Actriz, Rodney Owl and Seoul Metro on a single account. A fourth pair (Bird Streets, another account) predates the import — two saves 19 seconds apart, same underlying gap.
2. **It missed tombstones filed under the other slug**, so a re-sync would have resurrected a dismissal the function's own comment promises is permanent. Permanent dismissal is a locked spec decision, so this one matters more than the duplicates.

## The fix

Existing rows are looked up by `artist_id` as well as by slug — two `.in()` reads, since neither column alone finds both. The decision is made over *every* candidate row rather than one, and support updates target the row `id`, because a row matched on `artist_id` may be filed under a different slug than the one searched.

One rule corrected while in here: **a tombstone wins only when nothing live remains for that artist.** An absolute "any tombstone among the candidates → skip" reads safer and is worse — deduplicating an account leaves exactly the shape *tombstoned row beside live row*, and that rule would then strand the live row unsupported through every future re-sync.

## The migration

`20260814170000_dedupe-saved-artists.sql` collapses the rows already written. It keeps the canonical-slug row (falling back to the earliest save when neither slug is canonical), carries over the earliest `added_at`/`supported_at` across the pair — those are facts about when the fan first saved and first supported the artist, not properties of whichever row wins — and **tombstones the loser rather than deleting it**: the Apple app learns about removals only from `deleted = true` via its `?since=` pulls, so a hard delete would leave the duplicate on every device forever. Both rows get a fresh `last_modified` so that pull picks up both changes.

Validated against a throwaway `postgres:16` in Docker with a fixture covering all the shapes:

- `UPDATE 5` — exactly the five duplicate pairs' losing rows.
- Exactly the 10 rows in those groups were modified. The 6 that must be left alone provably were not (a single non-duplicate row, a standalone tombstone, an already-tombstoned pair whose live row is unique, and two live rows with `NULL artist_id` and different slugs — not provably the same artist, so untouched).
- Re-apply is `UPDATE 0`, 0 rows touched, 0 duplicate groups left.

The "untouched" assertion was toothless on the first pass — the fixture inserted rows with `last_modified DEFAULT now()`, so *every* row looked freshly bumped. Backdating them first is what made it a real check.

## Deliberately not done

No unique constraint on `(user_id, artist_id)`. `artist_id` is nullable, so it would exempt precisely the legacy rows most likely to duplicate, and a hard constraint turns a duplicate save into a failed one for the fan rather than a no-op. Happy to add it if you'd rather have the backstop.

## Reviewer notes

- **Three new tests, each verified to fail with the fix reverted.** Two needed the mock fixed first: it stubbed `.in()` as returning `savedRows` regardless of which *column* was queried, so it couldn't tell the `artist_id` read from the `artist_slug` read and every test passed with or without the fix. It now filters by the queried column.
- `npm run test:api` — 1192 passing across 69 files. `tsc -p api/tsconfig.json` clean; both changed files are in that tsconfig's `include`, so the typecheck is real coverage here rather than the usual `api/` blind spot.
- **Check `supabase-migrate.yml` goes green after merge.** It auto-applies on push to `main`, and per the history-divergence incident a stranded migration blocks everyone's deploys silently. Nothing here was applied to production ahead of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
