### PR TITLE
Stop tagging every production function error as "development" in Sentry

### DIFF
--- a/api/functions/__tests__/sentry-environment.test.ts
+++ b/api/functions/__tests__/sentry-environment.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { resolveSentryEnvironment } from '../../lib/sentry';
+
+/**
+ * The 29-hour release-alert outage of 2026-08-10 (`column releases.alert_sent_at does not exist`,
+ * every catalog run, production) was reported by Sentry as `environment: development`. The old
+ * fallback chain was `SENTRY_ENV || NODE_ENV || 'development'`, and a deployed Netlify function
+ * has neither variable — so production could not produce any other answer.
+ *
+ * These tests pin the runtime signal that can tell the difference. Note the last one: it fails
+ * against the old chain, which is the whole point.
+ */
+describe('resolveSentryEnvironment', () => {
+  const saved = { SENTRY_ENV: process.env.SENTRY_ENV, NODE_ENV: process.env.NODE_ENV, URL: process.env.URL };
+
+  beforeEach(() => {
+    delete process.env.SENTRY_ENV;
+    delete process.env.NODE_ENV;
+    delete process.env.URL;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('prefers an explicit SENTRY_ENV over anything derived', () => {
+    process.env.SENTRY_ENV = 'staging';
+    process.env.URL = 'https://unstream.stream';
+    expect(resolveSentryEnvironment()).toBe('staging');
+  });
+
+  it('tags the production site as production', () => {
+    process.env.URL = 'https://unstream.stream';
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+
+  it('tolerates a trailing slash on the site URL', () => {
+    process.env.URL = 'https://unstream.stream/';
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+
+  it('tags a netlify dev run as development', () => {
+    process.env.URL = 'http://localhost:8888';
+    expect(resolveSentryEnvironment()).toBe('development');
+  });
+
+  it('tags an unknown environment as development', () => {
+    expect(resolveSentryEnvironment()).toBe('development');
+  });
+
+  // The regression itself: production functions see no SENTRY_ENV and no NODE_ENV. Under the old
+  // chain this case returned 'development', which is how a production outage came in looking
+  // like someone's laptop.
+  it('does not fall back to development just because SENTRY_ENV and NODE_ENV are unset', () => {
+    process.env.URL = 'https://unstream.stream';
+    expect(process.env.SENTRY_ENV).toBeUndefined();
+    expect(process.env.NODE_ENV).toBeUndefined();
+    expect(resolveSentryEnvironment()).toBe('production');
+  });
+});

--- a/api/lib/sentry.ts
+++ b/api/lib/sentry.ts
@@ -19,7 +19,32 @@
 
 import * as Sentry from '@sentry/node';
 
+const PRODUCTION_SITE_URL = 'https://unstream.stream';
+
 let initialized = false;
+
+/**
+ * Which environment to tag events with.
+ *
+ * `SENTRY_ENV` wins when it's set, but it isn't set on this site, and the old fallback chain
+ * (`NODE_ENV` → `'development'`) meant every production function error arrived tagged
+ * `environment: development`. That isn't cosmetic: it reads as "someone's laptop" and buys a
+ * real outage another day of being ignored. The 29-hour release-alert outage of 2026-08-10 was
+ * reported exactly that way.
+ *
+ * `URL` is the signal because it is one of the three variables Netlify actually exposes to a
+ * function at runtime (`URL`, `SITE_NAME`, `SITE_ID`) — the same reason `request-catalog.ts`
+ * uses it. `CONTEXT` and `DEPLOY_PRIME_URL` are build-time only and are `undefined` here, so
+ * neither can be used to tell production from anything else. Under `netlify dev`, `URL` is the
+ * localhost origin, so local runs still tag as development.
+ */
+export function resolveSentryEnvironment(): string {
+  const explicit = process.env.SENTRY_ENV;
+  if (explicit) return explicit;
+
+  const siteUrl = process.env.URL?.replace(/\/$/, '');
+  return siteUrl === PRODUCTION_SITE_URL ? 'production' : 'development';
+}
 
 export function initSentry(): void {
   const dsn = process.env.SENTRY_DSN;
@@ -32,10 +57,14 @@ export function initSentry(): void {
 
   Sentry.init({
     dsn,
-    environment: process.env.SENTRY_ENV || process.env.NODE_ENV || 'development',
-    // SENTRY_RELEASE takes priority if set in Netlify (allows pinning release names
-    // independent of build SHA). Fall back through SENTRY_RELEASE → COMMIT_REF →
-    // COMMIT_SHA → 'unknown' so version tracking works reliably on Netlify.
+    environment: resolveSentryEnvironment(),
+    // COMMIT_REF and COMMIT_SHA are build-time variables and never reach a deployed function, so
+    // at runtime this resolves to SENTRY_RELEASE or 'unknown'. The chain stays because
+    // scripts/sentry-sourcemaps.sh deliberately mirrors it — but note that the mirror only holds
+    // for the web bundle: at build time that script resolves COMMIT_REF and uploads maps under
+    // the commit SHA, while these server-side events arrive tagged 'unknown'. Setting
+    // SENTRY_RELEASE in Netlify is what would make both ends agree; no runtime variable carries
+    // the deployed commit.
     release: process.env.SENTRY_RELEASE || process.env.COMMIT_REF || process.env.COMMIT_SHA || 'unknown',
     tracesSampleRate: 0.0, // no performance tracing — only error/message events
   });

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -88,6 +88,7 @@
     "functions/collection-utils.ts",
     "functions/collection-matching.ts",
     "functions/__tests__/collection-art.test.ts",
-    "functions/__tests__/collection-matching.test.ts"
+    "functions/__tests__/collection-matching.test.ts",
+    "functions/__tests__/sentry-environment.test.ts"
   ]
 }


### PR DESCRIPTION
## What this is

Triage of Sentry issue `UNSTREAM-WEB-W` — `claimDatedReleases: column releases.alert_sent_at does not exist`, 2026-08-11 18:30 UTC.

**The reported error needs no code change.** It was a migration/deploy race, and it stopped 69 minutes after that event fired:

| When (UTC) | What |
|---|---|
| Aug 10 14:05 | #440 merges — ships `notifications.ts` reading `alert_sent_at` **and** the migration creating it. `supabase-migrate` **fails**. |
| Aug 10 14:45 | #441 merges. `supabase-migrate` **fails** again. |
| **Aug 11 18:30** | **This error.** Every catalog run 400s on the claim query. |
| Aug 11 19:39 | #444 merges, `supabase-migrate` **succeeds** (run `31528946216`), column created. |
| Aug 14 15:33 | Next run, still green. |

Both runs failed for the reason CLAUDE.md documents: `20260809120000_bandcamp-collection.sql` had been applied to production by hand from the then-unmerged #438, so `supabase db push` refused to run and aborted *before applying anything*. Netlify deploys on push and doesn't wait on Actions, so the code went out without its column.

`claimDatedReleases` behaved correctly throughout — it captured to Sentry and returned `[]` rather than guessing, which is why the event is `handled: yes` and nothing was mis-mailed.

## What this actually fixes

The reason that report is hard to act on: **it says `environment: development` for a production outage.**

`SENTRY_ENV` is not set on this site — confirmed with `netlify env:get SENTRY_ENV --context production` — and `api/lib/sentry.ts` resolved the environment as `SENTRY_ENV || NODE_ENV || 'development'`. A deployed Netlify function has neither variable, so **production could not produce any other answer**. Every server-side event since the integration went live has been mislabelled. A real outage arriving tagged as someone's laptop buys it another day of being ignored.

`resolveSentryEnvironment()` now derives it from `process.env.URL` — one of the three variables Netlify exposes to a function at runtime (`URL`, `SITE_NAME`, `SITE_ID`), and the same signal `request-catalog.ts` already uses for its production gate. `CONTEXT` and `DEPLOY_PRIME_URL` are build-time only and are `undefined` here, so neither can tell production from anything else. An explicit `SENTRY_ENV` still wins; `netlify dev` still tags development because `URL` is the localhost origin there.

Also corrects the `release:` comment, which claimed the `COMMIT_REF` → `COMMIT_SHA` chain makes "version tracking work reliably on Netlify." Those are build-time variables too — which is precisely why the report says `release: unknown`.

## For the reviewer

- **One permanent consequence of the outage, already baked in and not recoverable here:** the migration's `ADD COLUMN ... DEFAULT now()` backfilled every existing row as already-alerted, so releases catalogued during those 29 hours were marked seen and will never be announced. That matches the design's stated trade-off, so there's nothing to repair — but those alerts didn't go out.
- **`release: unknown` is still open** and can't be closed in code: no runtime variable carries the deployed commit. Meanwhile `scripts/sentry-sourcemaps.sh` *does* see `COMMIT_REF` and uploads web source maps under the real SHA, so the two ends disagree. Setting `SENTRY_RELEASE` in Netlify is the fix, and env writes are sandbox-blocked for me.
- **The deploy race is structural, not a one-off.** Netlify deploys code on push while migrations run through Actions independently, with no ordering between them. CLAUDE.md documents the discipline; it will recur if that slips.

## Testing

`npm run verify` green — typecheck clean, 1223 API tests, 744 web tests.

The new `api/functions/__tests__/sentry-environment.test.ts` has teeth: I reverted the source to the old `NODE_ENV` chain and confirmed 3 of its 6 cases fail, including the one named for the regression itself. `api/tsconfig.json` gains the test so it's typechecked (`api/lib/sentry.ts` was already covered via `catalog-artist-background.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)