### PR TITLE
Fix magic-link sign-in in the Mac app and browser extension

### DIFF
--- a/apps/extension/content/auth-bridge.js
+++ b/apps/extension/content/auth-bridge.js
@@ -1,0 +1,17 @@
+// Bridges a magic-link sign-in completed on unstream.stream back into the extension.
+// The extension can't receive the emailed link directly (it opens in whatever tab/app
+// handles the user's email), so signInWithOtp() points redirectTo at /login — the same
+// page the web app itself uses. When that page loads with an access_token in the
+// redirect hash, this script forwards the callback URL to the background service worker,
+// which stores the session (see AUTH_MAGIC_LINK_CALLBACK in background/service-worker.js).
+// Runs at document_start so it reads the hash before the web app's own auth handling
+// strips it from the URL.
+if (window.location.hash.includes('access_token')) {
+  try {
+    if (chrome.runtime?.id) {
+      chrome.runtime.sendMessage({ type: 'AUTH_MAGIC_LINK_CALLBACK', url: window.location.href });
+    }
+  } catch {
+    // Extension context invalidated — ignore
+  }
+}

--- a/apps/extension/manifest-firefox.json
+++ b/apps/extension/manifest-firefox.json
@@ -92,6 +92,11 @@
       ],
       "js": ["content/common.js", "content/generic.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://unstream.stream/login*"],
+      "js": ["content/auth-bridge.js"],
+      "run_at": "document_start"
     }
   ],
   "permissions": [

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -80,6 +80,11 @@
       ],
       "js": ["content/common.js", "content/generic.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://unstream.stream/login*"],
+      "js": ["content/auth-bridge.js"],
+      "run_at": "document_start"
     }
   ],
   "permissions": [

--- a/apps/extension/popup/popup.js
+++ b/apps/extension/popup/popup.js
@@ -275,10 +275,12 @@ async function handleMagicLink(email) {
   elements.authMagicLink.disabled = true;
   elements.authError.classList.add('hidden');
 
-  // Send the magic link email — the user will click the link in their email
-  // which opens unstream.stream and establishes a session there.
-  // The extension picks up the session on next popup open.
-  const result = await signInWithOtp(email);
+  // Send the magic link email, redirecting to /login — the same page the web
+  // app itself uses. content/auth-bridge.js watches that page for the
+  // resulting access_token and forwards it to the background service worker,
+  // which stores the session. The extension picks up the session on next
+  // popup open.
+  const result = await signInWithOtp(email, 'https://unstream.stream/login');
 
   if (result.error) {
     elements.authError.textContent = result.error;

--- a/apps/mac/Unstream/Services/AuthService.swift
+++ b/apps/mac/Unstream/Services/AuthService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AuthenticationServices
 import Supabase
 
 /// Manages Supabase auth state for the Unstream app.
@@ -18,11 +17,7 @@ class AuthService: ObservableObject {
     @Published var session: Session?
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
-
-    #if os(macOS)
-    private var authPresentationAnchor: AuthPresentationAnchor?
-    private var pendingWebSession: ASWebAuthenticationSession?
-    #endif
+    @Published var magicLinkSent: Bool = false
 
     private init() {
         let anonKey = Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String ?? ""
@@ -97,84 +92,36 @@ class AuthService: ObservableObject {
 
     // MARK: - Magic Link
 
-    /// Starts a magic-link sign-in via `ASWebAuthenticationSession`.
+    /// Sends a magic-link sign-in email via Supabase's OTP endpoint.
     ///
-    /// Gets the OAuth authorize URL for `provider: .email` (Supabase's hosted
-    /// email auth page) via `getOAuthSignInURL`, then opens it in an
-    /// `ASWebAuthenticationSession` with PKCE. The web session validates the
-    /// caller and binds the callback to the original code challenge,
-    /// closing the custom-URL-scheme interception risk on macOS.
+    /// The email links to `unstream://auth/callback`. There's no interactive
+    /// window to wait on here — the user opens the email in their own time,
+    /// possibly on a different device, so this only confirms the email was
+    /// sent. The app's URL-scheme handling (`onOpenURL` in `UnstreamApp`)
+    /// hands the resulting callback URL to `handleAuthCallback` below.
     func sendMagicLink(email: String) {
         isLoading = true
         errorMessage = nil
-
-        let redirectURL = URL(string: "unstream://auth/callback")!
-
-        #if os(macOS)
-        let anchor = AuthPresentationAnchor()
-        authPresentationAnchor = anchor
-        #endif
+        magicLinkSent = false
 
         Task {
             do {
-                let authURL = try client.auth.getOAuthSignInURL(
-                    provider: .email,
-                    redirectTo: redirectURL,
-                    queryParams: [("email", email)]
+                try await client.auth.signInWithOTP(
+                    email: email,
+                    redirectTo: URL(string: "unstream://auth/callback")!
                 )
-
-                let callbackURL = try await openWebAuthSession(
-                    url: authURL,
-                    callbackScheme: redirectURL.scheme!
-                )
-
-                let result = try await client.auth.session(from: callbackURL)
-                session = result
+                magicLinkSent = true
             } catch {
                 errorMessage = error.localizedDescription
             }
             isLoading = false
-            #if os(macOS)
-            authPresentationAnchor = nil
-            #endif
-        }
-    }
-
-    /// Opens a URL in `ASWebAuthenticationSession` and returns the callback URL.
-    @MainActor
-    private func openWebAuthSession(url: URL, callbackScheme: String) async throws -> URL {
-        try await withCheckedThrowingContinuation { continuation in
-            let webSession = ASWebAuthenticationSession(
-                url: url,
-                callbackURLScheme: callbackScheme
-            ) { callbackURL, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let callbackURL {
-                    continuation.resume(returning: callbackURL)
-                } else {
-                    continuation.resume(throwing: URLError(.unknown))
-                }
-            }
-
-            webSession.prefersEphemeralWebBrowserSession = true
-
-            #if os(macOS)
-            webSession.presentationContextProvider = authPresentationAnchor
-            pendingWebSession = webSession
-            #endif
-
-            webSession.start()
         }
     }
 
     #if os(macOS)
-    /// Cancels any in-flight ASWebAuthenticationSession and resets loading state.
-    /// Called when the popover closes so the sign-in sheet doesn't reopen locked.
+    /// Resets loading state when the popover closes, so a slow magic-link
+    /// request doesn't leave the sign-in sheet stuck locked next time it opens.
     func cancelPendingAuth() {
-        let session = pendingWebSession
-        pendingWebSession = nil
-        session?.cancel()
         if isLoading {
             isLoading = false
             errorMessage = nil
@@ -184,9 +131,9 @@ class AuthService: ObservableObject {
 
     // MARK: - Deeplink handling
 
-    /// Handles an auth callback URL received outside `ASWebAuthenticationSession`
-    /// (e.g. via universal link or residual custom-scheme delivery).
-    /// The PKCE code-verifier in the SDK validates the token contents.
+    /// Completes a magic-link sign-in from the `unstream://auth/callback` URL
+    /// the browser opens after the user clicks the emailed link. The SDK
+    /// validates the token (or PKCE code) contained in the URL.
     func handleAuthCallback(url: URL) async {
         isLoading = true
         errorMessage = nil
@@ -194,6 +141,7 @@ class AuthService: ObservableObject {
         do {
             let result = try await client.auth.session(from: url)
             session = result
+            magicLinkSent = false
         } catch {
             errorMessage = "Sign-in failed: \(error.localizedDescription)"
         }
@@ -252,17 +200,3 @@ class AuthService: ObservableObject {
         UserDefaults.standard.set(true, forKey: migrationFlag)
     }
 }
-
-// MARK: - ASWebAuthenticationPresentationContextProviding
-
-#if os(macOS)
-/// Provides a presentation anchor for `ASWebAuthenticationSession` on macOS.
-/// Returns the app's key window so the web auth sheet attaches to the
-/// running app rather than a detached empty window.
-final class AuthPresentationAnchor: NSObject, ASWebAuthenticationPresentationContextProviding, @unchecked Sendable {
-    @MainActor
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        NSApp.keyWindow ?? ASPresentationAnchor()
-    }
-}
-#endif

--- a/apps/mac/Unstream/UnstreamApp.swift
+++ b/apps/mac/Unstream/UnstreamApp.swift
@@ -128,8 +128,14 @@ struct UnstreamApp: App {
         // The popover is driven by AppDelegate (NSStatusItem), but Settings is a real
         // SwiftUI Settings scene: that's what gives us the standard settings window,
         // its frame persistence, and a working "Unstream ▸ Settings… ⌘," menu item.
+        // It also registers this app's `unstream://` URL-scheme handling, which is
+        // what lets a magic-link email complete sign-in even though nothing opened
+        // the browser from inside the app (see handleAuthCallbackURL below).
         Settings {
             SettingsView(releaseAlertManager: container.releaseAlertManager)
+        }
+        .onOpenURL { url in
+            _ = handleAuthCallbackURL(url)
         }
         #else
         // iOS: Standard windowed app
@@ -140,6 +146,7 @@ struct UnstreamApp: App {
                 .environmentObject(container.releaseAlertManager)
                 .environmentObject(container.indieArtistDirectory)
                 .onOpenURL { url in
+                    if handleAuthCallbackURL(url) { return }
                     handleNonAuthIncomingURL(url)
                 }
                 .onAppear {
@@ -158,6 +165,15 @@ struct UnstreamApp: App {
                 }
         }
         #endif
+    }
+
+    /// Routes `unstream://auth/callback` (the redirect target for the magic-link
+    /// email) to `AuthService`. Returns whether the URL was handled, so callers
+    /// can fall through to other deeplink handling otherwise.
+    private func handleAuthCallbackURL(_ url: URL) -> Bool {
+        guard url.scheme == "unstream", url.host == "auth" else { return false }
+        Task { await AuthService.shared.handleAuthCallback(url: url) }
+        return true
     }
 
     #if os(iOS)

--- a/apps/mac/Unstream/Views/Shared/SignInView.swift
+++ b/apps/mac/Unstream/Views/Shared/SignInView.swift
@@ -75,7 +75,9 @@ struct SignInView: View {
                 .buttonStyle(.bordered)
                 .disabled(email.isEmpty || auth.isLoading)
 
-                Text("A sign-in window will open — complete the steps there to continue.")
+                Text(auth.magicLinkSent
+                     ? "Check your email for a link to finish signing in."
+                     : "We'll email you a link — no password needed.")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
Mac app: sendMagicLink() never sent an OTP email at all — it called
getOAuthSignInURL(provider: .email, ...), Supabase's OAuth-authorize flow
for a provider that doesn't exist. Replaced it with the real
signInWithOTP(email:redirectTo:) call, wired the unstream:// URL scheme
(already registered in both Info.plists) to AuthService.handleAuthCallback
via onOpenURL on both platforms, and dropped the now-unused
ASWebAuthenticationSession plumbing.

Extension: signInWithOtp() fires correctly, but the flow had no way to
complete — nothing ever sent the AUTH_MAGIC_LINK_CALLBACK message the
service worker already listens for, and the OTP request itself dropped
redirectTo. Now the popup requests a link to /login (the same page the
web app uses), and a new content script (content/auth-bridge.js) matching
that page forwards the resulting access_token to the background worker,
which stores the session for the extension to pick up.