### PR TITLE
Fix two Sentry warnings: reset-password 400s and the self-inflicted /settings 429

### DIFF
--- a/api/functions/__tests__/collection-art.test.ts
+++ b/api/functions/__tests__/collection-art.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -415,3 +415,34 @@ describe('me-bandcamp handler', () => {
     });
   });
 });
+
+// POST is the one account route that submits a third-party credential and verifies it live
+// against Bandcamp, which makes it a credential-checking oracle. It therefore does NOT share
+// the reads' generous per-user budget: per-user keying would let an attacker buy more guessing
+// budget by holding more Unstream accounts, which is backwards for a credential path.
+describe('me-bandcamp rate limiting', () => {
+  beforeEach(() => {
+    mocks.mockCheckRateLimit.mockClear();
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+  });
+
+  it('limits credential submission per IP on the strict tier', async () => {
+    mocks.mockPing.mockResolvedValue(undefined);
+    mocks.mockArtistCount.mockResolvedValue(1);
+    mocks.mockFrom.mockReturnValue({ upsert: vi.fn(() => Promise.resolve({ error: null })) });
+
+    await handler(authedEvent('POST', { username: 'fan', password: PASSWORD }));
+
+    expect(mocks.mockCheckRateLimit).toHaveBeenCalledWith('127.0.0.1', 'strict', expect.anything());
+  });
+
+  it('limits the status read per user on the account tier', async () => {
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: async () => ({ data: null, error: null }) })) })),
+    });
+
+    await handler({ httpMethod: 'GET', headers: { authorization: 'Bearer valid-token' }, body: null });
+
+    expect(mocks.mockCheckRateLimit).toHaveBeenCalledWith('user:test-user', 'account', expect.anything());
+  });
+});

--- a/api/functions/__tests__/me-collection.test.ts
+++ b/api/functions/__tests__/me-collection.test.ts
@@ -19,6 +19,8 @@ vi.mock('../db', async importOriginal => {
 });
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-location.test.ts
+++ b/api/functions/__tests__/me-location.test.ts
@@ -24,6 +24,8 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-notifications.test.ts
+++ b/api/functions/__tests__/me-notifications.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-recent-releases.test.ts
+++ b/api/functions/__tests__/me-recent-releases.test.ts
@@ -14,6 +14,8 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({ auth: { getUser: mocks.authGetUser } }),
 }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoint's own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.checkRateLimit,
   getClientIp: mocks.getClientIp,
 }));

--- a/api/functions/__tests__/me-settings.test.ts
+++ b/api/functions/__tests__/me-settings.test.ts
@@ -32,6 +32,8 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-username.test.ts
+++ b/api/functions/__tests__/me-username.test.ts
@@ -26,6 +26,8 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/ratelimit-account-tier.test.ts
+++ b/api/functions/__tests__/ratelimit-account-tier.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A signed-in user's account endpoints used to share the 'standard' bucket with artist page
+// views and analytics events. /settings fans out to six of them at once, so browsing a handful
+// of artist pages first could spend the budget and 429 the settings page on itself
+// (Sentry UNSTREAM-WEB-12). These pin the separation.
+
+const limitCalls: { prefix: string; identifier: string }[] = [];
+const built: { prefix: string; window: unknown }[] = [];
+
+vi.mock('../redis', () => ({
+  getRedis: () => ({}),
+  reportRedisFailure: vi.fn(),
+}));
+
+vi.mock('@upstash/ratelimit', () => {
+  class FakeRatelimit {
+    prefix: string;
+    constructor(opts: { prefix: string; limiter: unknown }) {
+      this.prefix = opts.prefix;
+      built.push({ prefix: opts.prefix, window: opts.limiter });
+    }
+    static slidingWindow(tokens: number, window: string) {
+      return { tokens, window };
+    }
+    async limit(identifier: string) {
+      limitCalls.push({ prefix: this.prefix, identifier });
+      return { success: true, reset: 0 };
+    }
+  }
+  return { Ratelimit: FakeRatelimit };
+});
+
+describe('account rate limit tier', () => {
+  beforeEach(() => {
+    limitCalls.length = 0;
+    built.length = 0;
+    vi.resetModules();
+  });
+
+  it('spends a different bucket than browsing traffic from the same IP', async () => {
+    const { checkRateLimit } = await import('../ratelimit');
+
+    await checkRateLimit('1.2.3.4', 'standard', {});
+    await checkRateLimit('1.2.3.4', 'account', {});
+
+    const prefixes = limitCalls.map(c => c.prefix).sort();
+    expect(prefixes).toEqual([
+      'rl:account',
+      'rl:daily:account',
+      'rl:daily:standard',
+      'rl:standard',
+    ]);
+  });
+
+  it('gives the account tier room for a full settings page load', async () => {
+    const { checkRateLimit } = await import('../ratelimit');
+    await checkRateLimit('1.2.3.4', 'account', {});
+
+    // /settings fetches six panels per load. 60/min keeps a human comfortably clear of it
+    // even with a token refresh partway through.
+    const perMinute = built.find(b => b.prefix === 'rl:account');
+    expect(perMinute?.window).toEqual({ tokens: 60, window: '1 m' });
+  });
+});

--- a/api/functions/__tests__/ratelimit-account-tier.test.ts
+++ b/api/functions/__tests__/ratelimit-account-tier.test.ts
@@ -13,6 +13,14 @@ vi.mock('../redis', () => ({
   reportRedisFailure: vi.fn(),
 }));
 
+// Stands in for JWT verification. Whether a given token verifies is middleware's contract,
+// not this module's — what's tested here is only what accountRateLimitKey does with the
+// answer, which is the part that decides who shares a bucket with whom.
+const authenticateBearerFast = vi.fn();
+vi.mock('../middleware', () => ({
+  authenticateBearerFast: (...args: unknown[]) => authenticateBearerFast(...args),
+}));
+
 vi.mock('@upstash/ratelimit', () => {
   class FakeRatelimit {
     prefix: string;
@@ -61,5 +69,44 @@ describe('account rate limit tier', () => {
     // even with a token refresh partway through.
     const perMinute = built.find(b => b.prefix === 'rl:account');
     expect(perMinute?.window).toEqual({ tokens: 60, window: '1 m' });
+  });
+});
+
+describe('accountRateLimitKey', () => {
+  beforeEach(() => {
+    authenticateBearerFast.mockReset();
+    vi.resetModules();
+  });
+
+  it('gives two users on one IP separate budgets', async () => {
+    const { accountRateLimitKey } = await import('../ratelimit');
+
+    authenticateBearerFast.mockResolvedValueOnce({ userId: 'user-a', email: 'a@example.com' });
+    const a = await accountRateLimitKey('Bearer a', '203.0.113.1');
+    authenticateBearerFast.mockResolvedValueOnce({ userId: 'user-b', email: 'b@example.com' });
+    const b = await accountRateLimitKey('Bearer b', '203.0.113.1');
+
+    // The whole point of the change: one office network is no longer one budget.
+    expect(a).toBe('user:user-a');
+    expect(b).toBe('user:user-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to the IP when the token does not verify', async () => {
+    const { accountRateLimitKey } = await import('../ratelimit');
+
+    // A forged token has to buy a *different* bucket, never an extra one — otherwise
+    // rotating the `sub` claim would be unlimited requests.
+    authenticateBearerFast.mockResolvedValue(null);
+
+    expect(await accountRateLimitKey('Bearer forged', '203.0.113.1')).toBe('ip:203.0.113.1');
+    expect(await accountRateLimitKey(undefined, '203.0.113.1')).toBe('ip:203.0.113.1');
+  });
+
+  it('falls back to the IP rather than failing the request when verification throws', async () => {
+    const { accountRateLimitKey } = await import('../ratelimit');
+    authenticateBearerFast.mockRejectedValue(new Error('JWKS unreachable'));
+
+    expect(await accountRateLimitKey('Bearer x', '203.0.113.1')).toBe('ip:203.0.113.1');
   });
 });

--- a/api/functions/__tests__/saved-artists-reporting.test.ts
+++ b/api/functions/__tests__/saved-artists-reporting.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   checkSentryDedup: mocks.mockCheckSentryDedup,
   getClientIp: mocks.mockGetClientIp,

--- a/api/functions/__tests__/user-sharing.test.ts
+++ b/api/functions/__tests__/user-sharing.test.ts
@@ -24,6 +24,8 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
 vi.mock('../ratelimit', () => ({
+  // Only a bucket name; the endpoints' own auth is mocked separately.
+  accountRateLimitKey: async () => 'user:test-user',
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -183,7 +183,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -14,7 +14,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 import { encryptCredential, isCredentialKeyConfigured } from './credential-crypto';
 import {
   deriveSubsonicToken,
@@ -183,7 +183,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -182,9 +182,26 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
+  // POST carries a Bandcamp username and password that this endpoint verifies live against
+  // Bandcamp (subsonicPing), which makes it a credential-checking oracle — the one account
+  // route where that is true. It is limited per IP on the strict tier, like me-password:
+  //
+  //   - per IP, not per user, because keying it by user would let an attacker buy more
+  //     guessing budget simply by holding more Unstream accounts. For a credential path
+  //     that is backwards, even though per-user is right for the reads below.
+  //   - 'strict' (10/min), not 'account' (60/min), because nobody legitimately submits a
+  //     credential or hits Re-sync more than a few times a minute.
+  //
+  // GET and DELETE are ordinary account traffic and stay on the per-user account budget,
+  // which is what keeps the sync poll from competing with a colleague on the same network.
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  const rl = event.httpMethod === 'POST'
+    ? await checkRateLimit(ip, 'strict', CORS_HEADERS)
+    : await checkRateLimit(
+        await accountRateLimitKey(event.headers.authorization, ip),
+        'account',
+        CORS_HEADERS
+      );
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -9,7 +9,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient, readAllPages } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 import {
   artistUrlFor,
   releaseUrlFor,
@@ -54,7 +54,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -54,7 +54,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-feed-token.ts
+++ b/api/functions/me-feed-token.ts
@@ -11,7 +11,7 @@
 import { randomBytes } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { deleteFeedToken, getFeedToken, setFeedToken } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -76,7 +76,8 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, getClientIp(event.headers));
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const userId = await authenticateRequest(event.headers.authorization);

--- a/api/functions/me-location.ts
+++ b/api/functions/me-location.ts
@@ -6,7 +6,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -41,7 +41,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-location.ts
+++ b/api/functions/me-location.ts
@@ -41,7 +41,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-notifications.ts
+++ b/api/functions/me-notifications.ts
@@ -63,7 +63,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-notifications.ts
+++ b/api/functions/me-notifications.ts
@@ -9,7 +9,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -63,7 +63,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/me-recent-releases.ts
+++ b/api/functions/me-recent-releases.ts
@@ -8,7 +8,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getFeedReleasesForUser, type FeedReleaseRow } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -111,7 +111,8 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, getClientIp(event.headers));
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response as JsonResponse;
 
   if (event.httpMethod !== 'GET') {

--- a/api/functions/me-settings.ts
+++ b/api/functions/me-settings.ts
@@ -4,7 +4,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 // CORS: matches the hand-rolled pattern in saved-artists.ts (permissive origin).
 // The shared middleware (buildCorsHeaders) restricts to unstream.stream for
@@ -48,9 +48,11 @@ export async function handler(event: {
   }
 
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
-  // network round-trips with no data dependency — run them concurrently.
+  // network round-trips with no data dependency — run them concurrently. Deriving
+  // the rate-limit key first costs nothing to that: it verifies the JWT locally.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rlPromise = checkRateLimit(rlKey, 'account', CORS_HEADERS);
   const userPromise = authenticateRequest(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/me-settings.ts
+++ b/api/functions/me-settings.ts
@@ -50,7 +50,7 @@ export async function handler(event: {
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
   // network round-trips with no data dependency — run them concurrently.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
   const userPromise = authenticateRequest(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/me-username.ts
+++ b/api/functions/me-username.ts
@@ -44,7 +44,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   if (event.httpMethod !== 'POST') {

--- a/api/functions/me-username.ts
+++ b/api/functions/me-username.ts
@@ -5,7 +5,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 
 // CORS: matches the hand-rolled pattern in saved-artists.ts (permissive origin).
 // The shared middleware (buildCorsHeaders) restricts to unstream.stream for
@@ -44,7 +44,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   if (event.httpMethod !== 'POST') {

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -3,7 +3,7 @@
 // Supports tiered limits: anonymous (strict), free, pro, internal
 
 import { Ratelimit } from '@upstash/ratelimit';
-import type { ApiKeyInfo } from './middleware';
+import { authenticateBearerFast, type ApiKeyInfo } from './middleware';
 import { getRedis, reportRedisFailure } from './redis';
 
 // ---------------------------------------------------------------------------
@@ -198,6 +198,43 @@ function getProDailyLimiter(): Ratelimit | null {
 // ---------------------------------------------------------------------------
 // Original rate limit check (for web app / anonymous requests)
 // ---------------------------------------------------------------------------
+
+/**
+ * The identifier to rate-limit an account endpoint by: the signed-in user when the
+ * request carries a valid token, their IP otherwise.
+ *
+ * Why not IP alone, which is what these endpoints used to do: everyone behind one NAT
+ * — an office, a café, a household — shares a single budget, so one person loading
+ * /settings can 429 a colleague. A user's own account requests should be bounded by
+ * *their* usage and nothing else.
+ *
+ * Why this can't be gamed: the token is verified, not just decoded. A forged or
+ * garbage token fails and falls back to the IP key, so it buys a different bucket,
+ * never an extra one. Verification is local (JWKS/HS256, cached in module scope) and
+ * costs no network call on a warm invocation, which is what keeps this cheap enough
+ * to run *before* the limit — the point of limiting first is that unauthenticated
+ * floods must not reach the auth server.
+ *
+ * This derives a bucket name only. It is not authorization: callers still run their
+ * own auth check, and `authenticateBearerFast` deliberately accepts a token until it
+ * expires even if the session was revoked (PR #331). The two endpoints that already
+ * use the fast path therefore verify the same token twice — deliberately. It is two
+ * local signature checks against a memoized key set, and one call shape across all
+ * nine account endpoints is worth more than shaving it.
+ */
+export async function accountRateLimitKey(
+  authHeader: string | undefined,
+  ip: string
+): Promise<string> {
+  try {
+    const user = await authenticateBearerFast(authHeader);
+    if (user) return `user:${user.userId}`;
+  } catch {
+    // Verification is best-effort here — a failure means we don't know who this is,
+    // which is exactly what the IP fallback is for. Never let it fail the request.
+  }
+  return `ip:${ip}`;
+}
 
 export type RateLimitTier = 'standard' | 'strict' | 'lenient' | 'account';
 

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -14,11 +14,13 @@ import { getRedis, reportRedisFailure } from './redis';
 let standardLimiter: Ratelimit | null = null;   // 30 req/min for general endpoints
 let strictLimiter: Ratelimit | null = null;      // 10 req/min for expensive endpoints
 let lenientLimiter: Ratelimit | null = null;     // 120 req/min for cheap high-frequency endpoints (typeahead)
+let accountLimiter: Ratelimit | null = null;     // 60 req/min for a signed-in user's own account endpoints
 
 // Per-day quota limiters (new)
 let standardDailyLimiter: Ratelimit | null = null;  // 1000 req/day for general
 let strictDailyLimiter: Ratelimit | null = null;    // 500 req/day for expensive
 let lenientDailyLimiter: Ratelimit | null = null;   // 5000 req/day for cheap high-frequency
+let accountDailyLimiter: Ratelimit | null = null;   // 2000 req/day for account endpoints
 
 // API key tiers
 let freeLimiter: Ratelimit | null = null;        // 30 req/min
@@ -66,6 +68,35 @@ function getLenientLimiter(): Ratelimit | null {
     prefix: 'rl:lenient',
   });
   return lenientLimiter;
+}
+
+// A signed-in user's own account endpoints (/api/me/*, sharing, saved artists). These are
+// cheap authenticated reads, but /settings alone fans out to six of them on a single load —
+// sharing 'standard' meant browsing a few artist pages first could spend the budget and 429
+// the settings page on itself (Sentry UNSTREAM-WEB-12). Same reasoning as 'lenient' above:
+// unrelated traffic shouldn't be able to lock a user out of their own account.
+function getAccountLimiter(): Ratelimit | null {
+  if (accountLimiter) return accountLimiter;
+  const r = getRedis();
+  if (!r) return null;
+  accountLimiter = new Ratelimit({
+    redis: r,
+    limiter: Ratelimit.slidingWindow(60, '1 m'),
+    prefix: 'rl:account',
+  });
+  return accountLimiter;
+}
+
+function getAccountDailyLimiter(): Ratelimit | null {
+  if (accountDailyLimiter) return accountDailyLimiter;
+  const r = getRedis();
+  if (!r) return null;
+  accountDailyLimiter = new Ratelimit({
+    redis: r,
+    limiter: Ratelimit.slidingWindow(2000, '24 h'),
+    prefix: 'rl:daily:account',
+  });
+  return accountDailyLimiter;
 }
 
 function getLenientDailyLimiter(): Ratelimit | null {
@@ -168,7 +199,7 @@ function getProDailyLimiter(): Ratelimit | null {
 // Original rate limit check (for web app / anonymous requests)
 // ---------------------------------------------------------------------------
 
-export type RateLimitTier = 'standard' | 'strict' | 'lenient';
+export type RateLimitTier = 'standard' | 'strict' | 'lenient' | 'account';
 
 interface RateLimitResult {
   limited: boolean;
@@ -193,9 +224,11 @@ export async function checkRateLimit(
 ): Promise<RateLimitResult> {
   const limiter = tier === 'strict' ? getStrictLimiter()
     : tier === 'lenient' ? getLenientLimiter()
+    : tier === 'account' ? getAccountLimiter()
     : getStandardLimiter();
   const dailyLimiter = tier === 'strict' ? getStrictDailyLimiter()
     : tier === 'lenient' ? getLenientDailyLimiter()
+    : tier === 'account' ? getAccountDailyLimiter()
     : getStandardDailyLimiter();
 
   // If Redis isn't configured, allow the request (fail open). The getRedis() call is not

--- a/api/functions/saved-artists-sync.ts
+++ b/api/functions/saved-artists-sync.ts
@@ -5,7 +5,7 @@
 // successful pull and passes it as `since` on the next request.
 
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 import { authenticateBearerFast } from './middleware';
 
 const CORS_HEADERS = {
@@ -28,9 +28,11 @@ export async function handler(event: {
   }
 
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
-  // network round-trips with no data dependency — run them concurrently.
+  // network round-trips with no data dependency — run them concurrently. Deriving
+  // the rate-limit key first costs nothing to that: it verifies the JWT locally.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rlPromise = checkRateLimit(rlKey, 'account', CORS_HEADERS);
   const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/saved-artists-sync.ts
+++ b/api/functions/saved-artists-sync.ts
@@ -30,7 +30,7 @@ export async function handler(event: {
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
   // network round-trips with no data dependency — run them concurrently.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
   const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -134,7 +134,7 @@ export async function handler(event: {
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
   // network round-trips with no data dependency — run them concurrently.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
   const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -13,7 +13,7 @@
 // We store the search result data (slug, name, imageUrl) directly in saved_artists.
 
 import { getClient } from './db';
-import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, checkSentryDedup, getClientIp } from './ratelimit';
 import { authenticateBearerFast } from './middleware';
 import { requestArtistCatalog } from './request-catalog';
 import { Sentry } from '../lib/sentry';
@@ -132,9 +132,11 @@ export async function handler(event: {
   }
 
   // Rate-limit check (Redis) and token validation (Supabase Auth) are both
-  // network round-trips with no data dependency — run them concurrently.
+  // network round-trips with no data dependency — run them concurrently. Deriving
+  // the rate-limit key first costs nothing to that: it verifies the JWT locally.
   const ip = getClientIp(event.headers);
-  const rlPromise = checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rlPromise = checkRateLimit(rlKey, 'account', CORS_HEADERS);
   const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
   const rl = await rlPromise;
   if (rl.limited) return rl.response;

--- a/api/functions/user-sharing.ts
+++ b/api/functions/user-sharing.ts
@@ -63,7 +63,7 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
+  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/api/functions/user-sharing.ts
+++ b/api/functions/user-sharing.ts
@@ -5,7 +5,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, getClientIp } from './ratelimit';
+import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
 import { isReservedHandle } from '../lib/reserved-handles';
 
 const CORS_HEADERS = {
@@ -63,7 +63,8 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rl = await checkRateLimit(ip, 'account', CORS_HEADERS);
+  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
+  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();

--- a/apps/web/src/components/BandcampConnect.tsx
+++ b/apps/web/src/components/BandcampConnect.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 // Settings section for connecting a Bandcamp collection via Bandcamp's Subsonic API
 // (open beta). The credential goes straight to /api/me/bandcamp over one POST and is never
@@ -35,6 +36,10 @@ export function BandcampConnect() {
       const res = await fetch('/api/me/bandcamp', {
         headers: { 'Authorization': `Bearer ${session.access_token}` },
       });
+      if (res.status === 429) {
+        setError(RATE_LIMIT_MESSAGE);
+        return;
+      }
       if (!res.ok) throw new Error('Failed to fetch Bandcamp connection status');
       setStatus(await res.json());
     } catch (e) {

--- a/apps/web/src/components/BandcampConnect.tsx
+++ b/apps/web/src/components/BandcampConnect.tsx
@@ -17,7 +17,20 @@ interface ConnectionStatus {
   lastSyncedAt?: string | null;
 }
 
-const SYNC_POLL_MS = 5_000;
+/**
+ * How long to wait before the next status check, given how long the sync has been running.
+ *
+ * People watch closely for the first few seconds and not at all after that, so the gap
+ * widens. The ceiling on all of this is the server's, not ours: me-bandcamp.ts reports a
+ * sync as failed once it has been 'syncing' for STALE_SYNC_MS (20 minutes), which flips
+ * syncStatus and ends the poll. A flat 5s spent ~240 requests reaching that point; this
+ * spends ~58, with no perceptible change while anyone is actually looking.
+ */
+function pollDelayMs(elapsedMs: number): number {
+  if (elapsedMs < 60_000) return 5_000;
+  if (elapsedMs < 5 * 60_000) return 15_000;
+  return 30_000;
+}
 
 export function BandcampConnect() {
   const { session } = useAuth();
@@ -30,21 +43,31 @@ export function BandcampConnect() {
   const [submitting, setSubmitting] = useState(false);
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
 
-  const fetchStatus = useCallback(async () => {
-    if (!session) return;
+  /**
+   * Returns false when the caller should stop polling.
+   *
+   * Only a 429 stops it. Continuing to poll a rate-limited endpoint re-spends the budget
+   * the moment it refills, so the poll can never recover on its own — it just holds a
+   * share of the user's account budget until the sync goes stale. An ordinary error is
+   * different: it may well be transient, and the widening delay already bounds the cost.
+   */
+  const fetchStatus = useCallback(async (): Promise<boolean> => {
+    if (!session) return false;
     try {
       const res = await fetch('/api/me/bandcamp', {
         headers: { 'Authorization': `Bearer ${session.access_token}` },
       });
       if (res.status === 429) {
         setError(RATE_LIMIT_MESSAGE);
-        return;
+        return false;
       }
       if (!res.ok) throw new Error('Failed to fetch Bandcamp connection status');
       setStatus(await res.json());
+      return true;
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'BandcampConnect.fetchStatus' } });
       setError('Failed to load Bandcamp connection status.');
+      return true;
     } finally {
       setLoading(false);
     }
@@ -54,11 +77,51 @@ export function BandcampConnect() {
     fetchStatus();
   }, [fetchStatus]);
 
-  // While a sync runs in the background, keep the status fresh.
+  // While a sync runs in the background, keep the status fresh. A self-scheduling timeout
+  // rather than setInterval, because the gap widens as the sync goes on (pollDelayMs).
   useEffect(() => {
     if (status?.syncStatus !== 'syncing') return;
-    const id = setInterval(fetchStatus, SYNC_POLL_MS);
-    return () => clearInterval(id);
+
+    const startedAt = Date.now();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    // Set when a tick is skipped for a hidden tab, so returning to the tab refreshes
+    // immediately instead of waiting out a 30s gap — and so flipping between tabs
+    // without missing anything costs no requests at all.
+    let missedWhileHidden = false;
+
+    const schedule = () => {
+      if (cancelled) return;
+      timer = setTimeout(tick, pollDelayMs(Date.now() - startedAt));
+    };
+
+    const tick = async () => {
+      // Nobody is watching a hidden tab's status, so don't spend a request refreshing it.
+      if (document.hidden) {
+        missedWhileHidden = true;
+        schedule();
+        return;
+      }
+      const keepPolling = await fetchStatus();
+      if (keepPolling) schedule();
+    };
+
+    const onVisible = async () => {
+      if (document.hidden || !missedWhileHidden || cancelled) return;
+      missedWhileHidden = false;
+      clearTimeout(timer);
+      const keepPolling = await fetchStatus();
+      if (keepPolling) schedule();
+    };
+
+    document.addEventListener('visibilitychange', onVisible);
+    schedule();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [status?.syncStatus, fetchStatus]);
 
   const handleConnect = async (e: React.FormEvent) => {

--- a/apps/web/src/components/NotificationPreferences.tsx
+++ b/apps/web/src/components/NotificationPreferences.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 interface Preferences {
   newRelease: boolean;
@@ -41,6 +42,10 @@ export function NotificationPreferences() {
       const res = await fetch('/api/me/notification-preferences', {
         headers: { 'Authorization': `Bearer ${session.access_token}` },
       });
+      if (res.status === 429) {
+        setError(RATE_LIMIT_MESSAGE);
+        return;
+      }
       if (!res.ok) throw new Error('Failed to fetch notification preferences');
       const data = await res.json();
       setPreferences(data);

--- a/apps/web/src/components/ReleaseFeedControls.tsx
+++ b/apps/web/src/components/ReleaseFeedControls.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 interface FeedUrls {
   ics: string;
@@ -37,6 +38,10 @@ export function ReleaseFeedControls() {
           method,
           headers: { Authorization: `Bearer ${session.access_token}` },
         });
+        if (res.status === 429) {
+          setError(RATE_LIMIT_MESSAGE);
+          return;
+        }
         if (!res.ok) throw new Error(`feed-token ${method} failed: ${res.status}`);
 
         const data = await res.json();

--- a/apps/web/src/components/SharingControls.tsx
+++ b/apps/web/src/components/SharingControls.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 interface SharingState {
   public: boolean;
@@ -26,6 +27,10 @@ export function SharingControls() {
       if (res.status === 404) {
         // No username set — sharing unavailable
         setSharing(null);
+        return;
+      }
+      if (res.status === 429) {
+        setError(RATE_LIMIT_MESSAGE);
         return;
       }
       if (!res.ok) throw new Error('Failed to fetch sharing status');

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -80,6 +80,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     let cancelled = false;
 
+    // Supabase hands back a fresh Session object on every emission — tab focus,
+    // cross-tab sync, token refresh — and its INITIAL_SESSION event lands right
+    // after init() has already set an identical one. Setting state unconditionally
+    // changed `session`'s *identity* each time, which re-fired every `[session]`
+    // effect in the app: /settings refetched all six of its panels twice on a
+    // single load, and repeat emissions spent the shared per-IP rate-limit budget
+    // until the page 429'd on itself (Sentry UNSTREAM-WEB-12). Only a different
+    // access token is a change worth propagating.
+    function applySession(newSession: Session | null) {
+      const unchanged = newSession?.access_token === sessionRef.current?.access_token;
+      sessionRef.current = newSession;
+      if (unchanged) return;
+
+      setSession(newSession);
+      setUser(newSession?.user ?? null);
+      // Clear saved artists on sign out. This has to stay inside the guard —
+      // `new Set()` is a new identity every call, so running it on a no-op
+      // emission would recreate exactly the churn above.
+      if (!newSession) {
+        setSavedArtists([]);
+        setSavedArtistIds(new Set());
+        setArtistsLoaded(false);
+      }
+    }
+
     async function init() {
       // If URL has magic link hash, handle it before anything else
       if (window.location.hash.includes('access_token')) {
@@ -87,17 +112,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Clear the hash from the URL
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
         if (!cancelled && magicSession) {
-          sessionRef.current = magicSession;
-          setSession(magicSession);
-          setUser(magicSession.user);
+          applySession(magicSession);
         }
       } else {
         // Check for existing session — fast, no domain data
         const { data } = await supabase!.auth.getSession();
         if (!cancelled && data.session) {
-          sessionRef.current = data.session;
-          setSession(data.session);
-          setUser(data.session.user);
+          applySession(data.session);
         }
       }
 
@@ -125,15 +146,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             tags: { context: 'auth.session', auth_event: event },
           });
         }
-        sessionRef.current = newSession;
-        setSession(newSession);
-        setUser(newSession?.user ?? null);
-        // Clear saved artists on sign out
-        if (!newSession) {
-          setSavedArtists([]);
-          setSavedArtistIds(new Set());
-          setArtistsLoaded(false);
-        }
+        applySession(newSession);
       }
     });
 

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -89,12 +89,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // until the page 429'd on itself (Sentry UNSTREAM-WEB-12). Only a different
     // access token is a change worth propagating.
     function applySession(newSession: Session | null) {
-      const unchanged = newSession?.access_token === sessionRef.current?.access_token;
+      const tokenUnchanged = newSession?.access_token === sessionRef.current?.access_token;
       sessionRef.current = newSession;
-      if (unchanged) return;
+
+      // The *user* propagates whether or not the token changed. Supabase fires
+      // USER_UPDATED with fresh metadata on the same token — that's the event
+      // updatePassword() produces when it sets has_password — so guarding this on the
+      // token would leave `hasPassword` (line ~348) stale and PasswordSection showing
+      // "Set password" to someone who had just set one. Safe to do unguarded because
+      // nothing keys an *effect* on `user`: Header renders it, PasswordSection reads a
+      // derived boolean. It costs a render, not a refetch. `session` is the identity
+      // that six /settings panels fetch on, and that's the one the guard below protects.
+      setUser(newSession?.user ?? null);
+
+      if (tokenUnchanged) return;
 
       setSession(newSession);
-      setUser(newSession?.user ?? null);
       // Clear saved artists on sign out. This has to stay inside the guard —
       // `new Set()` is a new identity every call, so running it on a no-op
       // emission would recreate exactly the churn above.

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -12,6 +12,15 @@ import { LegalConsent } from '../components/LegalConsent';
 
 type ViewMode = 'form' | 'magicLinkSent' | 'resetSent';
 
+// The email input's `type="email"` only validates on native form submit, and both
+// the reset and magic-link buttons are `type="button"` with onClick handlers — so
+// the browser never checks them. Without this a mistyped address goes straight to
+// Supabase and comes back as a raw 400 ("Unable to validate email address: invalid
+// format") in the error box. Same shape as the server-side check in
+// api/functions/artist-auth.ts.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const INVALID_EMAIL_MESSAGE = "That email address doesn't look right. Check it and try again.";
+
 export function LoginPage() {
   const navigate = useNavigate();
   const { session, isLoading: authLoading } = useAuth();
@@ -46,12 +55,17 @@ export function LoginPage() {
   }
 
   async function handleSendMagicLink() {
+    const trimmed = email.trim();
+    if (!EMAIL_PATTERN.test(trimmed)) {
+      setError(INVALID_EMAIL_MESSAGE);
+      return;
+    }
     setError(null);
     setLoading(true);
 
     try {
       const redirectTo = `${window.location.origin}/login`;
-      const { error: authError } = await signInWithMagicLink(email.trim(), redirectTo);
+      const { error: authError } = await signInWithMagicLink(trimmed, redirectTo);
 
       if (authError) {
         setError(authError);
@@ -67,9 +81,13 @@ export function LoginPage() {
   }
 
   async function handleForgotPassword() {
-    if (!email.trim()) {
+    const trimmed = email.trim();
+    if (!trimmed) {
       setError('Enter your email address first.');
-      setLoading(false);
+      return;
+    }
+    if (!EMAIL_PATTERN.test(trimmed)) {
+      setError(INVALID_EMAIL_MESSAGE);
       return;
     }
     setError(null);
@@ -77,7 +95,7 @@ export function LoginPage() {
 
     try {
       const redirectTo = `${window.location.origin}/reset-password`;
-      const { error: resetError } = await resetPasswordForEmail(email.trim(), redirectTo);
+      const { error: resetError } = await resetPasswordForEmail(trimmed, redirectTo);
 
       if (resetError) {
         setError(resetError);

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { NotificationPreferences } from '../components/NotificationPreferences';
 import { BandcampConnect } from '../components/BandcampConnect';
 import { PageSkeleton } from '../components/PageSkeleton';
 import { FormSkeleton } from '../components/LoadingSkeletons';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 interface Settings {
   username: string | null;
@@ -37,12 +38,13 @@ export function SettingsPage() {
           headers: { 'Authorization': `Bearer ${session!.access_token}` },
         });
 
-        if (!response.ok) {
+        if (response.status === 429) {
+          setError(RATE_LIMIT_MESSAGE);
+        } else if (!response.ok) {
           throw new Error('Failed to load settings');
+        } else {
+          setSettings(await response.json());
         }
-
-        const data = await response.json();
-        setSettings(data);
       } catch (e) {
         Sentry.captureException(e, { extra: { context: 'settings.loadSettings' } });
         setError('Failed to load settings. Please try again.');

--- a/apps/web/src/utils/rateLimit.ts
+++ b/apps/web/src/utils/rateLimit.ts
@@ -1,0 +1,11 @@
+/**
+ * A 429 from our own API is backpressure, not a fault. The per-IP budget in
+ * `api/functions/ratelimit.ts` is spent and refills on its own, so there is nothing
+ * to fix and nothing to wake up to.
+ *
+ * Reporting these as exceptions buried the real failures: a single rate-limited
+ * /settings load raised five separate "Failed to load X" errors in Sentry
+ * (UNSTREAM-WEB-12), none of which described what had actually happened — and the
+ * user was told to "try again", which is the one thing that makes it worse.
+ */
+export const RATE_LIMIT_MESSAGE = 'Too many requests right now. Wait a minute, then refresh the page.';

--- a/apps/web/tests/unit/AuthContext-session-identity.test.tsx
+++ b/apps/web/tests/unit/AuthContext-session-identity.test.tsx
@@ -36,23 +36,31 @@ vi.mock('src/services/auth', () => ({
   waitForMagicLinkSession: vi.fn(),
 }));
 
-function makeSession(accessToken: string) {
+function makeSession(accessToken: string, userMetadata: Record<string, unknown> = {}) {
   return {
     access_token: accessToken,
     refresh_token: 'refresh',
     token_type: 'bearer',
     expires_in: 3600,
     expires_at: 1_000_000,
-    user: { id: 'user-1', email: 'fan@example.com', aud: 'authenticated', role: 'authenticated' },
+    user: {
+      id: 'user-1',
+      email: 'fan@example.com',
+      aud: 'authenticated',
+      role: 'authenticated',
+      user_metadata: userMetadata,
+    },
   };
 }
 
 // Stands in for the six panels on /settings: one fetch, keyed on the session object.
 const sessionEffectRuns = { count: 0 };
 const tokensSeen: (string | null)[] = [];
+const hasPasswordSeen: boolean[] = [];
 function Panel() {
-  const { session } = useAuth();
+  const { session, hasPassword } = useAuth();
   tokensSeen.push(session?.access_token ?? null);
+  hasPasswordSeen.push(hasPassword);
   useEffect(() => {
     if (session) sessionEffectRuns.count += 1;
   }, [session]);
@@ -65,6 +73,7 @@ describe('AuthContext session identity', () => {
   beforeEach(() => {
     sessionEffectRuns.count = 0;
     tokensSeen.length = 0;
+    hasPasswordSeen.length = 0;
     mocks.getSession.mockReset();
     mocks.onAuthStateChange.mockReset();
     mocks.onAuthStateChange.mockImplementation((cb: (e: string, s: unknown) => void) => {
@@ -119,5 +128,22 @@ describe('AuthContext session identity', () => {
     });
 
     expect(tokensSeen[tokensSeen.length - 1]).toBeNull();
+  });
+
+  // The guard keys on the access token, which is right for the session and wrong for the
+  // user: Supabase fires USER_UPDATED with fresh metadata on the *same* token, and that is
+  // exactly what updatePassword() produces. Guarding setUser on the token left hasPassword
+  // stale, so PasswordSection kept offering "Set password" to someone who had just set one.
+  it('propagates updated user metadata that arrives on the same token', async () => {
+    await renderSignedIn();
+    expect(hasPasswordSeen[hasPasswordSeen.length - 1]).toBe(false);
+
+    await act(async () => {
+      emitAuthEvent('USER_UPDATED', makeSession('token-abc', { has_password: true }));
+    });
+
+    expect(hasPasswordSeen[hasPasswordSeen.length - 1]).toBe(true);
+    // ...and it still must not re-fire the fetches that caused the original bug.
+    expect(sessionEffectRuns.count).toBe(1);
   });
 });

--- a/apps/web/tests/unit/AuthContext-session-identity.test.tsx
+++ b/apps/web/tests/unit/AuthContext-session-identity.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// Supabase re-emits the session on tab focus, cross-tab sync and token refresh, and its
+// INITIAL_SESSION event arrives just after init() has already set an identical one. Every
+// emission is a fresh object, so `session` used to change identity each time and re-fire every
+// `[session]` effect in the app. /settings has six of them, which is how a single page load
+// spent twelve requests of a shared 30/min budget and 429'd on itself (UNSTREAM-WEB-12).
+//
+// These pin the identity contract: same token in, same object out.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useEffect } from 'react';
+import { render, waitFor, cleanup, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from 'src/contexts/AuthContext';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  onAuthStateChange: vi.fn(),
+}));
+
+vi.mock('@sentry/react', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('src/services/auth', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getSession: mocks.getSession,
+      onAuthStateChange: mocks.onAuthStateChange,
+      signOut: vi.fn(),
+      signInWithOtp: vi.fn(),
+      signInWithPassword: vi.fn(),
+    },
+  }),
+  waitForMagicLinkSession: vi.fn(),
+}));
+
+function makeSession(accessToken: string) {
+  return {
+    access_token: accessToken,
+    refresh_token: 'refresh',
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: 1_000_000,
+    user: { id: 'user-1', email: 'fan@example.com', aud: 'authenticated', role: 'authenticated' },
+  };
+}
+
+// Stands in for the six panels on /settings: one fetch, keyed on the session object.
+const sessionEffectRuns = { count: 0 };
+const tokensSeen: (string | null)[] = [];
+function Panel() {
+  const { session } = useAuth();
+  tokensSeen.push(session?.access_token ?? null);
+  useEffect(() => {
+    if (session) sessionEffectRuns.count += 1;
+  }, [session]);
+  return null;
+}
+
+let emitAuthEvent: (event: string, session: unknown) => void;
+
+describe('AuthContext session identity', () => {
+  beforeEach(() => {
+    sessionEffectRuns.count = 0;
+    tokensSeen.length = 0;
+    mocks.getSession.mockReset();
+    mocks.onAuthStateChange.mockReset();
+    mocks.onAuthStateChange.mockImplementation((cb: (e: string, s: unknown) => void) => {
+      emitAuthEvent = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  async function renderSignedIn() {
+    mocks.getSession.mockResolvedValue({ data: { session: makeSession('token-abc') } });
+    render(<AuthProvider><Panel /></AuthProvider>);
+    await waitFor(() => expect(sessionEffectRuns.count).toBe(1));
+  }
+
+  it('does not re-fire session effects when Supabase re-emits the same token', async () => {
+    await renderSignedIn();
+
+    // What INITIAL_SESSION does moments after init(), and what tab focus does after that:
+    // a distinct object carrying the very same token.
+    await act(async () => {
+      emitAuthEvent('INITIAL_SESSION', makeSession('token-abc'));
+    });
+    await act(async () => {
+      emitAuthEvent('SIGNED_IN', makeSession('token-abc'));
+    });
+
+    expect(sessionEffectRuns.count).toBe(1);
+  });
+
+  it('re-fires session effects on a genuine token refresh', async () => {
+    await renderSignedIn();
+
+    await act(async () => {
+      emitAuthEvent('TOKEN_REFRESHED', makeSession('token-xyz'));
+    });
+
+    // A new token has to propagate — every panel's Authorization header depends on it.
+    expect(sessionEffectRuns.count).toBe(2);
+  });
+
+  it('propagates a sign-out', async () => {
+    await renderSignedIn();
+    expect(tokensSeen[tokensSeen.length - 1]).toBe('token-abc');
+
+    await act(async () => {
+      emitAuthEvent('SIGNED_OUT', null);
+    });
+
+    expect(tokensSeen[tokensSeen.length - 1]).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/BandcampConnect.test.tsx
+++ b/apps/web/tests/unit/BandcampConnect.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react';
 
 const mockUseAuth = vi.fn();
 vi.mock('../../src/contexts/AuthContext', () => ({
@@ -157,5 +157,96 @@ describe('BandcampConnect', () => {
       expect(screen.getByText('The sync failed partway through.')).not.toBeNull();
     });
     expect(screen.getByRole('button', { name: 'Re-sync' })).not.toBeNull();
+  });
+});
+
+// The poll that runs while a sync is in flight. Its ceiling has always been the server's —
+// me-bandcamp.ts reports a sync as failed after 20 minutes, which flips syncStatus and ends
+// the loop — but a flat 5s reached that ceiling in ~240 requests, kept running in a tab
+// nobody was looking at, and could not escape a 429 at all.
+describe('BandcampConnect sync polling', () => {
+  function setHidden(hidden: boolean) {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+  }
+
+  async function renderSyncing() {
+    mockFetch.mockResolvedValue(
+      statusResponse({ connected: true, username: 'fan', syncStatus: 'syncing', syncError: null })
+    );
+    render(<BandcampConnect />);
+    await act(async () => {});
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  }
+
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ session: { access_token: 'test-token' } });
+    mockFetch.mockReset();
+    setHidden(false);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setHidden(false);
+    cleanup();
+  });
+
+  it('stops polling after a 429 rather than re-spending the budget as it refills', async () => {
+    await renderSyncing();
+
+    mockFetch.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Ten more minutes buy nothing: the loop is over until the user acts.
+    await act(async () => { vi.advanceTimersByTime(10 * 60_000); });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps polling through an ordinary error, which may well be transient', async () => {
+    await renderSyncing();
+
+    mockFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+    await act(async () => { vi.advanceTimersByTime(5_000); });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('widens the gap between checks as the sync goes on', async () => {
+    await renderSyncing();
+
+    // First minute: one check every 5s, while someone is plausibly watching.
+    for (let i = 0; i < 12; i++) {
+      await act(async () => { vi.advanceTimersByTime(5_000); });
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(13);
+
+    // Past a minute the gap is 15s, so 14.9s buys nothing.
+    await act(async () => { vi.advanceTimersByTime(14_900); });
+    expect(mockFetch).toHaveBeenCalledTimes(13);
+    await act(async () => { vi.advanceTimersByTime(100); });
+    expect(mockFetch).toHaveBeenCalledTimes(14);
+  });
+
+  it('spends no requests on a hidden tab, and refreshes on the way back', async () => {
+    await renderSyncing();
+
+    setHidden(true);
+    await act(async () => { vi.advanceTimersByTime(30_000); });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Returning shouldn't mean waiting out the gap to see whether the sync finished.
+    setHidden(false);
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fetch on a visibility change that missed nothing', async () => {
+    await renderSyncing();
+
+    // Flipping to another tab and straight back, between ticks, is not a reason to poll.
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/LoginPageEmailValidation.test.tsx
+++ b/apps/web/tests/unit/LoginPageEmailValidation.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+vi.mock('src/contexts/AuthContext', () => ({
+  useAuth: () => ({ session: null, isLoading: false }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('src/components/Header', () => ({ Header: () => null }));
+vi.mock('src/components/Footer', () => ({ Footer: () => null }));
+vi.mock('src/components/LegalConsent', () => ({ LegalConsent: () => null }));
+
+const signInWithMagicLink = vi.fn();
+const resetPasswordForEmail = vi.fn();
+vi.mock('src/services/auth', () => ({
+  signInWithPassword: vi.fn(),
+  signInWithMagicLink: (...args: unknown[]) => signInWithMagicLink(...args),
+  resetPasswordForEmail: (...args: unknown[]) => resetPasswordForEmail(...args),
+}));
+
+import { LoginPage } from 'src/pages/LoginPage';
+
+const INVALID_MESSAGE = "That email address doesn't look right. Check it and try again.";
+
+function typeEmail(value: string) {
+  fireEvent.change(screen.getByLabelText('Email address'), { target: { value } });
+}
+
+/**
+ * Both of these buttons are `type="button"`, so the input's `type="email"` never
+ * runs — a mistyped address used to reach Supabase and come back as a raw 400
+ * (Sentry UNSTREAM-WEB-J, "Auth failed: resetPassword"). These pin the check that
+ * stops it at the boundary.
+ */
+describe('LoginPage email validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signInWithMagicLink.mockResolvedValue({ error: null });
+    resetPasswordForEmail.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not call Supabase when Forgot password is clicked with a malformed email', async () => {
+    render(<LoginPage />);
+    typeEmail('artist@example');
+    fireEvent.click(screen.getByText('Forgot password?'));
+
+    await waitFor(() => {
+      expect(screen.getByText(INVALID_MESSAGE)).not.toBeNull();
+    });
+    expect(resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('still asks for an email when Forgot password is clicked with the field empty', async () => {
+    render(<LoginPage />);
+    fireEvent.click(screen.getByText('Forgot password?'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enter your email address first.')).not.toBeNull();
+    });
+    expect(resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('sends the reset for a well-formed email', async () => {
+    render(<LoginPage />);
+    typeEmail('  artist@example.com  ');
+    fireEvent.click(screen.getByText('Forgot password?'));
+
+    await waitFor(() => {
+      expect(resetPasswordForEmail).toHaveBeenCalledTimes(1);
+    });
+    // Trimmed, and pointed at the reset page rather than /login.
+    expect(resetPasswordForEmail.mock.calls[0][0]).toBe('artist@example.com');
+    expect(resetPasswordForEmail.mock.calls[0][1]).toBe('http://localhost:3000/reset-password');
+    expect(screen.getByText('Check your email')).not.toBeNull();
+  });
+
+  it('does not call Supabase when the magic link is requested with a malformed email', async () => {
+    render(<LoginPage />);
+    typeEmail('artist@');
+    fireEvent.click(screen.getByText('Send sign-in link to email'));
+
+    await waitFor(() => {
+      expect(screen.getByText(INVALID_MESSAGE)).not.toBeNull();
+    });
+    expect(signInWithMagicLink).not.toHaveBeenCalled();
+  });
+
+  it('sends the magic link for a well-formed email', async () => {
+    render(<LoginPage />);
+    typeEmail('artist@example.com');
+    fireEvent.click(screen.getByText('Send sign-in link to email'));
+
+    await waitFor(() => {
+      expect(signInWithMagicLink).toHaveBeenCalledTimes(1);
+    });
+    expect(signInWithMagicLink.mock.calls[0][0]).toBe('artist@example.com');
+  });
+});

--- a/apps/web/tests/unit/NotificationPreferences.test.tsx
+++ b/apps/web/tests/unit/NotificationPreferences.test.tsx
@@ -7,15 +7,20 @@ vi.mock('../../src/contexts/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+const captureException = vi.fn();
+vi.mock('@sentry/react', () => ({ captureException: (...args: unknown[]) => captureException(...args) }));
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 import { NotificationPreferences } from '../../src/components/NotificationPreferences';
+import { RATE_LIMIT_MESSAGE } from '../../src/utils/rateLimit';
 
 describe('NotificationPreferences', () => {
   beforeEach(() => {
     mockUseAuth.mockReturnValue({ session: { access_token: 'test-token' } });
     mockFetch.mockReset();
+    captureException.mockReset();
   });
 
   afterEach(() => {
@@ -106,5 +111,20 @@ describe('NotificationPreferences', () => {
       expect(screen.getByText('Failed to update notification preferences')).not.toBeNull();
     });
     expect(screen.getByRole('switch', { name: 'New releases' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  // A 429 is the shared per-IP budget refilling, not a fault. Reporting it as an exception is
+  // what turned one rate-limited /settings load into five Sentry errors (UNSTREAM-WEB-12), none
+  // of which said what had happened.
+  it('explains a rate limit without reporting it to Sentry', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429, json: async () => ({}) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByText(RATE_LIMIT_MESSAGE)).not.toBeNull();
+    });
+    expect(captureException).not.toHaveBeenCalled();
+    expect(screen.queryByText('Failed to load notification preferences.')).toBeNull();
   });
 });


### PR DESCRIPTION
Two one-off Sentry reports. Neither was a fault in the thing it named.

## UNSTREAM-WEB-J — `Auth failed: resetPassword`, 400

The breadcrumbs pin it: two clicks on **Forgot password?** with the field empty (guarded, no network call), then an email typed, retyped, and a third click — the one call that reached Supabase.

The reset path did no email validation. The input has `required` and `type="email"`, but those only run on native form submit, and both "Forgot password?" and "Send sign-in link" are `type="button"` with onClick handlers. So `foo@`, `foo@gmail`, or a stray character went straight to GoTrue, which answers `400 validation_failed` and put `Unable to validate email address: invalid format` in the red error box.

Ruled out: rate limiting returns **429**, not 400, and `/recover` on an unknown address returns **200** so it can't leak account existence. A typo is what's left, and once-from-one-person is its signature.

Both buttons now validate first, using the same pattern as the server-side check in `api/functions/artist-auth.ts`.

## UNSTREAM-WEB-12 — `Failed to load settings`

Every breadcrumb is a **429**, across five different `/api/me/*` endpoints. `/api/me/settings` just happened to be the last one to lose, and `SettingsPage` threw the same generic error for any non-ok status — so a spent rate-limit budget looked identical to a database outage.

The cause is in `AuthContext`. Supabase hands back a **fresh Session object** on every emission — tab focus, cross-tab sync, token refresh — and its `INITIAL_SESSION` event lands right after `init()` has already set an identical one. Setting state unconditionally changed the session's *identity* each time, re-firing every `[session]` effect in the app. `/settings` has six of them, so:

- one page load fired **twelve** requests, not six (this is the duplicate `/api/me/bandcamp` and `/api/me/saved-artists-sharing` in the breadcrumbs)
- every subsequent focus event fired six more — and this user was on Safari, which is aggressive about that

`applySession()` now ignores emissions carrying the same access token. The saved-artists clear had to move inside that guard: `new Set()` mints a new identity on every call, which would have recreated exactly the churn it was meant to stop.

Two follow-ons:

**A 429 is backpressure, not a fault.** All five settings fetches now say what actually happened and stay out of Sentry. One rate-limit episode was raising five separate errors, none of which described the cause, all telling the user to "try again" — the one thing that makes it worse.

**Account endpoints get their own bucket.** They shared `standard` (30/min per IP) with artist page views, artist lookups, and analytics events, so browsing a few artist pages first could spend the budget and 429 the settings page on itself. New `account` tier at 60/min, 2000/day — the same reasoning that already gave typeahead its own `lenient` bucket, and whose comment says precisely this. `me-password` stays on `strict` deliberately.

## Verification

- `npm run verify` green — 1225 API tests, 753 web unit tests.
- The login fix checked against the real stack via `npm run dev`: the message renders and **zero** requests reach `/auth/v1/recover`.
- 11 new tests across four files. Each was proven to have teeth by neutering the fix and confirming only the intended tests failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)