### PR TITLE
Add the missing /api/me/listening endpoint for Apple Music library sync

### DIFF
--- a/api/functions/__tests__/me-listening.test.ts
+++ b/api/functions/__tests__/me-listening.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
+  mockGetClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+// getClient is mocked; readAllPages stays real so the paged read of existing
+// signals is exercised, not stubbed (same pattern as bandcamp-sync.test.ts).
+vi.mock('../db', async importOriginal => {
+  const original = await importOriginal<typeof import('../db')>();
+  return { ...original, getClient: () => ({ from: mocks.mockFrom }) };
+});
+
+/** An Authorization header whose token does not verify — see the ratelimit mock below. */
+const REJECTED_TOKEN = 'Bearer rejected-token';
+
+vi.mock('../ratelimit', () => ({
+  // Mirrors the real helper: deriving the bucket verifies the token. A missing header and
+  // the REJECTED_TOKEN sentinel both resolve to null — the second is how a test says
+  // "header present, signature bad", the case an auth regression would actually hide.
+  resolveAccountRequest: async (authHeader?: string) =>
+    authHeader && authHeader !== REJECTED_TOKEN
+      ? { key: 'user:user-1', user: { userId: 'user-1', email: 'test@example.com' } }
+      : { key: 'ip:127.0.0.1', user: null },
+  checkRateLimit: mocks.mockCheckRateLimit,
+  getClientIp: mocks.mockGetClientIp,
+}));
+
+import { handler } from '../me-listening';
+
+/**
+ * Wire mockFrom to a listening_signals table holding `existing` rows for the select path,
+ * and return the upsert/delete spies for assertions. The select chain matches what the
+ * handler builds through readAllPages: select → eq → eq → order → range.
+ */
+function mockTable(existing: Array<{ artist_name: string; play_count: number }>) {
+  const upsert = vi.fn(
+    (_rows: Array<Record<string, unknown>>, _opts: { onConflict: string }) =>
+      Promise.resolve<{ error: { message: string } | null }>({ error: null })
+  );
+  const deleteEqSource = vi.fn(() => Promise.resolve({ error: null }));
+  const deleteEqUser = vi.fn(() => ({ eq: deleteEqSource }));
+  const del = vi.fn(() => ({ eq: deleteEqUser }));
+
+  mocks.mockFrom.mockImplementation(() => ({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            range: vi.fn((from: number, to: number) =>
+              Promise.resolve({ data: existing.slice(from, to + 1), error: null })),
+          })),
+        })),
+      })),
+    })),
+    upsert,
+    delete: del,
+  }));
+
+  return { upsert, del, deleteEqUser, deleteEqSource };
+}
+
+function postEvent(body: unknown) {
+  return {
+    httpMethod: 'POST',
+    headers: { authorization: 'Bearer valid-token' },
+    body: JSON.stringify(body),
+  };
+}
+
+describe('me-listening handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockCheckRateLimit.mockResolvedValue({ limited: false });
+  });
+
+  it('returns 401 when the token was checked and rejected, not just absent', async () => {
+    const res = await handler({ httpMethod: 'POST', headers: { authorization: REJECTED_TOKEN }, body: '{}' });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await handler({ httpMethod: 'POST', headers: {}, body: '{}' });
+    expect(res!.statusCode).toBe(401);
+  });
+
+  it('handles OPTIONS preflight', async () => {
+    const res = await handler({ httpMethod: 'OPTIONS', headers: {}, body: null });
+    expect(res!.statusCode).toBe(204);
+  });
+
+  it('returns 404 for other methods', async () => {
+    mockTable([]);
+    const res = await handler({ httpMethod: 'GET', headers: { authorization: 'Bearer valid-token' }, body: null });
+    expect(res!.statusCode).toBe(404);
+  });
+
+  it('POST rejects invalid JSON', async () => {
+    mockTable([]);
+    const res = await handler({ httpMethod: 'POST', headers: { authorization: 'Bearer valid-token' }, body: '{not json' });
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('POST rejects a source other than apple_music', async () => {
+    mockTable([]);
+    const res = await handler(postEvent({ source: 'lastfm', signals: [] }));
+    expect(res!.statusCode).toBe(400);
+  });
+
+  it('POST rejects non-array signals and malformed entries', async () => {
+    mockTable([]);
+    expect((await handler(postEvent({ source: 'apple_music', signals: 'nope' })))!.statusCode).toBe(400);
+    expect((await handler(postEvent({ source: 'apple_music', signals: [{ artistName: 'A', playCount: 1.5 }] })))!.statusCode).toBe(400);
+    expect((await handler(postEvent({ source: 'apple_music', signals: [{ artistName: 'A', playCount: -1 }] })))!.statusCode).toBe(400);
+    expect((await handler(postEvent({ source: 'apple_music', signals: [{ artistName: 42, playCount: 1 }] })))!.statusCode).toBe(400);
+  });
+
+  it('POST upserts only new and changed rows, in one chunked upsert on the unique key', async () => {
+    const { upsert } = mockTable([
+      { artist_name: 'Unchanged Artist', play_count: 5 },
+      { artist_name: 'Grew Artist', play_count: 3 },
+    ]);
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [
+        { artistName: 'Unchanged Artist', playCount: 5 },
+        { artistName: 'Grew Artist', playCount: 4 },
+        { artistName: 'New Artist', playCount: 1 },
+      ],
+    }));
+
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ received: 3, written: 2, unchanged: 1 });
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const [rows, opts] = upsert.mock.calls[0];
+    expect(opts).toEqual({ onConflict: 'user_id,source,artist_name' });
+    expect(rows.map(r => r.artist_name).sort()).toEqual(['Grew Artist', 'New Artist']);
+    expect(rows.every(r => r.user_id === 'user-1' && r.source === 'apple_music')).toBe(true);
+    expect(rows.find(r => r.artist_name === 'Grew Artist')!.play_count).toBe(4);
+  });
+
+  it('POST with nothing changed writes zero rows', async () => {
+    const { upsert } = mockTable([{ artist_name: 'A', play_count: 5 }]);
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [{ artistName: 'A', playCount: 5 }],
+    }));
+
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ received: 1, written: 0, unchanged: 1 });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('POST chunks large imports at 500 rows per upsert', async () => {
+    const { upsert } = mockTable([]);
+
+    const signals = Array.from({ length: 1200 }, (_, i) => ({
+      artistName: `Artist ${i}`,
+      playCount: i + 1,
+    }));
+    const res = await handler(postEvent({ source: 'apple_music', signals }));
+
+    expect(res!.statusCode).toBe(200);
+    expect(upsert).toHaveBeenCalledTimes(3);
+    const chunkSizes = upsert.mock.calls.map(call => call[0].length);
+    expect(chunkSizes).toEqual([500, 500, 200]);
+  });
+
+  it('POST diffs against a library larger than one PostgREST page', async () => {
+    // 1,000 is exactly PostgREST's silent per-response cap. Artist 1000 lives on page two:
+    // if the read stopped at one page, it would look new and be rewritten unchanged.
+    const existing = Array.from({ length: 1001 }, (_, i) => ({
+      artist_name: `Artist ${i}`,
+      play_count: 1,
+    }));
+    const { upsert } = mockTable(existing);
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [{ artistName: 'Artist 1000', playCount: 1 }],
+    }));
+
+    expect(res!.statusCode).toBe(200);
+    expect(JSON.parse(res!.body)).toEqual({ received: 1, written: 0, unchanged: 1 });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('POST dedupes repeated artist names, keeping the highest count', async () => {
+    const { upsert } = mockTable([]);
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [
+        { artistName: 'Twice', playCount: 2 },
+        { artistName: 'Twice', playCount: 7 },
+      ],
+    }));
+
+    expect(res!.statusCode).toBe(200);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const rows = upsert.mock.calls[0][0];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].play_count).toBe(7);
+  });
+
+  it('POST skips entries with a blank artist name rather than failing the sync', async () => {
+    const { upsert } = mockTable([]);
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [
+        { artistName: '   ', playCount: 3 },
+        { artistName: 'Real Artist', playCount: 1 },
+      ],
+    }));
+
+    expect(res!.statusCode).toBe(200);
+    const rows = upsert.mock.calls[0][0];
+    expect(rows.map(r => r.artist_name)).toEqual(['Real Artist']);
+  });
+
+  it('POST surfaces an upsert failure as a 500, not a silent success', async () => {
+    const { upsert } = mockTable([]);
+    upsert.mockResolvedValueOnce({ error: { message: 'boom' } });
+
+    const res = await handler(postEvent({
+      source: 'apple_music',
+      signals: [{ artistName: 'A', playCount: 1 }],
+    }));
+    expect(res!.statusCode).toBe(500);
+  });
+
+  it("DELETE removes the user's apple_music rows in one statement", async () => {
+    const { del, deleteEqUser, deleteEqSource } = mockTable([]);
+
+    const res = await handler({ httpMethod: 'DELETE', headers: { authorization: 'Bearer valid-token' }, body: null });
+
+    expect(res!.statusCode).toBe(200);
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(deleteEqUser).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(deleteEqSource).toHaveBeenCalledWith('source', 'apple_music');
+  });
+
+  it('DELETE surfaces a database failure', async () => {
+    const upsert = vi.fn();
+    mocks.mockFrom.mockImplementation(() => ({
+      upsert,
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ error: { message: 'boom' } })),
+        })),
+      })),
+    }));
+
+    const res = await handler({ httpMethod: 'DELETE', headers: { authorization: 'Bearer valid-token' }, body: null });
+    expect(res!.statusCode).toBe(500);
+  });
+});

--- a/api/functions/me-listening.ts
+++ b/api/functions/me-listening.ts
@@ -1,0 +1,193 @@
+// API endpoint: /api/me/listening
+// POST   — imports streaming-side play counts from the Mac app's Apple Music library scan.
+//          Body: { source: 'apple_music', signals: [{ artistName: string, playCount: number }] }
+//          Upserts into listening_signals; feeds the private gap report.
+// DELETE — removes all of the user's apple_music rows (the app's "remove my data" action).
+//
+// Only apple_music is accepted today because the Mac app is the only writer. The table's
+// CHECK constraint also allows 'lastfm' and 'mac_app' — extend the POST validation and the
+// DELETE filter together when a second source ships.
+
+import { getClient, readAllPages } from './db';
+import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'POST, DELETE, OPTIONS',
+};
+
+/** Rows per upsert batch — keeps each PostgREST request comfortably sized (matches bandcamp-sync). */
+const UPSERT_CHUNK = 500;
+
+/** More artists than any plausible personal library; bounds memory and abuse. */
+const MAX_SIGNALS = 10_000;
+
+const MAX_ARTIST_NAME_LENGTH = 500;
+
+/** Postgres `integer` max — a play count beyond this is a client bug, not a big library. */
+const MAX_PLAY_COUNT = 2_147_483_647;
+
+interface Signal {
+  artistName: string;
+  playCount: number;
+}
+
+/**
+ * Validate and normalize the signals array. Returns the clean list, or a string describing
+ * the first problem. Malformed *types* reject the whole request (that's a client bug worth
+ * surfacing), but entries whose trimmed name is empty are skipped — a blank artist field in
+ * someone's library is a data-quality quirk that must not brick their sync forever.
+ */
+function parseSignals(raw: unknown): Signal[] | string {
+  if (!Array.isArray(raw)) return 'signals must be an array';
+  if (raw.length > MAX_SIGNALS) return `signals must have at most ${MAX_SIGNALS} entries`;
+
+  const clean: Signal[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) return 'each signal must be an object';
+    const { artistName, playCount } = entry as Record<string, unknown>;
+    if (typeof artistName !== 'string') return 'artistName must be a string';
+    if (artistName.length > MAX_ARTIST_NAME_LENGTH) {
+      return `artistName must be ${MAX_ARTIST_NAME_LENGTH} characters or fewer`;
+    }
+    if (typeof playCount !== 'number' || !Number.isInteger(playCount) || playCount < 0 || playCount > MAX_PLAY_COUNT) {
+      return 'playCount must be a non-negative integer';
+    }
+    const name = artistName.trim();
+    if (!name) continue;
+    clean.push({ artistName: name, playCount });
+  }
+  return clean;
+}
+
+export async function handler(event: {
+  httpMethod: string;
+  headers: Record<string, string | undefined>;
+  body: string | null;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: CORS_HEADERS, body: '' };
+  }
+
+  const ip = getClientIp(event.headers);
+  // One verification, not two: deriving the rate-limit bucket already checked the token
+  // (see resolveAccountRequest), so the user it found is the user this handler uses.
+  const { key, user } = await resolveAccountRequest(event.headers.authorization, ip);
+  const rl = await checkRateLimit(key, 'account', CORS_HEADERS);
+  if (rl.limited) return rl.response;
+
+  const client = getClient();
+  if (!client) {
+    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Database not configured' }) };
+  }
+
+  if (!user) {
+    return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not authenticated' }) };
+  }
+
+  if (event.httpMethod === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(event.body || '{}');
+    } catch {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Invalid JSON' }) };
+    }
+
+    if (body.source !== 'apple_music') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: "source must be 'apple_music'" }) };
+    }
+
+    const parsed = parseSignals(body.signals);
+    if (typeof parsed === 'string') {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: parsed }) };
+    }
+
+    // Dedupe by artist name, keeping the highest count — a duplicate in one upsert batch is
+    // a Postgres error ("cannot affect row a second time"), not a harmless overwrite.
+    const byName = new Map<string, number>();
+    for (const s of parsed) {
+      const prev = byName.get(s.artistName);
+      if (prev === undefined || s.playCount > prev) byName.set(s.artistName, s.playCount);
+    }
+
+    try {
+      // Diff against what's already stored so a re-import of a library that gained 3 plays
+      // writes 3 rows, not thousands — every rewritten row is a dirty page the Supabase
+      // free tier's disk-IO budget pays for, even when the values are identical.
+      // Paged read: a real library can exceed PostgREST's silent 1,000-row cap.
+      const existing = await readAllPages<{ artist_name: string; play_count: number }>(
+        (from, to) => client
+          .from('listening_signals')
+          .select('artist_name, play_count')
+          .eq('user_id', user.userId)
+          .eq('source', 'apple_music')
+          .order('artist_name')
+          .range(from, to),
+        'listening_signals'
+      );
+      if (!existing.ok) {
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to read existing signals' }) };
+      }
+
+      const stored = new Map(existing.rows.map(r => [r.artist_name, r.play_count]));
+      const syncedAt = new Date().toISOString();
+      const rows = [...byName.entries()]
+        .filter(([name, count]) => stored.get(name) !== count)
+        .map(([name, count]) => ({
+          user_id: user.userId,
+          source: 'apple_music',
+          artist_name: name,
+          play_count: count,
+          synced_at: syncedAt,
+        }));
+
+      for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
+        const chunk = rows.slice(i, i + UPSERT_CHUNK);
+        const { error } = await client
+          .from('listening_signals')
+          .upsert(chunk, { onConflict: 'user_id,source,artist_name' });
+        if (error) {
+          console.error('[me-listening] Upsert failed:', error.message);
+          return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to save listening signals' }) };
+        }
+      }
+
+      return {
+        statusCode: 200,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({
+          received: byName.size,
+          written: rows.length,
+          unchanged: byName.size - rows.length,
+        }),
+      };
+    } catch (error) {
+      console.error('[me-listening] POST error:', error);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+    }
+  }
+
+  if (event.httpMethod === 'DELETE') {
+    try {
+      const { error } = await client
+        .from('listening_signals')
+        .delete()
+        .eq('user_id', user.userId)
+        .eq('source', 'apple_music');
+
+      if (error) {
+        console.error('[me-listening] Delete failed:', error.message);
+        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to delete listening signals' }) };
+      }
+
+      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ deleted: true }) };
+    } catch (error) {
+      console.error('[me-listening] DELETE error:', error);
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
+    }
+  }
+
+  return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -72,6 +72,8 @@
     "functions/__tests__/weekly-analytics-recap.test.ts",
     "functions/me-notifications.ts",
     "functions/__tests__/me-notifications.test.ts",
+    "functions/me-listening.ts",
+    "functions/__tests__/me-listening.test.ts",
     "functions/me-bandcamp.ts",
     "functions/me-collection.ts",
     "functions/bandcamp-sync-background.ts",

--- a/netlify.toml
+++ b/netlify.toml
@@ -221,6 +221,13 @@
   to = "/.netlify/functions/me-notifications"
   status = 200
 
+# Streaming-side play counts from the Mac app's Apple Music library import
+# (Support Loop Step 2). Feeds the private gap report; never public.
+[[redirects]]
+  from = "/api/me/listening"
+  to = "/.netlify/functions/me-listening"
+  status = 200
+
 [[redirects]]
   from = "/api/public/saved-artists/*"
   to = "/.netlify/functions/public-saved-artists"


### PR DESCRIPTION
## Why

The Mac app's Apple Music library import (Support Loop Step 2, #439) POSTs `{source: "apple_music", signals: [{artistName, playCount}]}` to `/api/me/listening` — but the endpoint never shipped. There was no `me-listening` function, no redirect, and no reference to `listening_signals` anywhere in `api/`, so every sync failed with "Couldn't sync your library to Unstream (error 404)". The `listening_signals` table has existed since the bandcamp-collection migration (with `UNIQUE (user_id, source, artist_name)`), waiting for a writer.

## What

- **`api/functions/me-listening.ts`** — follows the `me-*` pattern (auth + rate limiting via `resolveAccountRequest`, local JWT verify, `account` tier).
  - **POST** validates the payload (source must be `apple_music` — the only writer today; malformed types 400, blank artist names are skipped so a library quirk can't brick the sync), dedupes repeated names keeping the highest count, then **diffs against stored play counts before writing**: a re-import of a library that gained 3 plays writes 3 rows, not thousands. This matters because rewriting a row dirties a page whether or not values changed — and the Supabase free tier is under a disk-IO budget warning. Writes go through a single chunked upsert (500 rows per request, same as `bandcamp-sync-background.ts`) on the unique key — never a per-signal loop.
  - The existing-signals read pages via `readAllPages` — a real library can exceed PostgREST's silent 1,000-row cap, and a truncated read would make page-two artists look new and get rewritten unchanged forever.
  - **DELETE** removes the user's `apple_music` rows in one statement (the app's "remove my data" action).
- **`netlify.toml`** — adds the `/api/me/listening` redirect.
- **`api/tsconfig.json`** — the function and its test are in the typecheck include, per the account-endpoint convention.
- **Test** (16 cases) covers the auth boundary (rejected token vs absent), validation, the changed-rows-only diff, 500-row chunking, the >1,000-row paged read, dedup, and both failure paths surfacing as 500s.

## Verification

`npm run verify` passes: typecheck + API function tests + web unit tests.

No client change needed — the Mac app already targets this URL and treats any 2xx as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)