### PR TITLE
Let magic-link-only users set a password from /settings

### DIFF
--- a/apps/web/src/components/PasswordChangeForm.tsx
+++ b/apps/web/src/components/PasswordChangeForm.tsx
@@ -1,10 +1,16 @@
 import { useState } from 'react';
+import * as Sentry from '@sentry/react';
+import { updatePassword } from '../services/auth';
 
 interface PasswordChangeFormProps {
   accessToken: string;
+  // False for accounts that have only ever signed in with a magic link. Those users
+  // have no current password to type, so the field is hidden and the submit takes the
+  // client-side path below instead of /api/me/password.
+  hasPassword: boolean;
 }
 
-export function PasswordChangeForm({ accessToken }: PasswordChangeFormProps) {
+export function PasswordChangeForm({ accessToken, hasPassword }: PasswordChangeFormProps) {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -12,48 +18,70 @@ export function PasswordChangeForm({ accessToken }: PasswordChangeFormProps) {
   const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  // Changing an existing password goes through /api/me/password, which verifies the old
+  // one. Setting a first password can't: there is nothing to verify against. It uses
+  // supabase.auth.updateUser instead — the same call ResetPasswordPage and PasswordSection
+  // make — which Supabase authorizes on the session alone and which stamps has_password,
+  // so /settings shows the change form from then on.
+  //
+  // Deliberately NOT done by making current_password optional on /api/me/password: the
+  // only thing that endpoint could check to allow the omission is user_metadata.has_password,
+  // and user_metadata is writable by the user themselves. Trusting it there would let anyone
+  // holding a session clear the flag and change the password without knowing the old one.
+  async function setFirstPassword(): Promise<string | null> {
+    const { error: updateError } = await updatePassword(newPassword);
+    return updateError;
+  }
+
+  async function changeExistingPassword(): Promise<string | null> {
+    const response = await fetch('/api/me/password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) return data.error || 'Failed to update password.';
+    return null;
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setSuccess(null);
 
-    if (!currentPassword) {
+    if (hasPassword && !currentPassword) {
       setError('Current password is required.');
       return;
     }
 
     if (newPassword.length < 8) {
-      setError('New password must be at least 8 characters.');
+      setError(hasPassword ? 'New password must be at least 8 characters.' : 'Password must be at least 8 characters.');
       return;
     }
 
     if (newPassword !== confirmPassword) {
-      setError('New passwords do not match.');
+      setError(hasPassword ? 'New passwords do not match.' : 'Passwords do not match.');
       return;
     }
 
     setLoading(true);
     try {
-      const response = await fetch('/api/me/password', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
-      });
+      const submitError = hasPassword ? await changeExistingPassword() : await setFirstPassword();
 
-      const data = await response.json();
-
-      if (!response.ok) {
-        setError(data.error || 'Failed to update password.');
+      if (submitError) {
+        setError(submitError);
       } else {
-        setSuccess('Password updated.');
+        setSuccess(hasPassword ? 'Password updated.' : 'Password set. You can now sign in with your email and password.');
         setCurrentPassword('');
         setNewPassword('');
         setConfirmPassword('');
       }
-    } catch {
+    } catch (e) {
+      Sentry.captureException(e, { extra: { context: 'settings.passwordChange', hasPassword } });
       setError('Network error. Please try again.');
     }
     setLoading(false);
@@ -61,23 +89,31 @@ export function PasswordChangeForm({ accessToken }: PasswordChangeFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
-      <div>
-        <label htmlFor="current-password" className="block text-sm font-medium mb-1">
-          Current password
-        </label>
-        <input
-          id="current-password"
-          type="password"
-          required
-          value={currentPassword}
-          onChange={e => { setCurrentPassword(e.target.value); setError(null); setSuccess(null); }}
-          className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
-        />
-      </div>
+      {!hasPassword && (
+        <p className="text-sm text-text-muted">
+          Your account was created with a magic link. Set a password to sign in with it as well.
+        </p>
+      )}
+
+      {hasPassword && (
+        <div>
+          <label htmlFor="current-password" className="block text-sm font-medium mb-1">
+            Current password
+          </label>
+          <input
+            id="current-password"
+            type="password"
+            required
+            value={currentPassword}
+            onChange={e => { setCurrentPassword(e.target.value); setError(null); setSuccess(null); }}
+            className="w-full px-3 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary"
+          />
+        </div>
+      )}
 
       <div>
         <label htmlFor="new-password" className="block text-sm font-medium mb-1">
-          New password
+          {hasPassword ? 'New password' : 'Password'}
         </label>
         <input
           id="new-password"
@@ -94,7 +130,7 @@ export function PasswordChangeForm({ accessToken }: PasswordChangeFormProps) {
 
       <div>
         <label htmlFor="confirm-password" className="block text-sm font-medium mb-1">
-          Confirm new password
+          {hasPassword ? 'Confirm new password' : 'Confirm password'}
         </label>
         <input
           id="confirm-password"
@@ -120,7 +156,7 @@ export function PasswordChangeForm({ accessToken }: PasswordChangeFormProps) {
         disabled={loading}
         className="px-4 py-2 rounded-lg bg-accent-primary text-white text-sm font-medium hover:bg-accent-primary/90 transition-colors disabled:opacity-50"
       >
-        {loading ? 'Updating...' : 'Update password'}
+        {loading ? (hasPassword ? 'Updating...' : 'Saving...') : (hasPassword ? 'Update password' : 'Set password')}
       </button>
     </form>
   );

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -129,21 +129,10 @@ export function SettingsPage() {
           {/* Password section */}
           <section className="p-6 rounded-lg bg-bg-secondary border border-border space-y-4">
             <h2 className="text-lg font-semibold">Password</h2>
-            {settings?.hasPassword ? (
-              <PasswordChangeForm accessToken={session!.access_token} />
-            ) : (
-              <div className="space-y-2">
-                <p className="text-sm text-text-muted">
-                  Your account was created with a magic link. To set a password, use the password reset flow.
-                </p>
-                <a
-                  href="/login"
-                  className="inline-block text-sm text-accent-primary hover:underline"
-                >
-                  Send password-setup email &rarr;
-                </a>
-              </div>
-            )}
+            <PasswordChangeForm
+              accessToken={session!.access_token}
+              hasPassword={!!settings?.hasPassword}
+            />
           </section>
         </div>
       </main>

--- a/apps/web/tests/unit/PasswordChangeForm.test.tsx
+++ b/apps/web/tests/unit/PasswordChangeForm.test.tsx
@@ -2,114 +2,211 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { PasswordChangeForm } from '../../src/components/PasswordChangeForm';
+import { updatePassword } from '../../src/services/auth';
+
+vi.mock('../../src/services/auth', () => ({
+  updatePassword: vi.fn(),
+}));
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+const mockUpdatePassword = vi.mocked(updatePassword);
+
 describe('PasswordChangeForm', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockUpdatePassword.mockReset();
+    mockUpdatePassword.mockResolvedValue({ error: null });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it('renders all three password fields', () => {
-    render(<PasswordChangeForm accessToken="token123" />);
+  describe('when the account already has a password', () => {
+    it('renders all three password fields', () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
 
-    expect(screen.getByLabelText('Current password')).not.toBeNull();
-    expect(screen.getByLabelText('New password')).not.toBeNull();
-    expect(screen.getByLabelText('Confirm new password')).not.toBeNull();
+      expect(screen.getByLabelText('Current password')).not.toBeNull();
+      expect(screen.getByLabelText('New password')).not.toBeNull();
+      expect(screen.getByLabelText('Confirm new password')).not.toBeNull();
+    });
+
+    it('shows inline error when current password is wrong', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'Current password is incorrect' }),
+      });
+
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'wrongpass' } });
+      fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
+      fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'newpass123' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Current password is incorrect')).not.toBeNull();
+      });
+    });
+
+    it('shows inline error when new password is too short', async () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
+      fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'short' } });
+      fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'short' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(screen.getByText('New password must be at least 8 characters.')).not.toBeNull();
+      });
+    });
+
+    it('shows inline error when passwords do not match', async () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
+      fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
+      fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'different123' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(screen.getByText('New passwords do not match.')).not.toBeNull();
+      });
+    });
+
+    it('shows success message on valid password change', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
+      fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
+      fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'newpass123' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Password updated.')).not.toBeNull();
+      });
+    });
+
+    it('clears all fields after successful save', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      const currentInput = screen.getByLabelText('Current password') as HTMLInputElement;
+      const newInput = screen.getByLabelText('New password') as HTMLInputElement;
+      const confirmInput = screen.getByLabelText('Confirm new password') as HTMLInputElement;
+
+      fireEvent.change(currentInput, { target: { value: 'oldpass123' } });
+      fireEvent.change(newInput, { target: { value: 'newpass123' } });
+      fireEvent.change(confirmInput, { target: { value: 'newpass123' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(currentInput.value).toBe('');
+        expect(newInput.value).toBe('');
+        expect(confirmInput.value).toBe('');
+      });
+    });
+
+    it('posts the current password to /api/me/password', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      render(<PasswordChangeForm accessToken="token123" hasPassword={true} />);
+
+      fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
+      fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
+      fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'newpass123' } });
+      fireEvent.click(screen.getByText('Update password'));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('/api/me/password');
+      expect(JSON.parse(init.body)).toEqual({ current_password: 'oldpass123', new_password: 'newpass123' });
+      expect(mockUpdatePassword).not.toHaveBeenCalled();
+    });
   });
 
-  it('shows inline error when current password is wrong', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      json: async () => ({ error: 'Current password is incorrect' }),
+  describe('when the account has never had a password', () => {
+    it('does not ask for a current password', () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={false} />);
+
+      expect(screen.queryByLabelText('Current password')).toBeNull();
+      expect(screen.getByLabelText('Password')).not.toBeNull();
+      expect(screen.getByLabelText('Confirm password')).not.toBeNull();
+      expect(screen.getByText('Set password')).not.toBeNull();
     });
 
-    render(<PasswordChangeForm accessToken="token123" />);
+    it('sets the password via updateUser rather than /api/me/password', async () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={false} />);
 
-    fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'wrongpass' } });
-    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
-    fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'newpass123' } });
-    fireEvent.click(screen.getByText('Update password'));
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'brandnew123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'brandnew123' } });
+      fireEvent.click(screen.getByText('Set password'));
 
-    await waitFor(() => {
-      expect(screen.getByText('Current password is incorrect')).not.toBeNull();
-    });
-  });
-
-  it('shows inline error when new password is too short', async () => {
-    render(<PasswordChangeForm accessToken="token123" />);
-
-    fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
-    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'short' } });
-    fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'short' } });
-    fireEvent.click(screen.getByText('Update password'));
-
-    await waitFor(() => {
-      expect(screen.getByText('New password must be at least 8 characters.')).not.toBeNull();
-    });
-  });
-
-  it('shows inline error when passwords do not match', async () => {
-    render(<PasswordChangeForm accessToken="token123" />);
-
-    fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
-    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
-    fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'different123' } });
-    fireEvent.click(screen.getByText('Update password'));
-
-    await waitFor(() => {
-      expect(screen.getByText('New passwords do not match.')).not.toBeNull();
-    });
-  });
-
-  it('shows success message on valid password change', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ success: true }),
+      await waitFor(() => {
+        expect(screen.getByText('Password set. You can now sign in with your email and password.')).not.toBeNull();
+      });
+      expect(mockUpdatePassword).toHaveBeenCalledWith('brandnew123');
+      // The endpoint that demands a current password must never be called here —
+      // that is the bug this mode exists to fix.
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    render(<PasswordChangeForm accessToken="token123" />);
+    it('surfaces an error returned by updateUser', async () => {
+      mockUpdatePassword.mockResolvedValueOnce({ error: 'New password should be different from the old password.' });
 
-    fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'oldpass123' } });
-    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'newpass123' } });
-    fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'newpass123' } });
-    fireEvent.click(screen.getByText('Update password'));
+      render(<PasswordChangeForm accessToken="token123" hasPassword={false} />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Password updated.')).not.toBeNull();
-    });
-  });
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'brandnew123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'brandnew123' } });
+      fireEvent.click(screen.getByText('Set password'));
 
-  it('clears all fields after successful save', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ success: true }),
+      await waitFor(() => {
+        expect(screen.getByText('New password should be different from the old password.')).not.toBeNull();
+      });
     });
 
-    render(<PasswordChangeForm accessToken="token123" />);
+    it('still validates length and confirmation before submitting', async () => {
+      render(<PasswordChangeForm accessToken="token123" hasPassword={false} />);
 
-    const currentInput = screen.getByLabelText('Current password') as HTMLInputElement;
-    const newInput = screen.getByLabelText('New password') as HTMLInputElement;
-    const confirmInput = screen.getByLabelText('Confirm new password') as HTMLInputElement;
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'short' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'short' } });
+      fireEvent.click(screen.getByText('Set password'));
 
-    fireEvent.change(currentInput, { target: { value: 'oldpass123' } });
-    fireEvent.change(newInput, { target: { value: 'newpass123' } });
-    fireEvent.change(confirmInput, { target: { value: 'newpass123' } });
-    fireEvent.click(screen.getByText('Update password'));
+      await waitFor(() => {
+        expect(screen.getByText('Password must be at least 8 characters.')).not.toBeNull();
+      });
 
-    await waitFor(() => {
-      expect(currentInput.value).toBe('');
-      expect(newInput.value).toBe('');
-      expect(confirmInput.value).toBe('');
+      fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'brandnew123' } });
+      fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'different123' } });
+      fireEvent.click(screen.getByText('Set password'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Passwords do not match.')).not.toBeNull();
+      });
+
+      expect(mockUpdatePassword).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## The gap

A user who has only ever signed in with a magic link had **no way to set a password while logged in**.

`/settings` was already `hasPassword`-aware, but its no-password branch was a dead end — copy saying *"To set a password, use the password reset flow"* plus a link to `/login`. The other branch rendered `PasswordChangeForm`, which unconditionally demanded a current password the user didn't have.

## The finding worth reviewing

The app already had a working version of this. `/dashboard` renders `PasswordSection`, which handles both cases correctly and never asks for a current password. So this was **two rival password UIs**, and `/settings` had the broken one.

## What changed

`PasswordChangeForm` now takes a required `hasPassword` prop and renders two modes:

| | current-password field | submit path | button |
|---|---|---|---|
| `hasPassword: true` | yes | `POST /api/me/password` (unchanged) | Update password |
| `hasPassword: false` | **no** | client-side `supabase.auth.updateUser` | Set password |

The no-password path uses the same call `PasswordSection` and `ResetPasswordPage` already make in production. Supabase authorizes it on the valid session alone, and it stamps `has_password` — so the flag self-heals and the form switches to change mode afterwards.

`SettingsPage` now always renders the form and passes the flag.

## Security decision a reviewer should check

I did **not** make `current_password` optional on `/api/me/password`, which is the obvious way to do this.

The only signal that endpoint could check to allow the omission is `user_metadata.has_password` — and `user_metadata` is writable by the user themselves (that's exactly how `updatePassword` sets it). Trusting it server-side would let anyone holding a session clear the flag and change the password without knowing the old one. The endpoint keeps verifying unconditionally; the set-first-password case routes around it instead. The reasoning is a comment on the component so it doesn't get "simplified" away later.

## Verification

- `npm run verify` green — typecheck + 1242 API tests + 777 web unit tests.
- 11 component tests (7 pre-existing, updated for the new prop; 4 new). The 4 new ones were **proven to have teeth**: neutralizing the fix fails exactly those 4 while the 7 pre-existing still pass.
- Both modes rendered locally in a throwaway Vite harness and screenshotted (the component is fully prop-driven, so no auth needed). Harness files removed.

**Not verified:** end-to-end against a real magic-link-only account on production Supabase — that would mean mutating production auth state to manufacture one. The client-side call is the same one already live on `/dashboard`, but the live confirmation is worth doing after merge.

## Follow-ups, deliberately out of scope

- The two password components (`PasswordSection`, `PasswordChangeForm`) should probably collapse into one.
- The current-password check on `/settings` isn't actually a security boundary today — any session holder can bypass it via `/dashboard`'s client-side path. Worth deciding whether to make it real or drop the pretence.

## Deploy note

This touches `apps/web/`, so merging to `main` triggers a Netlify production build. Previews are disabled, so the PR itself won't build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)