### PR TITLE
Collection ≠ Saved Artists, and the gap endpoint that makes the library import useful

### DIFF
--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -213,152 +213,23 @@ describe('bandcamp-sync-background handler', () => {
     expect(byExternal['al-3'].release_id).toBeNull();
   });
 
-  describe('auto-mark supported (spec OQ6: buying is supporting)', () => {
-    const ciphertext = () => encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
-    const albums = [{ id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }];
-
-    function withArtists() {
-      mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
-      mocks.mockFetchAllAlbums.mockResolvedValue(albums);
-    }
-
-    it('saves a matched artist as supported when they have no saved row', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      const inserted = savedInserts.flat();
-      expect(inserted).toHaveLength(1);
-      expect(inserted[0]).toMatchObject({
-        user_id: 'user-1',
-        artist_id: 'artist-1',
-        artist_slug: 'sufjan-stevens',
-        artist_name: 'Sufjan Stevens',
-        supported: true,
-      });
-      expect(inserted[0].supported_at).toBeTruthy();
-      expect(inserted[0].last_modified).toBeTruthy();
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    it('upgrades an existing unsupported row instead of inserting', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        // No artist_id: the legacy shape, where only the slug identifies the artist.
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false }],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].patch).toMatchObject({ supported: true });
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-1']);
-    });
-
-    it('leaves an already-supported row untouched (original supported_at preserved)', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: true, deleted: false }],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    it('never resurrects a tombstoned row — permanent dismissal sticks across re-syncs', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: true }],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    // The two cases the slug-only lookup got wrong. A row saved from a search result is filed
-    // under a synthetic slug (`sufjanstevens`), which the canonical slug never equals, so only
-    // artist_id finds it — measured on production 2026-08-14, one import duplicated three of
-    // Brandon's saved artists this way.
-    it('upgrades a row saved under a synthetic slug rather than duplicating the artist', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: false },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-1']);
-    });
-
-    it('never resurrects a tombstone filed under a synthetic slug', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    // The shape deduplicating an account leaves behind: the superseded row tombstoned, the
-    // canonical one live. The tombstone must not be read as "artist dismissed" — that would
-    // strand the live row unsupported through every future re-sync — and neither row may be
-    // duplicated by a fresh insert.
-    it('supports the live row when a tombstone for the same artist sits beside it', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
-          { id: 'row-2', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-2']);
-    });
-
-    it('marks nothing for unmatched artists', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-      });
+  describe('collection import does not touch saved artists', () => {
+    // Reversed 2026-08-16 (Brandon): "Collection Imports should always add to the collection
+    // NOT saved artists." A purchase belongs in the collection; saving is a deliberate act
+    // that also subscribes you to alerts. Releases by collection artists still reach the
+    // dashboard — getFeedReleasesForUser unions both lists — without conscripting the list.
+    it('writes no saved_artists rows even when every artist matches', async () => {
+      const ciphertext = encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+      setupDb({ connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext } });
       mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
       mocks.mockFetchAllAlbums.mockResolvedValue([
-        { id: 'al-9', name: 'Some Album', artist: 'Nobody We Know' },
+        { id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' },
       ]);
 
-      await handler(internalEvent({ userId: 'user-1' }));
+      const res = await handler(internalEvent({ userId: 'user-1' }));
 
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
+      expect(res.statusCode).toBe(200);
+      expect(mocks.mockFrom).not.toHaveBeenCalledWith('saved_artists');
     });
   });
 

--- a/api/functions/__tests__/feed-collection-artists.test.ts
+++ b/api/functions/__tests__/feed-collection-artists.test.ts
@@ -1,0 +1,185 @@
+// Whose releases reach a fan's dashboard feed.
+//
+// Reversed 2026-08-16 (Brandon): "Collection Imports should always add to the collection NOT
+// saved artists. However, you should get upcoming/recent release information from artists both
+// in the collection and the saved artists list." Before this, the Bandcamp import conscripted
+// every matched artist into saved_artists, which is what made their releases show up at all —
+// so removing that write would have silently emptied the feed for anyone who imported. The
+// union here is what keeps the promise while the two lists stay separate.
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// recatalog-sweep-selection.test.ts, so the real query body runs.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Filter {
+  kind: 'eq' | 'in' | 'range' | 'gte' | 'order' | 'limit';
+  column?: string;
+  value?: unknown;
+}
+
+interface Query {
+  table: string;
+  columns: string;
+  filters: Filter[];
+}
+
+const queries: Query[] = [];
+
+const tables: Record<string, Record<string, unknown>[]> = {
+  saved_artists: [],
+  collection_items: [],
+  artists: [],
+  artist_slug_aliases: [],
+  releases: [],
+};
+
+let failingTable: string | null = null;
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          const query: Query = { table, columns, filters: [] };
+          queries.push(query);
+
+          const builder = {
+            eq(column: string, value: unknown) {
+              query.filters.push({ kind: 'eq', column, value });
+              return builder;
+            },
+            in(column: string, value: unknown) {
+              query.filters.push({ kind: 'in', column, value });
+              return builder;
+            },
+            gte(column: string, value: unknown) {
+              query.filters.push({ kind: 'gte', column, value });
+              return builder;
+            },
+            order(column: string) {
+              query.filters.push({ kind: 'order', column });
+              return builder;
+            },
+            limit(value: number) {
+              query.filters.push({ kind: 'limit', value });
+              return builder;
+            },
+            range(from: number, to: number) {
+              query.filters.push({ kind: 'range', value: [from, to] });
+              return builder;
+            },
+            then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
+              if (failingTable === table) {
+                return Promise.resolve({ data: null, error: { message: 'connection reset' } }).then(resolve, reject);
+              }
+
+              let rows = tables[table] ?? [];
+              for (const f of query.filters) {
+                if (f.kind === 'in') {
+                  const wanted = new Set(f.value as string[]);
+                  rows = rows.filter(r => wanted.has(r[f.column as string] as string));
+                } else if (f.kind === 'eq') {
+                  rows = rows.filter(r => r[f.column as string] === f.value);
+                }
+              }
+              const range = query.filters.find(f => f.kind === 'range');
+              if (range) {
+                const [from, to] = range.value as [number, number];
+                rows = rows.slice(from, to + 1);
+              }
+              return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getFeedReleasesForUser } = await import('../db');
+
+/** Dated inside the feed's trailing window so it isn't filtered on date. */
+const soon = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+
+function release(id: string, artistId: string) {
+  return {
+    id,
+    title: `Release ${id}`,
+    slug: id,
+    release_date: soon,
+    date_precision: 'day',
+    status: 'released',
+    artwork_url: null,
+    is_hidden: false,
+    needs_review: false,
+    artist_id: artistId,
+    artists: { name: `Artist ${artistId}`, slug: artistId },
+  };
+}
+
+describe('getFeedReleasesForUser — saved artists and collection artists', () => {
+  beforeEach(() => {
+    queries.length = 0;
+    failingTable = null;
+    for (const key of Object.keys(tables)) tables[key] = [];
+  });
+
+  it('includes releases by an artist that is only in the collection', async () => {
+    // Nothing saved at all — the state a fan is in right after an import now that the sync
+    // no longer writes saved_artists.
+    tables.collection_items = [{ user_id: 'user-1', artist_name: 'Sufjan Stevens', releases: { artist_id: 'artist-1' } }];
+    tables.releases = [release('illinois', 'artist-1')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['illinois']);
+  });
+
+  it('resolves a collection artist by derived slug when no release matched', async () => {
+    // 72% of a real import matches no release, so the slug path is the common one.
+    tables.collection_items = [{ user_id: 'user-1', artist_name: 'Anne Sulikowski', releases: null }];
+    tables.artists = [{ id: 'artist-2', slug: 'anne-sulikowski' }];
+    tables.releases = [release('tape', 'artist-2')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['tape']);
+  });
+
+  it('unions both lists without duplicating a shared artist', async () => {
+    tables.saved_artists = [{ user_id: 'user-1', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', artist_name: 'Sufjan Stevens', deleted: false }];
+    tables.collection_items = [
+      { user_id: 'user-1', artist_name: 'Sufjan Stevens', releases: { artist_id: 'artist-1' } },
+      { user_id: 'user-1', artist_name: 'Mirah', releases: { artist_id: 'artist-3' } },
+    ];
+    tables.releases = [release('illinois', 'artist-1'), release('advisory', 'artist-3')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug).sort()).toEqual(['advisory', 'illinois']);
+
+    // One query, one id list — the artist in both lists must not be asked for twice.
+    const releaseQuery = queries.find(q => q.table === 'releases');
+    const ids = releaseQuery?.filters.find(f => f.kind === 'in')?.value as string[];
+    expect(ids).toHaveLength(new Set(ids).size);
+  });
+
+  it('still returns saved-artist releases when the collection read fails', async () => {
+    // The collection is an addition to the feed; a failure there must narrow it, never blank it.
+    tables.saved_artists = [{ user_id: 'user-1', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', artist_name: 'Sufjan Stevens', deleted: false }];
+    tables.releases = [release('illinois', 'artist-1')];
+    failingTable = 'collection_items';
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['illinois']);
+  });
+
+  it('returns nothing when the fan has neither saved artists nor a collection', async () => {
+    tables.releases = [release('illinois', 'artist-1')];
+    expect(await getFeedReleasesForUser('user-1')).toEqual([]);
+  });
+});

--- a/api/functions/__tests__/me-listening.test.ts
+++ b/api/functions/__tests__/me-listening.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockReadAllPages: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+// Real artistSlug: the gap decides who counts as "already supported" by comparing derived
+// slugs, so a stub here would let the test pass while the comparison drifted from the key
+// every writer actually uses.
+vi.mock('../db', async importOriginal => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    getClient: () => ({ from: mocks.mockFrom }),
+    readAllPages: mocks.mockReadAllPages,
+    artistSlug: actual.artistSlug,
+  };
+});
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+vi.mock('../collection-utils', () => ({ resolveArtistPages: () => Promise.resolve(new Map()) }));
+
+import { handler, parseSignals } from '../me-listening';
+
+function authed(method: string, body: unknown = null) {
+  return {
+    httpMethod: method,
+    headers: { authorization: 'Bearer valid-token' },
+    body: body === null ? null : JSON.stringify(body),
+  };
+}
+
+/** readAllPages is called for listening_signals, then saved_artists, then collection_items. */
+function stubReads(signals: unknown[], saved: unknown[], collection: unknown[]) {
+  mocks.mockReadAllPages
+    .mockResolvedValueOnce({ ok: true, rows: signals })
+    .mockResolvedValueOnce({ ok: true, rows: saved })
+    .mockResolvedValueOnce({ ok: true, rows: collection });
+}
+
+describe('parseSignals', () => {
+  it('drops unusable entries and clamps counts', () => {
+    const out = parseSignals([
+      { artistName: '  Mirah  ', playCount: 12 },
+      { artistName: '', playCount: 5 },
+      { artistName: 'No Count' },
+      { artistName: 'Negative', playCount: -4 },
+      'junk',
+      null,
+    ]);
+    expect(out).toEqual([
+      { artistName: 'Mirah', playCount: 12, lastPlayed: null },
+      { artistName: 'No Count', playCount: 0, lastPlayed: null },
+      { artistName: 'Negative', playCount: 0, lastPlayed: null },
+    ]);
+  });
+
+  it('collapses a repeated artist, keeping the larger count', () => {
+    // A duplicate inside one upsert batch is a Postgres error, not a harmless overwrite.
+    const out = parseSignals([
+      { artistName: 'Mirah', playCount: 3 },
+      { artistName: 'mirah', playCount: 9 },
+    ]);
+    expect(out).toEqual([{ artistName: 'Mirah', playCount: 9, lastPlayed: null }]);
+  });
+
+  it('refuses a non-array or an implausibly large batch', () => {
+    expect(parseSignals({})).toBeNull();
+    expect(parseSignals(Array.from({ length: 10_001 }, () => ({ artistName: 'x', playCount: 1 })))).toBeNull();
+  });
+});
+
+describe('me-listening handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }) },
+    });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: {}, body: null });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('rejects an unknown source', async () => {
+    const res = await handler(authed('POST', { source: 'spotify', signals: [] }));
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('stores uploaded signals and never touches saved_artists', async () => {
+    const upsert = vi.fn((..._a: unknown[]) => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({ upsert });
+
+    const res = await handler(
+      authed('POST', {
+        source: 'apple_music',
+        signals: [{ artistName: 'Mirah', playCount: 47, lastPlayed: '2026-08-01T00:00:00Z' }],
+      })
+    );
+
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body).stored).toBe(1);
+    expect(mocks.mockFrom).toHaveBeenCalledWith('listening_signals');
+    // Listening is not saving — the whole point of the 2026-08-16 reversal.
+    expect(mocks.mockFrom).not.toHaveBeenCalledWith('saved_artists');
+    expect(upsert.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ user_id: 'user-1', source: 'apple_music', artist_name: 'Mirah', play_count: 47 }),
+    ]);
+  });
+
+  describe('GET — the gap', () => {
+    it('ranks unsupported artists by plays', async () => {
+      stubReads(
+        [
+          { artist_name: 'Heavy Rotation', play_count: 50, last_played: null },
+          { artist_name: 'Occasional', play_count: 5, last_played: null },
+        ],
+        [],
+        []
+      );
+      const res = await handler(authed('GET'));
+      const body = JSON.parse(res!.body);
+      expect(body.gap.map((g: { artistName: string }) => g.artistName)).toEqual([
+        'Heavy Rotation',
+        'Occasional',
+      ]);
+    });
+
+    it('excludes artists already marked supported', async () => {
+      stubReads(
+        [{ artist_name: 'Already Backed', play_count: 90, last_played: null }],
+        [{ artist_slug: 'already-backed', supported: true }],
+        []
+      );
+      const res = await handler(authed('GET'));
+      expect(JSON.parse(res!.body).gap).toEqual([]);
+    });
+
+    it('keeps an artist who is saved but NOT supported — saving is not paying', async () => {
+      stubReads(
+        [{ artist_name: 'Saved Only', play_count: 30, last_played: null }],
+        [{ artist_slug: 'saved-only', supported: false }],
+        []
+      );
+      const res = await handler(authed('GET'));
+      expect(JSON.parse(res!.body).gap.map((g: { artistName: string }) => g.artistName)).toEqual(['Saved Only']);
+    });
+
+    it('excludes artists you own a record by', async () => {
+      stubReads(
+        [{ artist_name: 'Sufjan Stevens', play_count: 80, last_played: null }],
+        [],
+        [{ artist_name: 'Sufjan Stevens' }]
+      );
+      const res = await handler(authed('GET'));
+      expect(JSON.parse(res!.body).gap).toEqual([]);
+    });
+
+    it('matches the collection on the derived slug, not raw text', async () => {
+      // "Sigur Rós" in the library vs "sigur ros" in the collection is one artist.
+      stubReads(
+        [{ artist_name: 'Sigur Rós', play_count: 80, last_played: null }],
+        [],
+        [{ artist_name: 'sigur ros' }]
+      );
+      const res = await handler(authed('GET'));
+      expect(JSON.parse(res!.body).gap).toEqual([]);
+    });
+
+    it('merges the same artist arriving from two sources', async () => {
+      stubReads(
+        [
+          { artist_name: 'Mirah', play_count: 30, last_played: '2026-07-01T00:00:00Z' },
+          { artist_name: 'Mirah', play_count: 20, last_played: '2026-08-01T00:00:00Z' },
+        ],
+        [],
+        []
+      );
+      const res = await handler(authed('GET'));
+      const gap = JSON.parse(res!.body).gap;
+      expect(gap).toHaveLength(1);
+      expect(gap[0].playCount).toBe(50);
+      expect(gap[0].lastPlayed).toBe('2026-08-01T00:00:00Z');
+    });
+
+    it('reports a failed read as an error, not an empty gap', async () => {
+      mocks.mockReadAllPages.mockResolvedValueOnce({ ok: false, reason: 'boom' });
+      const res = await handler(authed('GET'));
+      expect(res!.statusCode).toBe(500);
+    });
+  });
+
+  it('DELETE removes the uploaded signals', async () => {
+    const eq = vi.fn(() => Promise.resolve({ error: null }));
+    mocks.mockFrom.mockReturnValue({ delete: vi.fn(() => ({ eq })) });
+    const res = await handler(authed('DELETE'));
+    expect(res!.statusCode).toBe(200);
+    expect(eq).toHaveBeenCalledWith('user_id', 'user-1');
+  });
+});

--- a/api/functions/__tests__/saved-artist-resolution.test.ts
+++ b/api/functions/__tests__/saved-artist-resolution.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-interface Filter { kind: 'eq' | 'in' | 'gte' | 'order' | 'limit'; column?: string; value?: unknown }
+interface Filter { kind: 'eq' | 'in' | 'gte' | 'order' | 'limit' | 'range'; column?: string; value?: unknown }
 interface Query { table: string; columns: string; filters: Filter[] }
 
 const queries: Query[] = [];
@@ -22,6 +22,9 @@ const tables: Record<string, Record<string, unknown>[]> = {
   artists: [],
   artist_slug_aliases: [],
   releases: [],
+  // The feed also unions the fan's collection artists (2026-08-16). Empty here so these
+  // tests keep isolating the saved-artist resolution they exist for.
+  collection_items: [],
 };
 
 /** Set to a table name to make that table's read fail. */
@@ -41,6 +44,7 @@ function makeClient() {
             gte(column: string, value: unknown) { query.filters.push({ kind: 'gte', column, value }); return builder; },
             order(column: string, value: unknown) { query.filters.push({ kind: 'order', column, value }); return builder; },
             limit(value: number) { query.filters.push({ kind: 'limit', value }); return builder; },
+            range(from: number, to: number) { query.filters.push({ kind: 'range', value: [from, to] }); return builder; },
             then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
               if (failingTable === table) {
                 return Promise.resolve({ data: null, error: { message: 'connection reset' } }).then(resolve, reject);
@@ -52,6 +56,11 @@ function makeClient() {
                   const wanted = new Set(f.value as unknown[]);
                   rows = rows.filter(r => wanted.has(r[f.column as string]));
                 }
+              }
+              const range = query.filters.find(f => f.kind === 'range');
+              if (range) {
+                const [from, to] = range.value as [number, number];
+                rows = rows.slice(from, to + 1);
               }
               return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
             },

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -41,11 +41,9 @@ interface MatchedRelease {
   artwork_url: string | null;
 }
 
+/** Just the id: matching an artist is how we find their releases, nothing more. */
 interface MatchedArtist {
   id: string;
-  slug: string;
-  name: string;
-  imageUrl: string | null;
 }
 
 interface LibraryMatches {
@@ -69,8 +67,8 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
 
   // The artists table is a few thousand rows; normalization has to happen in JS, so read
   // it once and match in memory rather than issuing a query per imported artist name.
-  const artistRead = await readAllPages<{ id: string; slug: string; name: string; image_url: string | null }>(
-    (from, to) => client.from('artists').select('id, slug, name, image_url').order('id').range(from, to),
+  const artistRead = await readAllPages<{ id: string; name: string }>(
+    (from, to) => client.from('artists').select('id, name').order('id').range(from, to),
     'artists (bandcamp-sync matching)'
   );
   if (!artistRead.ok) {
@@ -87,7 +85,7 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
       norm,
       artistsByNorm.has(norm)
         ? 'ambiguous'
-        : { id: row.id, slug: row.slug, name: row.name, imageUrl: row.image_url }
+        : { id: row.id }
     );
   }
 
@@ -137,151 +135,6 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   return matches;
 }
 
-/** Artists per saved_artists read — stays far below PostgREST's 1,000-row response cap. */
-const SAVED_LOOKUP_CHUNK = 100;
-
-/** The saved_artists columns needed to decide insert vs. upgrade vs. leave alone. */
-const SAVED_SELECT = 'id, artist_id, artist_slug, supported, deleted';
-
-interface SavedRow {
-  id: string;
-  artist_id: string | null;
-  artist_slug: string | null;
-  supported: boolean;
-  deleted: boolean;
-}
-
-/**
- * Buying an artist's record IS supporting them, so a Bandcamp import marks every matched
- * artist as saved + supported (Brandon, 2026-08-09, spec open question 6). Collection and
- * saved list are two views of the same relationship.
- *
- * Three rules keep this from fighting the user:
- *   - a row the user tombstoned (deleted=true) is left completely alone — permanent
- *     dismissal is a locked spec decision and a re-sync must never resurrect it;
- *   - an already-supported row keeps its original supported_at;
- *   - only supported goes true; nothing here can ever un-support or overwrite notes.
- *
- * **An existing row is looked up by `artist_id` as well as by slug, and matching on the slug
- * alone broke the first of those rules.** `(user_id, artist_slug)` is the table's natural key
- * (migration 014), but a row saved from a search result carries a *synthetic* slug —
- * `modelactriz`, `seoulmetro`, `qobuz-robertlogan` — that the canonical slug never equals, and
- * `artist_id` is then the only thing identifying the artist. So the slug-only check found
- * nothing and inserted a **second live row for an artist already saved** (measured on
- * production 2026-08-14: Model/Actriz, Rodney Owl and Seoul Metro each duplicated by one
- * import), and it equally missed a **tombstone** filed under the other slug, resurrecting a
- * dismissal this function promises is permanent.
- *
- * Failure here degrades, not fails: items are the sync's primary artifact, and the mark
- * is derived state the next re-sync recomputes.
- */
-async function markArtistsSupported(userId: string, artists: MatchedArtist[]): Promise<void> {
-  const client = getClient();
-  if (!client || artists.length === 0) return;
-
-  const serverNow = new Date().toISOString();
-  const toInsert: Record<string, unknown>[] = [];
-  /** Row ids, not slugs: a row matched by `artist_id` may be filed under a different slug. */
-  const toSupport: string[] = [];
-
-  for (let i = 0; i < artists.length; i += SAVED_LOOKUP_CHUNK) {
-    const chunk = artists.slice(i, i + SAVED_LOOKUP_CHUNK);
-
-    // Two reads rather than one, because a saved row can name this artist either way and
-    // neither column alone finds both (see the doc comment above).
-    const [byId, bySlug] = await Promise.all([
-      client
-        .from('saved_artists')
-        .select(SAVED_SELECT)
-        .eq('user_id', userId)
-        .in('artist_id', chunk.map(a => a.id)),
-      client
-        .from('saved_artists')
-        .select(SAVED_SELECT)
-        .eq('user_id', userId)
-        .in('artist_slug', chunk.map(a => a.slug)),
-    ]);
-
-    const failure = byId.error || bySlug.error;
-    if (failure) {
-      // Without a reliable view of existing rows we can't insert safely (we might
-      // resurrect a tombstone), so skip this chunk's artists entirely.
-      console.warn('[bandcamp-sync] saved_artists read failed:', failure.message);
-      Sentry.captureException(new Error(`saved_artists read failed: ${failure.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-      continue;
-    }
-
-    const rows = [...(byId.data ?? []), ...(bySlug.data ?? [])] as SavedRow[];
-
-    for (const artist of chunk) {
-      // Both reads can return the same row, and an already-duplicated artist returns two — so
-      // decide over every candidate rather than picking one.
-      const candidates = rows.filter(
-        row => (row.artist_id && row.artist_id === artist.id) || row.artist_slug === artist.slug
-      );
-
-      if (candidates.length === 0) {
-        toInsert.push({
-          user_id: userId,
-          artist_id: artist.id,
-          artist_slug: artist.slug,
-          artist_name: artist.name,
-          artist_image_url: artist.imageUrl,
-          supported: true,
-          supported_at: serverNow,
-          // Stamped server-side on insert so the row is immediately visible to the Apple
-          // app's ?since= incremental pulls — same reasoning as saved-artists.ts.
-          last_modified: serverNow,
-        });
-        continue;
-      }
-
-      // A tombstone wins only when nothing live is left for this artist — then the dismissal
-      // is untouchable, and no row is inserted either. A tombstone sitting *beside* a live row
-      // means that row was superseded, not the artist dismissed (deduplicating an account
-      // leaves exactly that shape), and skipping there would strand the live row unsupported.
-      const live = candidates.filter(row => !row.deleted);
-      for (const row of live) {
-        if (!row.supported && !toSupport.includes(row.id)) toSupport.push(row.id);
-      }
-    }
-  }
-
-  for (let i = 0; i < toInsert.length; i += SAVED_LOOKUP_CHUNK) {
-    const { error } = await client
-      .from('saved_artists')
-      .upsert(toInsert.slice(i, i + SAVED_LOOKUP_CHUNK), { onConflict: 'user_id,artist_slug' });
-    if (error) {
-      console.warn('[bandcamp-sync] saved_artists insert failed:', error.message);
-      Sentry.captureException(new Error(`saved_artists insert failed: ${error.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-    }
-  }
-
-  for (let i = 0; i < toSupport.length; i += SAVED_LOOKUP_CHUNK) {
-    const { error } = await client
-      .from('saved_artists')
-      .update({ supported: true, supported_at: serverNow, last_modified: serverNow })
-      .eq('user_id', userId)
-      .in('id', toSupport.slice(i, i + SAVED_LOOKUP_CHUNK));
-    if (error) {
-      console.warn('[bandcamp-sync] saved_artists support update failed:', error.message);
-      Sentry.captureException(new Error(`saved_artists support update failed: ${error.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-    }
-  }
-
-  if (toInsert.length > 0 || toSupport.length > 0) {
-    console.log(`[bandcamp-sync] marked supported: ${toInsert.length} new, ${toSupport.length} upgraded`);
-  }
-}
 
 /**
  * Find the artists behind the collection items this account already holds.
@@ -429,10 +282,6 @@ export async function handler(event: {
       }
     }
 
-    // Buying is supporting: mark every matched artist saved + supported. After the items
-    // land — the mark is derived state, and a failure inside degrades rather than throwing.
-    await markArtistsSupported(userId, [...matches.artists.values()]);
-
     const { error: doneError } = await client
       .from('bandcamp_connections')
       .update({
@@ -453,7 +302,7 @@ export async function handler(event: {
       body: {
         imported: uniqueAlbums.length,
         matched: matches.releases.size,
-        artistsMarked: matches.artists.size,
+        artistsMatched: matches.artists.size,
       },
     };
   } catch (error) {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -4707,8 +4707,60 @@ async function savedArtistIdsForUser(
 }
 
 /**
- * Every release worth putting in one fan's feed: across all their saved artists, dated within
- * the trailing window or still to come.
+ * The artists a fan owns a record by, resolved to artist ids.
+ *
+ * `collection_items` stores the artist as the source spells it, not a foreign key, so this
+ * resolves two ways: exactly, through a matched release's `artist_id`, and by deriving the
+ * slug with `artistSlug()` — the same key every other writer uses — for items that never
+ * matched a release. Unresolvable artists simply contribute nothing.
+ *
+ * Read failures return an empty list rather than null: the collection is an *addition* to the
+ * saved-artist feed, so a failure here should quietly narrow the feed, never blank it.
+ */
+async function collectionArtistIdsForUser(
+  client: NonNullable<ReturnType<typeof getClient>>,
+  userId: string
+): Promise<string[]> {
+  const read = await readAllPages<{ artist_name: string; releases: { artist_id: string } | null }>(
+    (from, to) =>
+      client
+        .from('collection_items')
+        .select('artist_name, releases!left (artist_id)')
+        .eq('user_id', userId)
+        .range(from, to),
+    'collection_items (feed)'
+  );
+  if (!read.ok) return [];
+
+  const ids = new Set<string>();
+  const slugs = new Set<string>();
+  for (const row of read.rows) {
+    if (row.releases?.artist_id) ids.add(row.releases.artist_id);
+    else if (row.artist_name) {
+      const slug = artistSlug(row.artist_name);
+      if (slug) slugs.add(slug);
+    }
+  }
+
+  const pending = [...slugs];
+  for (let i = 0; i < pending.length; i += 100) {
+    const { data, error } = await client
+      .from('artists')
+      .select('id')
+      .in('slug', pending.slice(i, i + 100));
+    if (error) {
+      console.error('[DB] collectionArtistIdsForUser slug resolution failed:', error.message);
+      break;
+    }
+    for (const row of (data as { id: string }[]) || []) ids.add(row.id);
+  }
+
+  return [...ids];
+}
+
+/**
+ * Every release worth putting in one fan's feed: across their saved artists *and* the artists
+ * in their collection, dated within the trailing window or still to come.
  *
  * Two exclusions match the alert path for the same reasons — hidden releases are suppressed by
  * an artist and must stay invisible, and a `needs_review` tier-3 fuzzy flag means we aren't sure
@@ -4719,8 +4771,13 @@ export async function getFeedReleasesForUser(userId: string, now: Date = new Dat
   if (!client) return [];
 
   try {
-    const artistIds = await savedArtistIdsForUser(client, userId);
-    if (artistIds === null) return [];
+    // Saved artists AND artists you own a record by. Buying somebody's album is at least as
+    // strong a signal that you want their next one as saving them is — but the two lists stay
+    // separate everywhere else, because saving is a deliberate act and an import is not.
+    const savedIds = await savedArtistIdsForUser(client, userId);
+    if (savedIds === null) return [];
+    const collectionIds = await collectionArtistIdsForUser(client, userId);
+    const artistIds = [...new Set([...savedIds, ...collectionIds])];
     if (artistIds.length === 0) return [];
 
     const { data, error } = await client

--- a/api/functions/me-listening.ts
+++ b/api/functions/me-listening.ts
@@ -1,0 +1,252 @@
+// API endpoint: /api/me/listening
+// POST — upload per-artist listening signals from a client (today: the Mac app's iCloud
+//        Music Library import). Body: { source, signals: [{ artistName, playCount, lastPlayed? }] }
+// GET  — the gap: artists you play a lot and have never supported, ranked.
+//
+// Support Loop Steps 2 and 5. This is what makes the library import more than a local
+// curiosity — without it the Mac app reads a library and nothing downstream can use it.
+//
+// Nothing here is ever public. Listening is not support: an Apple Music play, and even an
+// iTunes purchase, maps to `owned`/`listened`, never `purchased`, so none of it reaches the
+// public collection page. It also deliberately does NOT touch saved_artists — saving is a
+// deliberate act that subscribes you to release alerts, and a library scan choosing it for
+// you would bury the alerts that matter. (Bandcamp auto-marks supported because a purchase
+// *is* support; a play isn't.)
+
+import { createClient } from '@supabase/supabase-js';
+import { artistSlug, getClient, readAllPages } from './db';
+import { checkRateLimit, getClientIp } from './ratelimit';
+import { resolveArtistPages } from './collection-utils';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+};
+
+const VALID_SOURCES = new Set(['apple_music', 'lastfm', 'mac_app']);
+
+/** A library can be thousands of artists; upsert in batches PostgREST is happy with. */
+const UPSERT_CHUNK = 500;
+
+/** Ceiling on one upload. A real library is a few thousand artists at most. */
+const MAX_SIGNALS = 10_000;
+
+/** How many gap rows to return. The list is a shopping list, not a database dump. */
+const GAP_LIMIT = 100;
+
+interface IncomingSignal {
+  artistName: string;
+  playCount: number;
+  lastPlayed?: string | null;
+}
+
+async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+  const { data, error } = await createClient(url, anonKey).auth.getUser(authHeader.slice(7));
+  if (error || !data.user) return null;
+  return { userId: data.user.id };
+}
+
+/** Validate and normalise the uploaded batch. Returns null when the body is unusable. */
+export function parseSignals(raw: unknown): IncomingSignal[] | null {
+  if (!Array.isArray(raw) || raw.length > MAX_SIGNALS) return null;
+
+  // Collapse duplicates in the payload: a repeated artist in one batch is a Postgres error
+  // ("cannot affect row a second time"), not a harmless overwrite.
+  const byName = new Map<string, IncomingSignal>();
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    const artistName = typeof record.artistName === 'string' ? record.artistName.trim() : '';
+    if (!artistName || artistName.length > 300) continue;
+    const playCount =
+      typeof record.playCount === 'number' && Number.isFinite(record.playCount)
+        ? Math.max(0, Math.floor(record.playCount))
+        : 0;
+    const lastPlayed = typeof record.lastPlayed === 'string' ? record.lastPlayed : null;
+
+    const key = artistName.toLowerCase();
+    const existing = byName.get(key);
+    if (!existing) {
+      byName.set(key, { artistName, playCount, lastPlayed });
+    } else {
+      // Keep the larger count, but the *first* spelling — a later lowercase duplicate
+      // shouldn't overwrite the properly-cased name the library actually shows.
+      if (playCount > existing.playCount) existing.playCount = playCount;
+      if (lastPlayed && (!existing.lastPlayed || lastPlayed > existing.lastPlayed)) {
+        existing.lastPlayed = lastPlayed;
+      }
+    }
+  }
+  return [...byName.values()];
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  const user = await authenticateRequest(event.headers.authorization);
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    const source = typeof body.source === 'string' ? body.source : '';
+    if (!VALID_SOURCES.has(source)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Unknown source' }) };
+    }
+
+    const signals = parseSignals(body.signals);
+    if (!signals) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'signals must be an array of at most 10000 entries' }) };
+    }
+
+    const syncedAt = new Date().toISOString();
+    const rows = signals.map(s => ({
+      user_id: user.userId,
+      source,
+      artist_name: s.artistName,
+      play_count: s.playCount,
+      last_played: s.lastPlayed,
+      synced_at: syncedAt,
+    }));
+
+    for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
+      const { error } = await client
+        .from('listening_signals')
+        .upsert(rows.slice(i, i + UPSERT_CHUNK), { onConflict: 'user_id,source,artist_name' });
+      if (error) {
+        console.error('[me-listening] upsert failed:', error.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to save listening data' }) };
+      }
+    }
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ stored: rows.length, syncedAt }),
+    };
+  }
+
+  if (event.httpMethod === 'DELETE') {
+    // Deleting the uploaded signals is the counterpart to the Mac app's "Forget imported
+    // data" — the promise that turning this off actually removes it.
+    const { error } = await client.from('listening_signals').delete().eq('user_id', user.userId);
+    if (error) {
+      console.error('[me-listening] delete failed:', error.message);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to delete listening data' }) };
+    }
+    return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ deleted: true }) };
+  }
+
+  if (event.httpMethod === 'GET') {
+    const signalsRead = await readAllPages<{ artist_name: string; play_count: number; last_played: string | null }>(
+      (from, to) =>
+        client
+          .from('listening_signals')
+          .select('artist_name, play_count, last_played')
+          .eq('user_id', user.userId)
+          .order('play_count', { ascending: false })
+          .range(from, to),
+      'listening_signals'
+    );
+    if (!signalsRead.ok) {
+      console.error('[me-listening] read failed:', signalsRead.reason);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load listening data' }) };
+    }
+
+    // What counts as already supported: an artist you marked supported, or one you own a
+    // release by. Both are compared on the derived slug, the same key the Bandcamp import
+    // uses to decide who to mark — so the two halves can't disagree about who's covered.
+    const savedRead = await readAllPages<{ artist_slug: string | null; supported: boolean }>(
+      (from, to) =>
+        client
+          .from('saved_artists')
+          .select('artist_slug, supported')
+          .eq('user_id', user.userId)
+          .eq('deleted', false)
+          .range(from, to),
+      'saved_artists (gap)'
+    );
+    const collectionRead = await readAllPages<{ artist_name: string }>(
+      (from, to) =>
+        client.from('collection_items').select('artist_name').eq('user_id', user.userId).range(from, to),
+      'collection_items (gap)'
+    );
+
+    const covered = new Set<string>();
+    if (savedRead.ok) {
+      for (const row of savedRead.rows) {
+        if (row.supported && row.artist_slug) covered.add(row.artist_slug);
+      }
+    }
+    if (collectionRead.ok) {
+      for (const row of collectionRead.rows) covered.add(artistSlug(row.artist_name));
+    }
+
+    // Merge sources: the same artist can arrive from Apple Music and the now-playing
+    // monitor, and the gap should rank them by total plays, not show them twice.
+    const totals = new Map<string, { artistName: string; playCount: number; lastPlayed: string | null }>();
+    for (const row of signalsRead.rows) {
+      const slug = artistSlug(row.artist_name);
+      if (!slug || covered.has(slug)) continue;
+      const existing = totals.get(slug);
+      if (existing) {
+        existing.playCount += row.play_count;
+        if (row.last_played && (!existing.lastPlayed || row.last_played > existing.lastPlayed)) {
+          existing.lastPlayed = row.last_played;
+        }
+      } else {
+        totals.set(slug, {
+          artistName: row.artist_name,
+          playCount: row.play_count,
+          lastPlayed: row.last_played,
+        });
+      }
+    }
+
+    const ranked = [...totals.values()].sort((a, b) => b.playCount - a.playCount).slice(0, GAP_LIMIT);
+    const artistPages = await resolveArtistPages(ranked.map(r => r.artistName));
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        gap: ranked.map(r => ({
+          artistName: r.artistName,
+          playCount: r.playCount,
+          lastPlayed: r.lastPlayed,
+          artistUrl: artistPages.has(r.artistName) ? `/a/${artistPages.get(r.artistName)}` : null,
+        })),
+        totalArtists: signalsRead.rows.length,
+      }),
+    };
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -90,6 +90,8 @@
     "functions/__tests__/collection-art.test.ts",
     "functions/__tests__/feed-collection-artists.test.ts",
     "functions/__tests__/collection-matching.test.ts",
-    "functions/__tests__/sentry-environment.test.ts"
+    "functions/__tests__/sentry-environment.test.ts",
+    "functions/me-listening.ts",
+    "functions/__tests__/me-listening.test.ts"
   ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -88,6 +88,7 @@
     "functions/collection-utils.ts",
     "functions/collection-matching.ts",
     "functions/__tests__/collection-art.test.ts",
+    "functions/__tests__/feed-collection-artists.test.ts",
     "functions/__tests__/collection-matching.test.ts"
   ]
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -204,6 +204,13 @@
   to = "/.netlify/functions/collection-art"
   status = 200
 
+# Listening signals from the Mac app's iCloud Music Library import, and the gap derived from
+# them. Never public, and deliberately never writes saved_artists — see me-listening.ts.
+[[redirects]]
+  from = "/api/me/listening"
+  to = "/.netlify/functions/me-listening"
+  status = 200
+
 # Newsletter signup. Proxies to Buttondown server-side so the API key stays out of the
 # browser and the CSP doesn't need a third-party script host. Requires BUTTONDOWN_API_KEY.
 [[redirects]]


### PR DESCRIPTION
Two related corrections from Brandon testing the live features, plus the server half of the Apple Music import.

## 1. Collection imports stop writing Saved Artists

> Collection Imports should always add to the collection NOT saved artists. However, you should get upcoming/recent release information from artists both in the collection and the saved artists list.

Saving is a deliberate act that also subscribes you to release alerts; buying a record belongs in the collection. Conflating them meant one Bandcamp import wrote **35 new saved-artist rows** on his account against 8 genuine hand-made marks.

- `markArtistsSupported` and its ~145 lines are gone. Collection artists still get artist rows and catalogues — `collection-matching.ts` handles that independently — so no release data is lost.
- `getFeedReleasesForUser` now unions saved ∪ collection, resolving collection artists exactly via a matched release's `artist_id` and otherwise by deriving the slug. **This is what makes the removal safe**: without it, dropping the write would have silently emptied the dashboard feed for anyone who had imported.

Blast radius checked: that function has exactly one consumer (the dashboard's Upcoming/Recent sections). Email alerts read `saved_artists` directly and are untouched, so a 96-artist import can't become an alert flood.

## 2. `/api/me/listening` — the gap

The Apple Music import (#439) reads a library and, until now, nothing downstream could use it. Per Brandon's "gap only" scope:

- **POST** stores per-artist play counts in `listening_signals`.
- **GET** derives the gap — artists you play a lot and have never supported — subtracting artists marked supported and artists you own a record by, comparing on derived slugs so "Sigur Rós" and "sigur ros" are one artist, and merging duplicates across sources.
- **DELETE** is the counterpart to the app's "Forget Imported Data".

Deliberately absent and tested for: it never writes `saved_artists`, and none of it can reach a public page — an Apple Music play, and even an iTunes purchase, is `owned`/`listened`, never `purchased`. A saved-but-not-supported artist stays **in** the gap: saving isn't paying.

## Verification

- 1,235 API tests pass; typecheck clean; lint at the pre-existing 71-problem baseline.
- 5 new tests for the feed union against a recording fake Supabase client (real query body, including paging), **mutation-tested** — stubbing the collection lookup fails three of them.
- 14 new tests for the listening endpoint, including the slug-matching and "saved ≠ supported" cases.
- The old auto-mark tests are replaced by their inverse: the import must write no `saved_artists` rows even when every artist matches.

Pairs with #439 (the Mac client that uploads to this endpoint). Independent — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)