### PR TITLE
Parallelize dashboard section loads, move saved artists to AuthContext

### DIFF
--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -14,7 +14,12 @@ vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-bandcamp.test.ts
+++ b/api/functions/__tests__/me-bandcamp.test.ts
@@ -12,12 +12,18 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -120,6 +126,11 @@ describe('me-bandcamp handler', () => {
       })),
     });
   }
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: { authorization: REJECTED_TOKEN }, body: null });
+    expect(res!.statusCode).toBe(401);
+  });
 
   it('returns 401 when not authenticated', async () => {
     const res = await handler({ httpMethod: 'GET', headers: {}, body: null });

--- a/api/functions/__tests__/me-collection.test.ts
+++ b/api/functions/__tests__/me-collection.test.ts
@@ -18,12 +18,18 @@ vi.mock('../db', async importOriginal => {
   };
 });
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -54,6 +60,11 @@ describe('me-collection handler', () => {
         }),
       },
     });
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ httpMethod: 'GET', headers: { authorization: REJECTED_TOKEN }, body: null });
+    expect(res!.statusCode).toBe(401);
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/api/functions/__tests__/me-collection.test.ts
+++ b/api/functions/__tests__/me-collection.test.ts
@@ -20,7 +20,12 @@ vi.mock('../db', async importOriginal => {
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-location.test.ts
+++ b/api/functions/__tests__/me-location.test.ts
@@ -25,7 +25,12 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-location.test.ts
+++ b/api/functions/__tests__/me-location.test.ts
@@ -23,12 +23,18 @@ vi.mock('../db', () => ({
 vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -63,6 +69,11 @@ describe('me-location handler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ ...validEvent, headers: { authorization: REJECTED_TOKEN } });
+    expect(res!.statusCode).toBe(401);
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/api/functions/__tests__/me-notifications.test.ts
+++ b/api/functions/__tests__/me-notifications.test.ts
@@ -9,12 +9,18 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -49,6 +55,11 @@ describe('me-notifications handler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ ...validEvent, headers: { authorization: REJECTED_TOKEN } });
+    expect(res!.statusCode).toBe(401);
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/api/functions/__tests__/me-notifications.test.ts
+++ b/api/functions/__tests__/me-notifications.test.ts
@@ -11,7 +11,12 @@ vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('@supabase/supabase-js', () => ({ createClient: mocks.mockCreateClient }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-recent-releases.test.ts
+++ b/api/functions/__tests__/me-recent-releases.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getFeedReleasesForUser: vi.fn(),
-  authGetUser: vi.fn(),
+  resolveAccountRequest: vi.fn(),
   checkRateLimit: vi.fn(),
   getClientIp: vi.fn(() => '127.0.0.1'),
 }));
@@ -10,12 +10,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../db', () => ({
   getFeedReleasesForUser: mocks.getFeedReleasesForUser,
 }));
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({ auth: { getUser: mocks.authGetUser } }),
-}));
+// The endpoint takes its user from here now rather than calling the auth server itself:
+// deriving the per-user rate-limit bucket already verified the token.
 vi.mock('../ratelimit', () => ({
-  // Only a bucket name; the endpoint's own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  resolveAccountRequest: mocks.resolveAccountRequest,
   checkRateLimit: mocks.checkRateLimit,
   getClientIp: mocks.getClientIp,
 }));
@@ -154,7 +152,13 @@ describe('me-recent-releases handler', () => {
     process.env.SUPABASE_ANON_KEY = 'anon-key';
     mocks.checkRateLimit.mockResolvedValue({ limited: false });
     mocks.getClientIp.mockReturnValue('127.0.0.1');
-    mocks.authGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    // Default: whatever the real helper would do — a request carrying a token resolves to a
+    // user, one without doesn't. Tests that need a rejected token override it.
+    mocks.resolveAccountRequest.mockImplementation(async (authHeader?: string) =>
+      authHeader
+        ? { key: 'user:test-user', user: { userId: 'user-1', email: 'fan@example.com' } }
+        : { key: 'ip:127.0.0.1', user: null }
+    );
     mocks.getFeedReleasesForUser.mockResolvedValue([]);
   });
 
@@ -192,7 +196,9 @@ describe('me-recent-releases handler', () => {
   });
 
   it('401s without a valid bearer token, and never reads the database', async () => {
-    mocks.authGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'bad token' } });
+    // Header present, signature bad: verification fails inside the helper, so there is no
+    // user even though the request looked authenticated.
+    mocks.resolveAccountRequest.mockResolvedValue({ key: 'ip:127.0.0.1', user: null });
 
     const res = await handler(GET);
 

--- a/api/functions/__tests__/me-username.test.ts
+++ b/api/functions/__tests__/me-username.test.ts
@@ -27,7 +27,12 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/__tests__/me-username.test.ts
+++ b/api/functions/__tests__/me-username.test.ts
@@ -25,12 +25,18 @@ vi.mock('../db', () => ({
 vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -65,6 +71,11 @@ describe('me-username handler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ ...validEvent, headers: { authorization: REJECTED_TOKEN } });
+    expect(res!.statusCode).toBe(401);
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/api/functions/__tests__/ratelimit-account-tier.test.ts
+++ b/api/functions/__tests__/ratelimit-account-tier.test.ts
@@ -13,6 +13,11 @@ vi.mock('../redis', () => ({
   reportRedisFailure: vi.fn(),
 }));
 
+const captureException = vi.fn();
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureException: (...args: unknown[]) => captureException(...args) },
+}));
+
 // Stands in for JWT verification. Whether a given token verifies is middleware's contract,
 // not this module's — what's tested here is only what accountRateLimitKey does with the
 // answer, which is the part that decides who shares a bucket with whom.
@@ -119,6 +124,7 @@ describe('accountRateLimitKey', () => {
 describe('resolveAccountRequest', () => {
   beforeEach(() => {
     authenticateBearerFast.mockReset();
+    captureException.mockReset();
     vi.resetModules();
   });
 
@@ -151,6 +157,20 @@ describe('resolveAccountRequest', () => {
       key: 'ip:203.0.113.1',
       user: null,
     });
+  });
+
+  it('reports a verification it could not perform, rather than swallowing it', async () => {
+    const { resolveAccountRequest } = await import('../ratelimit');
+    // Reaching this needs local verification to be unavailable *and* the auth-server fallback
+    // inside authenticateBearerFast to fail outright — i.e. Supabase Auth is unreachable. The
+    // caller will answer 401, telling a signed-in person they aren't signed in, so a wave of
+    // these has to be visible as an outage rather than looking like expired sessions.
+    authenticateBearerFast.mockRejectedValue(new Error('JWKS unreachable'));
+
+    const resolved = await resolveAccountRequest('Bearer x', '203.0.113.1');
+
+    expect(resolved).toEqual({ key: 'ip:203.0.113.1', user: null });
+    expect(captureException).toHaveBeenCalledTimes(1);
   });
 
   it('verifies the token once per request', async () => {

--- a/api/functions/__tests__/ratelimit-account-tier.test.ts
+++ b/api/functions/__tests__/ratelimit-account-tier.test.ts
@@ -110,3 +110,56 @@ describe('accountRateLimitKey', () => {
     expect(await accountRateLimitKey('Bearer x', '203.0.113.1')).toBe('ip:203.0.113.1');
   });
 });
+
+// The account endpoints take their user from here rather than calling the auth server a
+// second time for a user id the bucket already required. What has to hold is that the user
+// reported alongside the key is the one the key was derived from, and that "no bucket for
+// this user" and "no user" stay the same answer — otherwise an endpoint could act on a
+// caller whose token never verified.
+describe('resolveAccountRequest', () => {
+  beforeEach(() => {
+    authenticateBearerFast.mockReset();
+    vi.resetModules();
+  });
+
+  it('reports the verified user alongside the key derived from it', async () => {
+    const { resolveAccountRequest } = await import('../ratelimit');
+    authenticateBearerFast.mockResolvedValue({ userId: 'user-a', email: 'a@example.com' });
+
+    expect(await resolveAccountRequest('Bearer a', '203.0.113.1')).toEqual({
+      key: 'user:user-a',
+      user: { userId: 'user-a', email: 'a@example.com' },
+    });
+  });
+
+  it('reports no user whenever it falls back to the IP bucket', async () => {
+    const { resolveAccountRequest } = await import('../ratelimit');
+
+    authenticateBearerFast.mockResolvedValue(null);
+    expect(await resolveAccountRequest('Bearer forged', '203.0.113.1')).toEqual({
+      key: 'ip:203.0.113.1',
+      user: null,
+    });
+    expect(await resolveAccountRequest(undefined, '203.0.113.1')).toEqual({
+      key: 'ip:203.0.113.1',
+      user: null,
+    });
+
+    // A verification that throws is "we don't know who this is", not "trust them".
+    authenticateBearerFast.mockRejectedValue(new Error('JWKS unreachable'));
+    expect(await resolveAccountRequest('Bearer x', '203.0.113.1')).toEqual({
+      key: 'ip:203.0.113.1',
+      user: null,
+    });
+  });
+
+  it('verifies the token once per request', async () => {
+    const { resolveAccountRequest } = await import('../ratelimit');
+    authenticateBearerFast.mockResolvedValue({ userId: 'user-a', email: 'a@example.com' });
+
+    await resolveAccountRequest('Bearer a', '203.0.113.1');
+
+    // The whole point: one check answers both "which bucket" and "which user".
+    expect(authenticateBearerFast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/functions/__tests__/saved-artists-reporting.test.ts
+++ b/api/functions/__tests__/saved-artists-reporting.test.ts
@@ -21,13 +21,18 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({ getClient: () => ({ from: mocks.mockFrom }) }));
 vi.mock('../ratelimit', () => ({
-  // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // The endpoint now takes its user from here rather than authenticating separately, so this
+  // stands in for the real helper: one local verification, reported as both the bucket and
+  // the caller. Driving it off the same mock keeps every mockAuthenticateBearerFast(...) in
+  // the tests below meaningful.
+  resolveAccountRequest: async (authHeader?: string) => {
+    const user = await mocks.mockAuthenticateBearerFast(authHeader);
+    return { key: user ? `user:${user.userId}` : 'ip:127.0.0.1', user: user ?? null };
+  },
   checkRateLimit: mocks.mockCheckRateLimit,
   checkSentryDedup: mocks.mockCheckSentryDedup,
   getClientIp: mocks.mockGetClientIp,
 }));
-vi.mock('../middleware', () => ({ authenticateBearerFast: mocks.mockAuthenticateBearerFast }));
 vi.mock('../request-catalog', () => ({ requestArtistCatalog: mocks.mockRequestArtistCatalog }));
 vi.mock('../../lib/sentry', () => ({
   Sentry: { captureMessage: mocks.mockCaptureMessage, captureException: mocks.mockCaptureException },

--- a/api/functions/__tests__/user-sharing.test.ts
+++ b/api/functions/__tests__/user-sharing.test.ts
@@ -23,12 +23,18 @@ vi.mock('../db', () => ({
 vi.mock('@supabase/supabase-js', () => ({
   createClient: mocks.mockCreateClient,
 }));
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
   // Mirrors the real helper: deriving the bucket verifies the token, so a request that
-  // carries one resolves to a user and one that doesn't resolves to null.
+  // carries a good one resolves to a user. A missing header and the REJECTED_TOKEN sentinel
+  // both resolve to null — the second is how a test says "header present, signature bad",
+  // which is the case an auth regression would actually hide. Treating every truthy header
+  // as authenticated would let such a test pass without exercising anything.
   resolveAccountRequest: async (authHeader?: string) =>
-    authHeader
+    authHeader && authHeader !== REJECTED_TOKEN
       ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
       : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
@@ -65,6 +71,11 @@ describe('user-sharing handler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ ...validEvent, headers: { authorization: REJECTED_TOKEN } });
+    expect(res!.statusCode).toBe(401);
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/api/functions/__tests__/user-sharing.test.ts
+++ b/api/functions/__tests__/user-sharing.test.ts
@@ -25,7 +25,12 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 vi.mock('../ratelimit', () => ({
   // Only a bucket name; the endpoints' own auth is mocked separately.
-  accountRateLimitKey: async () => 'user:test-user',
+  // Mirrors the real helper: deriving the bucket verifies the token, so a request that
+  // carries one resolves to a user and one that doesn't resolves to null.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader
+      ? { key: 'user:test-user', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
   checkRateLimit: mocks.mockCheckRateLimit,
   getClientIp: mocks.mockGetClientIp,
 }));

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -11,10 +11,9 @@
 // (t, s) pair, encrypted (credential-crypto.ts), and discarded. It must never be logged,
 // stored, echoed back, or attached to a Sentry event.
 
-import { createClient } from '@supabase/supabase-js';
 import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import { encryptCredential, isCredentialKeyConfigured } from './credential-crypto';
 import {
   deriveSubsonicToken,
@@ -77,20 +76,6 @@ function toStatusShape(row: ConnectionRow | null) {
     itemCount: row.item_count,
     lastSyncedAt: row.last_synced_at,
   };
-}
-
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id };
 }
 
 /**
@@ -194,22 +179,32 @@ export async function handler(event: {
   //
   // GET and DELETE are ordinary account traffic and stay on the per-user account budget,
   // which is what keeps the sync poll from competing with a colleague on the same network.
+  //
+  // The two orders below are deliberate, and this is the one endpoint where they differ.
+  // POST is limited *before* its token is examined at all, so a flood of unauthenticated
+  // credential attempts can't reach the auth server even on a cold invocation. GET and
+  // DELETE need the user to derive their per-user bucket, so they verify first — locally,
+  // at no round-trip cost on a warm invocation (see resolveAccountRequest).
   const ip = getClientIp(event.headers);
-  const rl = event.httpMethod === 'POST'
-    ? await checkRateLimit(ip, 'strict', CORS_HEADERS)
-    : await checkRateLimit(
-        await accountRateLimitKey(event.headers.authorization, ip),
-        'account',
-        CORS_HEADERS
-      );
-  if (rl.limited) return rl.response;
+  const isCredentialWrite = event.httpMethod === 'POST';
+
+  if (isCredentialWrite) {
+    const rl = await checkRateLimit(ip, 'strict', CORS_HEADERS);
+    if (rl.limited) return rl.response;
+  }
+
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+
+  if (!isCredentialWrite) {
+    const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
+    if (rl.limited) return rl.response;
+  }
 
   const client = getClient();
   if (!client) {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -7,9 +7,8 @@
 // from this. Writes to collection_items happen only in sync code (bandcamp-sync-background)
 // — this endpoint can flip `hidden` and nothing else, so provenance stays server-asserted.
 
-import { createClient } from '@supabase/supabase-js';
 import { getClient, readAllPages } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import {
   artistUrlFor,
   releaseUrlFor,
@@ -30,20 +29,6 @@ const ITEM_COLUMNS =
 /** The same columns plus the joins the grid needs to build release and artist links. */
 const ITEM_COLUMNS_WITH_LINKS = `${ITEM_COLUMNS}, releases!left (slug, artwork_url, artists (slug))`;
 
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id };
-}
-
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -53,9 +38,11 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();
@@ -63,7 +50,6 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/me-feed-token.ts
+++ b/api/functions/me-feed-token.ts
@@ -9,9 +9,8 @@
 // files in api/tsconfig.json's typecheck include — keep this one in it.
 
 import { randomBytes } from 'crypto';
-import { createClient } from '@supabase/supabase-js';
 import { deleteFeedToken, getFeedToken, setFeedToken } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -38,20 +37,6 @@ function generateToken(): string {
   return randomBytes(32).toString('base64url');
 }
 
-async function authenticateRequest(authHeader: string | undefined): Promise<string | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return data.user.id;
-}
-
 function feedUrls(token: string) {
   return {
     ics: `${SITE}/feed/f/${token}.ics`,
@@ -76,12 +61,14 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  const rlKey = await accountRateLimitKey(event.headers.authorization, getClientIp(event.headers));
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, getClientIp(event.headers));
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
-  const userId = await authenticateRequest(event.headers.authorization);
-  if (!userId) return json(401, { error: 'Not signed in' });
+  if (!user) return json(401, { error: 'Not signed in' });
+  const userId = user.userId;
 
   if (event.httpMethod === 'GET') {
     // Created on first read rather than at signup: most fans will never subscribe, and a token

--- a/api/functions/me-location.ts
+++ b/api/functions/me-location.ts
@@ -4,9 +4,8 @@
 // Body: { location: string | null }
 // Returns the new location on success, or a friendly error on failure.
 
-import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -16,20 +15,6 @@ const CORS_HEADERS = {
 };
 
 const MAX_LENGTH = 100;
-
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id, email: data.user.email || '' };
-}
 
 export async function handler(event: {
   httpMethod: string;
@@ -41,8 +26,10 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();
@@ -50,7 +37,6 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/me-notifications.ts
+++ b/api/functions/me-notifications.ts
@@ -7,9 +7,8 @@
 // once they actually change something. Every sender (notifications.ts,
 // weekly-analytics-recap.ts) treats a missing row the same way.
 
-import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -39,20 +38,6 @@ function toResponseShape(row: PreferencesRow | null) {
   };
 }
 
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id };
-}
-
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -63,8 +48,10 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();
@@ -72,7 +59,6 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/me-recent-releases.ts
+++ b/api/functions/me-recent-releases.ts
@@ -6,9 +6,8 @@
 // Follows the same conventions as the other me-* endpoints (bearer auth against the anon client,
 // hand-rolled permissive CORS) and is in api/tsconfig.json's typecheck include — keep it there.
 
-import { createClient } from '@supabase/supabase-js';
 import { getFeedReleasesForUser, type FeedReleaseRow } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -33,20 +32,6 @@ interface JsonResponse {
   statusCode: number;
   headers: Record<string, string>;
   body: string;
-}
-
-async function authenticateRequest(authHeader: string | undefined): Promise<string | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return data.user.id;
 }
 
 function toShortlistRow(row: FeedReleaseRow) {
@@ -111,8 +96,10 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  const rlKey = await accountRateLimitKey(event.headers.authorization, getClientIp(event.headers));
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, getClientIp(event.headers));
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response as JsonResponse;
 
   if (event.httpMethod !== 'GET') {
@@ -123,12 +110,11 @@ export async function handler(event: {
     };
   }
 
-  const userId = await authenticateRequest(event.headers.authorization);
-  if (!userId) {
+  if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not signed in' }) };
   }
 
-  const rows = await getFeedReleasesForUser(userId);
+  const rows = await getFeedReleasesForUser(user.userId);
 
   return {
     statusCode: 200,

--- a/api/functions/me-settings.ts
+++ b/api/functions/me-settings.ts
@@ -20,6 +20,16 @@ const CORS_HEADERS = {
 // getUser(token) validates the token against the auth server and returns the
 // user's *current* record (not the stale token claims), so email and
 // user_metadata here are as fresh as a separate admin.getUserById lookup.
+//
+// This is the one account endpoint that still pays for that round trip. The others take
+// their user from resolveAccountRequest, which verifies the JWT locally — but local
+// verification surfaces only `sub` and `email`, and this endpoint needs
+// `user_metadata.has_password`. Reading that from token claims would be a guess about what
+// Supabase puts in an access token, and getting it wrong shows somebody who has a password
+// the "your account was created with a magic link" branch of /settings. So it stays.
+//
+// The cost is smaller here than it looks: the call below is started *before* the rate-limit
+// check and awaited after, so the round trip overlaps Redis rather than following it.
 async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string; hasPassword: boolean } | null> {
   if (!authHeader?.startsWith('Bearer ')) return null;
   const token = authHeader.slice(7);

--- a/api/functions/me-username.ts
+++ b/api/functions/me-username.ts
@@ -3,9 +3,8 @@
 // Body: { username: string }
 // Returns the new username on success, or a friendly error on failure.
 
-import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 // CORS: matches the hand-rolled pattern in saved-artists.ts (permissive origin).
 // The shared middleware (buildCorsHeaders) restricts to unstream.stream for
@@ -20,20 +19,6 @@ const CORS_HEADERS = {
 
 const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$/;
 
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id, email: data.user.email || '' };
-}
-
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -44,8 +29,10 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   if (event.httpMethod !== 'POST') {
@@ -57,7 +44,6 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/middleware.ts
+++ b/api/functions/middleware.ts
@@ -95,7 +95,7 @@ function getJwks(supabaseUrl: string): ReturnType<typeof createRemoteJWKSet> {
   return jwks;
 }
 
-interface BearerUser {
+export interface BearerUser {
   userId: string;
   email: string;
 }

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -3,7 +3,7 @@
 // Supports tiered limits: anonymous (strict), free, pro, internal
 
 import { Ratelimit } from '@upstash/ratelimit';
-import { authenticateBearerFast, type ApiKeyInfo } from './middleware';
+import { authenticateBearerFast, type ApiKeyInfo, type BearerUser } from './middleware';
 import { getRedis, reportRedisFailure } from './redis';
 
 // ---------------------------------------------------------------------------
@@ -215,25 +215,56 @@ function getProDailyLimiter(): Ratelimit | null {
  * to run *before* the limit — the point of limiting first is that unauthenticated
  * floods must not reach the auth server.
  *
- * This derives a bucket name only. It is not authorization: callers still run their
- * own auth check, and `authenticateBearerFast` deliberately accepts a token until it
- * expires even if the session was revoked (PR #331). The two endpoints that already
- * use the fast path therefore verify the same token twice — deliberately. It is two
- * local signature checks against a memoized key set, and one call shape across all
- * nine account endpoints is worth more than shaving it.
+ * Prefer `resolveAccountRequest` below, which hands back the verified user alongside the
+ * key so the caller doesn't re-verify. This narrower version remains for callers that
+ * genuinely only want a bucket name.
  */
 export async function accountRateLimitKey(
   authHeader: string | undefined,
   ip: string
 ): Promise<string> {
+  return (await resolveAccountRequest(authHeader, ip)).key;
+}
+
+/** A rate-limit bucket plus whoever the request's token says it belongs to. */
+export interface AccountRequest {
+  /** `user:<id>` when the token verified, `ip:<addr>` when it didn't. */
+  key: string;
+  /** The verified user, or null when the request carries no usable token. */
+  user: BearerUser | null;
+}
+
+/**
+ * Derive the rate-limit bucket *and* keep the user that deriving it already produced.
+ *
+ * The bucket can only be keyed by user if the token has been verified, so by the time a
+ * key exists the work of authenticating is done. Discarding the result meant nine account
+ * endpoints then called `anonClient.auth.getUser(token)` to learn the same user id — a
+ * round trip to the auth server on every request, on top of a local check that had
+ * already answered.
+ *
+ * #458 noted the double verification and judged it fine, correctly, for the two endpoints
+ * on the fast path: two local signature checks against a memoized key set cost nothing.
+ * That reasoning didn't extend to the rest, where the second check leaves the building.
+ *
+ * The trade this makes explicit is PR #331's, now applied to these endpoints too: a
+ * session revoked server-side keeps working until its access token expires (~1 hour).
+ * That is fine for reads and for a user's own settings. Where a fresh server-side check
+ * matters more than latency — `me-password`, which changes a credential, and the admin
+ * paths — keep using `authenticateBearer`.
+ */
+export async function resolveAccountRequest(
+  authHeader: string | undefined,
+  ip: string
+): Promise<AccountRequest> {
   try {
     const user = await authenticateBearerFast(authHeader);
-    if (user) return `user:${user.userId}`;
+    if (user) return { key: `user:${user.userId}`, user };
   } catch {
     // Verification is best-effort here — a failure means we don't know who this is,
     // which is exactly what the IP fallback is for. Never let it fail the request.
   }
-  return `ip:${ip}`;
+  return { key: `ip:${ip}`, user: null };
 }
 
 export type RateLimitTier = 'standard' | 'strict' | 'lenient' | 'account';

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -3,6 +3,7 @@
 // Supports tiered limits: anonymous (strict), free, pro, internal
 
 import { Ratelimit } from '@upstash/ratelimit';
+import { Sentry } from '../lib/sentry';
 import { authenticateBearerFast, type ApiKeyInfo, type BearerUser } from './middleware';
 import { getRedis, reportRedisFailure } from './redis';
 
@@ -260,9 +261,22 @@ export async function resolveAccountRequest(
   try {
     const user = await authenticateBearerFast(authHeader);
     if (user) return { key: `user:${user.userId}`, user };
-  } catch {
-    // Verification is best-effort here — a failure means we don't know who this is,
-    // which is exactly what the IP fallback is for. Never let it fail the request.
+  } catch (error) {
+    // Verification is best-effort for the *bucket* — not knowing who this is, is exactly
+    // what the IP fallback is for, and this must never fail the request.
+    //
+    // But it decides the *user* too now, and "we couldn't check the token" is not the same
+    // answer as "the token is bad". A throw here needs both local verification to be
+    // unavailable and the auth-server fallback inside authenticateBearerFast to fail
+    // outright, so it means Supabase Auth is unreachable — and the caller will answer 401,
+    // telling a signed-in person they aren't. Before this helper owned the auth decision
+    // that same outage surfaced as an unhandled 500, which at least reached Sentry. So it
+    // is reported rather than swallowed: a wave of these is an outage, not expired sessions.
+    Sentry.captureException(error, {
+      level: 'warning',
+      tags: { context: 'ratelimit.resolveAccountRequest' },
+      extra: { note: 'token verification unavailable — request will be treated as signed out' },
+    });
   }
   return { key: `ip:${ip}`, user: null };
 }

--- a/api/functions/saved-artists-sync.ts
+++ b/api/functions/saved-artists-sync.ts
@@ -5,8 +5,7 @@
 // successful pull and passes it as `since` on the next request.
 
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
-import { authenticateBearerFast } from './middleware';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -27,14 +26,12 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  // Rate-limit check (Redis) and token validation (Supabase Auth) are both
-  // network round-trips with no data dependency — run them concurrently. Deriving
-  // the rate-limit key first costs nothing to that: it verifies the JWT locally.
+  // The per-user rate-limit bucket can only exist once the token has been verified, so
+  // resolving the bucket resolves the caller too — one local JWT check, not two, and no
+  // round trip to the auth server on a warm invocation (see resolveAccountRequest).
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rlPromise = checkRateLimit(rlKey, 'account', CORS_HEADERS);
-  const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
-  const rl = await rlPromise;
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();
@@ -46,7 +43,6 @@ export async function handler(event: {
     return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  const user = await userPromise;
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/api/functions/saved-artists.ts
+++ b/api/functions/saved-artists.ts
@@ -13,8 +13,7 @@
 // We store the search result data (slug, name, imageUrl) directly in saved_artists.
 
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, checkSentryDedup, getClientIp } from './ratelimit';
-import { authenticateBearerFast } from './middleware';
+import { checkRateLimit, resolveAccountRequest, checkSentryDedup, getClientIp } from './ratelimit';
 import { requestArtistCatalog } from './request-catalog';
 import { Sentry } from '../lib/sentry';
 
@@ -131,14 +130,12 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }
 
-  // Rate-limit check (Redis) and token validation (Supabase Auth) are both
-  // network round-trips with no data dependency — run them concurrently. Deriving
-  // the rate-limit key first costs nothing to that: it verifies the JWT locally.
+  // The per-user rate-limit bucket can only exist once the token has been verified, so
+  // resolving the bucket resolves the caller too — one local JWT check, not two, and no
+  // round trip to the auth server on a warm invocation (see resolveAccountRequest).
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rlPromise = checkRateLimit(rlKey, 'account', CORS_HEADERS);
-  const userPromise = authenticateBearerFast(event.headers.authorization).catch(() => null);
-  const rl = await rlPromise;
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getServiceClient();
@@ -153,7 +150,6 @@ export async function handler(event: {
 
   // GET: List user's saved artists (auth required)
   if (event.httpMethod === 'GET') {
-    const user = await userPromise;
     if (!user) {
       return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
     }
@@ -221,7 +217,6 @@ export async function handler(event: {
 
   // POST: Route by action field
   if (event.httpMethod === 'POST') {
-    const user = await userPromise;
     if (!user) {
       return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
     }

--- a/api/functions/user-sharing.ts
+++ b/api/functions/user-sharing.ts
@@ -3,9 +3,8 @@
 // POST — toggles sharing on/off. Body: { public: boolean }
 // Sharing requires a username (set via /settings). 404 if no username.
 
-import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
-import { checkRateLimit, accountRateLimitKey, getClientIp } from './ratelimit';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import { isReservedHandle } from '../lib/reserved-handles';
 
 const CORS_HEADERS = {
@@ -39,20 +38,6 @@ function purgeCacheTag(handle: string): void {
     .catch((e) => console.error(`[user-sharing] CDN cache purge failed for user-share-${handle}:`, e));
 }
 
-async function authenticateRequest(authHeader: string | undefined): Promise<{ userId: string; email: string } | null> {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-
-  const url = process.env.SUPABASE_URL;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey) return null;
-
-  const anonClient = createClient(url, anonKey);
-  const { data, error } = await anonClient.auth.getUser(token);
-  if (error || !data.user) return null;
-  return { userId: data.user.id, email: data.user.email || '' };
-}
-
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -63,8 +48,10 @@ export async function handler(event: {
   }
 
   const ip = getClientIp(event.headers);
-  const rlKey = await accountRateLimitKey(event.headers.authorization, ip);
-  const rl = await checkRateLimit(rlKey, 'account', CORS_HEADERS);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
   const client = getClient();
@@ -72,7 +59,6 @@ export async function handler(event: {
     return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const user = await authenticateRequest(event.headers.authorization);
   if (!user) {
     return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
   }

--- a/apps/web/src/components/ClaimedArtistsSection.tsx
+++ b/apps/web/src/components/ClaimedArtistsSection.tsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { useAuth } from '../contexts/AuthContext';
+import { ArtistAnalytics } from './ArtistAnalytics';
+
+// The artist half of the dashboard: the profiles this user has claimed, with their stats.
+//
+// It fetches and skeletons on its own rather than being handed data by the page. Nothing
+// below it on the dashboard depends on the answer, so making the whole page wait for this
+// one — which is what a single page-level `loading` flag did — delayed the collection read
+// by a full round trip for no reason.
+
+interface ClaimedProfile {
+  id: string;
+  artistId: string;
+  name: string;
+  slug: string;
+  imageUrl?: string;
+  websiteUrl?: string;
+  bio?: string;
+  claimedAt: string;
+}
+
+export function ClaimedArtistsSection() {
+  const { session } = useAuth();
+  const navigate = useNavigate();
+  const [profiles, setProfiles] = useState<ClaimedProfile[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!session) return;
+    const controller = new AbortController();
+
+    fetch('/api/artist-auth', {
+      headers: { 'Authorization': `Bearer ${session.access_token}` },
+      signal: controller.signal,
+    })
+      .then(response => {
+        // A rejected token here means the session is gone, not that this section failed.
+        if (response.status === 401) {
+          navigate('/login', { replace: true });
+          return null;
+        }
+        if (!response.ok) throw new Error(`artist-auth failed: ${response.status}`);
+        return response.json();
+      })
+      .then(data => {
+        if (data) setProfiles(data.profiles || []);
+      })
+      .catch(e => {
+        if (controller.signal.aborted) return;
+        Sentry.captureException(e, { extra: { context: 'dashboard.loadClaimedProfiles' } });
+        setError("Couldn't load your artist profiles. Try refreshing.");
+        setProfiles([]);
+      });
+
+    return () => controller.abort();
+  }, [session, navigate]);
+
+  // Most people have claimed nothing, so this section stays entirely absent for them —
+  // including while it loads. A skeleton that resolves to nothing is worse than no skeleton.
+  if (!error && (profiles === null || profiles.length === 0)) {
+    return null;
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+        <svg className="w-5 h-5 text-accent-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM21 16c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
+        </svg>
+        Your Artists
+      </h2>
+
+      {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+
+      <div className="space-y-3">
+        {(profiles || []).map(profile => (
+          <div
+            key={profile.id}
+            className="p-4 rounded-lg bg-bg-secondary border border-border hover:border-border-hover transition-colors"
+          >
+            <div className="flex gap-4">
+              <div className="flex-shrink-0">
+                {profile.imageUrl ? (
+                  <img
+                    src={profile.imageUrl}
+                    alt={profile.name}
+                    className="w-12 h-12 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-12 h-12 rounded-full bg-bg-hover flex items-center justify-center text-text-muted text-lg">
+                    {profile.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold truncate">{profile.name}</p>
+                <p className="text-sm text-text-muted truncate">
+                  unstream.stream/a/{profile.slug}
+                </p>
+                <div className="flex items-center gap-2 mt-3">
+                  <Link
+                    to={`/artist-edit/${profile.slug}`}
+                    className="px-3 py-1.5 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
+                  >
+                    Edit
+                  </Link>
+                  <Link
+                    to={`/a/${profile.slug}`}
+                    className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
+                  >
+                    View
+                  </Link>
+                  {/* Reachable from the profile editor too, but releases are the thing an
+                      artist comes back to correct — worth one click from here. */}
+                  <Link
+                    to={`/artist-edit/${profile.slug}/releases`}
+                    className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
+                  >
+                    Releases
+                  </Link>
+                </div>
+              </div>
+            </div>
+            <ArtistAnalytics slug={profile.slug} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/SavedArtistsSection.tsx
+++ b/apps/web/src/components/SavedArtistsSection.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import type { SavedArtist } from '../contexts/AuthContext';
+import { SkeletonScreen } from './Skeleton';
+import { ArtistRowsSkeleton } from './LoadingSkeletons';
+
+// The fan half of the dashboard: artists saved to come back to, and which of them have
+// actually been supported.
+//
+// The list comes from AuthContext — the same one the save buttons on search results and
+// artist pages read — rather than a second copy fetched here. Two copies is how removing an
+// artist on this page left the heart on a search result still filled in for the rest of the
+// session: the dashboard mutated its own array and nothing told the context.
+
+const PAGE_SIZE = 10;
+
+export function SavedArtistsSection() {
+  const { session, savedArtists, artistsLoaded, loadSavedArtists, removeSavedArtist, saveArtist, setArtistSupported } = useAuth();
+
+  const [error, setError] = useState<string | null>(null);
+  const [undo, setUndo] = useState<SavedArtist | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    if (!session) return;
+    const controller = new AbortController();
+    loadSavedArtists(controller.signal);
+    return () => controller.abort();
+  }, [session, loadSavedArtists]);
+
+  useEffect(() => {
+    if (!undo) return;
+    const timer = setTimeout(() => setUndo(null), 6000);
+    return () => clearTimeout(timer);
+  }, [undo]);
+
+  const totalPages = Math.max(1, Math.ceil(savedArtists.length / PAGE_SIZE));
+  // Clamped rather than corrected in state: a removal that empties the last page should show
+  // the new last page on this render, not after a second one.
+  const currentPage = Math.min(page, totalPages);
+  const visible = savedArtists.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  async function handleRemove(artist: SavedArtist) {
+    setError(null);
+    // The row goes immediately — the context is optimistic — but the Undo offer waits for the
+    // server. A refused removal is rolled back, and "Removed X · Undo" above a row that is
+    // still there misdescribes what happened.
+    const removed = await removeSavedArtist(artist.artistId);
+    if (removed) {
+      setUndo(artist);
+    } else {
+      setError('Failed to remove artist. Please try again.');
+    }
+  }
+
+  async function handleUndo(artist: SavedArtist) {
+    setUndo(null);
+    await saveArtist(artist.artistId, artist.notes, artist.name, artist.imageUrl);
+    // Restoring the save doesn't restore the supported mark, and that mark records something
+    // the fan actually did — so it goes back too rather than being quietly dropped.
+    if (artist.supported) {
+      try {
+        await setArtistSupported(artist.artistId, true);
+      } catch {
+        setError("Restored, but couldn't restore the supported mark. Try setting it again.");
+      }
+    }
+  }
+
+  async function handleToggleSupport(artist: SavedArtist) {
+    setError(null);
+    setBusyId(artist.artistId);
+    try {
+      await setArtistSupported(artist.artistId, !artist.supported);
+    } catch {
+      setError('Failed to update support status. Please try again.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+        <svg className="w-5 h-5 text-accent-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+        </svg>
+        Saved Artists
+      </h2>
+
+      {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+
+      {!artistsLoaded ? (
+        <SkeletonScreen label="Loading your saved artists">
+          <ArtistRowsSkeleton count={4} />
+        </SkeletonScreen>
+      ) : savedArtists.length === 0 ? (
+        <div className="text-center py-12 rounded-lg border border-border border-dashed">
+          <p className="text-text-muted">No saved artists yet.</p>
+          <p className="text-text-muted text-sm mt-1">
+            Save artists you want to support for later.
+          </p>
+          <Link
+            to="/"
+            className="inline-block mt-4 px-4 py-2 rounded-lg bg-accent-secondary text-white text-sm font-medium hover:bg-accent-secondary/90 transition-colors"
+          >
+            Search for artists
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {visible.map(artist => (
+              <div
+                key={artist.artistId}
+                className="p-4 rounded-lg bg-bg-secondary border border-border hover:border-border-hover transition-colors"
+              >
+                <div className="flex gap-4">
+                  <div className="w-16 h-16 rounded-full bg-bg-hover flex items-center justify-center text-text-muted text-xl flex-shrink-0 overflow-hidden">
+                    {artist.imageUrl ? (
+                      <img
+                        src={artist.imageUrl}
+                        alt={artist.name}
+                        className="w-full h-full object-cover rounded-full"
+                        onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.querySelector('.fallback')?.classList.remove('hidden'); }}
+                      />
+                    ) : null}
+                    <span className={artist.imageUrl ? 'hidden fallback' : ''}>
+                      {artist.name.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold truncate">{artist.name}</p>
+                    {artist.claimed && artist.slug ? (
+                      <p className="text-sm text-text-muted truncate">
+                        unstream.stream/a/{artist.slug}
+                      </p>
+                    ) : (
+                      <p className="text-sm text-text-muted">Saved from search</p>
+                    )}
+                    {artist.notes && (
+                      <p className="text-xs text-text-muted mt-2 line-clamp-2">{artist.notes}</p>
+                    )}
+                    <div className="flex items-center gap-2 mt-3 flex-wrap">
+                      {artist.claimed && artist.slug ? (
+                        <Link
+                          to={`/a/${artist.slug}`}
+                          className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
+                        >
+                          View
+                        </Link>
+                      ) : (
+                        <Link
+                          to={`/?q=${encodeURIComponent(artist.name)}`}
+                          className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
+                        >
+                          Search
+                        </Link>
+                      )}
+                      <button
+                        onClick={() => handleToggleSupport(artist)}
+                        disabled={busyId === artist.artistId}
+                        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 ${
+                          artist.supported
+                            ? 'bg-accent-secondary/15 border border-accent-secondary/40 text-accent-secondary hover:bg-accent-secondary/25'
+                            : 'border border-border text-text-muted hover:text-text-primary hover:border-border-hover'
+                        } ${busyId === artist.artistId ? 'opacity-50 cursor-not-allowed' : ''}`}
+                      >
+                        {artist.supported ? (
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                        ) : (
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10" strokeWidth={2} />
+                          </svg>
+                        )}
+                        {artist.supported ? 'Supported' : 'Support'}
+                      </button>
+                      <button
+                        onClick={() => handleRemove(artist)}
+                        className="p-1.5 rounded-lg border border-border text-text-muted hover:text-red-400 hover:border-red-500/30 transition-colors"
+                        title="Remove"
+                        aria-label={`Remove ${artist.name}`}
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.862 21H9.138a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <button
+                onClick={() => setPage(currentPage - 1)}
+                disabled={currentPage === 1}
+                className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-text-muted px-2">
+                {currentPage} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {undo && (
+        <div className="fixed bottom-6 right-6 z-50 px-4 py-3 rounded-lg bg-accent-primary/10 border border-accent-primary/20 text-accent-primary shadow-lg flex items-center gap-3">
+          <span className="text-sm font-medium">Removed {undo.name}</span>
+          <button
+            onClick={() => handleUndo(undo)}
+            className="px-3 py-1 rounded-md bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
+          >
+            Undo
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/SavedArtistsSection.tsx
+++ b/apps/web/src/components/SavedArtistsSection.tsx
@@ -16,7 +16,7 @@ import { ArtistRowsSkeleton } from './LoadingSkeletons';
 const PAGE_SIZE = 10;
 
 export function SavedArtistsSection() {
-  const { session, savedArtists, artistsLoaded, loadSavedArtists, removeSavedArtist, saveArtist, setArtistSupported } = useAuth();
+  const { session, savedArtists, artistsLoaded, savedArtistsError, loadSavedArtists, removeSavedArtist, saveArtist, setArtistSupported } = useAuth();
 
   const [error, setError] = useState<string | null>(null);
   const [undo, setUndo] = useState<SavedArtist | null>(null);
@@ -57,14 +57,22 @@ export function SavedArtistsSection() {
 
   async function handleUndo(artist: SavedArtist) {
     setUndo(null);
-    await saveArtist(artist.artistId, artist.notes, artist.name, artist.imageUrl);
+    const restored = await saveArtist(artist.artistId, artist.notes, artist.name, artist.imageUrl);
+    if (!restored) {
+      setError(`Couldn't restore ${artist.name}. Search for them to save them again.`);
+      return;
+    }
     // Restoring the save doesn't restore the supported mark, and that mark records something
-    // the fan actually did — so it goes back too rather than being quietly dropped.
+    // the fan actually did — so it goes back too rather than being quietly dropped. The two
+    // calls aren't atomic and can't be: they're two writes to one row through an endpoint
+    // that takes one action at a time. What matters is that a half-done restore says which
+    // half — checking `restored` first is why this message can't blame the mark for a save
+    // that never landed.
     if (artist.supported) {
       try {
         await setArtistSupported(artist.artistId, true);
       } catch {
-        setError("Restored, but couldn't restore the supported mark. Try setting it again.");
+        setError(`Restored ${artist.name}, but not the supported mark. Press Support to set it again.`);
       }
     }
   }
@@ -92,7 +100,23 @@ export function SavedArtistsSection() {
 
       {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
 
-      {!artistsLoaded ? (
+      {!artistsLoaded && savedArtistsError ? (
+        /*
+          Not a skeleton. `artistsLoaded` stays false when the load fails — deliberately, so an
+          empty list is never presented as "you have saved nobody" — which would leave this
+          section shimmering forever. The old page-level error is what covered this before the
+          sections became independent.
+        */
+        <div className="text-center py-12 rounded-lg border border-border border-dashed">
+          <p className="text-text-muted">{savedArtistsError}</p>
+          <button
+            onClick={() => loadSavedArtists()}
+            className="mt-4 px-4 py-2 rounded-lg border border-border text-sm text-text-primary hover:border-border-hover transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      ) : !artistsLoaded ? (
         <SkeletonScreen label="Loading your saved artists">
           <ArtistRowsSkeleton count={4} />
         </SkeletonScreen>

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -5,7 +5,7 @@ import { getSupabaseClient, waitForMagicLinkSession } from '../services/auth';
 
 const ADMIN_EMAIL = 'info@kidlightbulbs.com';
 
-interface SavedArtist {
+export interface SavedArtist {
   artistId: string;
   name: string;
   slug: string;
@@ -13,6 +13,9 @@ interface SavedArtist {
   notes?: string;
   addedAt: string;
   claimed?: boolean;
+  /** Whether the fan has marked this artist as one they've actually supported. */
+  supported?: boolean;
+  supportedAt?: string;
 }
 
 interface AuthContextValue {
@@ -28,7 +31,10 @@ interface AuthContextValue {
   savedArtistIds: Set<string>;
   isArtistSaved: (artistId: string) => boolean;
   saveArtist: (artistId: string, notes?: string, artistName?: string, artistImageUrl?: string) => Promise<void>;
-  removeSavedArtist: (artistId: string) => Promise<void>;
+  /** Resolves false when the server refused and the removal was rolled back. */
+  removeSavedArtist: (artistId: string) => Promise<boolean>;
+  /** Mark a saved artist as supported, or take the mark off. Throws if the server refuses. */
+  setArtistSupported: (artistId: string, supported: boolean) => Promise<void>;
   loadSavedArtists: (signal?: AbortSignal) => Promise<void>;
   artistsLoaded: boolean;
 }
@@ -259,7 +265,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [session, savedArtistIds]);
 
   const removeSavedArtist = useCallback(async (artistId: string) => {
-    if (!session) return;
+    if (!session) return false;
 
     // Snapshot for rollback
     const removedFromList = savedArtists.find(a => a.artistId === artistId);
@@ -294,7 +300,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (removedFromList) {
           setSavedArtists(prev => [...prev, removedFromList]);
         }
+        return false;
       }
+      return true;
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'auth.removeSavedArtist' } });
       Sentry.captureMessage('Remove artist failed (rolled back)', {
@@ -307,6 +315,66 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (removedFromList) {
         setSavedArtists(prev => [...prev, removedFromList]);
       }
+      return false;
+    }
+  }, [session, savedArtists]);
+
+  /**
+   * Mark a saved artist as supported, or take the mark off again.
+   *
+   * Lives here rather than on the dashboard because it mutates the list this context owns.
+   * The dashboard used to keep its own copy of the saved artists and its own remove and
+   * support handlers, which is how removing an artist there left `savedArtistIds` stale and
+   * the save button on search results still showing saved for the rest of the session.
+   *
+   * Optimistic, and rolled back the same way save and remove are: the button records
+   * something the fan already did, so it shouldn't sit spinning. It throws on failure so the
+   * caller can say so — the two callers of save/remove above ignore failure by design, but a
+   * support toggle that silently flips back needs to explain itself.
+   */
+  const setArtistSupported = useCallback(async (artistId: string, supported: boolean) => {
+    if (!session) return;
+
+    const previous = savedArtists.find(a => a.artistId === artistId);
+    setSavedArtists(prev => prev.map(a =>
+      a.artistId === artistId
+        ? { ...a, supported, supportedAt: supported ? new Date().toISOString() : undefined }
+        : a
+    ));
+
+    try {
+      const response = await fetch('/api/saved-artists', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ action: supported ? 'support' : 'unsupport', artistId }),
+      });
+
+      if (!response.ok) {
+        const { statusCode, serverError } = await describeFailure(response);
+        Sentry.captureMessage('Set supported failed (rolled back)', {
+          level: 'warning',
+          extra: { artistId, supported, serverError },
+          tags: { context: 'auth.setArtistSupported', status_code: String(statusCode) },
+        });
+        throw new Error(serverError);
+      }
+
+      const data = await response.json();
+      setSavedArtists(prev => prev.map(a =>
+        a.artistId === artistId
+          ? { ...a, supported: data.savedArtist.supported, supportedAt: data.savedArtist.supportedAt }
+          : a
+      ));
+    } catch (e) {
+      setSavedArtists(prev => prev.map(a =>
+        a.artistId === artistId
+          ? { ...a, supported: previous?.supported, supportedAt: previous?.supportedAt }
+          : a
+      ));
+      throw e;
     }
   }, [session, savedArtists]);
 
@@ -358,7 +426,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const hasPassword = !!user?.user_metadata?.has_password;
 
   return (
-    <AuthContext.Provider value={{ session, user, isAdmin, isLoading, hasPassword, signOut: handleSignOut, signInWithMagicLink: handleSignInWithMagicLink, signInWithPassword: handleSignInWithPassword, savedArtists, savedArtistIds, isArtistSaved, saveArtist, removeSavedArtist, loadSavedArtists, artistsLoaded }}>
+    <AuthContext.Provider value={{ session, user, isAdmin, isLoading, hasPassword, signOut: handleSignOut, signInWithMagicLink: handleSignInWithMagicLink, signInWithPassword: handleSignInWithPassword, savedArtists, savedArtistIds, isArtistSaved, saveArtist, removeSavedArtist, setArtistSupported, loadSavedArtists, artistsLoaded }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback, useRef, ty
 import type { Session, User } from '@supabase/supabase-js';
 import * as Sentry from '@sentry/react';
 import { getSupabaseClient, waitForMagicLinkSession } from '../services/auth';
+import { RATE_LIMIT_MESSAGE } from '../utils/rateLimit';
 
 const ADMIN_EMAIL = 'info@kidlightbulbs.com';
 
@@ -30,13 +31,20 @@ interface AuthContextValue {
   savedArtists: SavedArtist[];
   savedArtistIds: Set<string>;
   isArtistSaved: (artistId: string) => boolean;
-  saveArtist: (artistId: string, notes?: string, artistName?: string, artistImageUrl?: string) => Promise<void>;
+  /** Resolves false when the server refused and the save was rolled back. */
+  saveArtist: (artistId: string, notes?: string, artistName?: string, artistImageUrl?: string) => Promise<boolean>;
   /** Resolves false when the server refused and the removal was rolled back. */
   removeSavedArtist: (artistId: string) => Promise<boolean>;
   /** Mark a saved artist as supported, or take the mark off. Throws if the server refuses. */
   setArtistSupported: (artistId: string, supported: boolean) => Promise<void>;
   loadSavedArtists: (signal?: AbortSignal) => Promise<void>;
   artistsLoaded: boolean;
+  /**
+   * Set when the saved-artists load failed. `artistsLoaded` deliberately stays false in that
+   * case — an empty list must never be presented as "you have saved nobody" when we simply
+   * don't know — so consumers need this to tell a load in progress from one that gave up.
+   */
+  savedArtistsError: string | null;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -67,6 +75,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [savedArtists, setSavedArtists] = useState<SavedArtist[]>([]);
   const [savedArtistIds, setSavedArtistIds] = useState<Set<string>>(new Set());
   const [artistsLoaded, setArtistsLoaded] = useState(false);
+  const [savedArtistsError, setSavedArtistsError] = useState<string | null>(null);
 
   // The auth listener below is installed once, so it cannot read `session` state:
   // that closure is pinned to the initial null forever, which is why the
@@ -118,6 +127,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSavedArtists([]);
         setSavedArtistIds(new Set());
         setArtistsLoaded(false);
+        setSavedArtistsError(null);
       }
     }
 
@@ -211,10 +221,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const isArtistSaved = useCallback((artistId: string) => savedArtistIds.has(artistId), [savedArtistIds]);
 
   const saveArtist = useCallback(async (artistId: string, notes?: string, artistName?: string, artistImageUrl?: string) => {
-    if (!session) return;
+    if (!session) return false;
 
-    // Skip if already saved (dedup)
-    if (savedArtistIds.has(artistId)) return;
+    // Skip if already saved (dedup). Reported as success: the artist is saved, which is what
+    // the caller asked for.
+    if (savedArtistIds.has(artistId)) return true;
 
     // Optimistic update
     setSavedArtistIds(prev => new Set(prev).add(artistId));
@@ -232,6 +243,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (response.ok) {
         const data = await response.json();
         setSavedArtists(prev => [...prev, data.savedArtist]);
+        return true;
       } else {
         const { statusCode, serverError } = await describeFailure(response);
         Sentry.captureMessage('Save artist failed (rolled back)', {
@@ -246,6 +258,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           return next;
         });
         setSavedArtists(prev => prev.filter(a => a.artistId !== artistId));
+        return false;
       }
     } catch (e) {
       Sentry.captureException(e, { extra: { context: 'auth.saveArtist' } });
@@ -261,6 +274,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return next;
       });
       setSavedArtists(prev => prev.filter(a => a.artistId !== artistId));
+      return false;
     }
   }, [session, savedArtistIds]);
 
@@ -397,6 +411,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const loadSavedArtists = useCallback(async (signal?: AbortSignal) => {
     if (!session) return;
     if (artistsLoaded) return;
+    setSavedArtistsError(null);
     try {
       const response = await fetch('/api/saved-artists', {
         headers: { 'Authorization': `Bearer ${session.access_token}` },
@@ -414,11 +429,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           extra: { statusCode, hasSession: !!session, serverError },
           tags: { context: 'auth.loadSavedArtists', status_code: String(statusCode) },
         });
+        setSavedArtistsError(
+          statusCode === 429
+            ? RATE_LIMIT_MESSAGE
+            : "Couldn't load your saved artists."
+        );
       }
     } catch (e) {
       if (signal?.aborted) return;
       Sentry.captureException(e, { extra: { context: 'auth.loadSavedArtists' } });
       console.error('Failed to load saved artists');
+      setSavedArtistsError("Couldn't load your saved artists.");
     }
   }, [session, artistsLoaded]);
 
@@ -426,7 +447,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const hasPassword = !!user?.user_metadata?.has_password;
 
   return (
-    <AuthContext.Provider value={{ session, user, isAdmin, isLoading, hasPassword, signOut: handleSignOut, signInWithMagicLink: handleSignInWithMagicLink, signInWithPassword: handleSignInWithPassword, savedArtists, savedArtistIds, isArtistSaved, saveArtist, removeSavedArtist, setArtistSupported, loadSavedArtists, artistsLoaded }}>
+    <AuthContext.Provider value={{ session, user, isAdmin, isLoading, hasPassword, signOut: handleSignOut, signInWithMagicLink: handleSignInWithMagicLink, signInWithPassword: handleSignInWithPassword, savedArtists, savedArtistIds, isArtistSaved, saveArtist, removeSavedArtist, setArtistSupported, loadSavedArtists, artistsLoaded, savedArtistsError }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,272 +1,59 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Link, useNavigate, Navigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { useAuth } from '../contexts/AuthContext';
 
 import { Header } from '../components/Header';
-import { ArtistAnalytics } from '../components/ArtistAnalytics';
 import { Footer } from '../components/Footer';
-import { PageSkeleton } from '../components/PageSkeleton';
-import { DashboardSkeleton } from '../components/LoadingSkeletons';
-import { RecentReleasesSection, type RecentRelease } from '../components/RecentReleasesSection';
+import { ClaimedArtistsSection } from '../components/ClaimedArtistsSection';
+import { SavedArtistsSection } from '../components/SavedArtistsSection';
 import { CollectionSection } from '../components/CollectionSection';
+import { RecentReleasesSection, type RecentRelease } from '../components/RecentReleasesSection';
 import { ReleaseFeedControls } from '../components/ReleaseFeedControls';
 
-interface ClaimedProfile {
-  id: string;
-  artistId: string;
-  name: string;
-  slug: string;
-  imageUrl?: string;
-  websiteUrl?: string;
-  bio?: string;
-  claimedAt: string;
-}
-
-interface SavedArtist {
-  artistId: string;
-  name: string;
-  slug: string;
-  imageUrl?: string;
-  notes?: string;
-  addedAt: string;
-  claimed?: boolean;
-  supported: boolean;
-  supportedAt?: string;
-}
-
+/**
+ * The signed-in home, as a composition of sections that each load on their own.
+ *
+ * It used to hold one `loading` flag covering three fetches, and render nothing until the
+ * slowest of them settled. Because `CollectionSection` only mounted after that, the
+ * collection read — the heaviest one on the page — didn't *start* until the other three had
+ * finished. Four requests in two serial waves, with no data dependency justifying the
+ * second. Now every section fetches as soon as the page mounts and shows its own skeleton,
+ * so the wall-clock cost is the slowest single request rather than the sum of two rounds.
+ */
 export function DashboardPage() {
-  const navigate = useNavigate();
-  const { session, isLoading: authLoading } = useAuth();
-  const [claimedProfiles, setClaimedProfiles] = useState<ClaimedProfile[]>([]);
-  const [savedArtists, setSavedArtists] = useState<SavedArtist[]>([]);
+  const { session, isLoading: authLoading, savedArtists, artistsLoaded } = useAuth();
   const [upcomingReleases, setUpcomingReleases] = useState<RecentRelease[]>([]);
   const [recentReleases, setRecentReleases] = useState<RecentRelease[]>([]);
   const [releasesError, setReleasesError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Toast state
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
-  const [undoToast, setUndoToast] = useState<{ message: string; artistId: string; onUndo: () => void } | null>(null);
-  const [supportingSlug, setSupportingSlug] = useState<string | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const PAGE_SIZE = 10;
 
   useEffect(() => {
-    if (authLoading) return;
+    if (!session) return;
+    const controller = new AbortController();
 
-    if (!session) {
-      navigate('/login', { replace: true });
-      return;
-    }
-
-    // Recent releases are a secondary section: if this read fails the rest of the dashboard is
-    // still worth showing, so it reports into the section rather than the page-level error.
-    async function loadRecentReleases() {
-      try {
-        const response = await fetch('/api/me/recent-releases', {
-          headers: { 'Authorization': `Bearer ${session!.access_token}` },
-        });
+    fetch('/api/me/recent-releases', {
+      headers: { 'Authorization': `Bearer ${session.access_token}` },
+      signal: controller.signal,
+    })
+      .then(response => {
         if (!response.ok) throw new Error(`recent-releases failed: ${response.status}`);
-        const data = await response.json();
+        return response.json();
+      })
+      .then(data => {
         setUpcomingReleases(data.upcoming || []);
         setRecentReleases(data.recent || []);
-      } catch (e) {
+      })
+      .catch(e => {
+        if (controller.signal.aborted) return;
         Sentry.captureException(e, { extra: { context: 'dashboard.loadRecentReleases' } });
         setReleasesError("Couldn't load recent releases. Try refreshing.");
-      }
-    }
-
-    async function loadData() {
-      try {
-        const [claimedResponse, savedResponse] = await Promise.all([
-          fetch('/api/artist-auth', {
-            headers: { 'Authorization': `Bearer ${session!.access_token}` },
-          }),
-          fetch('/api/saved-artists', {
-            headers: { 'Authorization': `Bearer ${session!.access_token}` },
-          }),
-          loadRecentReleases(),
-        ]);
-
-        if (!claimedResponse.ok) {
-          if (claimedResponse.status === 401) {
-            navigate('/login', { replace: true });
-            return;
-          }
-          throw new Error('Failed to load claimed profiles');
-        }
-
-        if (!savedResponse.ok) {
-          throw new Error('Failed to load saved artists');
-        }
-
-        const claimedData = await claimedResponse.json();
-        setClaimedProfiles(claimedData.profiles || []);
-
-        const savedData = await savedResponse.json();
-        setSavedArtists(savedData.savedArtists || []);
-      } catch (e) {
-        Sentry.captureException(e, { extra: { context: 'dashboard.loadData' } });
-        setError('Failed to load your profiles. Please try again.');
-      }
-      setLoading(false);
-    }
-    loadData();
-  }, [session, authLoading, navigate]);
-
-  // Show toast auto-dismiss
-  useEffect(() => {
-    if (toast) {
-      const timer = setTimeout(() => setToast(null), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [toast]);
-
-  // Show undo toast auto-dismiss
-  useEffect(() => {
-    if (undoToast) {
-      const timer = setTimeout(() => setUndoToast(null), 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [undoToast]);
-
-  const handleRemoveSavedArtist = async (artistId: string) => {
-    try {
-      const response = await fetch('/api/saved-artists', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${session!.access_token}`,
-        },
-        body: JSON.stringify({ action: 'remove', artistId }),
       });
 
-      if (!response.ok) {
-        throw new Error('Failed to remove saved artist');
-      }
+    return () => controller.abort();
+  }, [session]);
 
-      // Optimistically remove from list
-      setSavedArtists(prev => {
-        const next = prev.filter(a => a.artistId !== artistId);
-        // If current page is now empty, go to previous page
-        const totalPages = Math.ceil(next.length / PAGE_SIZE);
-        if (currentPage > totalPages && totalPages > 0) {
-          setCurrentPage(totalPages);
-        }
-        return next;
-      });
-
-      // Adjust page if the current page would be empty after removal
-      // Use a microtask to ensure state has updated before checking
-      const remaining = savedArtists.filter(a => a.artistId !== artistId);
-      const totalPagesAfter = Math.ceil(remaining.length / PAGE_SIZE);
-      if (currentPage > totalPagesAfter && totalPagesAfter > 0) {
-        setCurrentPage(totalPagesAfter);
-      } else if (remaining.length === 0) {
-        setCurrentPage(1);
-      }
-
-      // Show undo toast
-      setUndoToast({
-        message: 'Removed from saved',
-        artistId,
-        onUndo: () => handleUndoRemove(artistId),
-      });
-    } catch (e) {
-      Sentry.captureException(e, { extra: { context: 'dashboard.removeSavedArtist' } });
-      setError('Failed to remove artist. Please try again.');
-    }
-  };
-
-  const handleUndoRemove = async (artistId: string) => {
-    setUndoToast(null);
-
-    try {
-      const response = await fetch('/api/saved-artists', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${session!.access_token}`,
-        },
-        body: JSON.stringify({ artistId, notes: null }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to restore artist');
-      }
-
-      const data = await response.json();
-      setSavedArtists(prev => [...prev, data.savedArtist]);
-      setToast({ message: 'Artist restored!', type: 'success' });
-    } catch (e) {
-      Sentry.captureException(e, { extra: { context: 'dashboard.undoRemove' } });
-      setError('Failed to restore artist. Please try again.');
-    }
-  };
-
-  const handleToggleSupport = async (artist: SavedArtist) => {
-    const newSupported = !artist.supported;
-    const slug = artist.artistId;
-    const originalSupported = artist.supported;
-    const originalSupportedAt = artist.supportedAt;
-
-    setSavedArtists(prev => prev.map(a =>
-      a.artistId === slug ? { ...a, supported: newSupported, supportedAt: newSupported ? new Date().toISOString() : undefined } : a
-    ));
-
-    setSupportingSlug(slug);
-    try {
-      const response = await fetch('/api/saved-artists', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${session!.access_token}`,
-        },
-        body: JSON.stringify({ action: newSupported ? 'support' : 'unsupport', artistId: slug }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to update support status');
-      }
-
-      const data = await response.json();
-      setSavedArtists(prev => prev.map(a =>
-        a.artistId === slug ? { ...a, supported: data.savedArtist.supported, supportedAt: data.savedArtist.supportedAt } : a
-      ));
-    } catch (e) {
-      Sentry.captureException(e, { extra: { context: 'dashboard.toggleSupport' } });
-      setSavedArtists(prev => prev.map(a =>
-        a.artistId === slug ? { ...a, supported: originalSupported, supportedAt: originalSupportedAt } : a
-      ));
-      setToast({ message: 'Failed to update support status. Please try again.', type: 'error' });
-    } finally {
-      setSupportingSlug(null);
-    }
-  };
-
-  // Pagination helpers
-  const totalPages = Math.ceil(savedArtists.length / PAGE_SIZE);
-  const clampedPage = Math.min(currentPage, Math.max(1, totalPages));
-  const paginatedArtists = savedArtists.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE);
-
-  const goToPage = useCallback((page: number) => {
-    const clamped = Math.min(Math.max(1, page), totalPages);
-    if (clamped !== clampedPage) setCurrentPage(clamped);
-  }, [totalPages, clampedPage]);
-
-  // Redirect to login if not authenticated
   if (!authLoading && !session) {
     return <Navigate to="/login" replace />;
-  }
-
-  if (authLoading || loading) {
-    return (
-      <PageSkeleton label="Loading your dashboard" maxWidth="max-w-6xl">
-        <DashboardSkeleton />
-      </PageSkeleton>
-    );
   }
 
   return (
@@ -275,88 +62,18 @@ export function DashboardPage() {
 
       <main className="flex-1 p-6">
         <div className="max-w-6xl mx-auto space-y-8">
-          <div>
-            <h1 className="text-2xl font-bold">Dashboard</h1>
-          </div>
+          <h1 className="text-2xl font-bold">Dashboard</h1>
 
-          {error && (
-            <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
-              {error}
-            </div>
-          )}
-
-          {/* Your Artists Section - Only if user has claimed profiles */}
-          {claimedProfiles.length > 0 && (
-            <section>
-              <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                <svg className="w-5 h-5 text-accent-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM21 16c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z" />
-                </svg>
-                Your Artists
-              </h2>
-              <div className="space-y-3">
-                {claimedProfiles.map(profile => (
-                  <div
-                    key={profile.id}
-                    className="p-4 rounded-lg bg-bg-secondary border border-border hover:border-border-hover transition-colors"
-                  >
-                    <div className="flex gap-4">
-                      <div className="flex-shrink-0">
-                        {profile.imageUrl ? (
-                          <img
-                            src={profile.imageUrl}
-                            alt={profile.name}
-                            className="w-12 h-12 rounded-full object-cover"
-                          />
-                        ) : (
-                          <div className="w-12 h-12 rounded-full bg-bg-hover flex items-center justify-center text-text-muted text-lg">
-                            {profile.name.charAt(0).toUpperCase()}
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-semibold truncate">{profile.name}</p>
-                        <p className="text-sm text-text-muted truncate">
-                          unstream.stream/a/{profile.slug}
-                        </p>
-                        <div className="flex items-center gap-2 mt-3">
-                          <Link
-                            to={`/artist-edit/${profile.slug}`}
-                            className="px-3 py-1.5 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
-                          >
-                            Edit
-                          </Link>
-                          <Link
-                            to={`/a/${profile.slug}`}
-                            className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
-                          >
-                            View
-                          </Link>
-                          {/* Reachable from the profile editor too, but releases are the thing an
-                              artist comes back to correct — worth one click from here. */}
-                          <Link
-                            to={`/artist-edit/${profile.slug}/releases`}
-                            className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
-                          >
-                            Releases
-                          </Link>
-                        </div>
-                      </div>
-                    </div>
-                    <ArtistAnalytics slug={profile.slug} />
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
+          <ClaimedArtistsSection />
 
           {/*
-            Upcoming and Recent Releases — above Saved Artists because they are the part of this
-            page that changes, and only rendered once the fan has saved somebody: an empty releases
-            box for a fan with no saved artists would be a second empty state saying the same thing
-            as the one below it.
+            Upcoming and Recent Releases — above Saved Artists because they are the part of
+            this page that changes, and only rendered once the fan has saved somebody: an
+            empty releases box for a fan with no saved artists would be a second empty state
+            saying the same thing as the one below it. `artistsLoaded` gates it so the box
+            doesn't flash in and out while the list is still arriving.
           */}
-          {savedArtists.length > 0 && (
+          {artistsLoaded && savedArtists.length > 0 && (
             <RecentReleasesSection
               upcoming={upcomingReleases}
               recent={recentReleases}
@@ -372,176 +89,9 @@ export function DashboardPage() {
           */}
           <CollectionSection />
 
-          {/* Saved Artists Section */}
-          <section>
-            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <svg className="w-5 h-5 text-accent-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-              </svg>
-              Saved Artists
-            </h2>
-
-            {savedArtists.length === 0 ? (
-              <div className="text-center py-12 rounded-lg border border-border border-dashed">
-                <p className="text-text-muted">No saved artists yet.</p>
-                <p className="text-text-muted text-sm mt-1">
-                  Save artists you want to support for later.
-                </p>
-                <Link
-                  to="/"
-                  className="inline-block mt-4 px-4 py-2 rounded-lg bg-accent-secondary text-white text-sm font-medium hover:bg-accent-secondary/90 transition-colors"
-                >
-                  Search for artists
-                </Link>
-              </div>
-            ) : (
-              <>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {paginatedArtists.map(artist => (
-                  <div
-                    key={artist.artistId}
-                    className="p-4 rounded-lg bg-bg-secondary border border-border hover:border-border-hover transition-colors"
-                  >
-                    <div className="flex gap-4">
-                      <div className="flex-shrink-0">
-                        <div className="w-16 h-16 rounded-full bg-bg-hover flex items-center justify-center text-text-muted text-xl flex-shrink-0 overflow-hidden">
-                          {artist.imageUrl ? (
-                            <img
-                              src={artist.imageUrl}
-                              alt={artist.name}
-                              className="w-full h-full object-cover rounded-full"
-                              onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.querySelector('.fallback')?.classList.remove('hidden'); }}
-                            />
-                          ) : null}
-                          <span className={artist.imageUrl ? 'hidden fallback' : ''}>
-                            {artist.name.charAt(0).toUpperCase()}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-semibold truncate">{artist.name}</p>
-                        {artist.claimed && artist.slug ? (
-                          <p className="text-sm text-text-muted truncate">
-                            unstream.stream/a/{artist.slug}
-                          </p>
-                        ) : (
-                          <p className="text-sm text-text-muted">Saved from search</p>
-                        )}
-                        {artist.notes && (
-                          <p className="text-xs text-text-muted mt-2 line-clamp-2">
-                            {artist.notes}
-                          </p>
-                        )}
-                        <div className="flex items-center gap-2 mt-3 flex-wrap">
-                          {artist.claimed && artist.slug ? (
-                            <Link
-                              to={`/a/${artist.slug}`}
-                              className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
-                            >
-                              View
-                            </Link>
-                          ) : (
-                            <Link
-                              to={`/?q=${encodeURIComponent(artist.name)}`}
-                              className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors"
-                            >
-                              Search
-                            </Link>
-                          )}
-                          <button
-                            onClick={() => handleToggleSupport(artist)}
-                            disabled={supportingSlug === artist.artistId}
-                            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 ${
-                              artist.supported
-                                ? 'bg-accent-secondary/15 border border-accent-secondary/40 text-accent-secondary hover:bg-accent-secondary/25'
-                                : 'border border-border text-text-muted hover:text-text-primary hover:border-border-hover'
-                            } ${supportingSlug === artist.artistId ? 'opacity-50 cursor-not-allowed' : ''}`}
-                          >
-                            {artist.supported ? (
-                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                              </svg>
-                            ) : (
-                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <circle cx="12" cy="12" r="10" strokeWidth={2} />
-                              </svg>
-                            )}
-                            {artist.supported ? 'Supported' : 'Support'}
-                          </button>
-                            <button
-                            onClick={() => handleRemoveSavedArtist(artist.artistId)}
-                            className="p-1.5 rounded-lg border border-border text-text-muted hover:text-red-400 hover:border-red-500/30 transition-colors"
-                            title="Remove"
-                          >
-                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.862 21H9.138a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Pagination controls */}
-              {totalPages > 1 && (
-                <div className="flex items-center justify-center gap-2 mt-6">
-                  <button
-                    onClick={() => goToPage(clampedPage - 1)}
-                    disabled={clampedPage === 1}
-                    className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    Previous
-                  </button>
-                  <span className="text-sm text-text-muted px-2">
-                    {clampedPage} / {totalPages}
-                  </span>
-                  <button
-                    onClick={() => goToPage(clampedPage + 1)}
-                    disabled={clampedPage === totalPages}
-                    className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-sm hover:text-text-primary hover:border-border-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    Next
-                  </button>
-                </div>
-              )}
-              </>
-            )}
-          </section>
+          <SavedArtistsSection />
         </div>
       </main>
-
-      {/* Toast Notifications */}
-      <div className="fixed bottom-6 right-6 z-50 space-y-2 pointer-events-none">
-        {toast && (
-          <div className={`pointer-events-auto px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 animate-in slide-in-from-right duration-300 ${
-            toast.type === 'error' ? 'bg-red-500/10 border border-red-500/20 text-red-400' :
-            'bg-green-500/10 border border-green-500/20 text-green-400'
-          }`}>
-            <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              {toast.type === 'error' ? (
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              ) : (
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              )}
-            </svg>
-            <span className="text-sm font-medium">{toast.message}</span>
-          </div>
-        )}
-
-        {undoToast && (
-          <div className="pointer-events-auto px-4 py-3 rounded-lg bg-accent-primary/10 border border-accent-primary/20 text-accent-primary shadow-lg animate-in slide-in-from-right duration-300 flex items-center gap-3">
-            <span className="text-sm font-medium">{undoToast.message}</span>
-            <button
-              onClick={undoToast.onUndo}
-              className="px-3 py-1 rounded-md bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors"
-            >
-              Undo
-            </button>
-          </div>
-        )}
-      </div>
 
       <Footer />
     </div>

--- a/apps/web/tests/unit/DashboardPageWaves.test.tsx
+++ b/apps/web/tests/unit/DashboardPageWaves.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+// The dashboard's request timing.
+//
+// It used to hold one `loading` flag covering /api/artist-auth, /api/saved-artists and
+// /api/me/recent-releases, and render nothing until the slowest settled. CollectionSection
+// only mounted after that, so the collection read — the heaviest on the page — didn't start
+// until the other three had finished: four requests in two serial waves, with no data
+// dependency justifying the second.
+//
+// This pins the fix. Nothing here asserts on milliseconds; it asserts that a section's
+// request is in flight while another section's is still unresolved, which is the property
+// that a page-level loading gate destroys.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Chrome, not content: both fetch on their own and would add unrelated requests.
+vi.mock('../../src/components/Header', () => ({ Header: () => null }));
+vi.mock('../../src/components/Footer', () => ({ Footer: () => null }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { DashboardPage } from '../../src/pages/DashboardPage';
+
+/** A request that never answers, standing in for a slow endpoint. */
+function pending() {
+  return new Promise<never>(() => {});
+}
+
+function urlsRequested(): string[] {
+  return mockFetch.mock.calls.map(call => String(call[0]));
+}
+
+describe('DashboardPage request waves', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockUseAuth.mockReturnValue({
+      session: { access_token: 'token' },
+      isLoading: false,
+      savedArtists: [],
+      artistsLoaded: true,
+      loadSavedArtists: vi.fn(),
+      removeSavedArtist: vi.fn(async () => true),
+      saveArtist: vi.fn(async () => {}),
+      setArtistSupported: vi.fn(async () => {}),
+    });
+  });
+
+  afterEach(cleanup);
+
+  it('starts the collection read without waiting for the other sections', async () => {
+    // Everything except the collection hangs forever. Under the old page-level gate the
+    // collection request was never even made in this situation.
+    mockFetch.mockImplementation((url: string) =>
+      String(url).startsWith('/api/me/collection')
+        ? Promise.resolve({ ok: true, json: async () => ({ items: [], total: 0 }) })
+        : pending()
+    );
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(urlsRequested()).toContain('/api/me/collection');
+    });
+    // And the ones it isn't waiting for did go out too — concurrently, not instead.
+    expect(urlsRequested()).toContain('/api/artist-auth');
+    expect(urlsRequested()).toContain('/api/me/recent-releases');
+  });
+
+  it('does not fetch the saved-artists list itself', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ items: [], total: 0, profiles: [] }) })
+    );
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(urlsRequested()).toContain('/api/me/collection');
+    });
+    // The list comes from AuthContext, which loads it once per session and shares it with the
+    // save buttons on search results. A second copy here is the bug this replaced.
+    expect(urlsRequested().some(url => url.startsWith('/api/saved-artists'))).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/SavedArtistsSection.test.tsx
+++ b/apps/web/tests/unit/SavedArtistsSection.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+// The saved-artists block on the dashboard.
+//
+// What's worth locking is that it has no list of its own. It used to fetch /api/saved-artists
+// itself and mutate a local array, so the copy in AuthContext — the one the save buttons on
+// search results and artist pages read — went stale the moment you removed somebody here. A
+// removal on the dashboard left the heart on a search result filled in for the rest of the
+// session. Every mutation below therefore has to go through the context.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { SavedArtistsSection } from '../../src/components/SavedArtistsSection';
+
+const ARTIST = {
+  artistId: 'kid-lightbulbs',
+  name: 'Kid Lightbulbs',
+  slug: 'kid-lightbulbs',
+  imageUrl: undefined,
+  notes: 'saw them live',
+  addedAt: '2026-01-01T00:00:00Z',
+  claimed: true,
+  supported: false,
+};
+
+function auth(overrides: Record<string, unknown> = {}) {
+  return {
+    session: { access_token: 'token' },
+    savedArtists: [ARTIST],
+    artistsLoaded: true,
+    loadSavedArtists: vi.fn(),
+    removeSavedArtist: vi.fn(async () => true),
+    saveArtist: vi.fn(async () => {}),
+    setArtistSupported: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <SavedArtistsSection />
+    </MemoryRouter>
+  );
+}
+
+describe('SavedArtistsSection', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockUseAuth.mockReturnValue(auth());
+  });
+
+  afterEach(cleanup);
+
+  it('renders the context list without fetching one of its own', () => {
+    renderSection();
+
+    expect(screen.getByText('Kid Lightbulbs')).not.toBeNull();
+    // The whole point: no second copy. The section reads state, it doesn't load it.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('asks the context to load the list, so the fetch is shared and cached', () => {
+    const loadSavedArtists = vi.fn();
+    mockUseAuth.mockReturnValue(auth({ loadSavedArtists }));
+
+    renderSection();
+
+    expect(loadSavedArtists).toHaveBeenCalled();
+  });
+
+  it('removes through the context rather than posting directly', async () => {
+    const removeSavedArtist = vi.fn(async () => true);
+    mockUseAuth.mockReturnValue(auth({ removeSavedArtist }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+
+    await waitFor(() => {
+      expect(removeSavedArtist).toHaveBeenCalledWith('kid-lightbulbs');
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('offers Undo only once the removal has actually stuck', async () => {
+    mockUseAuth.mockReturnValue(auth());
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Undo' })).not.toBeNull();
+    });
+  });
+
+  it('says so instead of offering Undo when the server refused the removal', async () => {
+    mockUseAuth.mockReturnValue(auth({ removeSavedArtist: vi.fn(async () => false) }));
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to remove artist/)).not.toBeNull();
+    });
+    // A rollback happened, so the row is still there — an Undo would misdescribe it.
+    expect(screen.queryByRole('button', { name: 'Undo' })).toBeNull();
+  });
+
+  it('toggles support through the context, and reports a refusal', async () => {
+    const setArtistSupported = vi.fn(async () => { throw new Error('nope'); });
+    mockUseAuth.mockReturnValue(auth({ setArtistSupported }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: /Support/ }));
+
+    await waitFor(() => {
+      expect(setArtistSupported).toHaveBeenCalledWith('kid-lightbulbs', true);
+    });
+    expect(screen.getByText(/Failed to update support status/)).not.toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('restores the supported mark on Undo, not just the save', async () => {
+    const saveArtist = vi.fn(async () => {});
+    const setArtistSupported = vi.fn(async () => {});
+    mockUseAuth.mockReturnValue(auth({
+      savedArtists: [{ ...ARTIST, supported: true }],
+      saveArtist,
+      setArtistSupported,
+    }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Undo' }));
+
+    await waitFor(() => {
+      expect(saveArtist).toHaveBeenCalledWith('kid-lightbulbs', 'saw them live', 'Kid Lightbulbs', undefined);
+    });
+    // Supporting an artist is a record of something the fan did; restoring the save without it
+    // would drop that silently.
+    expect(setArtistSupported).toHaveBeenCalledWith('kid-lightbulbs', true);
+  });
+
+  it('shows a skeleton until the context reports the list loaded', () => {
+    mockUseAuth.mockReturnValue(auth({ savedArtists: [], artistsLoaded: false }));
+    renderSection();
+
+    expect(screen.getByRole('status')).not.toBeNull();
+    // Not the empty state — "no saved artists yet" is a claim we can't make yet.
+    expect(screen.queryByText(/No saved artists yet/)).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/SavedArtistsSection.test.tsx
+++ b/apps/web/tests/unit/SavedArtistsSection.test.tsx
@@ -36,9 +36,10 @@ function auth(overrides: Record<string, unknown> = {}) {
     session: { access_token: 'token' },
     savedArtists: [ARTIST],
     artistsLoaded: true,
+    savedArtistsError: null,
     loadSavedArtists: vi.fn(),
     removeSavedArtist: vi.fn(async () => true),
-    saveArtist: vi.fn(async () => {}),
+    saveArtist: vi.fn(async () => true),
     setArtistSupported: vi.fn(async () => {}),
     ...overrides,
   };
@@ -129,7 +130,7 @@ describe('SavedArtistsSection', () => {
   });
 
   it('restores the supported mark on Undo, not just the save', async () => {
-    const saveArtist = vi.fn(async () => {});
+    const saveArtist = vi.fn(async () => true);
     const setArtistSupported = vi.fn(async () => {});
     mockUseAuth.mockReturnValue(auth({
       savedArtists: [{ ...ARTIST, supported: true }],
@@ -147,6 +148,64 @@ describe('SavedArtistsSection', () => {
     // Supporting an artist is a record of something the fan did; restoring the save without it
     // would drop that silently.
     expect(setArtistSupported).toHaveBeenCalledWith('kid-lightbulbs', true);
+  });
+
+  it('shows an error with a retry when the list failed to load, not a skeleton forever', () => {
+    // artistsLoaded stays false on failure — on purpose, so an empty list is never presented
+    // as "you have saved nobody". Without reading the error that leaves this section
+    // shimmering indefinitely, which is what the old page-level error used to catch.
+    const loadSavedArtists = vi.fn();
+    mockUseAuth.mockReturnValue(auth({
+      savedArtists: [],
+      artistsLoaded: false,
+      savedArtistsError: "Couldn't load your saved artists.",
+      loadSavedArtists,
+    }));
+
+    renderSection();
+
+    expect(screen.getByText(/Couldn't load your saved artists/)).not.toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByText(/No saved artists yet/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(loadSavedArtists).toHaveBeenCalledTimes(2); // once on mount, once on retry
+  });
+
+  it('does not blame the supported mark when the restore itself failed', async () => {
+    const setArtistSupported = vi.fn(async () => {});
+    mockUseAuth.mockReturnValue(auth({
+      savedArtists: [{ ...ARTIST, supported: true }],
+      saveArtist: vi.fn(async () => false),
+      setArtistSupported,
+    }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Undo' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't restore Kid Lightbulbs/)).not.toBeNull();
+    });
+    // The save never landed, so there is no row to mark — attempting it would produce an
+    // error message about the mark for a restore that didn't happen.
+    expect(setArtistSupported).not.toHaveBeenCalled();
+  });
+
+  it('says which half of a restore succeeded when the mark fails', async () => {
+    mockUseAuth.mockReturnValue(auth({
+      savedArtists: [{ ...ARTIST, supported: true }],
+      saveArtist: vi.fn(async () => true),
+      setArtistSupported: vi.fn(async () => { throw new Error('nope'); }),
+    }));
+
+    renderSection();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Kid Lightbulbs' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Undo' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Restored Kid Lightbulbs, but not the supported mark/)).not.toBeNull();
+    });
   });
 
   it('shows a skeleton until the context reports the list loaded', () => {


### PR DESCRIPTION
## Summary

Refactors the dashboard to load all sections in parallel rather than serially, eliminating a performance bottleneck where the collection read (the heaviest request on the page) was blocked waiting for artist profile and saved artist fetches to complete. Also moves saved artist state management into `AuthContext` so mutations on the dashboard stay in sync with save buttons elsewhere in the app.

## Key changes

**Dashboard page structure:**
- Removed page-level `loading` flag that gated all three fetches (`/api/artist-auth`, `/api/saved-artists`, `/api/me/recent-releases`)
- Each section now fetches independently on mount and shows its own skeleton, allowing requests to start in parallel
- Extracted claimed artists into `ClaimedArtistsSection` component with its own fetch and error handling
- Extracted saved artists into `SavedArtistsSection` component that reads from `AuthContext` instead of fetching its own copy
- Recent releases fetch moved directly into the page component (no longer blocked by other sections)

**AuthContext enhancements:**
- Added `savedArtists`, `artistsLoaded`, `loadSavedArtists()`, `removeSavedArtist()`, and `setArtistSupported()` to the context
- `SavedArtist` interface now exported and includes `supported` and `supportedAt` fields
- `removeSavedArtist()` now returns a boolean indicating success (for undo UX)
- New `setArtistSupported()` method to toggle the supported mark on a saved artist

**API endpoint consolidation:**
- Introduced `resolveAccountRequest()` in `ratelimit.ts` to return both the rate-limit key and verified user, eliminating duplicate auth checks
- Updated all account endpoints (`me-bandcamp`, `me-recent-releases`, `me-feed-token`, `me-collection`, `me-location`, `me-notifications`, `me-username`, `user-sharing`, `saved-artists`, `saved-artists-sync`) to use `resolveAccountRequest()` instead of calling `authenticateBearerFast()` separately
- Removed redundant inline `authenticateRequest()` functions from each endpoint

**Tests:**
- Added `DashboardPageWaves.test.tsx` to verify that sections fetch in parallel (collection request starts before other sections resolve)
- Added `SavedArtistsSection.test.tsx` to verify mutations go through `AuthContext` rather than direct API calls
- Updated existing endpoint tests to mock `resolveAccountRequest()` instead of inline auth

## Notable implementation details

- The dashboard now renders immediately with skeletons for each section, rather than blocking on the slowest fetch. This is a wall-clock improvement from `max(t1, t2, t3) + t4` (collection blocked by others) to `max(t1, t2, t3, t4)`.
- `SavedArtistsSection` reads from `AuthContext` state rather than maintaining its own copy, ensuring that removing an artist here updates the save buttons on search results and artist pages in the same session.
- `ClaimedArtistsSection` silently hides itself if the user has no claimed profiles (no skeleton shown for empty state), since most users claim nothing.
- The undo toast for removing a saved artist only appears after the server confirms the removal, preventing misdescription if the removal fails and is rolled back.
- `resolveAccountRequest()` is narrower than the old pattern: it returns the verified user alongside the key, so callers don't re-verify the same token. The old `accountRateLimitKey()` remains for any future callers that genuinely only need a bucket name.

https://claude.ai/code/session_01UtrEqz1LBwwCGFVHkkKjKN