### PR TITLE
Stop the release-alert email test rotting with the calendar

### DIFF
--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   sendTransactionalEmail: vi.fn(),
@@ -230,6 +230,12 @@ describe('notifySavedArtistsOfNewRelease', () => {
     mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, messageId: 'msg_1' });
   });
 
+  // Only one test below pins the clock, and it has to hand it back — otherwise every test after
+  // it would judge recency against that date instead of today.
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('sends nothing when no release is unaccounted for', async () => {
     const client = releaseClient({ releases: { data: [], error: null } });
 
@@ -336,7 +342,25 @@ describe('notifySavedArtistsOfNewRelease', () => {
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('unstream.stream/a/test-artist');
   });
 
+  /**
+   * The only test here that asserts on a *formatted* date, and so the only one that pins the
+   * clock. Deriving the expected string from the same `Date.now()` as the fixture would make the
+   * assertion agree with itself even if the formatter broke, which is the one thing this test is
+   * for — so the date stays a literal and the clock moves to meet it.
+   *
+   * It also has to: this test failed on 2026-08-20 because a fixture dated 2026-08-12 had aged
+   * out of the seven-day window in `isNewsworthy`, so no email was sent at all and the failure
+   * read as a missing-mock TypeError rather than a stale date. Every other test in this file uses
+   * `isoDate` for exactly that reason — reach for that first, and only pin the clock when the
+   * rendered date itself is the thing under test.
+   *
+   * `toFake: ['Date']` leaves setTimeout and promise scheduling real, so the awaits below still
+   * resolve on their own.
+   */
   it('names the release, its date, and the platforms it can be bought on', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-13T12:00:00Z'));
+
     const client = releaseClient({
       releases: { data: [release('r1', 'Fine Motor Control', { release_date: '2026-08-12' })], error: null },
       releaseSources: {


### PR DESCRIPTION
## What broke

`npm run test:api` has been red on clean `main` since 2026-08-20 UTC:

```
notifySavedArtistsOfNewRelease > names the release, its date, and the platforms it can be bought on
TypeError: Cannot read properties of undefined (reading '0')
```

Not a real regression — the test rotted. It hardcoded a release date of `2026-08-12` and asserted the email rendered `12 August 2026`. `isNewsworthy` in `api/functions/notifications.ts` only treats a release as news if it came out within `RECENT_RELEASE_WINDOW_DAYS` (7). Once UTC ticked over to 2026-08-20, the cutoff became `2026-08-13`, the fixture fell outside it, `notifySavedArtistsOfNewRelease` correctly skipped the alert, and the assertion blew up reading `calls[0][0]` of an empty mock. The failure named a missing mock, not a stale date, which is the expensive part.

## The fix

Pin the clock for that one test (`vi.useFakeTimers({ toFake: ['Date'] })` + `setSystemTime`), rather than deriving the fixture date from `Date.now()`.

Deriving it was the other option and it's the wrong one here: an expected string computed from the same arithmetic as the fixture agrees with itself even if `formatReleaseDate` breaks, and the rendered date is the one thing this test exists to check. Keeping `2026-08-12` and `12 August 2026` as literals keeps that assertion honest — verified by mutating `formatReleaseDate`'s day format to `August 12, 2026`, which still fails the test with a real message:

```
AssertionError: expected '<p><strong>Test Artist</strong>…' to contain '12 August 2026'
```

`toFake: ['Date']` leaves `setTimeout` and promise scheduling real so the `await`s still resolve, and an `afterEach` hands the clock back so no later test judges recency against 2026-08-13.

## Nothing else rots

Rather than eyeballing date literals, I ran the whole `api/functions` suite against a shifted wall clock at +0, +8, +60, +400 and +1200 days. All 1,242 tests pass at every offset; the web unit suite (777 tests) is clean at +45 and +200 too. The other near-past literals in that directory are safe because they pass an explicit `now` into pure functions — the house pattern this file already follows via its `isoDate` helper. The diagnostic harness was temporary and is not part of this PR.

## Verification

`npm run verify` green: typecheck + 1,242 API tests + 777 web unit tests.

Test-only change, so nothing about production behaviour moves. Worth knowing before merge: `api/` is deliberately absent from `scripts/netlify-ignore-build.sh`, so landing this on `main` will spend a production deploy (~15 credits) even though only a test file changed — relevant given August is already at 307/300 minutes. Batching it with other pending work would avoid that, at the cost of leaving CI red for longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)