### PR TITLE
Disk I/O round 2, Phase 2: stop the repeated reads

### DIFF
--- a/api/edge/u-handle.ts
+++ b/api/edge/u-handle.ts
@@ -316,7 +316,12 @@ export default async function handler(request: Request, context: Context) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=0, must-revalidate',
-        'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
+        // An hour, not five minutes: every write that changes this page purges the
+        // user-share tag (save/unsave, the sharing toggle, hiding an item, a collection
+        // sync), so the TTL only bounds staleness if a purge is missed — it is not the
+        // freshness mechanism, and at 300s this was 3 queries per handle per five minutes
+        // of crawler traffic.
+        'Netlify-CDN-Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
         'Cache-Tag': `user-share-${handle}`,
       },
     });

--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -8,10 +8,16 @@ const mocks = vi.hoisted(() => ({
   mockResolveArtists: vi.fn(),
 }));
 
-vi.mock('../db', () => ({
-  getClient: () => ({ from: mocks.mockFrom }),
-  readAllPages: mocks.mockReadAllPages,
-}));
+// artistSlug passes through from the real module: the sync stores its output on every row, and a
+// test-local reimplementation would drift from the one the linker probes with.
+vi.mock('../db', async importOriginal => {
+  const original = await importOriginal<typeof import('../db')>();
+  return {
+    ...original,
+    getClient: () => ({ from: mocks.mockFrom }),
+    readAllPages: mocks.mockReadAllPages,
+  };
+});
 // Stubbed so these tests stay about the import. The pass it replaces probes Bandcamp for every
 // unknown artist name; left real against this file's mocked `../db` it would throw, and the
 // handler catches that on purpose, so the whole suite would go on passing while the pass did
@@ -231,7 +237,9 @@ describe('bandcamp-sync-background handler', () => {
       external_id: 'al-1',
       title: 'Illinois',
       artist_name: 'Sufjan Stevens',
+      artist_slug: 'sufjan-stevens',
       art_url: null,
+      art_ref: null,
       // Postgres serialization (+00:00), where Subsonic sends Z — a string compare would call
       // this changed and quietly turn the whole diff into a no-op. That's the point of the test.
       acquired_at: '2026-01-01T00:00:00+00:00',
@@ -308,6 +316,24 @@ describe('bandcamp-sync-background handler', () => {
       const rows = upsertBatches.flat();
       expect(rows).toHaveLength(1);
       expect(rows[0]).toMatchObject({ external_id: 'al-1', release_id: 'rel-1' });
+    });
+
+    it('backfills a pre-migration row missing artist_slug, exactly once', async () => {
+      const { upsertBatches } = setupDb({
+        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
+      });
+      // A row synced before the artist_slug/art_ref columns existed: NULLs where the built row
+      // has values. The diff must write it once — that write IS the backfill the linker's
+      // fallback read exists to bridge — and the fixture above proves a backfilled row is then
+      // left alone.
+      withStored([stored({ artist_slug: null })]);
+      mocks.mockFetchAllAlbums.mockResolvedValue([album()]);
+
+      await handler(internalEvent({ userId: 'user-1' }));
+
+      const rows = upsertBatches.flat();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ external_id: 'al-1', artist_slug: 'sufjan-stevens' });
     });
 
     it('falls back to writing everything when the stored read fails', async () => {

--- a/api/functions/__tests__/collection-art.test.ts
+++ b/api/functions/__tests__/collection-art.test.ts
@@ -27,7 +27,7 @@ vi.mock('../bandcamp-subsonic', async importOriginal => {
   };
 });
 
-import { handler } from '../collection-art';
+import { handler, clearConnectionCacheForTests } from '../collection-art';
 import { encryptCredential } from '../credential-crypto';
 
 const ITEM_ID = '11111111-1111-4111-8111-111111111111';
@@ -99,6 +99,9 @@ function signedInAs(userId: string | null) {
 describe('collection-art handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // The warm-invocation connection cache is real module state; without this, one case's
+    // connection (encrypted under that case's key) leaks into the next.
+    clearConnectionCacheForTests();
     process.env.SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_ANON_KEY = 'anon-key';
     process.env.BANDCAMP_CREDENTIAL_KEY = randomBytes(32).toString('base64');
@@ -193,5 +196,77 @@ describe('collection-art handler', () => {
     expect(res.body).not.toContain('tok');
     expect(res.body).not.toContain('salt');
     expect(res.body).not.toContain('ciphertext');
+  });
+
+  // The tokened path: an <img> tag carries no Authorization header, so the endpoints that
+  // already decided the viewer may see an item mint its URL with proof of that decision.
+  describe('art URL tokens', () => {
+    beforeEach(() => {
+      process.env.INTERNAL_FUNCTION_SECRET = 'art-token-secret';
+    });
+    afterEach(() => {
+      delete process.env.INTERNAL_FUNCTION_SECRET;
+    });
+
+    async function mintedToken() {
+      // The real minting function, so this can't pass with a token scheme the minters don't use.
+      const { collectionArtToken } = await import('../collection-utils');
+      return collectionArtToken(ITEM_ID)!;
+    }
+
+    it('serves a private, hidden item to a bare <img> request carrying a minted token', async () => {
+      // The bug this path fixes: a non-public owner's own dashboard art 404ing, because the
+      // browser sends no auth on images and sharing is off.
+      setupDb({ item: { ...PUBLIC_ITEM, hidden: true }, sharingPublic: false });
+      signedInAs(null);
+
+      const res = await handler({
+        httpMethod: 'GET',
+        headers: {},
+        pathParameters: { id: ITEM_ID },
+        queryStringParameters: { t: await mintedToken() },
+      });
+
+      expect(res.statusCode).toBe(200);
+      // And it cost no permission reads: only the item and the connection were consulted.
+      const tables = mocks.mockFrom.mock.calls.map(([table]) => table);
+      expect(tables).not.toContain('usernames');
+      expect(mocks.mockCreateClient).not.toHaveBeenCalled();
+    });
+
+    it('treats a forged token as no token at all', async () => {
+      setupDb({ item: { ...PUBLIC_ITEM, hidden: true }, sharingPublic: false });
+      signedInAs(null);
+
+      const res = await handler({
+        httpMethod: 'GET',
+        headers: {},
+        pathParameters: { id: ITEM_ID },
+        queryStringParameters: { t: 'f'.repeat(32) },
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(mocks.mockFetchCoverArt).not.toHaveBeenCalled();
+    });
+  });
+
+  it('uses the stored art_ref instead of asking Bandcamp for the album', async () => {
+    setupDb({ item: { ...PUBLIC_ITEM, art_ref: 'stored-art-9' }, sharingPublic: true });
+
+    const res = await get();
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.mockCoverArtId).not.toHaveBeenCalled();
+    expect(mocks.mockFetchCoverArt).toHaveBeenCalledWith(expect.anything(), 'stored-art-9', 600);
+  });
+
+  it('reuses the warm connection cache across a burst of tiles', async () => {
+    setupDb({ item: PUBLIC_ITEM, sharingPublic: true });
+
+    await get();
+    await get();
+
+    const connectionReads = mocks.mockFrom.mock.calls.filter(([t]) => t === 'bandcamp_connections');
+    expect(connectionReads).toHaveLength(1);
   });
 });

--- a/api/functions/__tests__/collection-matching.test.ts
+++ b/api/functions/__tests__/collection-matching.test.ts
@@ -120,6 +120,20 @@ describe('linkCollectionItemsForArtist', () => {
     expect(updates[0].releaseId).toBe('rel-jp');
   });
 
+  it('still links rows imported before artist_slug existed', async () => {
+    // The indexed probe reads slugged rows; a second read catches pre-migration rows whose
+    // artist_slug is NULL until their owner's next re-sync backfills it. Both must link.
+    const { updates } = setupLinkDb({ releases: [{ id: 'rel-bias', match_key: 'bias' }] });
+    pagedRows(
+      [{ id: 'item-new', title: 'Bias' }],   // artist_slug = 'king-triumph'
+      [{ id: 'item-old', title: 'bias' }]    // artist_slug IS NULL, matched by name
+    );
+
+    expect(await linkCollectionItemsForArtist('artist-1', 'King Triumph')).toBe(2);
+    expect(updates).toEqual([{ releaseId: 'rel-bias', itemIds: ['item-new', 'item-old'] }]);
+    expect(mocks.mockReadAllPages).toHaveBeenCalledTimes(2);
+  });
+
   it('does nothing, and reads no items, when the artist has no releases yet', async () => {
     const { updates } = setupLinkDb({ releases: [] });
 
@@ -155,6 +169,16 @@ function setupResolveDb({ artists = {} }: ResolveTables) {
     if (table === 'artists') {
       return {
         select: vi.fn(() => ({
+          // The batched whole-pass lookup — answers only the slugs that exist.
+          in: vi.fn((_column: string, slugs: string[]) =>
+            Promise.resolve({
+              data: slugs
+                .filter(slug => artists[slug])
+                .map(slug => ({ id: artists[slug].id, slug, match_confidence: artists[slug].match_confidence })),
+              error: null,
+            })
+          ),
+          // The per-slug lookup the Bandcamp-URL-owner path still uses.
           eq: vi.fn((_column: string, slug: string) => ({
             maybeSingle: vi.fn(() => Promise.resolve({ data: artists[slug] ?? null, error: null })),
           })),

--- a/api/functions/__tests__/get-artists-by-slugs.test.ts
+++ b/api/functions/__tests__/get-artists-by-slugs.test.ts
@@ -1,0 +1,112 @@
+// getArtistsBySlugs exists for the read bill: the name-contains search channel resolves up to
+// six known artists per fuzzy search, and per-slug getArtistBySlug calls cost 2-3 queries each —
+// 12-18 uncached reads inside every search. The batch must answer the whole list in at most
+// three queries and produce cards identical to the single-slug path (both feed the same
+// artistRowToResult), which is what these pin.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Row { [k: string]: unknown }
+
+const tables: Record<string, Row[]> = {};
+const queries: { table: string; op: string }[] = [];
+
+function makeClient() {
+  return {
+    from(table: string) {
+      const filters: { column: string; values: unknown[] }[] = [];
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        order() { return builder; },
+        eq(column: string, value: unknown) { filters.push({ column, values: [value] }); return builder; },
+        in(column: string, values: unknown[]) {
+          queries.push({ table, op: 'in' });
+          filters.push({ column, values });
+          return builder;
+        },
+        or() { return builder; },
+        single() { return builder.then as never; },
+        then(res: (v: unknown) => unknown) {
+          const rows = (tables[table] ?? []).filter(r =>
+            filters.every(f => f.values.includes(r[f.column]))
+          );
+          return Promise.resolve({ data: rows, error: null }).then(res);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+vi.mock('../request-catalog', () => ({ requestArtistCatalog: async () => true }));
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'k';
+
+const { getArtistsBySlugs } = await import('../db');
+
+const now = () => new Date().toISOString();
+
+beforeEach(() => {
+  for (const key of Object.keys(tables)) delete tables[key];
+  queries.length = 0;
+
+  tables.artists = [
+    {
+      id: 'a1', slug: 'king-triumph', name: 'King Triumph', image_url: 'https://img/kt.jpg',
+      match_confidence: 'verified', source: 'auto', updated_at: now(), last_enriched_at: null,
+      city: 'Baltimore', country: 'United States', country_code: 'US',
+    },
+    {
+      id: 'a2', slug: 'kid-lightbulbs', name: 'Kid Lightbulbs', image_url: null,
+      match_confidence: 'claimed', source: 'auto', updated_at: now(), last_enriched_at: null,
+      city: null, country: null, country_code: null,
+    },
+  ];
+  tables.artist_links = [
+    { id: 'l1', artist_id: 'a1', platform: 'bandcamp', url: 'https://kingtriumph.bandcamp.com', display_name: null, source: 'search', is_direct: true, latest_release: null, display_order: 0 },
+    { id: 'l2', artist_id: 'a2', platform: 'mirlo', url: 'https://mirlo.space/kidlightbulbs', display_name: null, source: 'claimed', is_direct: true, latest_release: null, display_order: 0 },
+  ];
+  tables.artist_profiles = [
+    { artist_id: 'a2', bio: 'Baltimore, MD', custom_image_url: 'https://img/custom.jpg', website_url: null, featured_embed: null, verified_at: now(), link_dividers: null },
+  ];
+});
+
+describe('getArtistsBySlugs', () => {
+  it('answers every slug with its links and profile in three batched queries', async () => {
+    const results = await getArtistsBySlugs(['king-triumph', 'kid-lightbulbs', 'nobody-here']);
+
+    expect(results.size).toBe(2);
+    expect(queries.map(q => q.table)).toEqual(['artists', 'artist_links', 'artist_profiles']);
+
+    const kt = results.get('king-triumph')!;
+    expect(kt.platforms).toEqual([
+      { sourceId: 'bandcamp', url: 'https://kingtriumph.bandcamp.com' },
+    ]);
+    expect(kt.location).toEqual({ city: 'Baltimore', country: 'United States', countryCode: 'US' });
+
+    const kl = results.get('kid-lightbulbs')!;
+    expect(kl.matchConfidence).toBe('claimed');
+    // The claimed card carries its profile — the custom image wins, matching getArtistBySlug.
+    expect(kl.profile).toMatchObject({ bio: 'Baltimore, MD', verified: true });
+    expect(kl.imageUrl).toBe('https://img/custom.jpg');
+  });
+
+  it('skips the profiles query entirely when no slug is claimed', async () => {
+    await getArtistsBySlugs(['king-triumph']);
+
+    expect(queries.map(q => q.table)).toEqual(['artists', 'artist_links']);
+  });
+
+  it('drops slugs that could not be stored ones instead of interpolating them', async () => {
+    const results = await getArtistsBySlugs(['king-triumph', 'not a slug!', 'slug.ilike.%25']);
+
+    expect(results.size).toBe(1);
+    expect(results.has('king-triumph')).toBe(true);
+  });
+
+  it('returns an empty map, not a throw, when every slug is unknown', async () => {
+    const results = await getArtistsBySlugs(['nobody', 'nobody-else']);
+    expect(results.size).toBe(0);
+  });
+});

--- a/api/functions/artist-directory.ts
+++ b/api/functions/artist-directory.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { isDirectLink, readAllPages } from './db';
+import { cacheGetOrFetch } from './cache';
 import { PLATFORMS } from '../shared/platform-registry';
 
 /**
@@ -91,19 +92,32 @@ export async function handler(event: { queryStringParameters?: Record<string, st
   //   * artists who have died — 107 of them, whose estates do still sell the music, but who the
   //     surrounding copy addresses as though they were here to be supported.
   if (event.queryStringParameters?.scope === 'known') {
-    const rows = await readVerifiedArtists(supabase);
+    // Redis-cached: this is the single largest-volume read in the codebase — every verified
+    // artist WITH their links embedded, ~3 paged requests of 1,000 rows each — behind only a
+    // 5-minute CDN window on a crawlable page. The index changes when an artist gains a
+    // buyable link or a page is verified, both of which tolerate an hour of lag. A failed
+    // read is never cached (the null check below 500s instead, and 5xx isn't CDN-cached
+    // either — same reasoning as the claimed path).
+    const { data: artists } = await cacheGetOrFetch(
+      'artist-directory:known',
+      async () => {
+        const rows = await readVerifiedArtists(supabase);
+        if (!rows) return null;
+        return rows
+          .filter(a => !a.died_on)
+          .filter(a =>
+            (a.artist_links || []).some(l => BUYABLE_PLATFORMS.has(l.platform) && isDirectLink(l.url))
+          )
+          .map(a => ({ slug: a.slug, name: a.name, imageUrl: a.image_url || null }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+      },
+      3600,
+      result => result !== null
+    );
 
-    if (!rows) {
+    if (!artists) {
       return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch artists' }) };
     }
-
-    const artists = rows
-      .filter(a => !a.died_on)
-      .filter(a =>
-        (a.artist_links || []).some(l => BUYABLE_PLATFORMS.has(l.platform) && isDirectLink(l.url))
-      )
-      .map(a => ({ slug: a.slug, name: a.name, imageUrl: a.image_url || null }))
-      .sort((a, b) => a.name.localeCompare(b.name));
 
     return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ artists }) };
   }

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -16,6 +16,7 @@
 import { Sentry } from '../lib/sentry';
 import { artistSlug, getClient, readAllPages } from './db';
 import { cacheGetOrFetch } from './cache';
+import { purgeUserShareCacheForUser } from './purge-cache';
 import { isInternalRequest } from './middleware';
 import { decryptCredential } from './credential-crypto';
 import {
@@ -516,6 +517,12 @@ export async function handler(event: {
     // Buying is supporting: mark every matched artist saved + supported. After the items
     // land — the mark is derived state, and a failure inside degrades rather than throwing.
     await markArtistsSupported(userId, [...matches.artists.values()]);
+
+    // The public page renders these items and is CDN-cached; a sync that wrote nothing
+    // changed nothing, so only a real write pays for the purge.
+    if (toWrite.length > 0) {
+      await purgeUserShareCacheForUser(userId, 'bandcamp-sync');
+    }
 
     const { error: doneError } = await client
       .from('bandcamp_connections')

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -14,7 +14,8 @@
 // import as a completed sync — that would show a user a quietly wrong collection.
 
 import { Sentry } from '../lib/sentry';
-import { getClient, readAllPages } from './db';
+import { artistSlug, getClient, readAllPages } from './db';
+import { cacheGetOrFetch } from './cache';
 import { isInternalRequest } from './middleware';
 import { decryptCredential } from './credential-crypto';
 import {
@@ -60,7 +61,9 @@ interface StoredCollectionItem {
   external_id: string;
   title: string | null;
   artist_name: string | null;
+  artist_slug: string | null;
   art_url: string | null;
+  art_ref: string | null;
   acquired_at: string | null;
   release_id: string | null;
 }
@@ -92,10 +95,21 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
 
   // The artists table is a few thousand rows; normalization has to happen in JS, so read
   // it once and match in memory rather than issuing a query per imported artist name.
-  const artistRead = await readAllPages<{ id: string; slug: string; name: string; image_url: string | null }>(
-    (from, to) => client.from('artists').select('id, slug, name, image_url').order('id').range(from, to),
-    'artists (bandcamp-sync matching)'
-  );
+  //
+  // Redis-cached because the map is identical across all users and all syncs, and reading it
+  // fresh was 3-4 paged requests streaming the whole table per sync. An hour of staleness is
+  // the same trade the failed-read path below already accepts: an artist created inside the
+  // window imports unmatched, and the next re-sync — or linkCollectionItemsForArtist, which is
+  // the real linking path and reads live — picks them up.
+  const artistRead = await cacheGetOrFetch(
+    'collection:artist-name-map',
+    () => readAllPages<{ id: string; slug: string; name: string; image_url: string | null }>(
+      (from, to) => client.from('artists').select('id, slug, name, image_url').order('id').range(from, to),
+      'artists (bandcamp-sync matching)'
+    ),
+    3600,
+    read => read.ok // never cache a failed read as an empty map
+  ).then(r => r.data);
   if (!artistRead.ok) {
     // Matching is enrichment: a failed read degrades to an unmatched import, not a failed sync.
     console.warn('[bandcamp-sync] artist read failed, importing unmatched:', artistRead.reason);
@@ -434,7 +448,13 @@ export async function handler(event: {
       external_id: album.id,
       title: album.name,
       artist_name: album.artist,
+      // The normalized slug is what linkCollectionItemsForArtist probes on (an indexed
+      // equality, where matching the raw name was a full ILIKE scan per catalogue pass).
+      artist_slug: artistSlug(album.artist) || null,
       art_url: matches.releases.get(album.id)?.artwork_url ?? null,
+      // The Subsonic cover-art id, so the art proxy can fetch the image directly instead of
+      // asking Bandcamp for the album first on every uncached tile.
+      art_ref: album.coverArt ?? null,
       acquired_at: album.created ?? null,
       provenance: 'purchased', // a Bandcamp collection is proof of purchase — spec §5
       acquisition: 'unknown',
@@ -452,7 +472,7 @@ export async function handler(event: {
     const existingRead = await readAllPages<StoredCollectionItem>(
       (from, to) => client
         .from('collection_items')
-        .select('external_id, title, artist_name, art_url, acquired_at, release_id')
+        .select('external_id, title, artist_name, artist_slug, art_url, art_ref, acquired_at, release_id')
         .eq('user_id', userId)
         .eq('source', 'bandcamp')
         .order('external_id')
@@ -471,10 +491,13 @@ export async function handler(event: {
       // whose artist read blipped must not undo it.
       row.release_id = row.release_id ?? prior.release_id;
       row.art_url = row.art_url ?? prior.art_url;
+      row.art_ref = row.art_ref ?? prior.art_ref;
       return (
         row.title !== prior.title ||
         row.artist_name !== prior.artist_name ||
+        row.artist_slug !== prior.artist_slug ||
         row.art_url !== prior.art_url ||
+        row.art_ref !== prior.art_ref ||
         row.release_id !== prior.release_id ||
         !sameInstant(row.acquired_at, prior.acquired_at)
       );

--- a/api/functions/collection-art.ts
+++ b/api/functions/collection-art.ts
@@ -19,6 +19,7 @@ import { createClient } from '@supabase/supabase-js';
 import { getClient } from './db';
 import { checkRateLimit, getClientIp } from './ratelimit';
 import { decryptCredential } from './credential-crypto';
+import { isValidCollectionArtToken } from './collection-utils';
 import {
   subsonicAlbumCoverArtId,
   subsonicFetchCoverArt,
@@ -52,8 +53,51 @@ const MISS_CACHE_HEADERS = {
 interface ItemRow {
   user_id: string;
   external_id: string | null;
+  art_ref: string | null;
   provenance: string;
   hidden: boolean;
+}
+
+interface ConnectionRow {
+  bandcamp_username: string;
+  credential_ciphertext: string;
+}
+
+/**
+ * The owner's Bandcamp connection, cached per warm invocation. A collection page fires 12-15
+ * art requests in one burst and every one needs the same connection row — this makes that one
+ * read instead of fifteen. Short TTL, module-scoped: nothing new at rest, and a disconnect is
+ * honoured within ten minutes (sooner in practice — a disconnect that deletes items makes the
+ * item lookup 404 first).
+ */
+const CONNECTION_CACHE_TTL_MS = 10 * 60 * 1000;
+const connectionCache = new Map<string, { row: ConnectionRow | null; expires: number }>();
+
+/** Test hook: module state would otherwise leak one case's connection into the next. */
+export function clearConnectionCacheForTests(): void {
+  connectionCache.clear();
+}
+
+async function connectionForUser(
+  client: NonNullable<ReturnType<typeof getClient>>,
+  userId: string
+): Promise<ConnectionRow | null> {
+  const cached = connectionCache.get(userId);
+  if (cached && cached.expires > Date.now()) return cached.row;
+
+  const { data, error } = await client
+    .from('bandcamp_connections')
+    .select('bandcamp_username, credential_ciphertext')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  // A failed read is not "no connection" — don't cache it, just answer this request.
+  if (error) {
+    console.error('[collection-art] connection lookup failed:', error.message);
+    return null;
+  }
+  connectionCache.set(userId, { row: (data as ConnectionRow | null) ?? null, expires: Date.now() + CONNECTION_CACHE_TTL_MS });
+  return (data as ConnectionRow | null) ?? null;
 }
 
 /** Declared so header lookups stay typed — this handler returns images as well as JSON. */
@@ -79,6 +123,7 @@ export async function handler(event: {
   headers: Record<string, string | undefined>;
   path?: string;
   pathParameters?: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string | undefined>;
 }): Promise<FunctionResponse> {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: BASE_HEADERS, body: '' };
@@ -112,7 +157,7 @@ export async function handler(event: {
 
   const { data: item, error: itemError } = await client
     .from('collection_items')
-    .select('user_id, external_id, provenance, hidden')
+    .select('user_id, external_id, art_ref, provenance, hidden')
     .eq('id', itemId)
     .maybeSingle<ItemRow>();
 
@@ -124,11 +169,23 @@ export async function handler(event: {
     return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'Not found' }) };
   }
 
-  // Two ways to be allowed to see this: you own it, or it is on a page anyone can see.
-  // The public test mirrors the public page exactly — purchased, not hidden, sharing on —
-  // so this endpoint can never expose a tile the page itself would withhold.
-  const viewerId = await authenticatedUserId(event.headers.authorization);
-  let allowed = viewerId === item.user_id;
+  // Three ways to be allowed to see this, checked cheapest first:
+  //
+  // 1. The URL carries a valid token, minted by an endpoint that already decided this viewer
+  //    may see this item (the owner's dashboard, or the public page after its own filters).
+  //    This is the only path a browser's <img> tag can actually take with credentials — images
+  //    carry no Authorization header, which is why non-public owners used to 404 on their own
+  //    dashboard art — and it costs zero extra reads.
+  // 2. You own it (a non-browser client sending a bearer token).
+  // 3. It is on a page anyone can see — the legacy bare-URL path, kept for URLs minted before
+  //    tokens existed (u-handle's crawler pages also still mint bare URLs; the check mirrors
+  //    the public page exactly: purchased, not hidden, sharing on).
+  let allowed = isValidCollectionArtToken(itemId, event.queryStringParameters?.t);
+
+  if (!allowed) {
+    const viewerId = await authenticatedUserId(event.headers.authorization);
+    allowed = viewerId === item.user_id;
+  }
 
   if (!allowed) {
     if (item.provenance !== 'purchased' || item.hidden) {
@@ -147,11 +204,7 @@ export async function handler(event: {
     return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
   }
 
-  const { data: connection } = await client
-    .from('bandcamp_connections')
-    .select('bandcamp_username, credential_ciphertext')
-    .eq('user_id', item.user_id)
-    .maybeSingle();
+  const connection = await connectionForUser(client, item.user_id);
 
   if (!connection) {
     return { statusCode: 404, headers: { ...JSON_HEADERS, ...MISS_CACHE_HEADERS }, body: JSON.stringify({ error: 'No art available' }) };
@@ -169,8 +222,10 @@ export async function handler(event: {
   }
 
   try {
-    // The album id is not guaranteed to be the cover-art id, so ask the album for it.
-    const coverArtId = await subsonicAlbumCoverArtId(credential, item.external_id);
+    // The album id is not guaranteed to be the cover-art id. The sync stores the real one on
+    // the item (`art_ref`); asking the album is the fallback for rows imported before that
+    // column existed, and costs one extra authenticated Bandcamp request.
+    const coverArtId = item.art_ref ?? await subsonicAlbumCoverArtId(credential, item.external_id);
     const art = coverArtId ? await subsonicFetchCoverArt(credential, coverArtId, 600) : null;
 
     if (!art) {

--- a/api/functions/collection-matching.ts
+++ b/api/functions/collection-matching.ts
@@ -133,21 +133,49 @@ export async function linkCollectionItemsForArtist(
     // Every user's unlinked items, not just one person's: a catalogue is built once and whoever
     // owns that record benefits. Paged because `collection_items` holds a row per purchase per
     // fan and PostgREST truncates a plain select at 1,000 rows without saying so.
+    //
+    // The probe is an equality on `artist_slug`, served by its partial index — this runs at the
+    // end of every catalogue pass (100+/day) and almost always finds nothing, and as an
+    // `artist_name ILIKE` it was a full scan of every user's items each time. Matching on the
+    // slug rather than the name is also deliberately accent-insensitive, the same equivalence
+    // resolveCollectionArtists already applies when it dedupes names ("Björk" and "Bjork" are
+    // one artist to it, so they should be one artist here).
+    const slug = artistSlug(artistName);
+    if (!slug) return 0;
     const itemRead = await readAllPages<{ id: string; title: string }>(
       (from, to) =>
         client
           .from('collection_items')
           .select('id, title')
           .is('release_id', null)
-          .ilike('artist_name', escapeLikePattern(artistName))
+          .eq('artist_slug', slug)
           .order('id')
           .range(from, to),
       'collection_items (awaiting a release)'
     );
     if (!itemRead.ok) return 0;
 
+    // Rows imported before artist_slug existed have it NULL until their owner's next re-sync
+    // backfills them (the sync's diff writes the new column once). This fallback keeps those
+    // items linkable in the meantime; it's a scan, but only of a population that shrinks to
+    // zero — delete it once `count(*) WHERE artist_slug IS NULL` reads 0 in production.
+    const legacyRead = await readAllPages<{ id: string; title: string }>(
+      (from, to) =>
+        client
+          .from('collection_items')
+          .select('id, title')
+          .is('release_id', null)
+          .is('artist_slug', null)
+          .ilike('artist_name', escapeLikePattern(artistName))
+          .order('id')
+          .range(from, to),
+      'collection_items (awaiting a release, pre-slug rows)'
+    );
+
+    const items = legacyRead.ok ? [...itemRead.rows, ...legacyRead.rows] : itemRead.rows;
+
     const itemsByRelease = new Map<string, string[]>();
-    for (const item of itemRead.rows) {
+    for (const item of items) {
       const releaseId = releaseByKey.get(releaseMatchKey(item.title));
       if (!releaseId) continue;
       const waiting = itemsByRelease.get(releaseId);
@@ -228,6 +256,39 @@ async function artistAtSlug(
   if (!data) return null;
   const row = data as { id: string; match_confidence: string | null };
   return { id: row.id, matchConfidence: row.match_confidence };
+}
+
+/** Slugs per artists lookup — keeps the id list well inside URL-length limits. */
+const SLUG_LOOKUP_CHUNK = 100;
+
+/**
+ * Every artist we already hold from one list of slugs, in one query per chunk. A resolve pass
+ * checks up to MAX_ARTISTS_PER_RESOLVE names, and asking one-at-a-time cost ~100 round trips
+ * per sync attempt — including failed syncs, which also run this pass. A failed chunk read just
+ * leaves its slugs out of the map, so those names fall through to the probe: more work, never a
+ * wrong answer.
+ */
+async function artistsAtSlugs(
+  client: SupabaseClient,
+  slugs: string[]
+): Promise<Map<string, { id: string; matchConfidence: string | null }>> {
+  const known = new Map<string, { id: string; matchConfidence: string | null }>();
+  for (let i = 0; i < slugs.length; i += SLUG_LOOKUP_CHUNK) {
+    const chunk = slugs.slice(i, i + SLUG_LOOKUP_CHUNK);
+    const { data, error } = await client
+      .from('artists')
+      .select('id, slug, match_confidence')
+      .in('slug', chunk);
+
+    if (error) {
+      console.error('[collection-match] artist batch lookup failed:', error.message);
+      continue;
+    }
+    for (const row of (data ?? []) as { id: string; slug: string; match_confidence: string | null }[]) {
+      known.set(row.slug, { id: row.id, matchConfidence: row.match_confidence });
+    }
+  }
+  return known;
 }
 
 /**
@@ -346,6 +407,13 @@ export async function resolveCollectionArtists(userId: string): Promise<Collecti
   const artistIds: string[] = [];
   const deadline = Date.now() + RESOLVE_DEADLINE_MS;
 
+  // One batched read answers "which of these do we already hold?" for the whole pass — the
+  // overwhelmingly common case, since a collection's artists only need probing once ever.
+  const knownBySlug = await artistsAtSlugs(
+    client,
+    toResolve.map(name => artistSlug(name)).filter(Boolean)
+  );
+
   for (const [index, name] of toResolve.entries()) {
     if (Date.now() > deadline) {
       summary.deferred += toResolve.length - index;
@@ -364,7 +432,7 @@ export async function resolveCollectionArtists(userId: string): Promise<Collecti
       continue;
     }
 
-    const existing = await artistAtSlug(client, slug);
+    const existing = knownBySlug.get(slug) ?? null;
     if (existing) {
       summary.alreadyKnown++;
       // A claimed profile is left entirely alone — its links are the artist's own curation — but

--- a/api/functions/collection-utils.ts
+++ b/api/functions/collection-utils.ts
@@ -1,7 +1,48 @@
 // Shared shaping for collection reads — used by the owner's view (me-collection) and the
 // public page (public-saved-artists), so the two can't drift in what they link to.
 
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { artistSlug, getClient } from './db';
+
+/**
+ * Capability tokens for the cover-art proxy.
+ *
+ * A collection grid renders art as plain <img> tags, and a browser sends no Authorization
+ * header on an image subresource — so the proxy could never tell an owner from a stranger and
+ * answered a non-public owner's own dashboard with 404s, while re-deriving permission from two
+ * database reads on every tile for everyone else. Instead, the endpoints that already decided
+ * the viewer may see an item mint its art URL with a token proving that decision, and the proxy
+ * verifies the token instead of re-asking the database.
+ *
+ * Deliberately unexpiring: the token grants exactly one thing — the cover art of one purchased
+ * album, an image that is public on Bandcamp anyway — and a stable URL is what lets the CDN
+ * keep an image for its full month. It does NOT grant the collection listing, which stays
+ * behind its own endpoints' auth and sharing checks. HMAC output truncated to 128 bits, which
+ * is a capability, not a stored hash.
+ *
+ * Uses INTERNAL_FUNCTION_SECRET (already present wherever functions run) with a context prefix
+ * so an art token can never pass for an internal-dispatch credential or vice versa. Without the
+ * secret the URL is minted bare and the proxy falls back to its database permission check.
+ */
+export function collectionArtToken(itemId: string): string | null {
+  const secret = process.env.INTERNAL_FUNCTION_SECRET;
+  if (!secret) return null;
+  return createHmac('sha256', secret).update(`collection-art:${itemId}`).digest('hex').slice(0, 32);
+}
+
+/** The proxy URL for one item's art, tokened when the secret is available. */
+export function collectionArtUrl(itemId: string): string {
+  const token = collectionArtToken(itemId);
+  return token ? `/api/collection/art/${itemId}?t=${token}` : `/api/collection/art/${itemId}`;
+}
+
+/** Constant-time verification, so the token can't be guessed byte by byte. */
+export function isValidCollectionArtToken(itemId: string, token: string | null | undefined): boolean {
+  if (!token) return false;
+  const expected = collectionArtToken(itemId);
+  if (!expected || token.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+}
 
 /** Slugs per lookup. A 190-item collection is ~96 artists, so this is one query in practice. */
 const ARTIST_LOOKUP_CHUNK = 100;

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -3399,48 +3399,131 @@ export async function getArtistBySlug(
 
     if (linksError) return null;
 
-    const platforms: PlatformLink[] = (links as LinkRow[]).map(link => ({
-      sourceId: link.platform,
-      url: link.url,
-      ...(link.display_name ? { displayName: link.display_name } : {}),
-      ...(link.latest_release ? { latestRelease: link.latest_release as PlatformLink['latestRelease'] } : {}),
-    }));
-
-    let profile: ArtistProfile | undefined;
-    if (row.match_confidence === 'claimed') {
-      if (profileData) {
-        profile = {
-          bio: profileData.bio || undefined,
-          customImageUrl: profileData.custom_image_url || undefined,
-          websiteUrl: profileData.website_url || undefined,
-          featuredEmbed: profileData.featured_embed || undefined,
-          verified: !!profileData.verified_at,
-          ...(profileData.link_dividers?.length ? { linkDividers: profileData.link_dividers } : {}),
-        };
-      }
-    }
-
-    const location = (row.city || row.country || row.country_code)
-      ? {
-          ...(row.city ? { city: row.city } : {}),
-          ...(row.country ? { country: row.country } : {}),
-          ...(row.country_code ? { countryCode: row.country_code } : {}),
-        }
-      : undefined;
-
-    return {
-      id: row.slug,
-      name: row.name,
-      type: 'artist',
-      imageUrl: profile?.customImageUrl || row.image_url || undefined,
-      platforms,
-      matchConfidence: (row.match_confidence as ArtistResult['matchConfidence']) || undefined,
-      profile,
-      location,
-    };
+    return artistRowToResult(row, (links as LinkRow[]) ?? [], profileData as ProfileRow | null);
   } catch (error) {
     console.error('[DB] getArtistBySlug error:', error);
     return null;
+  }
+}
+
+interface ProfileRow {
+  bio: string | null;
+  custom_image_url: string | null;
+  website_url: string | null;
+  featured_embed: string | null;
+  verified_at: string | null;
+  link_dividers: number[] | null;
+}
+
+/**
+ * The one place a stored artist row becomes an ArtistResult, shared by the single-slug and
+ * batched lookups so the two can't drift in what a card carries.
+ */
+function artistRowToResult(row: ArtistRow, links: LinkRow[], profileData: ProfileRow | null): ArtistResult {
+  const platforms: PlatformLink[] = links.map(link => ({
+    sourceId: link.platform,
+    url: link.url,
+    ...(link.display_name ? { displayName: link.display_name } : {}),
+    ...(link.latest_release ? { latestRelease: link.latest_release as PlatformLink['latestRelease'] } : {}),
+  }));
+
+  let profile: ArtistProfile | undefined;
+  if (row.match_confidence === 'claimed' && profileData) {
+    profile = {
+      bio: profileData.bio || undefined,
+      customImageUrl: profileData.custom_image_url || undefined,
+      websiteUrl: profileData.website_url || undefined,
+      featuredEmbed: profileData.featured_embed || undefined,
+      verified: !!profileData.verified_at,
+      ...(profileData.link_dividers?.length ? { linkDividers: profileData.link_dividers } : {}),
+    };
+  }
+
+  const location = (row.city || row.country || row.country_code)
+    ? {
+        ...(row.city ? { city: row.city } : {}),
+        ...(row.country ? { country: row.country } : {}),
+        ...(row.country_code ? { countryCode: row.country_code } : {}),
+      }
+    : undefined;
+
+  return {
+    id: row.slug,
+    name: row.name,
+    type: 'artist',
+    imageUrl: profile?.customImageUrl || row.image_url || undefined,
+    platforms,
+    matchConfidence: (row.match_confidence as ArtistResult['matchConfidence']) || undefined,
+    profile,
+    location,
+  };
+}
+
+/**
+ * The batched form of getArtistBySlug, for the name-contains search channel: it gets back up
+ * to six slugs from findKnownArtistSlugsByName and used to resolve each one separately — 2-3
+ * uncached queries per slug, so 12-18 reads inside every fuzzy search. This answers the whole
+ * list in at most three: the artist rows, all their links, and the claimed ones's profiles.
+ *
+ * Exact slug match only, no variants: these slugs just came out of the artists table, so they
+ * are stored spellings by construction. Freshness is deliberately not checked — the one caller
+ * passed allowStale, for the reason documented on getArtistBySlug's allowStale option.
+ */
+export async function getArtistsBySlugs(slugs: string[]): Promise<Map<string, ArtistResult>> {
+  const results = new Map<string, ArtistResult>();
+  const client = getClient();
+  if (!client) return results;
+
+  // Same guard as getArtistBySlug: anything else can't match a stored slug.
+  const safe = [...new Set(slugs.filter(s => /^[A-Za-z0-9-]+$/.test(s)))];
+  if (safe.length === 0) return results;
+
+  try {
+    const { data: artistRows, error: artistError } = await client
+      .from('artists')
+      .select('*')
+      .in('slug', safe);
+
+    if (artistError || !artistRows || artistRows.length === 0) return results;
+    const rows = artistRows as ArtistRow[];
+
+    const claimedIds = rows.filter(r => r.match_confidence === 'claimed').map(r => r.id);
+    const [{ data: links, error: linksError }, { data: profiles }] = await Promise.all([
+      client
+        .from('artist_links')
+        .select('*')
+        .in('artist_id', rows.map(r => r.id))
+        .order('display_order', { ascending: true, nullsFirst: false }),
+      claimedIds.length > 0
+        ? client
+            .from('artist_profiles')
+            .select('artist_id, bio, custom_image_url, website_url, featured_embed, verified_at, link_dividers')
+            .in('artist_id', claimedIds)
+        : Promise.resolve({ data: [] }),
+    ]);
+
+    if (linksError) return results;
+
+    const linksByArtist = new Map<string, LinkRow[]>();
+    for (const link of (links as LinkRow[]) ?? []) {
+      const list = linksByArtist.get(link.artist_id);
+      if (list) list.push(link);
+      else linksByArtist.set(link.artist_id, [link]);
+    }
+    const profileByArtist = new Map(
+      ((profiles as (ProfileRow & { artist_id: string })[]) ?? []).map(p => [p.artist_id, p])
+    );
+
+    for (const row of rows) {
+      results.set(
+        row.slug,
+        artistRowToResult(row, linksByArtist.get(row.id) ?? [], profileByArtist.get(row.id) ?? null)
+      );
+    }
+    return results;
+  } catch (error) {
+    console.error('[DB] getArtistsBySlugs error:', error);
+    return results;
   }
 }
 

--- a/api/functions/me-bandcamp.ts
+++ b/api/functions/me-bandcamp.ts
@@ -13,6 +13,7 @@
 
 import { Sentry } from '../lib/sentry';
 import { getClient } from './db';
+import { purgeUserShareCacheForUser } from './purge-cache';
 import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import { encryptCredential, isCredentialKeyConfigured } from './credential-crypto';
 import {
@@ -410,6 +411,8 @@ export async function handler(event: {
         };
       }
       itemsDeleted = count ?? 0;
+      // The public page rendered these items and is CDN-cached under the user-share tag.
+      await purgeUserShareCacheForUser(user.userId, 'me-bandcamp');
     }
 
     return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ connected: false, itemsDeleted }) };

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -8,6 +8,7 @@
 // — this endpoint can flip `hidden` and nothing else, so provenance stays server-asserted.
 
 import { getClient, readAllPages } from './db';
+import { purgeUserShareCacheForUser } from './purge-cache';
 import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import {
   artistUrlFor,
@@ -128,6 +129,10 @@ export async function handler(event: {
     if (!row) {
       return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Item not found' }) };
     }
+
+    // Hiding an item changes the public page, which is CDN-cached under this tag. Awaited:
+    // a serverless response ends the invocation, so fire-and-forget purges never happen.
+    await purgeUserShareCacheForUser(user.userId, 'me-collection');
 
     return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(row) };
   }

--- a/api/functions/me-collection.ts
+++ b/api/functions/me-collection.ts
@@ -11,6 +11,7 @@ import { getClient, readAllPages } from './db';
 import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 import {
   artistUrlFor,
+  collectionArtUrl,
   releaseUrlFor,
   resolveArtistPages,
   type CollectionRowWithRelease,
@@ -78,8 +79,11 @@ export async function handler(event: {
     const items = read.rows.map(({ releases, ...row }) => ({
       ...row,
       // Same art fallback as the public page: unmatched items get their cover from Bandcamp
-      // via the proxy rather than rendering an empty box.
-      art_url: row.art_url || releases?.artwork_url || `/api/collection/art/${row.id}`,
+      // via the proxy rather than rendering an empty box. Tokened, because this response just
+      // authenticated the owner and an <img> tag can't carry that proof itself — the token is
+      // what lets a non-public owner see their own art (browsers send no auth on images), and
+      // what saves the proxy re-deriving permission from the database per tile.
+      art_url: row.art_url || releases?.artwork_url || collectionArtUrl(row.id),
       url: releaseUrlFor({ ...row, releases }),
       artist_url: artistUrlFor({ ...row, releases }, artistPages),
     }));

--- a/api/functions/public-saved-artists.ts
+++ b/api/functions/public-saved-artists.ts
@@ -9,7 +9,7 @@
 // else as support would be lying, and the whole value of the artifact is that it isn't.
 
 import { getClient, readAllPages } from './db';
-import { artistUrlFor, releaseUrlFor, resolveArtistPages } from './collection-utils';
+import { artistUrlFor, collectionArtUrl, releaseUrlFor, resolveArtistPages } from './collection-utils';
 import { checkRateLimit, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
@@ -131,7 +131,9 @@ export async function handler(event: {
       artist_name: row.artist_name,
       // Falls back to the art proxy, which fetches from Bandcamp server-side. Only ~28% of a
       // real collection matches an Unstream release, so without this most tiles are blank.
-      art_url: row.art_url || row.releases?.artwork_url || `/api/collection/art/${row.id}`,
+      // Tokened: this endpoint has already applied the public-page rules (sharing on,
+      // purchased, not hidden), so the proxy can trust the URL instead of re-checking them.
+      art_url: row.art_url || row.releases?.artwork_url || collectionArtUrl(row.id),
       acquired_at: row.acquired_at,
       // Matched items link to the release page, so a viewer can buy the same record —
       // the loop closes. Unmatched items still render, just without a link.

--- a/api/functions/public-saved-artists.ts
+++ b/api/functions/public-saved-artists.ts
@@ -154,7 +154,18 @@ export async function handler(event: {
 
     return {
       statusCode: 200,
-      headers: CORS_HEADERS,
+      headers: {
+        ...CORS_HEADERS,
+        // Fully public and identical for every viewer, yet this served four fresh queries per
+        // view of a shared link. Five minutes at the CDN absorbs a share going around, and the
+        // Cache-Tag is the SAME tag the u-handle edge page carries — every write that changes
+        // this page (save/unsave, the sharing toggle, hiding an item, a collection sync)
+        // already purges it or does as of this change, so the TTL is a backstop, not the
+        // freshness mechanism.
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+        'Cache-Tag': `user-share-${handle}`,
+      },
       body: JSON.stringify({
         owner_display_name: ownerDisplayName,
         owner_location: ownerLocation,

--- a/api/functions/purge-cache.ts
+++ b/api/functions/purge-cache.ts
@@ -9,6 +9,8 @@
 // shared `artist-releases-${slug}` tag alongside their own: it's the only way to clear all of one
 // artist's release pages in a single call.
 
+import { getClient } from './db';
+
 /**
  * Fire the purge and report what happened, without ever throwing at the caller.
  *
@@ -45,4 +47,34 @@ export async function purgeCacheTags(tags: string[], label: string): Promise<voi
  */
 export async function purgeArtistReleaseCaches(slug: string, label = 'PurgeCache'): Promise<void> {
   await purgeCacheTags([`artist-${slug}`, `artist-releases-${slug}`], label);
+}
+
+/**
+ * Purge one user's shared-list page (`/u/:handle` and its data endpoint) by looking up their
+ * handle. The tag is only worth purging when the user has a handle at all — no handle, no
+ * public page, nothing cached. Costs one usernames read per *mutation* (hide an item, finish
+ * a sync, disconnect), which is what pays for the page itself being CDN-cached per *view*.
+ */
+export async function purgeUserShareCacheForUser(userId: string, label: string): Promise<void> {
+  // Same rule as purgeCacheTags: never throw at the caller. The write this purge follows has
+  // already succeeded, and stale-for-the-TTL beats failing a user's action over cache hygiene.
+  try {
+    const client = getClient();
+    if (!client) return;
+
+    const { data, error } = await client
+      .from('usernames')
+      .select('username')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      console.warn(`[${label}] could not resolve handle for share-page purge:`, error.message);
+      return;
+    }
+    const handle = (data as { username: string } | null)?.username;
+    if (handle) await purgeCacheTags([`user-share-${handle}`], label);
+  } catch (error) {
+    console.warn(`[${label}] share-page purge failed:`, error instanceof Error ? error.message : String(error));
+  }
 }

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { findBandcampArtist } from '../search/bandcamp-probe';
 import { cacheGetOrFetch, artistCacheKey } from './cache';
-import { persistSearchResults, getArtistBySlug, artistSlug, getMergeOverrides, getLinkSuppressions, findKnownArtistSlugsByName } from './db';
+import { persistSearchResults, getArtistBySlug, getArtistsBySlugs, artistSlug, getMergeOverrides, getLinkSuppressions, findKnownArtistSlugsByName } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
 import { parseMirloArtistSearch } from './search-parsers';
@@ -1988,16 +1988,16 @@ export async function handler(event: { queryStringParameters?: Record<string, st
       });
     // Name-contains is a fuzzy-only channel: a detection query IS the artist's
     // exact name, so a known artist merely containing it is someone else.
+    // Resolved as ONE batched lookup: per-slug getArtistBySlug calls cost 2-3
+    // queries each, which made this channel 12-18 reads per fuzzy search. The
+    // slugs stay in ranked order — the map lookup preserves it.
     const knownByNamePromise: Promise<AggregatedResult[]> = mode === 'exact'
       ? Promise.resolve([])
       : findKnownArtistSlugsByName(normalizedQuery)
-        .then(slugs => Promise.all(
-          slugs.map(s =>
-            getArtistBySlug(s, { allowStale: true })
-              .then(dbArtist => toStoredResult(dbArtist, s))
-              .catch(() => null)
-          )
-        ))
+        .then(async slugs => {
+          const bySlug = await getArtistsBySlugs(slugs);
+          return slugs.map(s => toStoredResult(bySlug.get(s) ?? null, s));
+        })
         .then(list => list.filter((r): r is AggregatedResult => r !== null))
         .catch(err => {
           console.error('[DB] Known artist name search failed:', err);

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -93,6 +93,7 @@
     "functions/__tests__/sentry-environment.test.ts",
     "functions/analytics-event.ts",
     "functions/__tests__/analytics-event.test.ts",
-    "functions/__tests__/persist-release-detail-churn.test.ts"
+    "functions/__tests__/persist-release-detail-churn.test.ts",
+    "functions/__tests__/get-artists-by-slugs.test.ts"
   ]
 }

--- a/apps/web/src/hooks/useArtistSuggestions.ts
+++ b/apps/web/src/hooks/useArtistSuggestions.ts
@@ -7,7 +7,9 @@ export interface ArtistSuggestion {
 }
 
 const SUGGEST_DEBOUNCE_MS = 250;
-const SUGGEST_MIN_CHARS = 2;
+// 3, not 2: every uncached prefix is its own trigram query against the artists table, and
+// two-character prefixes are both the most numerous and the least useful suggestions.
+const SUGGEST_MIN_CHARS = 3;
 
 /**
  * Typeahead against /api/suggest, shared by the header search and the larger

--- a/supabase/migrations/20260820120000_collection-items-io.sql
+++ b/supabase/migrations/20260820120000_collection-items-io.sql
@@ -1,0 +1,40 @@
+-- Disk IO round 2, Phase 2: make collection matching indexable and art resolvable at sync time.
+--
+-- Two columns and two indexes on collection_items:
+--
+-- * `artist_slug` — artistSlug(artist_name), written by the sync. linkCollectionItemsForArtist
+--   runs at the end of EVERY catalogue pass (100+/day) and used to find waiting items with
+--   `artist_name ILIKE ?` — a full sequential scan of every user's items, across all users, with
+--   no index that could ever serve it. With the slug stored, the same question is an equality
+--   probe on the partial index below, returning its usual zero rows in microseconds.
+--
+--   Backfill is deliberately left to the sync: artistSlug is JS (unicode normalization), and a
+--   SQL approximation that disagrees with it would un-match items in exactly the way
+--   slug-vs-name normalization bugs always do. Rows synced before this migration have a NULL
+--   slug until their owner's next re-sync rewrites them (the diff treats the new column as a
+--   change, once); the linker keeps an ILIKE fallback for NULL-slug rows and drops it when
+--   `SELECT count(*) FROM collection_items WHERE artist_slug IS NULL` reaches zero.
+--
+-- * `art_ref` — the Subsonic cover-art id the album list already returns and the sync used to
+--   throw away. The art proxy needed one extra authenticated Bandcamp request per image
+--   (getAlbum) just to re-derive this; stored, that request disappears. NULL means "not seen by
+--   a sync since this column existed" and the proxy falls back to asking Bandcamp.
+--
+-- * The partial index serves the linker's probe. Partial on release_id IS NULL because linked
+--   items are never candidates, which also keeps the index small and cheap to maintain.
+--
+-- * idx_collection_items_release_id covers the ON DELETE SET NULL foreign key — without it a
+--   release delete or merge scans collection_items.
+--
+-- No RLS changes: collection_items already has its policies (20260809120000), and neither
+-- column widens what a row reveals.
+
+ALTER TABLE collection_items ADD COLUMN IF NOT EXISTS artist_slug text;
+ALTER TABLE collection_items ADD COLUMN IF NOT EXISTS art_ref text;
+
+CREATE INDEX IF NOT EXISTS idx_collection_items_artist_slug
+  ON collection_items (artist_slug)
+  WHERE release_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_collection_items_release_id
+  ON collection_items (release_id);


### PR DESCRIPTION
Phase 2 of the [second disk I/O audit](https://claude.ai/code/artifact/715bad5e-1c21-4020-b9a7-3a5ae871aa5c) — the read side, following Phase 1's write fixes (#463). Five commits, each independently revertable:

**1. Migration: `artist_slug` + `art_ref` on `collection_items`, plus two indexes.** Additive, idempotent, validated twice against a local postgres:16. Backfill is deliberately left to each user's next re-sync (the slug function is JS; a SQL approximation would un-match items) — the linker keeps a fallback for pre-migration rows until then.

**2. Collection matching stops scanning.** The per-catalogue-pass item probe (100+/day, ~99% empty-handed) becomes an indexed equality instead of a cross-user `ILIKE` seq scan. Artist resolution answers ~100 names in one batched read instead of ~100 round trips — on failed syncs too. The whole-artists-table read per sync (3–4 requests of 1,000 rows) is Redis-cached for an hour.

**3. The art proxy stops re-deriving permission per tile — and non-public owners can see their own art again.** Art URLs are minted with an HMAC capability token by the endpoints that already decided the viewer may see the item; the proxy verifies the token instead of reading `usernames` + calling the auth server per image. Browsers send no auth header on `<img>` requests, which is why a fan who hadn't made their list public got 404s on their own dashboard art — the token fixes that too. Tokens are stable (full CDN month-cache preserved), grant exactly one Bandcamp-public artwork, and never the listing. The owner's connection row is cached per warm invocation (one read per burst of 15 tiles, not 15), and the stored `art_ref` drops the extra authenticated Bandcamp request per uncached tile. Bare URLs keep the old checks.

**4. Search's known-artist channel batches.** Up to 6 slugs resolved one at a time (2–3 uncached queries each — 12–18 reads per fuzzy search, the heaviest read path in the codebase) become at most 3 batched queries, sharing the row→card mapping with the single-slug path so they can't drift. Typeahead minimum rises from 2 to 3 characters.

**5. Public pages cache, and the writes that change them purge.** The shared-list data endpoint gets its first cache header (5 min + the `user-share` tag); `/u/:handle` rises to an hour now that every mutating write purges the tag (added the missing three: hide-item, sync-with-writes, disconnect-with-delete). The known-artists directory — the largest-volume read in the codebase, ~3,000 rows with links per request — is Redis-cached for an hour.

**Verification:** typecheck clean (api include extended with the new files), 1,272 API + 781 web unit tests pass (12 new tests: indexed-probe fallback, slug backfill, art tokens incl. forgery, warm-cache burst, batched search lookup), lint at the known 71-problem baseline. Migration validated twice (idempotency) against postgres:16.

**Merge note:** contains a migration — merge promptly once approved. `INTERNAL_FUNCTION_SECRET` already exists in the functions environment; without it art URLs mint bare and behave exactly as before.

Remaining from the audit after this: the small per-page taxes (admin header polls, `me-settings`'s auth-server call, duplicate reads per page) and the Storage-backed-art endgame — none load-bearing for the I/O warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)