### PR TITLE
Resolve collection artists even when Bandcamp refuses the collection fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,12 +316,14 @@ row to match against.
 
 `collection-matching.ts` closes the gap in two halves that become possible at different times:
 
-- `resolveCollectionArtists(userId)` runs at the end of a sync, *after* the connection is marked
-  idle so a discovery failure is never recorded as a failed import. It probes Bandcamp for each
-  unknown artist name (cached forever, negatives included), stores the artist plus their Bandcamp
-  link, and requests catalogues for up to 25 — matching `MAX_ARTISTS_PER_REQUEST`, which silently
-  slices anything longer. The rest ride the six-hourly sweep, whose pool is every artist with a
-  catalogue-able link.
+- `resolveCollectionArtists(userId)` runs at the end of a sync, on **both** the success and the
+  failure path, and after the connection row is written either way — it reads stored
+  `collection_items` and probes `<slug>.bandcamp.com/music`, touching neither the Subsonic API
+  nor the credential, so a Subsonic 500 (routine in this beta) must not block discovery for
+  items imported days earlier. It stores each artist plus their Bandcamp link and requests
+  catalogues for up to 25 — matching `MAX_ARTISTS_PER_REQUEST`, which silently slices anything
+  longer. The rest ride the six-hourly sweep, whose pool is every artist with a catalogue-able
+  link.
 - `linkCollectionItemsForArtist(artistId, name)` runs at the end of every catalogue pass in
   `catalog-artist-background.ts` — the moment the releases exist — and attaches them to the items
   that were waiting. It re-runs forever, so a release added later still finds fans who own it.

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -427,6 +427,27 @@ describe('bandcamp-sync-background handler', () => {
     expect(JSON.parse(res.body).resolved).toMatchObject({ created: 1 });
   });
 
+  it('still resolves stored artists when Bandcamp refuses to hand over the collection', async () => {
+    const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+    const { connectionUpdates } = setupDb({
+      connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext },
+    });
+    mocks.mockFetchAllAlbums.mockRejectedValue(
+      new SubsonicError('getAlbumList2: HTTP 500 (offset 0, size 100)', null, true)
+    );
+    mocks.mockResolveArtists.mockResolvedValue({ created: 3, catalogRequested: 3 });
+
+    const res = await handler(internalEvent({ userId: 'user-1' }));
+
+    // The sync failed and says so. Resolution reads items imported by *earlier* syncs and
+    // never touches the Subsonic API, so a Bandcamp outage has no business blocking it —
+    // that coupling is what a real HTTP 500 exposed on the day this shipped.
+    expect(res.statusCode).toBe(500);
+    expect(connectionUpdates.at(-1)).toMatchObject({ sync_status: 'error' });
+    expect(mocks.mockResolveArtists).toHaveBeenCalledWith('user-1');
+    expect(JSON.parse(res.body)).toMatchObject({ error: 'Sync failed', resolved: { created: 3 } });
+  });
+
   it('still reports a successful import when artist resolution fails', async () => {
     const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
     const { connectionUpdates, upsertBatches } = setupDb({

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -283,6 +283,40 @@ async function markArtistsSupported(userId: string, artists: MatchedArtist[]): P
   }
 }
 
+/**
+ * Find the artists behind the collection items this account already holds.
+ *
+ * **Runs whether or not the fetch above succeeded, because it needs nothing the fetch
+ * provides.** It reads `collection_items` that are already stored and probes
+ * `<slug>.bandcamp.com/music` — neither the Subsonic API nor the credential is involved. This
+ * originally sat inside the success path, which coupled it to something unrelated: a Subsonic
+ * 500 is routine in this beta, and the first one in production (Sentry, 2026-08-14 — twelve
+ * requests, every page size down to the floor, all failing at offset 0) also blocked discovery
+ * for items imported days earlier, which had nothing to do with that failure.
+ *
+ * A Bandcamp-wide outage will simply make the probes inconclusive, and the probe cache refuses
+ * to record an `undecided` verdict — so the worst case is a wasted pass, never a stored
+ * "this artist isn't on Bandcamp".
+ *
+ * Never throws: the import is the primary artifact and its outcome is already decided by the
+ * time this runs. Reported to Sentry rather than logged, because a pass that always fails
+ * would otherwise look exactly like a collection whose artists simply aren't on Bandcamp.
+ */
+async function resolveArtistsSafely(userId: string): Promise<CollectionResolveSummary | null> {
+  try {
+    const resolved = await resolveCollectionArtists(userId);
+    console.log('[bandcamp-sync] resolved collection artists:', JSON.stringify(resolved));
+    return resolved;
+  } catch (error) {
+    console.error('[bandcamp-sync] artist resolution failed:', error instanceof Error ? error.message : String(error));
+    Sentry.captureException(error, {
+      tags: { function: 'bandcamp-sync' },
+      extra: { stage: 'resolve-collection-artists' },
+    });
+    return null;
+  }
+}
+
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -333,6 +367,8 @@ export async function handler(event: {
       .update({ sync_status: 'error', sync_error: message })
       .eq('user_id', userId);
   }
+
+  let outcome: { statusCode: number; body: Record<string, unknown> };
 
   try {
     let credential: SubsonicCredential;
@@ -412,39 +448,13 @@ export async function handler(event: {
 
     console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${matches.releases.size} matched to releases, ${matches.artists.size} artists)`);
 
-    // Everything above this line is the sync. What follows is discovery for the items it could
-    // not match — most of a real collection, because most artists a fan buys from have never
-    // been searched and so have no `artists` row to match against.
-    //
-    // Deliberately *after* the connection is marked idle: the collection is complete and worth
-    // showing whether or not the artists behind it resolve, the pass costs a paced probe per
-    // unknown name, and a failure in it must never be recorded as a failed import. Still inside
-    // this invocation rather than a second background function — a background function has 15
-    // minutes and this needs about two.
-    let resolved: CollectionResolveSummary | null = null;
-    try {
-      resolved = await resolveCollectionArtists(userId);
-      console.log('[bandcamp-sync] resolved collection artists:', JSON.stringify(resolved));
-    } catch (error) {
-      // Reported, not thrown: the import succeeded, and the next re-sync tries again. Sentry
-      // rather than a log line because a pass that always fails would otherwise look exactly
-      // like a collection whose artists simply aren't on Bandcamp.
-      console.error('[bandcamp-sync] artist resolution failed:', error instanceof Error ? error.message : String(error));
-      Sentry.captureException(error, {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'resolve-collection-artists' },
-      });
-    }
-
-    return {
+    outcome = {
       statusCode: 200,
-      headers: RESPONSE_HEADERS,
-      body: JSON.stringify({
+      body: {
         imported: uniqueAlbums.length,
         matched: matches.releases.size,
         artistsMarked: matches.artists.size,
-        resolved,
-      }),
+      },
     };
   } catch (error) {
     const isAuth = error instanceof SubsonicError && error.isAuthFailure;
@@ -463,6 +473,15 @@ export async function handler(event: {
         ? 'Bandcamp rejected the stored login. Disconnect and reconnect with a fresh username and password from Fan Settings → Subsonic.'
         : 'The sync failed partway through. Bandcamp’s Subsonic support is in beta — use Re-sync to try again.'
     );
-    return { statusCode: 500, headers: RESPONSE_HEADERS, body: JSON.stringify({ error: 'Sync failed' }) };
+    outcome = { statusCode: 500, body: { error: 'Sync failed' } };
   }
+
+  // Discovery for the items we hold, on both paths — see resolveArtistsSafely.
+  const resolved = await resolveArtistsSafely(userId);
+
+  return {
+    statusCode: outcome.statusCode,
+    headers: RESPONSE_HEADERS,
+    body: JSON.stringify({ ...outcome.body, resolved }),
+  };
 }


### PR DESCRIPTION
## What this fixes

The artist-discovery pass added in #449 sat inside the sync's success path, which coupled it to something it has nothing to do with. It reads `collection_items` that are already stored and probes `<slug>.bandcamp.com/music` — neither the Subsonic API nor the stored credential is involved — so whether the collection fetch succeeded has no bearing on whether the artists behind an earlier import can be found.

That coupling bit the same day it shipped. Bandcamp answered `HTTP 500` to `getAlbumList2` at offset 0, so the sync failed and discovery never ran for items imported days earlier. In practice that meant a Re-sync accomplished nothing: the unlinked releases on a profile stayed unlinked.

## What the Sentry event actually says

`getAlbumList2: HTTP 500 (offset 0, size 100)` means #448's shrink ladder ran all the way to the floor — page sizes 500 → 250 → 125 → 100, each with one attempt plus two retries. Twelve requests, all failing at offset 0.

So the hypothesis behind that ladder (Bandcamp timing out while building a large page) does not explain this event: a 100-album page at the very start fails just as hard. This was the Subsonic endpoint declining to answer at all. Nothing to fix on our side for that part — the retry and shrink behaviour from #448 is untouched here.

## The change

Resolution now runs on both the success and the failure path, after the connection row is written either way, and still cannot fail the invocation. Moved into `resolveArtistsSafely()` so both paths share one behaviour and one Sentry report.

A Bandcamp-wide outage makes the probes inconclusive rather than wrong: the probe cache refuses to record an `undecided` verdict, so the worst case is a wasted pass, never a stored "this artist isn't on Bandcamp".

## Testing

`npm run test:api` (1,217 passing) and `npm run typecheck:api`.

New test drives the exact production failure — a retryable `SubsonicError` from `getAlbumList2` — and asserts the sync still reports failure and marks the connection `error`, while resolution runs anyway. The existing test covering "resolution fails, import still succeeds" is unchanged.

## Not included

Two things noticed while diagnosing, deliberately left out of this PR:

- Production Sentry events are tagged `environment: development`. `api/lib/sentry.ts` falls back to `NODE_ENV || 'development'` and `SENTRY_ENV` isn't set on the Functions environment — a config change, not a code one.
- Now that shrinking is known not to help, the ladder spends twelve requests when the *first* page fails at full size. Shrinking only makes sense mid-collection; a failure at offset 0 reads as "Bandcamp is down". Worth revisiting if this recurs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWjFj2puBf3jhnX3uNHUMF)_