### PR TITLE
Remove recent events table from admin analytics dashboard

### DIFF
--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -50,7 +50,6 @@ export async function handler(event: {
       byApp30d,
       platforms30d,
       streamingServices30d,
-      recentEvents,
     ] = await Promise.all([
       // Searches today
       client
@@ -110,13 +109,6 @@ export async function handler(event: {
         .select('context')
         .eq('event_type', 'extension_activated')
         .gte('created_at', ago30),
-
-      // Recent 20 events
-      client
-        .from('app_events')
-        .select('event_type, app, context, created_at')
-        .order('created_at', { ascending: false })
-        .limit(20),
     ]);
 
     // Surface query errors early — Supabase returns { error } rather than throwing
@@ -215,12 +207,6 @@ export async function handler(event: {
         by_app: byApp,
         platforms,
         streaming_services: streamingServices,
-        recent: (recentEvents.data || []).map(e => ({
-          event_type: e.event_type,
-          app: e.app,
-          context: e.context,
-          created_at: e.created_at,
-        })),
       }),
     };
   } catch (err) {

--- a/apps/web/src/pages/AdminAnalyticsPage.tsx
+++ b/apps/web/src/pages/AdminAnalyticsPage.tsx
@@ -34,13 +34,6 @@ interface StreamingStat {
   activations: number;
 }
 
-interface RecentEvent {
-  event_type: string;
-  app: string;
-  context: Record<string, unknown>;
-  created_at: string;
-}
-
 interface DashboardData {
   summary: {
     searches_today: number;
@@ -54,7 +47,6 @@ interface DashboardData {
   by_app: AppStat[];
   platforms: PlatformStat[];
   streaming_services: StreamingStat[];
-  recent: RecentEvent[];
 }
 
 // ─── Bar chart ───────────────────────────────────────────────────────────────
@@ -245,20 +237,6 @@ function DataTable<T extends Record<string, unknown>>({
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
-function formatEventType(t: string) {
-  return t.replace(/_/g, ' ');
-}
-
-function formatRelativeTime(iso: string) {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
 export function AdminAnalyticsPage() {
   const { isAdmin, isLoading: authLoading, session } = useAuth();
   const navigate = useNavigate();
@@ -313,22 +291,13 @@ export function AdminAnalyticsPage() {
 
   if (!data) return null;
 
-  const { summary, daily, by_app, platforms, streaming_services, recent } = data;
+  const { summary, daily, by_app, platforms, streaming_services } = data;
 
   const appRows = by_app.map(a => ({
     app: a.app,
     searches: a.searches,
     clicks: a.clicks,
     total: a.searches + a.clicks,
-  }));
-
-  const recentRows = recent.map(e => ({
-    type: formatEventType(e.event_type),
-    app: e.app,
-    detail: Object.entries(e.context)
-      .map(([k, v]) => `${k}: ${v}`)
-      .join(', ') || '—',
-    when: formatRelativeTime(e.created_at),
   }));
 
   return (
@@ -432,21 +401,6 @@ export function AdminAnalyticsPage() {
                   { key: 'activations', label: 'Activations', align: 'right' },
                 ]}
                 emptyLabel="No extension activations yet"
-              />
-            </div>
-
-            {/* Recent events */}
-            <div className="bg-surface-secondary rounded-xl border border-border p-5">
-              <h2 className="font-display text-sm font-semibold text-text-primary mb-4">Recent events</h2>
-              <DataTable
-                rows={recentRows as unknown as Record<string, unknown>[]}
-                columns={[
-                  { key: 'type', label: 'Event' },
-                  { key: 'app', label: 'App' },
-                  { key: 'detail', label: 'Detail' },
-                  { key: 'when', label: 'When', align: 'right' },
-                ]}
-                emptyLabel="No events yet"
               />
             </div>
           </div>


### PR DESCRIPTION
Drops the "Recent events" panel and its backing query from the
analytics dashboard endpoint, which is no longer needed.