### PR TITLE
Retry Bandcamp's Subsonic 500s during import, and unstick killed syncs

### DIFF
--- a/api/functions/__tests__/bandcamp-subsonic.test.ts
+++ b/api/functions/__tests__/bandcamp-subsonic.test.ts
@@ -19,6 +19,26 @@ function okEnvelope(extra: Record<string, unknown> = {}) {
   } as Response;
 }
 
+/**
+ * Runs a call that may back off between retries without waiting out the backoff. The
+ * rejection is captured before timers advance so it never surfaces as an unhandled one.
+ */
+async function runWithTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const settled = run().then(
+      value => ({ ok: true as const, value }),
+      error => ({ ok: false as const, error })
+    );
+    await vi.runAllTimersAsync();
+    const result = await settled;
+    if (!result.ok) throw result.error;
+    return result.value;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe('bandcamp-subsonic', () => {
   const fetchMock = vi.fn();
 
@@ -155,8 +175,72 @@ describe('bandcamp-subsonic', () => {
       const fullPage = Array.from({ length: 500 }, (_, i) => album(i));
       fetchMock
         .mockResolvedValueOnce(okEnvelope({ albumList2: { album: fullPage } }))
-        .mockResolvedValueOnce({ ok: false, status: 500 } as Response);
-      await expect(subsonicFetchAllAlbums(CRED)).rejects.toThrow(SubsonicError);
+        .mockResolvedValue({ ok: false, status: 500 } as Response);
+      await expect(runWithTimers(() => subsonicFetchAllAlbums(CRED))).rejects.toThrow(SubsonicError);
+    });
+
+    // Bandcamp's beta 500s on collections it imports fine at other times, so a failure is
+    // retried, then retried smaller, before it is believed.
+    it('retries a transient 500 and succeeds', async () => {
+      fetchMock
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockResolvedValueOnce(okEnvelope({ albumList2: { album: [album(1)] } }));
+
+      const albums = await runWithTimers(() => subsonicFetchAllAlbums(CRED));
+      expect(albums).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('asks for a smaller page when a page keeps failing, from the same offset', async () => {
+      const fullPage = Array.from({ length: 500 }, (_, i) => album(i));
+      fetchMock.mockImplementation((url: string) => {
+        const params = new URL(url).searchParams;
+        if (params.get('offset') === '0') {
+          return Promise.resolve(okEnvelope({ albumList2: { album: fullPage } }));
+        }
+        // The second page is only servable in smaller bites.
+        return params.get('size') === '500'
+          ? Promise.resolve({ ok: false, status: 500 } as Response)
+          : Promise.resolve(okEnvelope({ albumList2: { album: [album(500)] } }));
+      });
+
+      const albums = await runWithTimers(() => subsonicFetchAllAlbums(CRED));
+      expect(albums).toHaveLength(501);
+
+      const retried = new URL(fetchMock.mock.calls.at(-1)![0] as string).searchParams;
+      expect(retried.get('offset')).toBe('500');
+      expect(Number(retried.get('size'))).toBeLessThan(500);
+    });
+
+    it('names the page that failed, without leaking the credential', async () => {
+      const fullPage = Array.from({ length: 500 }, (_, i) => album(i));
+      fetchMock.mockImplementation((url: string) =>
+        new URL(url).searchParams.get('offset') === '0'
+          ? Promise.resolve(okEnvelope({ albumList2: { album: fullPage } }))
+          : Promise.resolve({ ok: false, status: 500 } as Response)
+      );
+
+      const err = await runWithTimers(() => subsonicFetchAllAlbums(CRED)).catch(e => e);
+      expect(err.message).toContain('offset 500');
+      expect(err.message).not.toContain('deadbeef');
+      expect(err.message).not.toContain('salt1234');
+    });
+
+    it('does not retry a rejected credential', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          'subsonic-response': {
+            status: 'failed',
+            error: { code: 40, message: 'Wrong username or password' },
+          },
+        }),
+      } as Response);
+
+      const err = await runWithTimers(() => subsonicFetchAllAlbums(CRED)).catch(e => e);
+      expect(err.isAuthFailure).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -63,6 +63,8 @@ describe('selfDispatchOrigin', () => {
 
 const PASSWORD = 'bandcamp-generated-credential';
 
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 3_600_000).toISOString();
+
 function authedEvent(method: string, body: unknown = null) {
   return {
     httpMethod: method,
@@ -101,6 +103,17 @@ describe('me-bandcamp handler', () => {
     delete process.env.URL;
   });
 
+  /** One connection row answering the GET's select().eq().maybeSingle() chain. */
+  function mockConnectionRow(row: Record<string, unknown>) {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: { bandcamp_username: 'fan', ...row }, error: null })),
+        })),
+      })),
+    });
+  }
+
   it('returns 401 when not authenticated', async () => {
     const res = await handler({ httpMethod: 'GET', headers: {}, body: null });
     expect(res!.statusCode).toBe(401);
@@ -117,6 +130,26 @@ describe('me-bandcamp handler', () => {
     const res = await handler(authedEvent('GET'));
     expect(res!.statusCode).toBe(200);
     expect(JSON.parse(res!.body)).toEqual({ connected: false });
+  });
+
+  // A sync that Netlify killed leaves the row claiming 'syncing' forever. The settings page
+  // hides Re-sync while a sync runs, so believing that row strands the user on "Importing…".
+  it('GET reports a long-running sync as a failure the user can retry', async () => {
+    mockConnectionRow({ sync_status: 'syncing', sync_error: null, updated_at: hoursAgo(1) });
+    const body = JSON.parse((await handler(authedEvent('GET')))!.body);
+    expect(body.syncStatus).toBe('error');
+    expect(body.syncError).toContain('Re-sync');
+  });
+
+  it('GET still reports a recently started sync as running', async () => {
+    mockConnectionRow({
+      sync_status: 'syncing',
+      sync_error: null,
+      updated_at: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const body = JSON.parse((await handler(authedEvent('GET')))!.body);
+    expect(body.syncStatus).toBe('syncing');
+    expect(body.syncError).toBeNull();
   });
 
   it('GET returns connection status without any credential material', async () => {
@@ -305,12 +338,48 @@ describe('me-bandcamp handler', () => {
       mocks.mockFrom.mockReturnValue({
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
-            maybeSingle: vi.fn(() => Promise.resolve({ data: { sync_status: 'syncing' }, error: null })),
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({
+                data: { sync_status: 'syncing', updated_at: new Date().toISOString() },
+                error: null,
+              })
+            ),
           })),
         })),
       });
       const res = await handler(authedEvent('POST', { resync: true }));
       expect(res!.statusCode).toBe(409);
+    });
+
+    // Netlify kills a background function at 15 minutes, and it dies without recording an
+    // error — so refusing here would leave the user with no way to retry, ever.
+    it('starts a sync when the running one is old enough to be dead', async () => {
+      const row = { sync_status: 'syncing', updated_at: hoursAgo(1) };
+      const update = vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) }));
+      mocks.mockFrom.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: row, error: null })),
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: { ...row, bandcamp_username: 'fan', updated_at: new Date().toISOString() },
+                error: null,
+              })
+            ),
+          })),
+        })),
+        update,
+      });
+
+      const res = await handler(authedEvent('POST', { resync: true }));
+      expect(res!.statusCode).toBe(200);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({ sync_status: 'syncing', sync_error: null })
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://unstream.stream/.netlify/functions/bandcamp-sync-background',
+        expect.anything()
+      );
     });
   });
 

--- a/api/functions/bandcamp-subsonic.ts
+++ b/api/functions/bandcamp-subsonic.ts
@@ -24,13 +24,22 @@ const CLIENT_NAME = 'unstream';
 // Max page size the Subsonic spec allows for getAlbumList2.
 const PAGE_SIZE = 500;
 
-// Backstop against a server that never returns a short page (40 pages = 20,000 albums —
-// far past any real collection). Hitting it is reported as a failure, not a truncation:
-// a sync that silently stopped early would record a partial collection as complete.
-const MAX_PAGES = 40;
+// The smallest page worth asking for. A page that keeps failing is retried smaller (see
+// subsonicFetchAllAlbums) — below this the request count stops being worth the trade.
+const MIN_PAGE_SIZE = 100;
+
+// Backstop against a server that never returns a short page — far past any real collection.
+// Hitting it is reported as a failure, not a truncation: a sync that silently stopped early
+// would record a partial collection as complete.
+const MAX_ALBUMS = 20_000;
 
 // Bandcamp warns large libraries are slow in the beta; be generous per request.
 const REQUEST_TIMEOUT_MS = 30_000;
+
+// Backoff between retries of a transient failure. Only the collection fetch retries — it
+// runs in a background function with minutes to spare, while connect runs on the request
+// path where a Netlify function is killed in seconds.
+const RETRY_DELAYS_MS = [1_000, 4_000];
 
 /** The stored credential: t = md5(password + s). The password itself is never stored. */
 export interface SubsonicCredential {
@@ -53,16 +62,25 @@ export interface SubsonicAlbum {
 /** Subsonic error code 40 is "wrong username or password". */
 export class SubsonicError extends Error {
   readonly code: number | null;
+  /**
+   * The server failed to answer rather than answering "no" — a 5xx, a 429, a dropped
+   * connection or a timeout. Those are worth retrying; a rejected credential, a malformed
+   * body or a Subsonic error envelope are the server's actual answer and are not.
+   */
+  readonly retryable: boolean;
 
-  constructor(message: string, code: number | null = null) {
+  constructor(message: string, code: number | null = null, retryable = false) {
     super(message);
     this.name = 'SubsonicError';
     this.code = code;
+    this.retryable = retryable;
   }
   get isAuthFailure(): boolean {
     return this.code === 40 || this.code === 41;
   }
 }
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * Derive the salted-token pair from a password, per the Subsonic spec:
@@ -101,7 +119,7 @@ interface SubsonicResponseBody {
  * One Subsonic call. Throws SubsonicError on transport failure, non-JSON, or a
  * status:"failed" envelope. Never includes the URL in any error.
  */
-async function subsonicRequest(
+async function subsonicRequestOnce(
   credential: SubsonicCredential,
   method: string,
   params: Record<string, string> = {}
@@ -115,13 +133,15 @@ async function subsonicRequest(
     });
   } catch (error) {
     const aborted = error instanceof Error && error.name === 'AbortError';
-    throw new SubsonicError(`${method}: ${aborted ? 'timed out' : 'request failed'}`);
+    throw new SubsonicError(`${method}: ${aborted ? 'timed out' : 'request failed'}`, null, true);
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!response.ok) {
-    throw new SubsonicError(`${method}: HTTP ${response.status}`);
+    // 5xx and 429 are the server struggling, not an answer about the collection.
+    const retryable = response.status >= 500 || response.status === 429;
+    throw new SubsonicError(`${method}: HTTP ${response.status}`, null, retryable);
   }
 
   let body: SubsonicResponseBody;
@@ -143,6 +163,27 @@ async function subsonicRequest(
     );
   }
   return envelope;
+}
+
+/**
+ * A Subsonic call that retries a transient failure. `retries` defaults to 0 because most
+ * callers run on the request path, where waiting is worse than reporting.
+ */
+async function subsonicRequest(
+  credential: SubsonicCredential,
+  method: string,
+  params: Record<string, string> = {},
+  retries = 0
+): Promise<NonNullable<SubsonicResponseBody['subsonic-response']>> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await subsonicRequestOnce(credential, method, params);
+    } catch (error) {
+      const retryable = error instanceof SubsonicError && error.retryable;
+      if (!retryable || attempt >= retries) throw error;
+      await sleep(RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)]);
+    }
+  }
 }
 
 /** Verify a credential works. Throws SubsonicError (isAuthFailure for bad credentials). */
@@ -218,13 +259,14 @@ export async function subsonicFetchCoverArt(
     });
   } catch (error) {
     const aborted = error instanceof Error && error.name === 'AbortError';
-    throw new SubsonicError(`getCoverArt: ${aborted ? 'timed out' : 'request failed'}`);
+    throw new SubsonicError(`getCoverArt: ${aborted ? 'timed out' : 'request failed'}`, null, true);
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!response.ok) {
-    throw new SubsonicError(`getCoverArt: HTTP ${response.status}`);
+    const retryable = response.status >= 500 || response.status === 429;
+    throw new SubsonicError(`getCoverArt: HTTP ${response.status}`, null, retryable);
   }
 
   const contentType = response.headers.get('content-type') || '';
@@ -234,26 +276,72 @@ export async function subsonicFetchCoverArt(
 }
 
 /**
+ * Add the page that failed to an error's message. Offsets and page sizes are not sensitive;
+ * the request URL — which carries the credential — is still never included. Without this a
+ * sync failure reports only "getAlbumList2: HTTP 500", which can't distinguish "Bandcamp is
+ * down" from "Bandcamp can't build page 4 of this collection".
+ */
+function withPageContext(error: unknown, offset: number, size: number): unknown {
+  if (!(error instanceof SubsonicError)) return error;
+  return new SubsonicError(
+    `${error.message} (offset ${offset}, size ${size})`,
+    error.code,
+    error.retryable
+  );
+}
+
+/**
  * Fetch the whole collection via paginated getAlbumList2. Throws mid-pagination rather
  * than returning what it has: a partial result recorded as a complete sync would be a
  * silently wrong collection, which is the "never cache uncertainty" bug class.
+ *
+ * Two concessions to the beta, which returns HTTP 500 on collections it imports fine at
+ * other times (Sentry, 2026-08-14):
+ *   - a transient failure is retried before it is believed;
+ *   - a page that still fails is asked for again, smaller, from the same offset. A 500 that
+ *     only some users see, on the one call that asks for 500 records at once, reads like
+ *     Bandcamp timing out while building a big page — so making the page smaller is the
+ *     one lever we have. Halving stops at MIN_PAGE_SIZE, then the sync fails honestly.
  */
 export async function subsonicFetchAllAlbums(
   credential: SubsonicCredential
 ): Promise<SubsonicAlbum[]> {
   const albums: SubsonicAlbum[] = [];
-  for (let page = 0; page < MAX_PAGES; page++) {
-    const envelope = await subsonicRequest(credential, 'getAlbumList2', {
-      type: 'alphabeticalByArtist',
-      size: String(PAGE_SIZE),
-      offset: String(page * PAGE_SIZE),
-    });
+  let pageSize = PAGE_SIZE;
+  let offset = 0;
+
+  // Bounded on rows consumed, not rows kept: a server answering with full pages of entries
+  // that all fail toAlbum would otherwise loop forever.
+  while (offset < MAX_ALBUMS) {
+    let envelope;
+    try {
+      envelope = await subsonicRequest(
+        credential,
+        'getAlbumList2',
+        {
+          type: 'alphabeticalByArtist',
+          size: String(pageSize),
+          offset: String(offset),
+        },
+        RETRY_DELAYS_MS.length
+      );
+    } catch (error) {
+      if (error instanceof SubsonicError && error.retryable && pageSize > MIN_PAGE_SIZE) {
+        pageSize = Math.max(MIN_PAGE_SIZE, Math.floor(pageSize / 2));
+        continue;
+      }
+      throw withPageContext(error, offset, pageSize);
+    }
+
     const rawAlbums = envelope.albumList2?.album ?? [];
     for (const raw of rawAlbums) {
       const album = toAlbum(raw);
       if (album) albums.push(album);
     }
-    if (rawAlbums.length < PAGE_SIZE) return albums;
+    // A short page is the end of the collection. Advance by what arrived, not by what was
+    // asked for, so a shrunken page can't leave a gap.
+    if (rawAlbums.length < pageSize) return albums;
+    offset += rawAlbums.length;
   }
-  throw new SubsonicError('getAlbumList2: exceeded maximum page count');
+  throw new SubsonicError(`getAlbumList2: collection exceeded ${MAX_ALBUMS} albums`);
 }

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -417,7 +417,15 @@ export async function handler(event: {
   } catch (error) {
     const isAuth = error instanceof SubsonicError && error.isAuthFailure;
     console.error('[bandcamp-sync] sync failed:', error instanceof Error ? error.message : String(error));
-    Sentry.captureException(error, { tags: { function: 'bandcamp-sync' }, extra: { stage: 'sync' } });
+    Sentry.captureException(error, {
+      tags: { function: 'bandcamp-sync' },
+      // `retryable` separates "Bandcamp couldn't answer even after retries" from a failure
+      // of ours — the two look identical in the message alone.
+      extra: {
+        stage: 'sync',
+        retryable: error instanceof SubsonicError ? error.retryable : null,
+      },
+    });
     await recordFailure(
       isAuth
         ? 'Bandcamp rejected the stored login. Disconnect and reconnect with a fresh username and password from Fan Settings → Subsonic.'

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -30,21 +30,50 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
 };
 
+const CONNECTION_SELECT =
+  'bandcamp_username, sync_status, sync_error, item_count, last_synced_at, updated_at';
+
 interface ConnectionRow {
   bandcamp_username: string;
   sync_status: string;
   sync_error: string | null;
   item_count: number | null;
   last_synced_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * How long a row may claim 'syncing' before we stop believing it. Netlify kills a background
+ * function at 15 minutes, so past that the sync is gone — and it died without reaching the
+ * catch block that records an error.
+ *
+ * Nothing else rescues that row: the settings UI hides Re-sync while a sync is running and
+ * the resync endpoint answers 409, so a killed sync leaves the user stuck on "Importing…"
+ * forever with no way to retry. `updated_at` is the sync's start time here, because the row
+ * is stamped 'syncing' immediately before the background function is asked to run and
+ * nothing writes it again until the sync finishes.
+ */
+const STALE_SYNC_MS = 20 * 60 * 1000;
+
+const STALE_SYNC_MESSAGE =
+  'The last import didn’t finish. Bandcamp’s Subsonic support is in beta and can stall on large collections — use Re-sync to try again.';
+
+function isStaleSync(row: { sync_status: string; updated_at: string | null }): boolean {
+  if (row.sync_status !== 'syncing' || !row.updated_at) return false;
+  const startedAt = new Date(row.updated_at).getTime();
+  return Number.isFinite(startedAt) && Date.now() - startedAt > STALE_SYNC_MS;
 }
 
 function toStatusShape(row: ConnectionRow | null) {
   if (!row) return { connected: false as const };
+  const stale = isStaleSync(row);
   return {
     connected: true as const,
     username: row.bandcamp_username,
-    syncStatus: row.sync_status,
-    syncError: row.sync_error,
+    // Reported as an error rather than written back as one: a GET shouldn't mutate, and the
+    // next Re-sync overwrites the status anyway.
+    syncStatus: stale ? 'error' : row.sync_status,
+    syncError: stale ? STALE_SYNC_MESSAGE : row.sync_error,
     itemCount: row.item_count,
     lastSyncedAt: row.last_synced_at,
   };
@@ -170,7 +199,7 @@ export async function handler(event: {
   if (event.httpMethod === 'GET') {
     const { data: row, error } = await client
       .from('bandcamp_connections')
-      .select('bandcamp_username, sync_status, sync_error, item_count, last_synced_at')
+      .select(CONNECTION_SELECT)
       .eq('user_id', user.userId)
       .maybeSingle();
 
@@ -194,7 +223,7 @@ export async function handler(event: {
     if (body.resync === true) {
       const { data: existing, error } = await client
         .from('bandcamp_connections')
-        .select('sync_status')
+        .select('sync_status, updated_at')
         .eq('user_id', user.userId)
         .maybeSingle();
       if (error) {
@@ -204,7 +233,9 @@ export async function handler(event: {
       if (!existing) {
         return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'No Bandcamp connection to sync' }) };
       }
-      if (existing.sync_status === 'syncing') {
+      // A stale 'syncing' row is a sync that was killed, not one still running — refusing it
+      // would leave the user with no way to retry at all.
+      if (existing.sync_status === 'syncing' && !isStaleSync(existing)) {
         return { statusCode: 409, headers: CORS_HEADERS, body: JSON.stringify({ error: 'A sync is already running' }) };
       }
 
@@ -229,7 +260,7 @@ export async function handler(event: {
 
       const { data: row, error: readError } = await client
         .from('bandcamp_connections')
-        .select('bandcamp_username, sync_status, sync_error, item_count, last_synced_at')
+        .select(CONNECTION_SELECT)
         .eq('user_id', user.userId)
         .single();
       if (readError) {


### PR DESCRIPTION
Users hit "SubsonicError: getAlbumList2: HTTP 500" partway through the
Bandcamp collection import. The call is the only one that asks Bandcamp for
500 records at once, and it fails for some users while completing for others
— which reads as the beta timing out while building a big page, not as an
answer about the collection. It was believed on the first try and the whole
sync was recorded as failed.

- A 5xx, a 429, a dropped connection or a timeout is now flagged retryable on
  SubsonicError and retried (1s, 4s) before it is believed. A rejected
  credential, a non-JSON body or a Subsonic error envelope is the server's
  actual answer and is still fatal on the first try. Only the collection
  fetch retries; connect stays on the request path where waiting is worse.
- A page that still fails is re-requested smaller from the same offset
  (500 → 250 → 125 → 100), then the sync fails honestly. Pagination now
  advances by rows returned rather than page number, so a shrunken page
  can't leave a gap, and the runaway backstop counts rows consumed.
- The failure names the page it died on ("offset 500, size 500"). Offsets
  aren't sensitive; the URL carrying the credential is still never included.

Also fixes the state a killed sync leaves behind. Netlify kills a background
function at 15 minutes and it dies without reaching the catch block, so the
row claims 'syncing' forever — the settings page hides Re-sync while a sync
runs and the resync endpoint answers 409, stranding the user on "Importing…"
with no way to retry. A row that has claimed 'syncing' for over 20 minutes is
now reported as a retryable error, and Re-sync is accepted instead of refused.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjqyY2Ttd5q8wiSncMwnZW