### PR TITLE
Stop the cover-art proxy spending everyone's standard rate-limit budget

### DIFF
--- a/api/functions/__tests__/collection-art-ratelimit.test.ts
+++ b/api/functions/__tests__/collection-art-ratelimit.test.ts
@@ -1,0 +1,73 @@
+// Which rate-limit bucket the cover-art proxy spends.
+//
+// Separate file from collection-art.test.ts on purpose: this pins one property that is easy
+// to regress by copying another endpoint's boilerplate, and a whole page of a fan's
+// collection depends on it.
+//
+// A collection grid renders 15 tiles, and most have no stored art_url — only ~28% of a real
+// import matches an Unstream release — so one page view fires a dozen or more requests here.
+// On the 30/min 'standard' bucket that spends the person's entire budget in two page views
+// and then 429s their settings page, their release lists, and any artist page they open.
+// Reported in production 2026-08-16.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockCheckRateLimit: vi.fn((): Promise<{ limited: boolean; response?: unknown }> =>
+    Promise.resolve({ limited: false })
+  ),
+  mockGetClientIp: vi.fn(() => '203.0.113.7'),
+}));
+
+vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+
+import { handler } from '../collection-art';
+
+const ITEM_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('collection-art rate limiting', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+    mocks.mockCreateClient.mockReturnValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: 'no token' }) },
+    });
+    // Item lookup returns nothing; the request is refused after the rate-limit check, which
+    // is all this file cares about.
+    mocks.mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })) })),
+      })),
+    });
+  });
+
+  it('spends the lenient bucket, not the standard one shared with account endpoints', async () => {
+    await handler({ httpMethod: 'GET', headers: {}, pathParameters: { id: ITEM_ID } });
+
+    expect(mocks.mockCheckRateLimit).toHaveBeenCalledWith(
+      '203.0.113.7',
+      'lenient',
+      expect.anything()
+    );
+  });
+
+  it('still refuses the request when the bucket is spent', async () => {
+    mocks.mockCheckRateLimit.mockResolvedValue({
+      limited: true,
+      response: { statusCode: 429, headers: {}, body: '{"error":"Rate limit exceeded"}' },
+    });
+
+    const res = await handler({ httpMethod: 'GET', headers: {}, pathParameters: { id: ITEM_ID } });
+
+    expect(res.statusCode).toBe(429);
+    // Refused before any database work — the point of checking first.
+    expect(mocks.mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/collection-art.ts
+++ b/api/functions/collection-art.ts
@@ -87,7 +87,13 @@ export async function handler(event: {
     return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
   }
 
-  const rl = await checkRateLimit(getClientIp(event.headers), 'standard', JSON_HEADERS);
+  // 'lenient', not 'standard'. One collection page renders 15 tiles and most of them miss
+  // `art_url` (only ~28% of a real import matches an Unstream release), so a single page view
+  // fires a dozen or more requests here. On the 30/min 'standard' bucket that spends a
+  // person's whole budget in two page views and 429s them out of their own settings and
+  // release lists — which is exactly the failure the lenient tier's own comment describes for
+  // typeahead. High-frequency and low-cost (a CDN hit after the first view) is the same shape.
+  const rl = await checkRateLimit(getClientIp(event.headers), 'lenient', JSON_HEADERS);
   // `response` is optional on the rate-limit result, so returning it bare can hand Netlify
   // `undefined`. Substitute a plain 429 rather than relying on the caller's shape.
   if (rl.limited) {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -88,6 +88,7 @@
     "functions/collection-utils.ts",
     "functions/collection-matching.ts",
     "functions/__tests__/collection-art.test.ts",
+    "functions/__tests__/collection-art-ratelimit.test.ts",
     "functions/__tests__/collection-matching.test.ts",
     "functions/__tests__/sentry-environment.test.ts"
   ]


### PR DESCRIPTION
## The symptom

Reported in production today: settings failing to load, releases not loading, the collection UI apparently missing — **on one laptop, while the same account worked fine on a phone.** That's an IP-scoped 429, not a deploy or code-removal problem (I verified the deployed bundles contain all the UI, and no commit since #438 touched those pages).

## The cause

`/api/collection/art` was on the **`standard`** bucket — 30/min per IP.

A collection page renders 15 tiles, and most of them have no stored `art_url`, because only ~28% of a real import matches an Unstream release. So **one page view fires a dozen or more requests through this endpoint**, and two page views spend the whole budget. Everything else on `standard` then 429s: the release lists, artist pages, artist lookups.

The `lenient` tier's own comment already describes this exact failure for typeahead:

> fires on every debounced typing pause, so it needs its own bucket — sharing 'standard' would let an actively-searching user 429 themselves out of account actions

Cover art is the same shape: high frequency, low cost, and a CDN hit after the first view. It moves to `lenient` (120/min).

## Relationship to #455

Complementary, and both are needed:

- **#455** fixes the larger cause — `AuthContext` re-firing every `[session]` effect on each Supabase emission, doubling request counts and re-firing on every tab focus — and moves account endpoints to their own `account` tier.
- **This PR** covers the gap #455 doesn't: it never touches `collection-art.ts`, and `me-recent-releases` stays on `standard`. So without this, a collection page view can still 429 the release lists.

Merge order doesn't matter. The new test lives in its own file rather than in `collection-art.test.ts`, which #455 also edits, so they merge cleanly either way.

## Verification

- 1,225 API tests pass; typecheck clean; lint at the pre-existing 71-problem baseline.
- 2 new tests: the endpoint spends `lenient`, and a spent bucket still refuses before any database work.
- Verified the proxy itself is healthy in production — it returns real JPEGs; the problem was only its cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)