### PR TITLE
Fix the blank page and broken Back when opening a release from a collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,35 @@ Artists claim profiles via `/claim/:slug` (email magic link or password auth, wi
 
 Signed-in fans can save artists and mark artists as supported (migrations 013–018), synced to the Apple app via `saved-artists-sync.ts` with tombstones and scheduled GC. Users can claim a public username (migration 021) and opt into sharing their list (migration 022); the public list renders at `/u/:handle` via the `u-handle` edge function, backed by `public-saved-artists.ts`. Reserved handles live in `api/lib/reserved-handles.ts`.
 
+### Collections, and why most items start unlinked
+
+A Bandcamp import (`bandcamp-sync-background.ts`) writes a `collection_items` row per album and
+attaches an Unstream release only when one already exists. Most of a real collection therefore
+arrives unlinked — the fan bought from artists nobody has ever searched, so there is no `artists`
+row to match against.
+
+**There is no source URL to fall back to.** Bandcamp's Subsonic API returns `id`, `name`,
+`artist`, `coverArt`, `year`, `genre`, `created` and nothing else — no album or artist URL — so
+"just link to Bandcamp" is not available, and deriving `<artist>.bandcamp.com/album/<title>` mints
+404s. Don't reach for it.
+
+`collection-matching.ts` closes the gap in two halves that become possible at different times:
+
+- `resolveCollectionArtists(userId)` runs at the end of a sync, *after* the connection is marked
+  idle so a discovery failure is never recorded as a failed import. It probes Bandcamp for each
+  unknown artist name (cached forever, negatives included), stores the artist plus their Bandcamp
+  link, and requests catalogues for up to 25 — matching `MAX_ARTISTS_PER_REQUEST`, which silently
+  slices anything longer. The rest ride the six-hourly sweep, whose pool is every artist with a
+  catalogue-able link.
+- `linkCollectionItemsForArtist(artistId, name)` runs at the end of every catalogue pass in
+  `catalog-artist-background.ts` — the moment the releases exist — and attaches them to the items
+  that were waiting. It re-runs forever, so a release added later still finds fans who own it.
+
+Matching is exact on `releases.match_key` via `releaseMatchKey`, the function that produced the
+column. Use that one, never `normalizeForComparison`: it strips to `[a-z0-9]`, so any title with
+no Latin characters normalizes to the empty string and can never match. A near-miss stays
+unlinked on purpose — a collection page asserts a specific person bought a specific record.
+
 ### Account settings
 
 `/settings` is backed by the `me-*` functions: `me-settings.ts`, `me-username.ts`, `me-location.ts`, `me-password.ts`, plus `user-sharing.ts` for the sharing toggle. These are the only files in `api/tsconfig.json`'s typecheck include, and each has a test in `api/functions/__tests__/` — follow that pattern for new account endpoints.

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -5,11 +5,19 @@ const mocks = vi.hoisted(() => ({
   mockFrom: vi.fn(),
   mockReadAllPages: vi.fn(),
   mockFetchAllAlbums: vi.fn(),
+  mockResolveArtists: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
   getClient: () => ({ from: mocks.mockFrom }),
   readAllPages: mocks.mockReadAllPages,
+}));
+// Stubbed so these tests stay about the import. The pass it replaces probes Bandcamp for every
+// unknown artist name; left real against this file's mocked `../db` it would throw, and the
+// handler catches that on purpose, so the whole suite would go on passing while the pass did
+// nothing. Its own behaviour is covered in collection-matching.test.ts.
+vi.mock('../collection-matching', () => ({
+  resolveCollectionArtists: mocks.mockResolveArtists,
 }));
 vi.mock('../bandcamp-subsonic', async importOriginal => {
   const original = await importOriginal<typeof import('../bandcamp-subsonic')>();
@@ -117,6 +125,7 @@ describe('bandcamp-sync-background handler', () => {
     process.env.INTERNAL_FUNCTION_SECRET = 'internal-secret';
     process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
     mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [] });
+    mocks.mockResolveArtists.mockResolvedValue({ created: 0, catalogRequested: 0 });
   });
 
   afterEach(() => {
@@ -395,5 +404,45 @@ describe('bandcamp-sync-background handler', () => {
       sync_status: 'error',
       sync_error: expect.stringContaining('reconnect'),
     });
+  });
+
+  it('looks for the artists behind unmatched items only after the import is recorded', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockResolvedValue([
+      { id: 'al-1', name: 'Bias', artist: 'King Triumph' },
+    ]);
+    // The order is the point: resolution probes Bandcamp for every unknown name, and a fan's
+    // collection must be complete and visible before that starts rather than after it.
+    mocks.mockResolveArtists.mockImplementation(() => {
+      expect(connectionUpdates.at(-1)).toMatchObject({ sync_status: 'idle' });
+      return Promise.resolve({ created: 1, catalogRequested: 1 });
+    });
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    expect(res.statusCode).toBe(200);
+    expect(mocks.mockResolveArtists).toHaveBeenCalledWith('user-1');
+    expect(JSON.parse(res.body).resolved).toMatchObject({ created: 1 });
+  });
+
+  it('still reports a successful import when artist resolution fails', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates, upsertBatches } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockResolvedValue([
+      { id: 'al-1', name: 'Bias', artist: 'King Triumph' },
+    ]);
+    mocks.mockResolveArtists.mockRejectedValue(new Error('bandcamp said no'));
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+    // The items are imported and the connection is idle. Discovery is an extra on top of a
+    // finished sync, so its failure must never be recorded as a failed import.
+    expect(res.statusCode).toBe(200);
+    expect(upsertBatches.flat()).toHaveLength(1);
+    expect(connectionUpdates.at(-1)).toMatchObject({ sync_status: 'idle', sync_error: null });
+    expect(JSON.parse(res.body).resolved).toBeNull();
   });
 });

--- a/api/functions/__tests__/collection-matching.test.ts
+++ b/api/functions/__tests__/collection-matching.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockReadAllPages: vi.fn(),
+  mockFindBandcampArtist: vi.fn(),
+  mockFindSlugByBandcampUrl: vi.fn(),
+  mockRequestCatalog: vi.fn(),
+}));
+
+vi.mock('../db', async importOriginal => {
+  // artistSlug is the real one: the dedup here keys on it, and a stub would hide the case it
+  // exists for — two spellings of one artist collapsing to a single lookup.
+  const original = await importOriginal<typeof import('../db')>();
+  return {
+    artistSlug: original.artistSlug,
+    getClient: () => ({ from: mocks.mockFrom }),
+    readAllPages: mocks.mockReadAllPages,
+    findArtistSlugByBandcampUrl: mocks.mockFindSlugByBandcampUrl,
+  };
+});
+vi.mock('../../search/bandcamp-probe', () => ({ findBandcampArtist: mocks.mockFindBandcampArtist }));
+vi.mock('../request-catalog', () => ({ requestArtistCatalog: mocks.mockRequestCatalog }));
+
+import { linkCollectionItemsForArtist, resolveCollectionArtists } from '../collection-matching';
+
+/** Rows handed to `readAllPages`, in the order the module asks for them. */
+function pagedRows(...batches: Record<string, unknown>[][]) {
+  let call = 0;
+  mocks.mockReadAllPages.mockImplementation(() =>
+    Promise.resolve({ ok: true, rows: batches[call++] ?? [] })
+  );
+}
+
+interface LinkTables {
+  releases?: { id: string; match_key: string | null }[];
+}
+
+/** Routes the reads and records every release_id write. */
+function setupLinkDb({ releases = [] }: LinkTables) {
+  const updates: { releaseId: unknown; itemIds: unknown }[] = [];
+
+  mocks.mockFrom.mockImplementation((table: string) => {
+    if (table === 'releases') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve({ data: releases, error: null })),
+          })),
+        })),
+      };
+    }
+    if (table === 'collection_items') {
+      return {
+        update: vi.fn((patch: { release_id: string }) => ({
+          in: vi.fn((_column: string, itemIds: unknown) => {
+            updates.push({ releaseId: patch.release_id, itemIds });
+            return Promise.resolve({ error: null });
+          }),
+        })),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return { updates };
+}
+
+describe('linkCollectionItemsForArtist', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('attaches a release to the items that were waiting for it', async () => {
+    const { updates } = setupLinkDb({
+      releases: [
+        { id: 'rel-bias', match_key: 'bias' },
+        { id: 'rel-other', match_key: 'someotherrecord' },
+      ],
+    });
+    pagedRows([
+      { id: 'item-1', title: 'Bias' },
+      { id: 'item-2', title: 'bias' },
+      { id: 'item-3', title: 'A Record We Have Never Catalogued' },
+    ]);
+
+    const linked = await linkCollectionItemsForArtist('artist-1', 'King Triumph');
+
+    expect(linked).toBe(2);
+    expect(updates).toEqual([{ releaseId: 'rel-bias', itemIds: ['item-1', 'item-2'] }]);
+  });
+
+  it('links nothing when the title only nearly matches', async () => {
+    // A collection page says someone bought a specific record. "Bias (Deluxe)" is a different
+    // record from "Bias" until something better than a title tells us otherwise, and a wrong
+    // link here is a false claim about a person's purchase.
+    const { updates } = setupLinkDb({ releases: [{ id: 'rel-bias', match_key: 'bias' }] });
+    pagedRows([{ id: 'item-1', title: 'Bias (Deluxe Edition)' }]);
+
+    expect(await linkCollectionItemsForArtist('artist-1', 'King Triumph')).toBe(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('matches titles that normalize away punctuation and accents', async () => {
+    const { updates } = setupLinkDb({ releases: [{ id: 'rel-cl', match_key: 'carrielowell' }] });
+    pagedRows([{ id: 'item-1', title: 'Carrie & Lowell' }]);
+
+    expect(await linkCollectionItemsForArtist('artist-1', 'Sufjan Stevens')).toBe(1);
+    expect(updates[0].releaseId).toBe('rel-cl');
+  });
+
+  it('matches a title with no Latin characters at all', async () => {
+    // `releases.match_key` keeps any Unicode letter, so a Japanese title has a real key. The
+    // import's original comparison stripped to [a-z0-9] and rendered it the empty string, which
+    // could never equal that key — those albums silently never matched.
+    const { updates } = setupLinkDb({ releases: [{ id: 'rel-jp', match_key: '東京' }] });
+    pagedRows([{ id: 'item-1', title: '東京' }]);
+
+    expect(await linkCollectionItemsForArtist('artist-1', 'Some Artist')).toBe(1);
+    expect(updates[0].releaseId).toBe('rel-jp');
+  });
+
+  it('does nothing, and reads no items, when the artist has no releases yet', async () => {
+    const { updates } = setupLinkDb({ releases: [] });
+
+    expect(await linkCollectionItemsForArtist('artist-1', 'King Triumph')).toBe(0);
+    expect(mocks.mockReadAllPages).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+  });
+
+  it('reports zero rather than throwing when the release read fails', async () => {
+    mocks.mockFrom.mockImplementation(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ data: null, error: { message: 'boom' } })),
+        })),
+      })),
+    }));
+
+    // An artist's catalogue run must not fail because somebody's profile page missed a link.
+    expect(await linkCollectionItemsForArtist('artist-1', 'King Triumph')).toBe(0);
+  });
+});
+
+interface ResolveTables {
+  /** slug -> the artists row that exists for it. */
+  artists?: Record<string, { id: string; match_confidence: string | null }>;
+}
+
+function setupResolveDb({ artists = {} }: ResolveTables) {
+  const artistUpserts: Record<string, unknown>[] = [];
+  const linkUpserts: Record<string, unknown>[] = [];
+
+  mocks.mockFrom.mockImplementation((table: string) => {
+    if (table === 'artists') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((_column: string, slug: string) => ({
+            maybeSingle: vi.fn(() => Promise.resolve({ data: artists[slug] ?? null, error: null })),
+          })),
+        })),
+        upsert: vi.fn((row: Record<string, unknown>) => {
+          artistUpserts.push(row);
+          return {
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: { id: `new-${row.slug}` }, error: null })),
+            })),
+          };
+        }),
+      };
+    }
+    if (table === 'artist_links') {
+      return {
+        upsert: vi.fn((row: Record<string, unknown>) => {
+          linkUpserts.push(row);
+          return Promise.resolve({ error: null });
+        }),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return { artistUpserts, linkUpserts };
+}
+
+describe('resolveCollectionArtists', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    mocks.mockFindSlugByBandcampUrl.mockResolvedValue(null);
+    mocks.mockRequestCatalog.mockResolvedValue(true);
+  });
+
+  /** The pass paces itself between probes, so the timers have to be driven. */
+  async function run(userId = 'user-1') {
+    const pending = resolveCollectionArtists(userId);
+    await vi.runAllTimersAsync();
+    return pending;
+  }
+
+  it('stores an artist it can verify on Bandcamp and asks for their catalogue', async () => {
+    const { artistUpserts, linkUpserts } = setupResolveDb({});
+    pagedRows([{ artist_name: 'King Triumph' }, { artist_name: 'King Triumph' }]);
+    mocks.mockFindBandcampArtist.mockResolvedValue({
+      url: 'https://kingtriumph.bandcamp.com',
+      bandName: 'King Triumph',
+      location: null,
+      releaseTitles: ['bias'],
+      imageUrl: 'https://img/kt.jpg',
+    });
+
+    const summary = await run();
+
+    expect(summary).toMatchObject({
+      unlinkedItems: 2,
+      artistNames: 1, // the same artist twice is one lookup
+      created: 1,
+      catalogRequested: 1,
+    });
+    expect(artistUpserts).toEqual([
+      expect.objectContaining({
+        slug: 'king-triumph',
+        name: 'King Triumph',
+        image_url: 'https://img/kt.jpg',
+        // Not 'verified': the probe confirmed the account carries this name and holds releases,
+        // which is not the release-level corroboration the search pipeline means by that word.
+        match_confidence: 'unverified',
+      }),
+    ]);
+    expect(linkUpserts).toEqual([
+      expect.objectContaining({ platform: 'bandcamp', url: 'https://kingtriumph.bandcamp.com' }),
+    ]);
+    expect(mocks.mockRequestCatalog).toHaveBeenCalledWith(['new-king-triumph'], 'saved');
+  });
+
+  it('never probes for an artist it already holds', async () => {
+    setupResolveDb({ artists: { 'sufjan-stevens': { id: 'artist-1', match_confidence: 'verified' } } });
+    pagedRows([{ artist_name: 'Sufjan Stevens' }]);
+
+    const summary = await run();
+
+    expect(mocks.mockFindBandcampArtist).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ alreadyKnown: 1, created: 0 });
+    // Still worth a catalogue: an artist can be stored and never crawled.
+    expect(mocks.mockRequestCatalog).toHaveBeenCalledWith(['artist-1'], 'saved');
+  });
+
+  it('reuses the artist who already holds that Bandcamp URL under another spelling', async () => {
+    const { artistUpserts } = setupResolveDb({
+      artists: { bigthief: { id: 'artist-big', match_confidence: 'unverified' } },
+    });
+    pagedRows([{ artist_name: 'Big Thief' }]);
+    mocks.mockFindBandcampArtist.mockResolvedValue({
+      url: 'https://bigthief.bandcamp.com',
+      bandName: 'Big Thief',
+      location: null,
+      releaseTitles: [],
+      imageUrl: null,
+    });
+    mocks.mockFindSlugByBandcampUrl.mockResolvedValue('bigthief');
+
+    const summary = await run();
+
+    // A second row would split one artist's releases across two pages.
+    expect(artistUpserts).toHaveLength(0);
+    expect(summary).toMatchObject({ alreadyKnown: 1, created: 0 });
+    expect(mocks.mockRequestCatalog).toHaveBeenCalledWith(['artist-big'], 'saved');
+  });
+
+  it('stores nothing when the probe cannot verify a Bandcamp page', async () => {
+    const { artistUpserts } = setupResolveDb({});
+    pagedRows([{ artist_name: 'Nobody We Can Find' }]);
+    mocks.mockFindBandcampArtist.mockResolvedValue(null);
+
+    const summary = await run();
+
+    expect(artistUpserts).toHaveLength(0);
+    expect(summary).toMatchObject({ notFound: 1, created: 0, catalogRequested: 0 });
+    expect(mocks.mockRequestCatalog).not.toHaveBeenCalled();
+  });
+
+  it('refuses names on the non-artist and excluded lists without probing', async () => {
+    const { artistUpserts } = setupResolveDb({});
+    // 'Saturday Night Live' is on the non-artist list and 'Absurd' on the excluded one. Paying
+    // for a record is a strong signal, but neither list is about signal strength: one keeps TV
+    // shows and software from minting artist pages, the other is a deliberate exclusion.
+    pagedRows([{ artist_name: 'Saturday Night Live' }, { artist_name: 'Absurd' }]);
+
+    const summary = await run();
+
+    expect(mocks.mockFindBandcampArtist).not.toHaveBeenCalled();
+    expect(artistUpserts).toHaveLength(0);
+    expect(summary).toMatchObject({ refused: 2 });
+  });
+
+  it('reports the names it did not get to instead of dropping them silently', async () => {
+    setupResolveDb({});
+    // 120 distinct artists, against a per-run ceiling of 100.
+    pagedRows(Array.from({ length: 120 }, (_, i) => ({ artist_name: `Artist ${i}` })));
+    mocks.mockFindBandcampArtist.mockResolvedValue(null);
+
+    const summary = await run();
+
+    expect(summary).toMatchObject({ artistNames: 120, deferred: 20 });
+    expect(mocks.mockFindBandcampArtist).toHaveBeenCalledTimes(100);
+  });
+
+  it('asks for no more artists than one catalogue invocation accepts', async () => {
+    // requestArtistCatalog slices anything longer than 25, so asking for more would silently
+    // crawl a quarter of them. The rest are left to the scheduled sweep, which picks up any
+    // artist holding a Bandcamp link.
+    setupResolveDb({});
+    pagedRows(Array.from({ length: 40 }, (_, i) => ({ artist_name: `Artist ${i}` })));
+    mocks.mockFindBandcampArtist.mockImplementation((name: string) =>
+      Promise.resolve({
+        url: `https://${name.replace(/\W/g, '')}.bandcamp.com`,
+        bandName: name,
+        location: null,
+        releaseTitles: [],
+        imageUrl: null,
+      })
+    );
+
+    const summary = await run();
+
+    expect(summary).toMatchObject({ created: 40, catalogRequested: 25 });
+    expect(mocks.mockRequestCatalog.mock.calls[0][0]).toHaveLength(25);
+  });
+
+  it('stops probing at its deadline and counts what is left as deferred', async () => {
+    setupResolveDb({});
+    pagedRows(Array.from({ length: 10 }, (_, i) => ({ artist_name: `Artist ${i}` })));
+    // Each probe burns two minutes of fake time, so the six-minute deadline bites partway
+    // through. Being killed at Netlify's ceiling instead would lose the summary entirely.
+    mocks.mockFindBandcampArtist.mockImplementation(() => {
+      vi.advanceTimersByTime(2 * 60_000);
+      return Promise.resolve(null);
+    });
+
+    const summary = await run();
+
+    expect(mocks.mockFindBandcampArtist.mock.calls.length).toBeLessThan(10);
+    expect(summary.notFound + summary.deferred).toBe(10);
+    expect(summary.deferred).toBeGreaterThan(0);
+  });
+
+  it('returns an empty summary when the unlinked-items read fails', async () => {
+    setupResolveDb({});
+    mocks.mockReadAllPages.mockResolvedValue({ ok: false, reason: 'PostgREST said no' });
+
+    const summary = await run();
+
+    expect(summary).toMatchObject({ unlinkedItems: 0, artistNames: 0, created: 0 });
+    expect(mocks.mockFindBandcampArtist).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -23,6 +23,8 @@ import {
   type SubsonicAlbum,
   type SubsonicCredential,
 } from './bandcamp-subsonic';
+import { resolveCollectionArtists, type CollectionResolveSummary } from './collection-matching';
+import { releaseMatchKey } from './release-utils';
 import { normalizeForComparison } from './search-utils';
 
 const RESPONSE_HEADERS = { 'Content-Type': 'application/json' };
@@ -125,7 +127,11 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   for (const album of albums) {
     const artist = albumArtist.get(album.id);
     if (!artist) continue;
-    const release = releaseByKey.get(`${artist.id}:${normalizeForComparison(album.name)}`);
+    // `releaseMatchKey`, not `normalizeForComparison`: the former is the function that produced
+    // `releases.match_key`, and the two disagree. normalizeForComparison strips to [a-z0-9], so
+    // it renders any title with no Latin characters — Japanese, Cyrillic, Greek — as the empty
+    // string, which can never equal the stored key. Those albums silently never matched.
+    const release = releaseByKey.get(`${artist.id}:${releaseMatchKey(album.name)}`);
     if (release) matches.releases.set(album.id, release);
   }
   return matches;
@@ -405,6 +411,31 @@ export async function handler(event: {
     }
 
     console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${matches.releases.size} matched to releases, ${matches.artists.size} artists)`);
+
+    // Everything above this line is the sync. What follows is discovery for the items it could
+    // not match — most of a real collection, because most artists a fan buys from have never
+    // been searched and so have no `artists` row to match against.
+    //
+    // Deliberately *after* the connection is marked idle: the collection is complete and worth
+    // showing whether or not the artists behind it resolve, the pass costs a paced probe per
+    // unknown name, and a failure in it must never be recorded as a failed import. Still inside
+    // this invocation rather than a second background function — a background function has 15
+    // minutes and this needs about two.
+    let resolved: CollectionResolveSummary | null = null;
+    try {
+      resolved = await resolveCollectionArtists(userId);
+      console.log('[bandcamp-sync] resolved collection artists:', JSON.stringify(resolved));
+    } catch (error) {
+      // Reported, not thrown: the import succeeded, and the next re-sync tries again. Sentry
+      // rather than a log line because a pass that always fails would otherwise look exactly
+      // like a collection whose artists simply aren't on Bandcamp.
+      console.error('[bandcamp-sync] artist resolution failed:', error instanceof Error ? error.message : String(error));
+      Sentry.captureException(error, {
+        tags: { function: 'bandcamp-sync' },
+        extra: { stage: 'resolve-collection-artists' },
+      });
+    }
+
     return {
       statusCode: 200,
       headers: RESPONSE_HEADERS,
@@ -412,6 +443,7 @@ export async function handler(event: {
         imported: uniqueAlbums.length,
         matched: matches.releases.size,
         artistsMarked: matches.artists.size,
+        resolved,
       }),
     };
   } catch (error) {

--- a/api/functions/catalog-artist-background.ts
+++ b/api/functions/catalog-artist-background.ts
@@ -25,6 +25,7 @@ import {
   type CatalogTrigger,
   type PersistedRelease,
 } from './db';
+import { linkCollectionItemsForArtist } from './collection-matching';
 import { isInternalRequest, isUrlHostnameAllowed } from './middleware';
 import { safeFetch, safeHostname } from './safe-fetch';
 import {
@@ -486,6 +487,19 @@ async function catalogArtist(
     releasesFound: totalFound,
     releasesDetailed: totalDetailed,
   });
+
+  // A catalogue existing is what makes a fan's collection item linkable, and this is the moment
+  // it starts existing — the import that created those items ran days earlier against an artist
+  // we held no releases for. Runs on every pass, not only the first, so a release added to a
+  // discography later still finds the fans who already own it. Never fails the run: a link is an
+  // improvement to somebody's profile page, not part of cataloguing.
+  if (totalFound > 0) {
+    const linked = await linkCollectionItemsForArtist(artistId, artist.name);
+    if (linked > 0) {
+      console.log(`[catalog] linked ${linked} collection item(s) to ${artist.name}`);
+    }
+  }
+
   return totalFound;
 }
 

--- a/api/functions/collection-matching.ts
+++ b/api/functions/collection-matching.ts
@@ -1,0 +1,420 @@
+// Turning collection items into linked releases.
+//
+// A Bandcamp import writes what Bandcamp tells us — a title, an artist name, an album id — and
+// attaches an Unstream release only when we already hold one. Most of a real collection is
+// therefore unlinked: the fan bought from artists nobody has ever searched, so there is no
+// `artists` row, no catalogue, and no release page to point at. On a public profile that renders
+// as a wall of plain text, which is the opposite of the point of the page.
+//
+// **Linking straight out to Bandcamp instead is not available.** Bandcamp's Subsonic API returns
+// no URLs at all — id, name, artist, coverArt, year, genre, created is the whole album payload
+// (see bandcamp-subsonic.ts) — so there is no source link to fall back to, and deriving one from
+// the title would mint URLs that 404 whenever a slug isn't the obvious one. What the import does
+// give us is a trustworthy artist name, and that is enough to run the same discovery the rest of
+// the product runs.
+//
+// Two halves, deliberately apart because they become possible at different moments:
+//
+//   resolveCollectionArtists()      After an import. Finds the artists we don't hold yet, probes
+//                                   for their Bandcamp page, stores them, and asks for their
+//                                   catalogues. Costs one probe per name we've never seen.
+//   linkCollectionItemsForArtist()  After a catalogue is built. Attaches the releases that pass
+//                                   just created to the items that were waiting for them. Pure
+//                                   database work, called from every catalogue run from now on —
+//                                   so an item that can be linked eventually is, whatever caused
+//                                   the crawl.
+//
+// Neither half guesses. An item is linked only when its title matches a release exactly on
+// `releases.match_key`, because a collection page asserts that a specific person bought a
+// specific record — the same reasoning that makes the import's matching deliberately
+// conservative, and the reason a near-miss stays unlinked rather than becoming a wrong claim.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { findBandcampArtist } from '../search/bandcamp-probe';
+import {
+  artistSlug,
+  findArtistSlugByBandcampUrl,
+  getClient,
+  readAllPages,
+} from './db';
+import { releaseMatchKey } from './release-utils';
+import { requestArtistCatalog } from './request-catalog';
+import { isNonArtistSlug } from '../lib/non-artist-names';
+import { isExcludedArtistSlug } from '../lib/excluded-artists';
+
+/** Item ids per update request. Realistically a handful; this only bounds the URL length. */
+const UPDATE_CHUNK = 100;
+
+/**
+ * Artist names one resolve pass will look up.
+ *
+ * Each unknown name costs one probe round (up to three requests, cached forever afterwards
+ * including the negatives), so this is the pass's whole crawl cost. A large collection is a few
+ * hundred artists, and 100 covers most of one in a single run at roughly two minutes of paced
+ * requests — comfortably inside a background function's 15-minute ceiling. Anything past it is
+ * reported, never dropped silently, and the next re-sync starts where this stopped.
+ */
+const MAX_ARTISTS_PER_RESOLVE = 100;
+
+/**
+ * Artists this pass asks to be catalogued directly.
+ *
+ * **Must stay equal to MAX_ARTISTS_PER_REQUEST in request-catalog.ts**, which slices anything
+ * longer — asking for 100 would silently crawl 25. Everything beyond this is left to the
+ * six-hourly sweep rather than fanned out across four concurrent invocations: a newly stored
+ * artist has a Bandcamp link, which puts them in `getStaleCatalogCandidates`' pool as
+ * never-catalogued, and that tier is ranked above the refresh tail. So the rest arrive within a
+ * day or so, at the sweep's pace rather than all at once, and no one has to press anything.
+ */
+const MAX_CATALOG_REQUESTS = 25;
+
+/** Pause between probe rounds. One artist per second, matching the crawler's own spacing. */
+const DELAY_BETWEEN_PROBES_MS = 1_000;
+
+/**
+ * Stop starting new probes after this long, however many names are left.
+ *
+ * The count above bounds the ordinary case; this bounds the bad one. A probe round is normally
+ * 270-980ms but may spend its full 5-second budget, so 100 names have a worst case near ten
+ * minutes — and this pass runs *after* an import that has already spent some of the same
+ * invocation. Stopping early is a deferral, reported like any other, where being killed at
+ * Netlify's ceiling would lose the summary and with it any sign of what happened.
+ */
+const RESOLVE_DEADLINE_MS = 6 * 60_000;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/** `ilike` treats % and _ as wildcards, and both turn up in real artist names. */
+function escapeLikePattern(value: string): string {
+  return value.replace(/[%_\\]/g, match => `\\${match}`);
+}
+
+/**
+ * Attach an artist's releases to collection items that were imported before those releases
+ * existed.
+ *
+ * Called at the end of every catalogue run, which is the moment the releases become linkable —
+ * the import that created these items ran days earlier, when this artist had no catalogue to
+ * match against. It re-runs for every later catalogue pass too, so a release added to a
+ * discography later still finds the fans who already own it.
+ *
+ * Matched on `releases.match_key` via `releaseMatchKey`, the function that produced the column.
+ * Titles are compared against the artist's own catalogue only, so the exactness is a guard
+ * against linking a fan to the wrong record, not against a different artist's album.
+ *
+ * Returns how many items were linked. Never throws: a fan's collection page not gaining a link
+ * is not a reason to fail an artist's catalogue run.
+ */
+export async function linkCollectionItemsForArtist(
+  artistId: string,
+  artistName: string
+): Promise<number> {
+  const client = getClient();
+  if (!client) return 0;
+
+  try {
+    const { data: releaseRows, error: releaseError } = await client
+      .from('releases')
+      .select('id, match_key')
+      .eq('artist_id', artistId)
+      .eq('is_hidden', false);
+
+    if (releaseError) {
+      console.error('[collection-match] release read failed:', releaseError.message);
+      return 0;
+    }
+
+    const releaseByKey = new Map<string, string>();
+    for (const row of (releaseRows ?? []) as { id: string; match_key: string | null }[]) {
+      if (row.match_key) releaseByKey.set(row.match_key, row.id);
+    }
+    if (releaseByKey.size === 0) return 0;
+
+    // Every user's unlinked items, not just one person's: a catalogue is built once and whoever
+    // owns that record benefits. Paged because `collection_items` holds a row per purchase per
+    // fan and PostgREST truncates a plain select at 1,000 rows without saying so.
+    const itemRead = await readAllPages<{ id: string; title: string }>(
+      (from, to) =>
+        client
+          .from('collection_items')
+          .select('id, title')
+          .is('release_id', null)
+          .ilike('artist_name', escapeLikePattern(artistName))
+          .order('id')
+          .range(from, to),
+      'collection_items (awaiting a release)'
+    );
+    if (!itemRead.ok) return 0;
+
+    const itemsByRelease = new Map<string, string[]>();
+    for (const item of itemRead.rows) {
+      const releaseId = releaseByKey.get(releaseMatchKey(item.title));
+      if (!releaseId) continue;
+      const waiting = itemsByRelease.get(releaseId);
+      if (waiting) waiting.push(item.id);
+      else itemsByRelease.set(releaseId, [item.id]);
+    }
+
+    let linked = 0;
+    for (const [releaseId, itemIds] of itemsByRelease) {
+      for (let i = 0; i < itemIds.length; i += UPDATE_CHUNK) {
+        const chunk = itemIds.slice(i, i + UPDATE_CHUNK);
+        const { error } = await client
+          .from('collection_items')
+          .update({ release_id: releaseId })
+          .in('id', chunk);
+
+        if (error) {
+          console.error('[collection-match] link update failed:', error.message);
+          continue;
+        }
+        linked += chunk.length;
+      }
+    }
+
+    return linked;
+  } catch (error) {
+    console.error('[collection-match] link failed:', error instanceof Error ? error.message : String(error));
+    return 0;
+  }
+}
+
+/** What one resolve pass did. Every name is accounted for by exactly one of these counts. */
+export interface CollectionResolveSummary {
+  /** Items with no release attached when the pass started. */
+  unlinkedItems: number;
+  /** Distinct artists behind those items. */
+  artistNames: number;
+  /** Already had an `artists` row — no probe needed. */
+  alreadyKnown: number;
+  /** Stored from a verified Bandcamp probe by this pass. */
+  created: number;
+  /** The probe found no verifiable Bandcamp page for the name. */
+  notFound: number;
+  /** Names the non-artist and excluded-artist lists refuse. */
+  refused: number;
+  /** Past the per-run cap. Reported so a partial pass never reads as a complete one. */
+  deferred: number;
+  /** Artists whose catalogue this pass asked for directly. */
+  catalogRequested: number;
+}
+
+const emptySummary = (): CollectionResolveSummary => ({
+  unlinkedItems: 0,
+  artistNames: 0,
+  alreadyKnown: 0,
+  created: 0,
+  notFound: 0,
+  refused: 0,
+  deferred: 0,
+  catalogRequested: 0,
+});
+
+/** The artist at this slug, if any. `match_confidence` comes back so a claimed row is left alone. */
+async function artistAtSlug(
+  client: SupabaseClient,
+  slug: string
+): Promise<{ id: string; matchConfidence: string | null } | null> {
+  const { data, error } = await client
+    .from('artists')
+    .select('id, match_confidence')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[collection-match] artist lookup failed:', error.message);
+    return null;
+  }
+  if (!data) return null;
+  const row = data as { id: string; match_confidence: string | null };
+  return { id: row.id, matchConfidence: row.match_confidence };
+}
+
+/**
+ * Store an artist discovered from someone's collection, and their Bandcamp link.
+ *
+ * `match_confidence` is 'unverified', matching what a search stores for an artist whose releases
+ * haven't corroborated the match. The probe verified that the account carries this artist's name
+ * and holds real releases, which is what makes the row worth creating — it is not the
+ * release-level corroboration the search pipeline means by 'verified', so it doesn't claim to be.
+ */
+async function storeBandcampArtist(
+  client: SupabaseClient,
+  input: { slug: string; name: string; bandcampUrl: string; imageUrl: string | null }
+): Promise<string | null> {
+  const { data: artist, error: artistError } = await client
+    .from('artists')
+    .upsert(
+      {
+        slug: input.slug,
+        name: input.name,
+        image_url: input.imageUrl,
+        match_confidence: 'unverified',
+        source: 'auto',
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'slug' }
+    )
+    .select('id')
+    .single();
+
+  if (artistError || !artist) {
+    console.error(`[collection-match] could not store "${input.name}":`, artistError?.message);
+    return null;
+  }
+
+  const artistId = (artist as { id: string }).id;
+
+  // `ignoreDuplicates` rather than an overwrite: if this artist somehow already has a Bandcamp
+  // row, it came from a search or from the artist themselves, and either is at least as
+  // trustworthy as a probe result.
+  const { error: linkError } = await client.from('artist_links').upsert(
+    {
+      artist_id: artistId,
+      platform: 'bandcamp',
+      url: input.bandcampUrl,
+      source: 'collection',
+      is_direct: true,
+      display_order: 0,
+    },
+    { onConflict: 'artist_id,platform', ignoreDuplicates: true }
+  );
+
+  if (linkError) {
+    // Without the link there is nothing to catalogue, so the row alone is not worth reporting
+    // as a success.
+    console.error(`[collection-match] could not link "${input.name}":`, linkError.message);
+    return null;
+  }
+
+  return artistId;
+}
+
+/**
+ * Find the artists behind a fan's unlinked collection items and get their catalogues started.
+ *
+ * Run after an import, off the request path. The expensive step — one Bandcamp probe per artist
+ * name we've never seen — is why: probes are cached in Supabase forever afterwards, negatives
+ * included, so this is expensive exactly once per artist across the whole product.
+ *
+ * Nothing here links anything. Cataloguing is asynchronous by design, so the items stay unlinked
+ * until `linkCollectionItemsForArtist` runs at the end of the crawl this pass requests.
+ *
+ * Never throws. This runs after a sync has already been recorded as complete, and a fan's
+ * collection is imported and visible whether or not the artists behind it could be resolved.
+ */
+export async function resolveCollectionArtists(userId: string): Promise<CollectionResolveSummary> {
+  const summary = emptySummary();
+  const client = getClient();
+  if (!client) return summary;
+
+  const itemRead = await readAllPages<{ artist_name: string }>(
+    (from, to) =>
+      client
+        .from('collection_items')
+        .select('artist_name')
+        .eq('user_id', userId)
+        .is('release_id', null)
+        .order('acquired_at', { ascending: false, nullsFirst: false })
+        .range(from, to),
+    'collection_items (unlinked)'
+  );
+
+  if (!itemRead.ok) {
+    console.warn('[collection-match] could not read unlinked items:', itemRead.reason);
+    return summary;
+  }
+
+  summary.unlinkedItems = itemRead.rows.length;
+
+  // Deduped on the slug rather than the raw string, so "Björk" and "Bjork" are one lookup. Newest
+  // purchases first, because that's the order the read asked for and the end of a truncated pass
+  // should be the records someone bought longest ago.
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const row of itemRead.rows) {
+    const slug = artistSlug(row.artist_name);
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    names.push(row.artist_name);
+  }
+
+  summary.artistNames = names.length;
+  const toResolve = names.slice(0, MAX_ARTISTS_PER_RESOLVE);
+  summary.deferred = names.length - toResolve.length;
+
+  const artistIds: string[] = [];
+  const deadline = Date.now() + RESOLVE_DEADLINE_MS;
+
+  for (const [index, name] of toResolve.entries()) {
+    if (Date.now() > deadline) {
+      summary.deferred += toResolve.length - index;
+      console.warn(`[collection-match] out of time with ${toResolve.length - index} name(s) left`);
+      break;
+    }
+
+    const slug = artistSlug(name);
+
+    // The same two editorial gates a search passes through. A collection is a stronger signal
+    // than a search — someone paid for this — but neither list is about signal strength: one
+    // keeps software and TV shows from minting artist pages, the other is a deliberate
+    // exclusion, and a purchase doesn't overturn either.
+    if (isNonArtistSlug(slug) || isExcludedArtistSlug(slug)) {
+      summary.refused++;
+      continue;
+    }
+
+    const existing = await artistAtSlug(client, slug);
+    if (existing) {
+      summary.alreadyKnown++;
+      // A claimed profile is left entirely alone — its links are the artist's own curation — but
+      // it is still worth cataloguing, which is gated by whether it has a catalogue-able link.
+      artistIds.push(existing.id);
+      continue;
+    }
+
+    const match = await findBandcampArtist(name);
+    await sleep(DELAY_BETWEEN_PROBES_MS);
+
+    if (!match) {
+      // Either genuinely not on Bandcamp under any candidate slug, or the probe couldn't tell.
+      // It caches those two differently, so a transient failure here retries next time rather
+      // than becoming a permanent verdict — see findBandcampArtist.
+      summary.notFound++;
+      continue;
+    }
+
+    // Whoever already owns this Bandcamp URL owns these releases too, whatever name the
+    // collection spells them under.
+    const ownerSlug = await findArtistSlugByBandcampUrl(match.url);
+    if (ownerSlug && ownerSlug !== slug) {
+      const owner = await artistAtSlug(client, ownerSlug);
+      if (owner) {
+        summary.alreadyKnown++;
+        artistIds.push(owner.id);
+        continue;
+      }
+    }
+
+    const artistId = await storeBandcampArtist(client, {
+      slug,
+      name,
+      bandcampUrl: match.url,
+      imageUrl: match.imageUrl,
+    });
+
+    if (!artistId) continue;
+    summary.created++;
+    artistIds.push(artistId);
+  }
+
+  // 'saved' rather than 'searched': the trigger picks the hourly budget, and the larger one is
+  // for work a person deliberately asked for. Connecting a collection is that — and buying a
+  // record is a stronger statement of interest than saving an artist, which already qualifies.
+  const requested = [...new Set(artistIds)].slice(0, MAX_CATALOG_REQUESTS);
+  if (requested.length > 0 && (await requestArtistCatalog(requested, 'saved'))) {
+    summary.catalogRequested = requested.length;
+  }
+
+  return summary;
+}

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3597,6 +3597,21 @@ async function findArtistSlugByIdentityUrl(
 }
 
 /**
+ * The slug of an artist who already holds this Bandcamp URL, or null.
+ *
+ * The single-URL case of `findArtistSlugByIdentityUrl`, exported for the collection matcher.
+ * An artist discovered from a fan's Bandcamp collection is often one we already hold under a
+ * different spelling — the collection carries Bandcamp's spelling, the stored row carries
+ * whichever name won aggregation — and creating a second row would split their releases across
+ * two pages exactly as "Big Thief" / "Bigthief" once did.
+ */
+export async function findArtistSlugByBandcampUrl(url: string): Promise<string | null> {
+  const client = getClient();
+  if (!client) return null;
+  return findArtistSlugByIdentityUrl(client, [{ sourceId: 'bandcamp', url }]);
+}
+
+/**
  * Persist artist search results to the database.
  * Only persists artist-type results. Runs as fire-and-forget after search.
  */

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -86,6 +86,8 @@
     "functions/__tests__/public-saved-artists.test.ts",
     "functions/collection-art.ts",
     "functions/collection-utils.ts",
-    "functions/__tests__/collection-art.test.ts"
+    "functions/collection-matching.ts",
+    "functions/__tests__/collection-art.test.ts",
+    "functions/__tests__/collection-matching.test.ts"
   ]
 }

--- a/apps/web/src/components/CollectionGrid.tsx
+++ b/apps/web/src/components/CollectionGrid.tsx
@@ -54,9 +54,17 @@ function Tile({ item }: { item: CollectionGridItem }) {
 
       <div className="mt-1.5 min-w-0">
         {item.releaseUrl ? (
-          <Link to={item.releaseUrl} className="block text-xs font-medium truncate hover:underline">
+          // A plain anchor, never <Link>: /a/{artist}/{release} is rendered by the release-page
+          // edge function and has NO route in main.tsx, so React Router's client-side navigation
+          // pushed the URL and then rendered nothing — a blank page at the release's own URL. The
+          // browser only showed the real page once the visitor reloaded, and Back afterwards
+          // restored that release document under the profile's URL, which is the "hard refresh to
+          // get back" report. Same reasoning, and the same plain <a>, as ReleasesSection and
+          // RecentReleasesSection. The artist link below is a <Link> because /a/{artist} *is* an
+          // SPA route.
+          <a href={item.releaseUrl} className="block text-xs font-medium truncate hover:underline">
             {item.title}
-          </Link>
+          </a>
         ) : (
           <p className="text-xs font-medium truncate">{item.title}</p>
         )}

--- a/apps/web/tests/unit/CollectionGrid.test.tsx
+++ b/apps/web/tests/unit/CollectionGrid.test.tsx
@@ -139,6 +139,29 @@ describe('CollectionGrid', () => {
     expect(screen.getByText('Obscure Tape')).not.toBeNull();
   });
 
+  it('navigates to a release as a document, not through the client-side router', () => {
+    // /a/{artist}/{release} is rendered by an edge function and has no route in main.tsx. A
+    // <Link> there pushed the URL and rendered nothing — a blank page at the release's own URL,
+    // and a Back button that needed a hard refresh afterwards. A router <Link> cancels the
+    // click; a plain anchor lets the browser navigate, which is the whole fix.
+    renderGrid([
+      item({
+        key: 'linked',
+        title: 'Illinois',
+        artistName: 'Sufjan Stevens',
+        releaseUrl: '/a/sufjan-stevens/illinois',
+        artistUrl: '/a/sufjan-stevens',
+      }),
+    ]);
+
+    const release = screen.getByRole('link', { name: 'Illinois' });
+    expect(fireEvent.click(release)).toBe(true);
+
+    // The artist page is a real SPA route, so that one stays client-side.
+    const artist = screen.getByRole('link', { name: 'Sufjan Stevens' });
+    expect(fireEvent.click(artist)).toBe(false);
+  });
+
   it('drops to the placeholder, keeping the caption, when cover art fails to load', () => {
     renderGrid([item({ key: 'a', title: 'Missing Art', artUrl: '/api/collection/art/a' })]);
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -27,7 +27,7 @@ create table artist_links (
   artist_id uuid not null references artists(id) on delete cascade,
   platform text not null,
   url text not null,
-  source text not null default 'search', -- 'search' | 'musicbrainz' | 'claimed'
+  source text not null default 'search', -- 'search' | 'musicbrainz' | 'claimed' | 'collection'
   is_direct boolean not null default true,
   latest_release jsonb, -- { title, type, url, imageUrl, releaseDate }
   display_order integer,


### PR DESCRIPTION
The collection grid linked releases with React Router's <Link>, but
/a/{artist}/{release} is rendered by the release-page edge function and has no
route in main.tsx. So the click pushed the URL and rendered nothing: a blank
page at the release's own URL. The release only appeared once the visitor
reloaded, which is the "takes a long time to load" half of the report, and
Back afterwards restored that release document under the profile's URL, which
is the half that needed a hard refresh.

Reproduced in Chromium against the built SPA: click -> empty body at
/a/kingtriumph/bias; reload -> release page; Back -> URL /u/brandon still
showing the release page. With a plain <a> the click loads the release
directly and Back returns to the profile.

Every other release link in the app (ReleasesSection, RecentReleasesSection,
AdminReleaseReviewPage) was already a plain anchor for this reason; the
collection grid was the one that slipped. The artist link beside it stays a
<Link> because /a/{artist} really is an SPA route.

The new test clicks both links and asserts the release one is not cancelled by
the router, so a <Link> can't come back unnoticed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HWjFj2puBf3jhnX3uNHUMF