### PR TITLE
Disk I/O round 2, Phase 1: stop the wasted writes

### DIFF
--- a/api/edge/release-page.ts
+++ b/api/edge/release-page.ts
@@ -123,7 +123,6 @@ interface OfferRow {
   price: number | null;
   currency: string | null;
   availability: string;
-  captured_at: string;
 }
 
 interface SourceRow {
@@ -222,7 +221,7 @@ export default async function handler(request: Request, context: Context) {
         .select(`
           title, release_type, release_date, date_precision, status, artwork_url,
           release_sources ( platform, url, detail_checked_at,
-            release_offers ( format, price, currency, availability, captured_at )
+            release_offers ( format, price, currency, availability )
           )
         `)
         .eq('artist_id', artist.id)
@@ -272,10 +271,13 @@ export default async function handler(request: Request, context: Context) {
       (a, b) => payoutRank(b.platform) - payoutRank(a.platform)
     );
 
-    // The oldest price on the page is the honest freshness claim: saying "checked today"
-    // because *one* source was re-read would overstate the rest.
+    // The oldest check on the page is the honest freshness claim: saying "checked today"
+    // because *one* source was re-read would overstate the rest. `detail_checked_at`, not the
+    // offers' `captured_at`: the detail pass skips rewriting offers whose prices haven't moved,
+    // so `captured_at` only advances when a price changes and would read as stale data we had
+    // in fact just re-verified. `detail_checked_at` is stamped on every pass.
     const capturedTimes = sources
-      .flatMap(s => (s.release_offers || []).map(o => o.captured_at))
+      .map(s => s.detail_checked_at)
       .filter(Boolean)
       .sort();
     const oldestCapture = capturedTimes[0] ?? null;

--- a/api/functions/__tests__/analytics-event.test.ts
+++ b/api/functions/__tests__/analytics-event.test.ts
@@ -1,0 +1,106 @@
+// /api/analytics/event accepts two body shapes: { slug, metric } — one event, what the
+// extension and Mac app send — and { slugs: [...], metric } — the web app's batched search
+// appearances. The batch exists for the write bill: a search that rendered N claimed artists
+// used to cost N requests and N increment transactions; it must now cost one request, at most
+// one slug-resolution read, and exactly one RPC.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockIn: vi.fn(),
+  mockRpc: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({
+    from: () => ({ select: () => ({ in: mocks.mockIn, eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+    rpc: mocks.mockRpc,
+  }),
+}));
+vi.mock('../ratelimit', () => ({
+  checkRateLimit: async () => ({ limited: false }),
+  getClientIp: () => '203.0.113.7',
+}));
+
+import { handler } from '../analytics-event';
+
+const ARTISTS: Record<string, string> = {
+  'artist-a': 'id-a',
+  'artist-b': 'id-b',
+};
+
+function post(body: unknown) {
+  return handler({ httpMethod: 'POST', headers: {}, body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockIn.mockImplementation((_column: string, slugs: string[]) =>
+    Promise.resolve({
+      data: slugs.filter(s => ARTISTS[s]).map(s => ({ id: ARTISTS[s], slug: s })),
+      error: null,
+    })
+  );
+  mocks.mockRpc.mockResolvedValue({ data: null, error: null });
+});
+
+describe('batched slugs', () => {
+  it('resolves the batch in one read and increments in one RPC', async () => {
+    // A fresh slug per test would fight the module-level slug cache; unique slugs per case
+    // keep each test's read observable.
+    const res = await post({ slugs: ['artist-a', 'artist-b', 'artist-a'], metric: 'search' });
+
+    expect(res?.statusCode).toBe(204);
+    expect(mocks.mockIn).toHaveBeenCalledTimes(1);
+    expect(mocks.mockRpc).toHaveBeenCalledTimes(1);
+    const [fn, args] = mocks.mockRpc.mock.calls[0];
+    expect(fn).toBe('increment_analytics_batch');
+    expect((args as { p_artist_ids: string[] }).p_artist_ids.sort()).toEqual(['id-a', 'id-b']);
+    expect(args).toMatchObject({ p_metric: 'search' });
+  });
+
+  it('serves a repeat batch from the warm slug cache with no read at all', async () => {
+    await post({ slugs: ['artist-a', 'artist-b'], metric: 'search' });
+    mocks.mockIn.mockClear();
+
+    await post({ slugs: ['artist-a', 'artist-b'], metric: 'search' });
+
+    expect(mocks.mockIn).not.toHaveBeenCalled();
+    expect(mocks.mockRpc).toHaveBeenLastCalledWith('increment_analytics_batch', expect.anything());
+  });
+
+  it('drops unknown slugs and no-ops when none resolve', async () => {
+    const res = await post({ slugs: ['nobody-here', 'nor-here'], metric: 'search' });
+
+    expect(res?.statusCode).toBe(204);
+    expect(mocks.mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('refuses a batch bigger than any real search by truncating it', async () => {
+    const slugs = Array.from({ length: 40 }, (_, i) => `flood-${i}`);
+    await post({ slugs, metric: 'search' });
+
+    const asked = mocks.mockIn.mock.calls[0][1] as string[];
+    expect(asked.length).toBeLessThanOrEqual(24);
+  });
+});
+
+describe('the single-event shape (extension and Mac app)', () => {
+  it('still increments through the single-row RPC', async () => {
+    await post({ slug: 'artist-a', metric: 'view' });
+
+    expect(mocks.mockRpc).toHaveBeenCalledTimes(1);
+    expect(mocks.mockRpc).toHaveBeenCalledWith('increment_analytics', {
+      p_artist_id: 'id-a',
+      p_date: expect.any(String),
+      p_metric: 'view',
+    });
+  });
+
+  it('no-ops an invalid metric without touching the database', async () => {
+    const res = await post({ slug: 'artist-a', metric: 'drop table' });
+
+    expect(res?.statusCode).toBe(204);
+    expect(mocks.mockRpc).not.toHaveBeenCalled();
+  });
+});

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -213,6 +213,121 @@ describe('bandcamp-sync-background handler', () => {
     expect(byExternal['al-3'].release_id).toBeNull();
   });
 
+  // A re-sync used to upsert every album every time, and the table's updated_at trigger makes
+  // any upsert a real row rewrite — 190 rewrites to record that nothing changed, repeated on
+  // every retry of a stalled sync. These tests pin the diff: unchanged rows are not written,
+  // and "no match this run" never erases what a previous run or the linker already stored.
+  describe('re-sync write churn', () => {
+    const ciphertext = () => encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
+
+    /** Route the two paged reads by label: artists for matching, stored items for the diff. */
+    function withStored(existing: Record<string, unknown>[], artists: Record<string, unknown>[] = []) {
+      mocks.mockReadAllPages.mockImplementation(async (_run: unknown, label: string) =>
+        label.startsWith('collection_items') ? { ok: true, rows: existing } : { ok: true, rows: artists }
+      );
+    }
+
+    const stored = (overrides: Record<string, unknown> = {}) => ({
+      external_id: 'al-1',
+      title: 'Illinois',
+      artist_name: 'Sufjan Stevens',
+      art_url: null,
+      // Postgres serialization (+00:00), where Subsonic sends Z — a string compare would call
+      // this changed and quietly turn the whole diff into a no-op. That's the point of the test.
+      acquired_at: '2026-01-01T00:00:00+00:00',
+      release_id: null,
+      ...overrides,
+    });
+
+    const album = (overrides: Record<string, unknown> = {}) => ({
+      id: 'al-1',
+      name: 'Illinois',
+      artist: 'Sufjan Stevens',
+      created: '2026-01-01T00:00:00Z',
+      ...overrides,
+    });
+
+    it('writes nothing when the stored collection already matches the library', async () => {
+      const { upsertBatches, connectionUpdates } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      withStored([stored()]);
+      mocks.mockFetchAllAlbums.mockResolvedValue([album()]);
+
+      const res = await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(res.statusCode).toBe(200);
+      expect(upsertBatches).toHaveLength(0);
+      // The sync itself still completes and reports the full collection.
+      expect(connectionUpdates.at(-1)).toMatchObject({ sync_status: 'idle', item_count: 1 });
+    });
+
+    it('writes only the rows that actually changed', async () => {
+      const { upsertBatches } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      withStored([stored(), stored({ external_id: 'al-2', title: 'Old Title' })]);
+      mocks.mockFetchAllAlbums.mockResolvedValue([
+        album(),
+        album({ id: 'al-2', name: 'Carrie & Lowell', created: null }),
+        album({ id: 'al-3', name: 'Javelin' }), // the new purchase
+      ]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      const written = upsertBatches.flat().map(r => (r as Record<string, unknown>).external_id);
+      expect(written.sort()).toEqual(['al-2', 'al-3']);
+    });
+
+    it('never erases a release link the linker set after the last sync', async () => {
+      const { upsertBatches } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      // Stored row is linked; this run matches nothing (no artists), so the built row would
+      // carry release_id: null. Null means "no new information", not "unlink".
+      withStored([stored({ release_id: 'rel-1', art_url: 'https://f4.bcbits.com/a.jpg' })]);
+      mocks.mockFetchAllAlbums.mockResolvedValue([album()]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      expect(upsertBatches).toHaveLength(0);
+    });
+
+    it('does write a newly matched release link', async () => {
+      const { upsertBatches } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+        releases: [
+          { id: 'rel-1', artist_id: 'artist-1', match_key: 'illinois', artwork_url: 'https://f4.bcbits.com/a.jpg' },
+        ],
+      });
+      withStored([stored()], [SUFJAN]);
+      mocks.mockFetchAllAlbums.mockResolvedValue([album()]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      const rows = upsertBatches.flat();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ external_id: 'al-1', release_id: 'rel-1' });
+    });
+
+    it('falls back to writing everything when the stored read fails', async () => {
+      const { upsertBatches } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      mocks.mockReadAllPages.mockImplementation(async (_run: unknown, label: string) =>
+        label.startsWith('collection_items')
+          ? { ok: false, reason: 'read blipped' }
+          : { ok: true, rows: [] }
+      );
+      mocks.mockFetchAllAlbums.mockResolvedValue([album()]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      // Skipping a real update because a read blipped is the worse trade — write as before.
+      expect(upsertBatches.flat()).toHaveLength(1);
+    });
+  });
+
   describe('auto-mark supported (spec OQ6: buying is supporting)', () => {
     const ciphertext = () => encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
     const albums = [{ id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }];

--- a/api/functions/__tests__/notifications.test.ts
+++ b/api/functions/__tests__/notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   sendTransactionalEmail: vi.fn(),
@@ -230,6 +230,12 @@ describe('notifySavedArtistsOfNewRelease', () => {
     mocks.sendTransactionalEmail.mockResolvedValue({ ok: true, messageId: 'msg_1' });
   });
 
+  // Only one test below pins the clock, and it has to hand it back — otherwise every test after
+  // it would judge recency against that date instead of today.
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('sends nothing when no release is unaccounted for', async () => {
     const client = releaseClient({ releases: { data: [], error: null } });
 
@@ -336,7 +342,25 @@ describe('notifySavedArtistsOfNewRelease', () => {
     expect(mocks.sendTransactionalEmail.mock.calls[0][0].html).toContain('unstream.stream/a/test-artist');
   });
 
+  /**
+   * The only test here that asserts on a *formatted* date, and so the only one that pins the
+   * clock. Deriving the expected string from the same `Date.now()` as the fixture would make the
+   * assertion agree with itself even if the formatter broke, which is the one thing this test is
+   * for — so the date stays a literal and the clock moves to meet it.
+   *
+   * It also has to: this test failed on 2026-08-20 because a fixture dated 2026-08-12 had aged
+   * out of the seven-day window in `isNewsworthy`, so no email was sent at all and the failure
+   * read as a missing-mock TypeError rather than a stale date. Every other test in this file uses
+   * `isoDate` for exactly that reason — reach for that first, and only pin the clock when the
+   * rendered date itself is the thing under test.
+   *
+   * `toFake: ['Date']` leaves setTimeout and promise scheduling real, so the awaits below still
+   * resolve on their own.
+   */
   it('names the release, its date, and the platforms it can be bought on', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-13T12:00:00Z'));
+
     const client = releaseClient({
       releases: { data: [release('r1', 'Fine Motor Control', { release_date: '2026-08-12' })], error: null },
       releaseSources: {

--- a/api/functions/__tests__/persist-release-detail-churn.test.ts
+++ b/api/functions/__tests__/persist-release-detail-churn.test.ts
@@ -1,0 +1,196 @@
+// persistReleaseDetail used to write on every 30-day detail pass whether or not anything had
+// changed: the release row's status/date (six indexes on `releases`), a full offers upsert with a
+// fresh captured_at (so the rows were guaranteed "different"), and a prune delete. In steady state
+// a re-check re-derives exactly what the rows already say, so almost all of that was write churn —
+// the same bug persistReleases fixed for `title`, one function up. These tests pin the skip, its
+// failure mode (a failed pre-read falls through to writing), and the one write that must never be
+// skipped: the detail_checked_at stamp, which is the cooldown's own state AND what the release
+// page now shows as "prices checked".
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Row { [k: string]: unknown }
+
+const state = {
+  release: null as Row | null,
+  offers: [] as Row[],
+  releaseReadError: null as string | null,
+  offersReadError: null as string | null,
+};
+
+/** Every write the code attempted, so a skipped write is observable rather than inferred. */
+const writes: { table: string; kind: 'update' | 'upsert' | 'delete'; payload?: unknown }[] = [];
+
+function makeClient() {
+  return {
+    from(table: string) {
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        eq() { return builder; },
+        not() { return builder; },
+        maybeSingle() {
+          if (table === 'releases' && state.releaseReadError) {
+            return Promise.resolve({ data: null, error: { message: state.releaseReadError } });
+          }
+          return Promise.resolve({ data: state.release, error: null });
+        },
+        update(patch: Row) {
+          writes.push({ table, kind: 'update', payload: patch });
+          return builder;
+        },
+        upsert(rows: Row[]) {
+          writes.push({ table, kind: 'upsert', payload: rows });
+          return builder;
+        },
+        delete() {
+          writes.push({ table, kind: 'delete' });
+          return builder;
+        },
+        then(res: (v: unknown) => unknown) {
+          if (table === 'release_offers' && state.offersReadError) {
+            return Promise.resolve({ data: null, error: { message: state.offersReadError } }).then(res);
+          }
+          return Promise.resolve({ data: state.offers, error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+vi.mock('../request-catalog', () => ({ requestArtistCatalog: async () => true }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { persistReleaseDetail } = await import('../db');
+
+const RELEASE = {
+  releaseId: 'rel-1',
+  sourceId: 'src-1',
+  url: 'https://artist.bandcamp.com/album/javelin',
+  detailCheckedAt: null,
+  curatedFields: [] as string[],
+};
+
+const DETAIL = {
+  releaseDate: '2026-05-01',
+  datePrecision: 'day',
+  status: 'released',
+  offers: [
+    { format: 'digital', price: 10, currency: 'USD', availability: 'available' },
+    { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+  ],
+};
+
+const writesTo = (table: string, kind?: string) =>
+  writes.filter(w => w.table === table && (!kind || w.kind === kind));
+
+beforeEach(() => {
+  state.release = { status: 'released', release_date: '2026-05-01', date_precision: 'day' };
+  // `price` as a string: Postgres `numeric` can serialize that way, and a strict compare
+  // against the parser's number would call every offer changed — a silent no-op fix.
+  state.offers = [
+    { format: 'digital', price: '10', currency: 'USD', availability: 'available' },
+    { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+  ];
+  state.releaseReadError = null;
+  state.offersReadError = null;
+  writes.length = 0;
+});
+
+describe('a detail pass that re-derives exactly what is stored', () => {
+  it('writes only the detail_checked_at stamp', async () => {
+    const ok = await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(ok).toBe(true);
+    expect(writesTo('releases')).toHaveLength(0);
+    expect(writesTo('release_offers')).toHaveLength(0);
+    // The stamp is the cooldown's own state — skipping it would re-fetch every page every pass.
+    expect(writesTo('release_sources', 'update')).toHaveLength(1);
+  });
+
+  it('still skips when the stored date is a full timestamp serialization', async () => {
+    // A `date` column reads back as YYYY-MM-DD, but defend the compare against a timestamp
+    // shape anyway — a raw string compare would never match and never skip.
+    state.release = { status: 'released', release_date: '2026-05-01T00:00:00+00:00', date_precision: 'day' };
+
+    await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(writesTo('releases')).toHaveLength(0);
+  });
+});
+
+describe('a detail pass that found a real change', () => {
+  it('writes the release row when status moved', async () => {
+    state.release = { status: 'announced', release_date: '2026-05-01', date_precision: 'day' };
+
+    await persistReleaseDetail(RELEASE, DETAIL);
+
+    const updates = writesTo('releases', 'update');
+    expect(updates).toHaveLength(1);
+    expect(updates[0].payload).toMatchObject({ status: 'released' });
+  });
+
+  it('rewrites and prunes offers when a price moved', async () => {
+    state.offers = [
+      { format: 'digital', price: 8, currency: 'USD', availability: 'available' },
+      { format: 'vinyl', price: 25, currency: 'USD', availability: 'available' },
+    ];
+
+    await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(writesTo('release_offers', 'upsert')).toHaveLength(1);
+    expect(writesTo('release_offers', 'delete')).toHaveLength(1);
+    expect(writesTo('releases')).toHaveLength(0);
+  });
+
+  it('rewrites offers when a stored format disappeared from the page', async () => {
+    state.offers = [
+      ...state.offers,
+      { format: 'cassette', price: 12, currency: 'USD', availability: 'available' },
+    ];
+
+    await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(writesTo('release_offers', 'upsert')).toHaveLength(1);
+    expect(writesTo('release_offers', 'delete')).toHaveLength(1);
+  });
+});
+
+describe('failure modes fall toward writing', () => {
+  it('writes the release row when its pre-read fails', async () => {
+    state.releaseReadError = 'read blipped';
+
+    const ok = await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(ok).toBe(true);
+    expect(writesTo('releases', 'update')).toHaveLength(1);
+  });
+
+  it('writes the offers when their pre-read fails', async () => {
+    state.offersReadError = 'read blipped';
+
+    await persistReleaseDetail(RELEASE, DETAIL);
+
+    expect(writesTo('release_offers', 'upsert')).toHaveLength(1);
+  });
+});
+
+describe('rules that predate the skip and must survive it', () => {
+  it('leaves the release row alone when the artist curated the date, even when it differs', async () => {
+    state.release = { status: 'announced', release_date: '2026-06-01', date_precision: 'day' };
+
+    await persistReleaseDetail({ ...RELEASE, curatedFields: ['release_date'] }, DETAIL);
+
+    expect(writesTo('releases')).toHaveLength(0);
+  });
+
+  it('leaves the release row alone when the source has no status to offer', async () => {
+    state.release = { status: 'announced', release_date: null, date_precision: null };
+
+    await persistReleaseDetail(RELEASE, { ...DETAIL, status: null, releaseDate: null });
+
+    expect(writesTo('releases')).toHaveLength(0);
+  });
+});

--- a/api/functions/__tests__/release-detail.test.ts
+++ b/api/functions/__tests__/release-detail.test.ts
@@ -551,20 +551,32 @@ describe('offers and freshness', () => {
     expect(byPlatform.bandcamp.detailCheckedAt).toBeNull();
   });
 
-  // The *oldest* capture across every source. Claiming "checked today" because one source was
-  // re-read would overstate the rest.
-  it('reports the oldest capture across all sources as the freshness claim', async () => {
+  // The *oldest* check across every source. Claiming "checked today" because one source was
+  // re-read would overstate the rest. Derived from detail_checked_at, NOT the offers'
+  // captured_at: the detail pass skips rewriting offers whose prices haven't moved, so
+  // captured_at sits still on a quiet release that was in fact re-verified yesterday. The
+  // fixture's deliberately ancient capturedAt values are the proof — deriving from them would
+  // return April, not August.
+  it('reports the oldest detail check across all sources as the freshness claim', async () => {
     mocks.getReleaseDetail.mockResolvedValue({
       detail: detail({
         sources: [
-          source({ platform: 'bandcamp', offers: [offer({ capturedAt: '2026-08-01T00:00:00.000Z' })] }),
-          source({ platform: 'faircamp', offers: [offer({ capturedAt: '2026-07-04T00:00:00.000Z' })] }),
+          source({
+            platform: 'bandcamp',
+            detailCheckedAt: '2026-08-15T00:00:00.000Z',
+            offers: [offer({ capturedAt: '2026-05-01T00:00:00.000Z' })],
+          }),
+          source({
+            platform: 'faircamp',
+            detailCheckedAt: '2026-08-10T00:00:00.000Z',
+            offers: [offer({ capturedAt: '2026-04-01T00:00:00.000Z' })],
+          }),
         ],
       }),
       failed: false,
     });
 
-    expect((await body(await get())).release.pricesCheckedAt).toBe('2026-07-04T00:00:00.000Z');
+    expect((await body(await get())).release.pricesCheckedAt).toBe('2026-08-10T00:00:00.000Z');
   });
 
   it('reports null freshness rather than a date when nothing has been captured', async () => {

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -73,8 +73,10 @@ export async function handler(event: {
         .gte('created_at', ago30),
 
       // All search events (with context) last 7 days — filtered in JS for success rate.
-      // We fire two 'search' events per query: initiation (no has_results) and completion
-      // (has_results: true/false). We filter in JS to avoid flaky JSONB null checks.
+      // The web app writes one 'search' event per query, on completion (has_results:
+      // true/false). Rows from before 2026-08-19 include a second, context-free initiation
+      // event per query — the JS filter below excludes those from the success rate, and it's
+      // why search counts stepped down (and became accurate) on that date.
       client
         .from('app_events')
         .select('context')

--- a/api/functions/analytics-event.ts
+++ b/api/functions/analytics-event.ts
@@ -5,7 +5,7 @@
 
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
-import { type SourceId, CURATED_PLATFORMS, SEARCH_ONLY_PLATFORMS } from './search-utils';
+import { CURATED_PLATFORMS, SEARCH_ONLY_PLATFORMS } from './search-utils';
 
 // Build set of valid source IDs for click: metrics from the SourceId union + platform sets
 const VALID_SOURCE_IDS = new Set<string>([
@@ -39,6 +39,9 @@ function isValidMetric(metric: string): boolean {
 // Module-level cache: slug → artist_id (persists across warm invocations)
 const slugCache = new Map<string, string>();
 
+// More slugs than any real search renders is abuse, not analytics.
+const MAX_BATCH_SLUGS = 24;
+
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
@@ -58,18 +61,23 @@ export async function handler(event: {
   const rl = await checkRateLimit(ip, 'standard', CORS_HEADERS);
   if (rl.limited) return rl.response;
 
-  // Parse and validate
-  let slug: string;
+  // Parse and validate. Two body shapes: { slug, metric } — one event, what the extension and
+  // Mac app send — and { slugs: [...], metric } — the web app's batched search appearances,
+  // one request for every claimed artist a search rendered instead of one request per card.
+  let slugs: string[];
   let metric: string;
   try {
     const body = JSON.parse(event.body || '{}');
-    slug = body.slug;
     metric = body.metric;
+    slugs = Array.isArray(body.slugs) ? body.slugs : [body.slug];
   } catch {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' }; // silent no-op on bad JSON
   }
 
-  if (!slug || !metric || !isValidMetric(metric)) {
+  slugs = [...new Set(slugs.filter(s => typeof s === 'string' && s.length > 0 && s.length <= 200))]
+    .slice(0, MAX_BATCH_SLUGS);
+
+  if (slugs.length === 0 || !metric || !isValidMetric(metric)) {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' }; // silent no-op
   }
 
@@ -78,30 +86,47 @@ export async function handler(event: {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' }; // DB not configured
   }
 
-  // Resolve artist_id from slug (with cache)
-  let artistId = slugCache.get(slug);
-  if (!artistId) {
-    const { data: artist } = await client
+  // Resolve artist ids from slugs — cache first, then one query for whatever's left
+  const ids: string[] = [];
+  const missing: string[] = [];
+  for (const slug of slugs) {
+    const cached = slugCache.get(slug);
+    if (cached) ids.push(cached);
+    else missing.push(slug);
+  }
+  if (missing.length > 0) {
+    const { data: artists } = await client
       .from('artists')
-      .select('id')
-      .eq('slug', slug)
-      .single();
-
-    if (!artist) {
-      return { statusCode: 204, headers: CORS_HEADERS, body: '' }; // unknown artist
+      .select('id, slug')
+      .in('slug', missing);
+    for (const artist of (artists as Array<{ id: string; slug: string }>) ?? []) {
+      slugCache.set(artist.slug, artist.id);
+      ids.push(artist.id);
     }
-    artistId = artist.id;
-    slugCache.set(slug, artistId);
+    // Unknown slugs are dropped silently, same as the single-event path always has.
   }
 
-  // Atomic upsert-increment
+  if (ids.length === 0) {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  // Atomic upsert-increment: the single-row RPC for one event, the batch RPC for many —
+  // one transaction either way.
   const today = new Date().toISOString().split('T')[0];
   try {
-    await client.rpc('increment_analytics', {
-      p_artist_id: artistId,
-      p_date: today,
-      p_metric: metric,
-    });
+    if (ids.length === 1) {
+      await client.rpc('increment_analytics', {
+        p_artist_id: ids[0],
+        p_date: today,
+        p_metric: metric,
+      });
+    } else {
+      await client.rpc('increment_analytics_batch', {
+        p_artist_ids: ids,
+        p_date: today,
+        p_metric: metric,
+      });
+    }
   } catch {
     // Silent fail — don't break the caller's experience for analytics
   }

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -55,6 +55,29 @@ interface LibraryMatches {
   artists: Map<string, MatchedArtist>;
 }
 
+/** The stored columns a re-sync compares against before writing a row back. */
+interface StoredCollectionItem {
+  external_id: string;
+  title: string | null;
+  artist_name: string | null;
+  art_url: string | null;
+  acquired_at: string | null;
+  release_id: string | null;
+}
+
+/**
+ * Timestamp equality across serializations. Postgres reads a timestamptz back as
+ * `2024-05-01T10:00:00+00:00` where Subsonic sent `2024-05-01T10:00:00Z` — a raw string
+ * compare would call every row changed and quietly turn the re-sync diff into a no-op.
+ */
+function sameInstant(a: string | null, b: string | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const parsedA = Date.parse(a);
+  const parsedB = Date.parse(b);
+  return Number.isFinite(parsedA) && Number.isFinite(parsedB) && parsedA === parsedB;
+}
+
 /**
  * Match imported albums to Unstream artists (by normalized name) and releases (by
  * normalized artist name + normalized title — releases.match_key is already
@@ -419,8 +442,46 @@ export async function handler(event: {
       // `hidden` deliberately omitted: re-syncs must not un-hide items the user hid.
     }));
 
-    for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
-      const chunk = rows.slice(i, i + UPSERT_CHUNK);
+    // Write only what a re-sync actually changes. This used to upsert every row every time,
+    // and the table's updated_at trigger guarantees an upsert dirties the row — so a re-sync
+    // of a 190-album collection where nothing changed rewrote 190 rows plus their indexes to
+    // say nothing, and a stalled sync retried after the 20-minute staleness window re-paid
+    // that on every attempt. In the usual case the only rows worth writing are the new
+    // purchases. A failed read degrades to writing everything, exactly as before — skipping a
+    // real update because a read blipped is the worse trade.
+    const existingRead = await readAllPages<StoredCollectionItem>(
+      (from, to) => client
+        .from('collection_items')
+        .select('external_id, title, artist_name, art_url, acquired_at, release_id')
+        .eq('user_id', userId)
+        .eq('source', 'bandcamp')
+        .order('external_id')
+        .range(from, to),
+      'collection_items (bandcamp-sync diff)'
+    );
+    const existingById = new Map(
+      existingRead.ok ? existingRead.rows.map(row => [row.external_id, row]) : []
+    );
+
+    const toWrite = rows.filter(row => {
+      const prior = existingById.get(row.external_id);
+      if (!prior) return true;
+      // Matching is best-effort: a null from this run means "no new information", not "unlink
+      // this item" — linkCollectionItemsForArtist sets release_id after the fact, and a re-sync
+      // whose artist read blipped must not undo it.
+      row.release_id = row.release_id ?? prior.release_id;
+      row.art_url = row.art_url ?? prior.art_url;
+      return (
+        row.title !== prior.title ||
+        row.artist_name !== prior.artist_name ||
+        row.art_url !== prior.art_url ||
+        row.release_id !== prior.release_id ||
+        !sameInstant(row.acquired_at, prior.acquired_at)
+      );
+    });
+
+    for (let i = 0; i < toWrite.length; i += UPSERT_CHUNK) {
+      const chunk = toWrite.slice(i, i + UPSERT_CHUNK);
       const { error } = await client
         .from('collection_items')
         .upsert(chunk, { onConflict: 'user_id,source,external_id' });
@@ -446,7 +507,7 @@ export async function handler(event: {
       throw new Error(`connection status update failed: ${doneError.message}`);
     }
 
-    console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${matches.releases.size} matched to releases, ${matches.artists.size} artists)`);
+    console.log(`[bandcamp-sync] imported ${uniqueAlbums.length} albums (${toWrite.length} written, ${uniqueAlbums.length - toWrite.length} unchanged, ${matches.releases.size} matched to releases, ${matches.artists.size} artists)`);
 
     outcome = {
       statusCode: 200,

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -1380,6 +1380,48 @@ interface DetailToPersist {
   }>;
 }
 
+interface ReleaseDetailColumns {
+  status: string | null;
+  release_date: string | null;
+  date_precision: string | null;
+}
+
+interface StoredOffer {
+  format: string;
+  price: number | string | null;
+  currency: string | null;
+  availability: string;
+}
+
+/** Would writing this detail's status/date change the release row at all? */
+function releaseRowMatchesDetail(prior: ReleaseDetailColumns | null, detail: DetailToPersist): boolean {
+  if (!prior) return false;
+  if (prior.status !== detail.status) return false;
+  if (!detail.releaseDate) return true;
+  // A `date` column reads back as YYYY-MM-DD whatever ISO shape was written into it, so
+  // compare on that prefix — a raw string compare against a full timestamp would never match
+  // and would quietly turn this skip into a no-op.
+  const priorDate = prior.release_date ? String(prior.release_date).slice(0, 10) : null;
+  return priorDate === detail.releaseDate.slice(0, 10) && prior.date_precision === detail.datePrecision;
+}
+
+/** Same offers, field for field? Order-independent; formats are unique per source. */
+function offersMatch(prior: StoredOffer[], offers: DetailToPersist['offers']): boolean {
+  if (prior.length !== offers.length) return false;
+  const byFormat = new Map(prior.map(o => [o.format, o]));
+  return offers.every(offer => {
+    const stored = byFormat.get(offer.format);
+    if (!stored) return false;
+    // `price` is numeric in Postgres; normalize so a string-serialized number still matches.
+    const storedPrice = stored.price == null ? null : Number(stored.price);
+    return (
+      storedPrice === (offer.price ?? null) &&
+      (stored.currency ?? null) === (offer.currency ?? null) &&
+      stored.availability === offer.availability
+    );
+  });
+}
+
 /**
  * Write what a release's own page told us: its date, and what you can buy there.
  *
@@ -1395,6 +1437,18 @@ interface DetailToPersist {
  *   erase real prices.
  * - Stamping last means an interrupted run is retried next cycle instead of being recorded as
  *   done.
+ *
+ * Both writes are read-compare-skip, for the same reason as persistReleases' title comparison:
+ * in steady state a 30-day re-check re-derives exactly what the rows already say, and writing
+ * it anyway costs a new tuple plus every index to restate nothing — at ~hundreds of detail
+ * refreshes a day, that was the largest remaining write source after the first Disk IO audit.
+ * A failed pre-read falls through to writing (same rule as getExistingSources): skipping a real
+ * update because a read blipped is the worse trade.
+ *
+ * The casualty is `release_offers.captured_at`, which now advances only when an offer actually
+ * changes — it means "when this price last moved", not "when we last confirmed it". The
+ * "prices checked" freshness shown to users comes from `release_sources.detail_checked_at`,
+ * which IS stamped on every pass (release-detail.ts and release-page.ts both read it).
  *
  * Returns false when nothing could be written, so the caller can count it as a failure.
  */
@@ -1415,42 +1469,60 @@ export async function persistReleaseDetail(
         patch.date_precision = detail.datePrecision;
       }
 
-      const { error } = await client.from('releases').update(patch).eq('id', release.releaseId);
-      if (error) {
-        console.error('[DB] persistReleaseDetail release update failed:', error.message);
-        return false;
+      const { data: prior } = await client
+        .from('releases')
+        .select('status, release_date, date_precision')
+        .eq('id', release.releaseId)
+        .maybeSingle();
+
+      if (!releaseRowMatchesDetail(prior as ReleaseDetailColumns | null, detail)) {
+        const { error } = await client.from('releases').update(patch).eq('id', release.releaseId);
+        if (error) {
+          console.error('[DB] persistReleaseDetail release update failed:', error.message);
+          return false;
+        }
       }
     }
 
     if (detail.offers.length > 0) {
-      const capturedAt = new Date().toISOString();
-      const { error: offerError } = await client.from('release_offers').upsert(
-        detail.offers.map(offer => ({
-          release_source_id: release.sourceId,
-          format: offer.format,
-          price: offer.price,
-          currency: offer.currency,
-          availability: offer.availability,
-          captured_at: capturedAt,
-        })),
-        { onConflict: 'release_source_id,format' }
-      );
-
-      if (offerError) {
-        console.error('[DB] persistReleaseDetail offer upsert failed:', offerError.message);
-        return false;
-      }
-
-      const { error: pruneError } = await client
+      const { data: priorOffers, error: priorOffersError } = await client
         .from('release_offers')
-        .delete()
-        .eq('release_source_id', release.sourceId)
-        .not('format', 'in', `(${detail.offers.map(o => o.format).join(',')})`);
+        .select('format, price, currency, availability')
+        .eq('release_source_id', release.sourceId);
 
-      // A failed prune leaves a stale format listed, which is worth logging but not worth
-      // failing the whole detail write over — the prices we did just refresh are still good.
-      if (pruneError) {
-        console.error('[DB] persistReleaseDetail offer prune failed:', pruneError.message);
+      const unchanged =
+        !priorOffersError && offersMatch((priorOffers as StoredOffer[]) ?? [], detail.offers);
+
+      if (!unchanged) {
+        const capturedAt = new Date().toISOString();
+        const { error: offerError } = await client.from('release_offers').upsert(
+          detail.offers.map(offer => ({
+            release_source_id: release.sourceId,
+            format: offer.format,
+            price: offer.price,
+            currency: offer.currency,
+            availability: offer.availability,
+            captured_at: capturedAt,
+          })),
+          { onConflict: 'release_source_id,format' }
+        );
+
+        if (offerError) {
+          console.error('[DB] persistReleaseDetail offer upsert failed:', offerError.message);
+          return false;
+        }
+
+        const { error: pruneError } = await client
+          .from('release_offers')
+          .delete()
+          .eq('release_source_id', release.sourceId)
+          .not('format', 'in', `(${detail.offers.map(o => o.format).join(',')})`);
+
+        // A failed prune leaves a stale format listed, which is worth logging but not worth
+        // failing the whole detail write over — the prices we did just refresh are still good.
+        if (pruneError) {
+          console.error('[DB] persistReleaseDetail offer prune failed:', pruneError.message);
+        }
       }
     }
 

--- a/api/functions/release-detail.ts
+++ b/api/functions/release-detail.ts
@@ -209,11 +209,16 @@ export async function handler(event: {
         };
       });
 
-    // The oldest price across every source is the honest freshness claim: saying "checked today"
+    // The oldest check across every source is the honest freshness claim: saying "checked today"
     // because *one* source was re-read would overstate the rest. ISO rather than the page's
     // "3 days ago" — a native client formats dates in the user's own locale.
+    //
+    // `detail_checked_at`, not the offers' `captured_at`: the detail pass skips rewriting
+    // offers whose prices haven't moved, so `captured_at` now means "when this price last
+    // changed" — it stops advancing on a quiet release and would read as stale data we had in
+    // fact just re-verified. `detail_checked_at` is stamped on every pass, changed or not.
     const pricesCheckedAt = sources
-      .flatMap(s => s.offers.map(o => o.capturedAt))
+      .map(s => s.detailCheckedAt)
       .filter(Boolean)
       .sort()[0] ?? null;
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -90,6 +90,9 @@
     "functions/__tests__/collection-art.test.ts",
     "functions/__tests__/collection-art-ratelimit.test.ts",
     "functions/__tests__/collection-matching.test.ts",
-    "functions/__tests__/sentry-environment.test.ts"
+    "functions/__tests__/sentry-environment.test.ts",
+    "functions/analytics-event.ts",
+    "functions/__tests__/analytics-event.test.ts",
+    "functions/__tests__/persist-release-detail-churn.test.ts"
   ]
 }

--- a/apps/web/src/components/ResultCardRelease.tsx
+++ b/apps/web/src/components/ResultCardRelease.tsx
@@ -51,8 +51,10 @@ export function ResultCardRelease({ result, latestRelease, platformsWithRelease,
                 }}
                 onClick={(e) => {
                   e.stopPropagation();
-                  analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
+                  // One tracker per click: trackArtistLinkClick already records the platform_click
+                  // product event, so also calling trackPlatformClick double-counted claimed clicks.
                   if (result.claimedSlug) analytics.trackArtistLinkClick(result.claimedSlug, platform.sourceId);
+                  else analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
                 }}
               >
                 <span>{getSource(platform.sourceId).icon}</span>

--- a/apps/web/src/components/ResultCardSocial.tsx
+++ b/apps/web/src/components/ResultCardSocial.tsx
@@ -29,8 +29,10 @@ export function ResultCardSocial({ platforms, claimedSlug, onRemoveLink }: Resul
             title={platform.displayName ?? getSource(platform.sourceId).name}
             onClick={(e) => {
               e.stopPropagation();
-              analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
+              // One tracker per click: trackArtistLinkClick already records the platform_click
+              // product event, so also calling trackPlatformClick double-counted claimed clicks.
               if (claimedSlug) analytics.trackArtistLinkClick(claimedSlug, platform.sourceId);
+              else analytics.trackPlatformClick(platform.displayName ?? getSource(platform.sourceId).name);
             }}
           >
             <SocialIcon platform={platform.sourceId} />

--- a/apps/web/src/services/analytics.ts
+++ b/apps/web/src/services/analytics.ts
@@ -53,6 +53,28 @@ function trackArtistEvent(slug: string, metric: string): void {
   }).catch(() => {});
 }
 
+/**
+ * Search appearances arrive as a burst — one per claimed artist the moment the results render —
+ * and each used to be its own POST, which cost one database transaction per card. Buffer the
+ * burst and send it as a single batched request instead. The window is generous because it only
+ * delays analytics, never the UI; enrichment results that land seconds later simply start a
+ * second batch.
+ */
+let appearanceBuffer: string[] = [];
+let appearanceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushSearchAppearances(): void {
+  const slugs = [...new Set(appearanceBuffer)];
+  appearanceBuffer = [];
+  appearanceTimer = null;
+  if (slugs.length === 0) return;
+  fetch('/api/analytics/event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slugs, metric: 'search' }),
+  }).catch(() => {});
+}
+
 /** Fire-and-forget POST to the product analytics endpoint. */
 function trackAppEvent(
   event_type: string,
@@ -85,13 +107,14 @@ export const analytics = {
   },
   trackReportIssue: () => trackEvent('/report-issue'),
 
-  // Search initiated (GoatCounter + product analytics)
+  // Search initiated (GoatCounter only — the app_events row is written once, on completion,
+  // by trackSearchResults. Firing both wrote two 'search' rows per query, which doubled the
+  // admin dashboard's search counts and doubled the write cost for no information.)
   trackSearch: () => {
     trackEvent('/search');
-    trackAppEvent('search', {});
   },
 
-  // Search results received (product analytics only)
+  // Search completed (product analytics — the one 'search' event per query)
   trackSearchResults: (hasResults: boolean, resultCount: number) => {
     trackAppEvent('search', { has_results: hasResults, result_count: resultCount });
   },
@@ -102,11 +125,6 @@ export const analytics = {
     trackAppEvent('platform_click', { platform: platformName.toLowerCase() });
   },
 
-  // Page views (product analytics only — GoatCounter handles page views automatically)
-  trackPageView: (page: string) => {
-    trackAppEvent('page_view', { page });
-  },
-
   // Artist-specific events (GoatCounter + Supabase artist analytics + product analytics)
   trackArtistPageView: (slug: string) => {
     trackEvent('/artist-view');
@@ -115,8 +133,13 @@ export const analytics = {
   },
   trackArtistSearchAppearance: (slug: string) => {
     trackEvent('/artist-search');
-    trackArtistEvent(slug, 'search');
+    appearanceBuffer.push(slug);
+    if (!appearanceTimer) appearanceTimer = setTimeout(flushSearchAppearances, 1000);
   },
+  // Fires everything a link click means: GoatCounter, the artist's own dashboard metric, and
+  // the product 'platform_click' event. A call site with a claimed slug calls this INSTEAD OF
+  // trackPlatformClick, never alongside it — calling both wrote the product event twice, which
+  // double-counted clicks for claimed artists (and only claimed artists) in the admin dashboard.
   trackArtistLinkClick: (slug: string, platform: string) => {
     trackEvent(`/artist-click/${platform.toLowerCase()}`);
     trackArtistEvent(slug, `click:${platform.toLowerCase()}`);

--- a/apps/web/tests/unit/analytics.test.ts
+++ b/apps/web/tests/unit/analytics.test.ts
@@ -51,3 +51,72 @@ describe('analytics — never throws, whatever GoatCounter is doing', () => {
     expect(count).toHaveBeenCalledWith({ path: '/search', event: true });
   });
 });
+
+/**
+ * These pin the write-side of the Disk IO fixes (2026-08-19): one product event per user action,
+ * and search appearances batched into one request per burst instead of one per rendered card.
+ * Every fetch here is a Postgres write on the other end.
+ */
+describe('analytics — one write per user action', () => {
+  const fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 204 }));
+
+  const appEventCalls = (type: string) =>
+    fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        url === '/api/analytics/app-event' &&
+        JSON.parse((init as RequestInit).body as string).event_type === type
+    );
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    fetchMock.mockClear();
+    delete (window as { goatcounter?: unknown }).goatcounter;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('records a search once, on completion — initiation is GoatCounter-only', () => {
+    analytics.trackSearch();
+    analytics.trackSearchResults(true, 7);
+
+    const searchEvents = appEventCalls('search');
+    expect(searchEvents).toHaveLength(1);
+    expect(JSON.parse((searchEvents[0][1] as RequestInit).body as string).context).toMatchObject({
+      has_results: true,
+      result_count: 7,
+    });
+  });
+
+  it('records one platform_click per claimed link click', () => {
+    analytics.trackArtistLinkClick('some-artist', 'mirlo');
+
+    expect(appEventCalls('platform_click')).toHaveLength(1);
+  });
+
+  it('batches a burst of search appearances into a single deduplicated request', () => {
+    analytics.trackArtistSearchAppearance('artist-a');
+    analytics.trackArtistSearchAppearance('artist-b');
+    analytics.trackArtistSearchAppearance('artist-a'); // a re-render must not double-count
+
+    expect(fetchMock.mock.calls.filter(([url]) => url === '/api/analytics/event')).toHaveLength(0);
+    vi.runAllTimers();
+
+    const eventCalls = fetchMock.mock.calls.filter(([url]) => url === '/api/analytics/event');
+    expect(eventCalls).toHaveLength(1);
+    expect(JSON.parse((eventCalls[0][1] as RequestInit).body as string)).toEqual({
+      slugs: ['artist-a', 'artist-b'],
+      metric: 'search',
+    });
+  });
+
+  it('starts a fresh batch for appearances that land after a flush (enrichment results)', () => {
+    analytics.trackArtistSearchAppearance('artist-a');
+    vi.runAllTimers();
+    analytics.trackArtistSearchAppearance('artist-c');
+    vi.runAllTimers();
+
+    const eventCalls = fetchMock.mock.calls.filter(([url]) => url === '/api/analytics/event');
+    expect(eventCalls).toHaveLength(2);
+    expect(JSON.parse((eventCalls[1][1] as RequestInit).body as string).slugs).toEqual(['artist-c']);
+  });
+});

--- a/supabase/migrations/20260819120000_analytics-batch-increment.sql
+++ b/supabase/migrations/20260819120000_analytics-batch-increment.sql
@@ -1,0 +1,28 @@
+-- Batch variant of increment_analytics (migration 003).
+--
+-- One search response renders every claimed artist it matched, and the web client used to POST
+-- one analytics event per rendered card — N requests, N transactions, for one user action. The
+-- client now sends the whole burst as a single { slugs: [...], metric } request, and this
+-- function applies it as one INSERT ... ON CONFLICT statement: one transaction however many
+-- artists appeared. Part of the second Disk IO Budget fix round (2026-08-19).
+--
+-- DISTINCT because ON CONFLICT DO UPDATE refuses to touch the same row twice within one
+-- INSERT ("cannot affect row a second time") — a duplicated id must collapse before the write,
+-- which does mean a duplicate counts once, matching the deduplication the endpoint already does.
+--
+-- SECURITY DEFINER for the same reason as increment_analytics: it runs with owner privileges so
+-- event ingestion can write rows that RLS otherwise reserves for the artist reading their own
+-- stats. CREATE OR REPLACE keeps the migration idempotent.
+CREATE OR REPLACE FUNCTION increment_analytics_batch(
+  p_artist_ids UUID[],
+  p_date DATE,
+  p_metric TEXT
+) RETURNS void AS $$
+BEGIN
+  INSERT INTO artist_analytics (artist_id, date, metric, count)
+  SELECT DISTINCT id, p_date, p_metric, 1
+  FROM unnest(p_artist_ids) AS id
+  ON CONFLICT (artist_id, date, metric)
+  DO UPDATE SET count = artist_analytics.count + 1;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Second Supabase disk I/O budget warning (2026-08-19). The [full audit](https://claude.ai/code/artifact/715bad5e-1c21-4020-b9a7-3a5ae871aa5c) found all of PR #443's fixes intact; this PR is Phase 1 of round 2 — eliminating the remaining steady-state write churn. Three commits, independently revertable:

**1. `persistReleaseDetail` read-compare-skip** (~2,500 avoidable writes/day)
The 30-day detail pass rewrote the release row, every offer (with a fresh `captured_at`, so rows were guaranteed "different"), and a prune delete even when nothing changed — the identical bug #443 fixed in `persistReleases`, one function up. Now both writes compare first and fail toward writing on a blipped pre-read. Because `captured_at` no longer advances on unchanged prices, the "prices checked" freshness shown on release pages and in the API now derives from `detail_checked_at` (stamped every pass) — server-side only, no client changes.

**2. Collection re-sync diff-before-upsert**
A re-sync upserted the whole library every time, and the table's `updated_at` trigger guarantees every upsert dirties the row — ~190 rewrites per re-sync where 0–2 are needed, re-paid on every retry of a stalled sync. Now it reads what's stored once and writes only new/changed rows. Instant-normalized timestamp compares (Z vs +00:00) and null-coalescing on `release_id`/`art_url` so a blipped match can't unlink items. No retry cap needed: retries are user-initiated (409 + 20-min staleness window + 10/min limit), and with the diff a retry's write cost is ~zero.

**3. Analytics: one write per user action**
- Claimed-link clicks fired `platform_click` twice → call sites pick one tracker. **This also fixes the admin dashboard double-counting clicks for claimed artists (and only claimed artists).**
- Each search wrote two `app_events` rows → one, on completion, with result context. **Admin search counts will step down (and become accurate) at merge — that's the dedup, not a traffic drop.** A comment in `analytics-dashboard.ts` records the date.
- One counter increment per rendered claimed result card (~10+ transactions/search) → client batches the burst into one request; new `increment_analytics_batch` RPC applies it in one statement. Migration validated against a throwaway postgres:16, including the duplicate-id case `ON CONFLICT` refuses.
- Deletes dead `trackPageView`; adds `analytics-event.ts` to the api typecheck include (strict surfaced one unused import, removed).

**Verification:** typecheck (root, web, api) clean; 1,261 API tests + 781 web unit tests pass. The one red test (`notifications.test.ts`) fails on clean `main` too — a fixture date aged out of the alert window on 2026-08-19; fix is queued separately. CI on this PR will show that same pre-existing failure.

**Migration note:** additive `CREATE OR REPLACE FUNCTION` only — merge promptly once approved so the migrations workflow stays in sync (the #438 lesson).

After a few days of this in production, re-run the audit's Step 0 SQL for the before/after we didn't capture last round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)