### PR TITLE
Update Beatport AI policy to formal ban (Aug 2026)

### DIFF
--- a/api/shared/platform-registry.ts
+++ b/api/shared/platform-registry.ts
@@ -98,8 +98,11 @@ export const PLATFORMS: Record<string, PlatformMeta> = {
     category: 'marketplace',
     payoutPercent: '55-70%',
     homepageUrl: 'https://www.beatport.com',
-    aiPolicy: 'discouraged',
-    aiPolicyUrl: 'https://greenroomsupport.beatport.com/hc/en-us/articles/19093504988820-Content-Policy',
+    // Formal ban on fully/majority AI-generated tracks (Aug 2026): withheld at ingestion,
+    // rights holders notified. AI-assisted tracks (mixing/mastering/stem separation) are
+    // still allowed but tagged as such. Detection via Beatdapp.
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://support.beatport.com/hc/en-us/articles/52381231418004-Beatport-s-Stance-on-Artificial-Intelligence',
   },
   even: {
     name: 'EVEN',

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -174,8 +174,11 @@ export const sources: Record<SourceId, Source> = {
     searchUrlTemplate: 'https://www.beatport.com/search?q={query}',
     homepageUrl: 'https://www.beatport.com',
     artistPayoutPercent: '55-70%',
-    aiPolicy: 'discouraged',
-    aiPolicyUrl: 'https://greenroomsupport.beatport.com/hc/en-us/articles/19093504988820-Content-Policy',
+    // Formal ban on fully/majority AI-generated tracks (Aug 2026): withheld at ingestion,
+    // rights holders notified. AI-assisted tracks (mixing/mastering/stem separation) are
+    // still allowed but tagged as such. Detection via Beatdapp.
+    aiPolicy: 'formal',
+    aiPolicyUrl: 'https://support.beatport.com/hc/en-us/articles/52381231418004-Beatport-s-Stance-on-Artificial-Intelligence',
   },
   even: {
     id: 'even',

--- a/data/guides/every-platform-unstream-supports-compared.md
+++ b/data/guides/every-platform-unstream-supports-compared.md
@@ -96,6 +96,8 @@ The dominant marketplace for electronic music and DJs. Beatport specializes in d
 
 The payout rate is lower than the other marketplaces here, which matters — but for electronic music, Beatport is often the only option for a proper release outside streaming.
 
+In August 2026, Beatport [banned fully and majority AI-generated tracks](https://support.beatport.com/hc/en-us/articles/52381231418004-Beatport-s-Stance-on-Artificial-Intelligence) from the platform — AI-assisted production like mixing, mastering, and stem separation is still allowed, but tagged as such.
+
 **Best for:** Fans of electronic, DJ, and dance music who want to buy tracks legally and DRM-free.
 
 ---


### PR DESCRIPTION
## Summary
Updates Beatport's AI policy classification from "discouraged" to "formal" across both the platform registry and web sources configuration, reflecting their formal ban on fully/majority AI-generated tracks effective August 2026.

## Changes
- **Platform registry** (`api/shared/platform-registry.ts`): Updated Beatport's `aiPolicy` from `'discouraged'` to `'formal'` with clarified policy details and new support URL
- **Web sources** (`apps/web/src/services/sources.ts`): Applied the same AI policy update to maintain consistency across the codebase
- **Documentation**: Added inline comments explaining the policy scope:
  - Formal ban on fully/majority AI-generated tracks (enforcement Aug 2026)
  - Tracks withheld at ingestion; rights holders notified
  - AI-assisted tracks (mixing/mastering/stem separation) remain allowed but tagged
  - Detection via Beatdapp

## Implementation details
- Updated support URL from `greenroomsupport.beatport.com` to `support.beatport.com` with new article ID
- Consistent changes across both configuration sources to ensure the web app and API use the same platform metadata

https://claude.ai/code/session_0134Af8Z72rmXRyLBaf52Ghd