### PR TITLE
Rescue the rest of #454: the gap report, and collection ≠ saved artists

### DIFF
--- a/api/functions/__tests__/bandcamp-sync.test.ts
+++ b/api/functions/__tests__/bandcamp-sync.test.ts
@@ -45,16 +45,15 @@ function internalEvent(body: unknown) {
 interface TableMocks {
   connectionRow?: Record<string, unknown> | null;
   releases?: Record<string, unknown>[];
-  savedRows?: Record<string, unknown>[];
 }
 
-// Routes supabase table calls; records connection updates, item upserts, and
-// saved_artists writes (the auto-mark-supported side effect).
-function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableMocks) {
+// Routes supabase table calls; records connection updates and item upserts.
+//
+// `saved_artists` deliberately has no branch: the import stopped writing it on 2026-08-16, so
+// reaching for that table now throws "unexpected table" rather than being quietly absorbed.
+function setupDb({ connectionRow = null, releases = [] }: TableMocks) {
   const connectionUpdates: Record<string, unknown>[] = [];
   const upsertBatches: Record<string, unknown>[][] = [];
-  const savedInserts: Record<string, unknown>[][] = [];
-  const savedUpdates: { patch: Record<string, unknown>; column: string; values: unknown }[] = [];
 
   mocks.mockFrom.mockImplementation((table: string) => {
     if (table === 'bandcamp_connections') {
@@ -87,43 +86,13 @@ function setupDb({ connectionRow = null, releases = [], savedRows = [] }: TableM
         })),
       };
     }
-    if (table === 'saved_artists') {
-      return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            // Honours the column actually queried. Without this the mock answers the
-            // artist_id read and the artist_slug read identically, and a row filed under a
-            // synthetic slug would look findable by slug when in production it isn't — the
-            // exact blindness the dedup fix exists to close.
-            in: vi.fn((column: string, values: unknown[]) =>
-              Promise.resolve({
-                data: savedRows.filter(row => values.includes(row[column])),
-                error: null,
-              })
-            ),
-          })),
-        })),
-        upsert: vi.fn((rows: Record<string, unknown>[]) => {
-          savedInserts.push(rows);
-          return Promise.resolve({ error: null });
-        }),
-        update: vi.fn((patch: Record<string, unknown>) => ({
-          eq: vi.fn(() => ({
-            in: vi.fn((column: string, values: unknown) => {
-              savedUpdates.push({ patch, column, values });
-              return Promise.resolve({ error: null });
-            }),
-          })),
-        })),
-      };
-    }
     throw new Error(`unexpected table ${table}`);
   });
 
-  return { connectionUpdates, upsertBatches, savedInserts, savedUpdates };
+  return { connectionUpdates, upsertBatches };
 }
 
-const SUFJAN = { id: 'artist-1', slug: 'sufjan-stevens', name: 'Sufjan Stevens', image_url: 'https://img/s.jpg' };
+const SUFJAN = { id: 'artist-1', name: 'Sufjan Stevens' };
 
 describe('bandcamp-sync-background handler', () => {
   beforeEach(() => {
@@ -354,153 +323,29 @@ describe('bandcamp-sync-background handler', () => {
     });
   });
 
-  describe('auto-mark supported (spec OQ6: buying is supporting)', () => {
-    const ciphertext = () => encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' }));
-    const albums = [{ id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }];
-
-    function withArtists() {
-      mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
-      mocks.mockFetchAllAlbums.mockResolvedValue(albums);
-    }
-
-    it('saves a matched artist as supported when they have no saved row', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      const inserted = savedInserts.flat();
-      expect(inserted).toHaveLength(1);
-      expect(inserted[0]).toMatchObject({
-        user_id: 'user-1',
-        artist_id: 'artist-1',
-        artist_slug: 'sufjan-stevens',
-        artist_name: 'Sufjan Stevens',
-        supported: true,
-      });
-      expect(inserted[0].supported_at).toBeTruthy();
-      expect(inserted[0].last_modified).toBeTruthy();
-      expect(savedUpdates).toHaveLength(0);
+  // Reversed 2026-08-16 (Brandon): "Collection Imports should always add to the collection NOT
+  // saved artists. However, you should get upcoming/recent release information from artists both
+  // in the collection and the saved artists list." Before this, the import marked every matched
+  // artist saved + supported, which duplicated rows, risked resurrecting a permanent dismissal,
+  // and flooded release alerts with back-catalog. The feed keeps its half of the promise in
+  // db.ts instead — see feed-collection-artists.test.ts.
+  it('never writes saved_artists — an import is not a deliberate save', async () => {
+    const { upsertBatches } = setupDb({
+      connectionRow: {
+        bandcamp_username: 'fan',
+        credential_ciphertext: encryptCredential(JSON.stringify({ t: 'tok', s: 'salt' })),
+      },
     });
+    mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
+    mocks.mockFetchAllAlbums.mockResolvedValue([{ id: 'al-1', name: 'Illinois', artist: 'Sufjan Stevens' }]);
 
-    it('upgrades an existing unsupported row instead of inserting', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        // No artist_id: the legacy shape, where only the slug identifies the artist.
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false }],
-      });
-      withArtists();
+    const res = await handler(internalEvent({ userId: 'user-1' }));
 
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].patch).toMatchObject({ supported: true });
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-1']);
-    });
-
-    it('leaves an already-supported row untouched (original supported_at preserved)', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: true, deleted: false }],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    it('never resurrects a tombstoned row — permanent dismissal sticks across re-syncs', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [{ id: 'row-1', artist_slug: 'sufjan-stevens', supported: false, deleted: true }],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    // The two cases the slug-only lookup got wrong. A row saved from a search result is filed
-    // under a synthetic slug (`sufjanstevens`), which the canonical slug never equals, so only
-    // artist_id finds it — measured on production 2026-08-14, one import duplicated three of
-    // Brandon's saved artists this way.
-    it('upgrades a row saved under a synthetic slug rather than duplicating the artist', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: false },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-1']);
-    });
-
-    it('never resurrects a tombstone filed under a synthetic slug', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
-
-    // The shape deduplicating an account leaves behind: the superseded row tombstoned, the
-    // canonical one live. The tombstone must not be read as "artist dismissed" — that would
-    // strand the live row unsupported through every future re-sync — and neither row may be
-    // duplicated by a fresh insert.
-    it('supports the live row when a tombstone for the same artist sits beside it', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-        savedRows: [
-          { id: 'row-1', artist_id: 'artist-1', artist_slug: 'sufjanstevens', supported: false, deleted: true },
-          { id: 'row-2', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', supported: false, deleted: false },
-        ],
-      });
-      withArtists();
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(1);
-      expect(savedUpdates[0].column).toBe('id');
-      expect(savedUpdates[0].values).toEqual(['row-2']);
-    });
-
-    it('marks nothing for unmatched artists', async () => {
-      const { savedInserts, savedUpdates } = setupDb({
-        connectionRow: { bandcamp_username: 'fan', credential_ciphertext: ciphertext() },
-      });
-      mocks.mockReadAllPages.mockResolvedValue({ ok: true, rows: [SUFJAN] });
-      mocks.mockFetchAllAlbums.mockResolvedValue([
-        { id: 'al-9', name: 'Some Album', artist: 'Nobody We Know' },
-      ]);
-
-      await handler(internalEvent({ userId: 'user-1' }));
-
-      expect(savedInserts).toHaveLength(0);
-      expect(savedUpdates).toHaveLength(0);
-    });
+    // The artist still matched — that is how the item gets its release_id — it just isn't saved.
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ imported: 1, artistsMatched: 1 });
+    expect(upsertBatches.flat()).toHaveLength(1);
+    expect(mocks.mockFrom).not.toHaveBeenCalledWith('saved_artists');
   });
 
   it('records an error — not a partial success — when the fetch dies mid-sync', async () => {

--- a/api/functions/__tests__/feed-collection-artists.test.ts
+++ b/api/functions/__tests__/feed-collection-artists.test.ts
@@ -1,0 +1,185 @@
+// Whose releases reach a fan's dashboard feed.
+//
+// Reversed 2026-08-16 (Brandon): "Collection Imports should always add to the collection NOT
+// saved artists. However, you should get upcoming/recent release information from artists both
+// in the collection and the saved artists list." Before this, the Bandcamp import conscripted
+// every matched artist into saved_artists, which is what made their releases show up at all —
+// so removing that write would have silently emptied the feed for anyone who imported. The
+// union here is what keeps the promise while the two lists stay separate.
+//
+// Driven against a recording fake Supabase client rather than a module mock, following
+// recatalog-sweep-selection.test.ts, so the real query body runs.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+interface Filter {
+  kind: 'eq' | 'in' | 'range' | 'gte' | 'order' | 'limit';
+  column?: string;
+  value?: unknown;
+}
+
+interface Query {
+  table: string;
+  columns: string;
+  filters: Filter[];
+}
+
+const queries: Query[] = [];
+
+const tables: Record<string, Record<string, unknown>[]> = {
+  saved_artists: [],
+  collection_items: [],
+  artists: [],
+  artist_slug_aliases: [],
+  releases: [],
+};
+
+let failingTable: string | null = null;
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          const query: Query = { table, columns, filters: [] };
+          queries.push(query);
+
+          const builder = {
+            eq(column: string, value: unknown) {
+              query.filters.push({ kind: 'eq', column, value });
+              return builder;
+            },
+            in(column: string, value: unknown) {
+              query.filters.push({ kind: 'in', column, value });
+              return builder;
+            },
+            gte(column: string, value: unknown) {
+              query.filters.push({ kind: 'gte', column, value });
+              return builder;
+            },
+            order(column: string) {
+              query.filters.push({ kind: 'order', column });
+              return builder;
+            },
+            limit(value: number) {
+              query.filters.push({ kind: 'limit', value });
+              return builder;
+            },
+            range(from: number, to: number) {
+              query.filters.push({ kind: 'range', value: [from, to] });
+              return builder;
+            },
+            then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
+              if (failingTable === table) {
+                return Promise.resolve({ data: null, error: { message: 'connection reset' } }).then(resolve, reject);
+              }
+
+              let rows = tables[table] ?? [];
+              for (const f of query.filters) {
+                if (f.kind === 'in') {
+                  const wanted = new Set(f.value as string[]);
+                  rows = rows.filter(r => wanted.has(r[f.column as string] as string));
+                } else if (f.kind === 'eq') {
+                  rows = rows.filter(r => r[f.column as string] === f.value);
+                }
+              }
+              const range = query.filters.find(f => f.kind === 'range');
+              if (range) {
+                const [from, to] = range.value as [number, number];
+                rows = rows.slice(from, to + 1);
+              }
+              return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeClient() }));
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+const { getFeedReleasesForUser } = await import('../db');
+
+/** Dated inside the feed's trailing window so it isn't filtered on date. */
+const soon = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+
+function release(id: string, artistId: string) {
+  return {
+    id,
+    title: `Release ${id}`,
+    slug: id,
+    release_date: soon,
+    date_precision: 'day',
+    status: 'released',
+    artwork_url: null,
+    is_hidden: false,
+    needs_review: false,
+    artist_id: artistId,
+    artists: { name: `Artist ${artistId}`, slug: artistId },
+  };
+}
+
+describe('getFeedReleasesForUser — saved artists and collection artists', () => {
+  beforeEach(() => {
+    queries.length = 0;
+    failingTable = null;
+    for (const key of Object.keys(tables)) tables[key] = [];
+  });
+
+  it('includes releases by an artist that is only in the collection', async () => {
+    // Nothing saved at all — the state a fan is in right after an import now that the sync
+    // no longer writes saved_artists.
+    tables.collection_items = [{ user_id: 'user-1', artist_name: 'Sufjan Stevens', releases: { artist_id: 'artist-1' } }];
+    tables.releases = [release('illinois', 'artist-1')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['illinois']);
+  });
+
+  it('resolves a collection artist by derived slug when no release matched', async () => {
+    // 72% of a real import matches no release, so the slug path is the common one.
+    tables.collection_items = [{ user_id: 'user-1', artist_name: 'Anne Sulikowski', releases: null }];
+    tables.artists = [{ id: 'artist-2', slug: 'anne-sulikowski' }];
+    tables.releases = [release('tape', 'artist-2')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['tape']);
+  });
+
+  it('unions both lists without duplicating a shared artist', async () => {
+    tables.saved_artists = [{ user_id: 'user-1', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', artist_name: 'Sufjan Stevens', deleted: false }];
+    tables.collection_items = [
+      { user_id: 'user-1', artist_name: 'Sufjan Stevens', releases: { artist_id: 'artist-1' } },
+      { user_id: 'user-1', artist_name: 'Mirah', releases: { artist_id: 'artist-3' } },
+    ];
+    tables.releases = [release('illinois', 'artist-1'), release('advisory', 'artist-3')];
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug).sort()).toEqual(['advisory', 'illinois']);
+
+    // One query, one id list — the artist in both lists must not be asked for twice.
+    const releaseQuery = queries.find(q => q.table === 'releases');
+    const ids = releaseQuery?.filters.find(f => f.kind === 'in')?.value as string[];
+    expect(ids).toHaveLength(new Set(ids).size);
+  });
+
+  it('still returns saved-artist releases when the collection read fails', async () => {
+    // The collection is an addition to the feed; a failure there must narrow it, never blank it.
+    tables.saved_artists = [{ user_id: 'user-1', artist_id: 'artist-1', artist_slug: 'sufjan-stevens', artist_name: 'Sufjan Stevens', deleted: false }];
+    tables.releases = [release('illinois', 'artist-1')];
+    failingTable = 'collection_items';
+
+    const rows = await getFeedReleasesForUser('user-1');
+    expect(rows.map(r => r.releaseSlug)).toEqual(['illinois']);
+  });
+
+  it('returns nothing when the fan has neither saved artists nor a collection', async () => {
+    tables.releases = [release('illinois', 'artist-1')];
+    expect(await getFeedReleasesForUser('user-1')).toEqual([]);
+  });
+});

--- a/api/functions/__tests__/me-listening.test.ts
+++ b/api/functions/__tests__/me-listening.test.ts
@@ -4,7 +4,12 @@ const mocks = vi.hoisted(() => ({
   mockFrom: vi.fn(),
   mockCheckRateLimit: vi.fn(() => Promise.resolve({ limited: false })),
   mockGetClientIp: vi.fn(() => '127.0.0.1'),
+  mockResolveArtistPages: vi.fn((_names: string[]) => Promise.resolve(new Map<string, string>())),
 }));
+
+// The gap's artist links are an enhancement layered on top of the computed list, and
+// collection-utils resolves them with its own reads. Mocked so the gap logic is what's tested.
+vi.mock('../collection-utils', () => ({ resolveArtistPages: mocks.mockResolveArtistPages }));
 
 // getClient is mocked; readAllPages stays real so the paged read of existing
 // signals is exercised, not stubbed (same pattern as bandcamp-sync.test.ts).
@@ -70,6 +75,60 @@ function postEvent(body: unknown) {
   };
 }
 
+function getEvent() {
+  return { httpMethod: 'GET', headers: { authorization: 'Bearer valid-token' }, body: null };
+}
+
+interface GapBuilder {
+  eq: () => GapBuilder;
+  order: () => GapBuilder;
+  range: (from: number, to: number) => Promise<{ data: unknown; error: { message: string } | null }>;
+}
+
+interface GapTables {
+  signals?: Array<{ artist_name: string; play_count: number; last_played?: string | null }>;
+  saved?: Array<{ artist_slug?: string | null; artist_name?: string | null; supported: boolean }>;
+  collection?: Array<{ artist_name: string }>;
+  /** Make one table's read fail, to separate "nothing found" from "couldn't look". */
+  failing?: string;
+}
+
+/**
+ * Wire mockFrom for the GET path: each table answers its own rows through the eq/order/range
+ * chain readAllPages drives. There is nothing to spy on — the gap is derived from these rows,
+ * so the response body is the assertion.
+ */
+function mockGapTables({ signals = [], saved = [], collection = [], failing }: GapTables) {
+  const rowsFor: Record<string, Record<string, unknown>[]> = {
+    listening_signals: signals.map(row => ({ last_played: null, ...row })),
+    saved_artists: saved.map(row => ({ artist_slug: null, artist_name: null, ...row })),
+    collection_items: collection,
+  };
+
+  mocks.mockFrom.mockImplementation((table: string) => ({
+    select: () => {
+      const builder: GapBuilder = {
+        eq: () => builder,
+        order: () => builder,
+        range: (from, to) =>
+          Promise.resolve(
+            failing === table
+              ? { data: null, error: { message: 'connection reset' } }
+              : { data: (rowsFor[table] ?? []).slice(from, to + 1), error: null }
+          ),
+      };
+      return builder;
+    },
+  }));
+}
+
+/** The gap list, in rank order. */
+async function gapNames(): Promise<string[]> {
+  const res = await handler(getEvent());
+  expect(res!.statusCode).toBe(200);
+  return JSON.parse(res!.body).gap.map((row: { artistName: string }) => row.artistName);
+}
+
 describe('me-listening handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,7 +152,7 @@ describe('me-listening handler', () => {
 
   it('returns 404 for other methods', async () => {
     mockTable([]);
-    const res = await handler({ httpMethod: 'GET', headers: { authorization: 'Bearer valid-token' }, body: null });
+    const res = await handler({ httpMethod: 'PUT', headers: { authorization: 'Bearer valid-token' }, body: null });
     expect(res!.statusCode).toBe(404);
   });
 
@@ -141,6 +200,10 @@ describe('me-listening handler', () => {
     expect(rows.map(r => r.artist_name).sort()).toEqual(['Grew Artist', 'New Artist']);
     expect(rows.every(r => r.user_id === 'user-1' && r.source === 'apple_music')).toBe(true);
     expect(rows.find(r => r.artist_name === 'Grew Artist')!.play_count).toBe(4);
+
+    // Listening is not saving. An upload conscripting artists into the saved list is the
+    // behaviour Brandon reversed on 2026-08-16, and it would flood release alerts.
+    expect(mocks.mockFrom).not.toHaveBeenCalledWith('saved_artists');
   });
 
   it('POST with nothing changed writes zero rows', async () => {
@@ -244,6 +307,141 @@ describe('me-listening handler', () => {
     expect(del).toHaveBeenCalledTimes(1);
     expect(deleteEqUser).toHaveBeenCalledWith('user_id', 'user-1');
     expect(deleteEqSource).toHaveBeenCalledWith('source', 'apple_music');
+  });
+
+  // The gap report: artists you play and have never paid. Private by construction — derived
+  // from one user's own rows, returned only to that authenticated user, never rendered publicly.
+  describe('GET — the gap report', () => {
+    it('requires authentication, and does not read anything before refusing', async () => {
+      mockGapTables({ signals: [{ artist_name: 'Private', play_count: 9 }] });
+      const res = await handler({ httpMethod: 'GET', headers: {}, body: null });
+      expect(res!.statusCode).toBe(401);
+      expect(mocks.mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('refuses a token that was checked and rejected, not just absent', async () => {
+      mockGapTables({ signals: [{ artist_name: 'Private', play_count: 9 }] });
+      const res = await handler({ httpMethod: 'GET', headers: { authorization: REJECTED_TOKEN }, body: null });
+      expect(res!.statusCode).toBe(401);
+      expect(mocks.mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('ranks unsupported artists by plays, and reports the signal total', async () => {
+      mockGapTables({
+        signals: [
+          { artist_name: 'Occasional', play_count: 5 },
+          { artist_name: 'Heavy Rotation', play_count: 50 },
+        ],
+      });
+
+      const res = await handler(getEvent());
+      const body = JSON.parse(res!.body);
+      expect(body.gap.map((row: { artistName: string }) => row.artistName)).toEqual([
+        'Heavy Rotation',
+        'Occasional',
+      ]);
+      expect(body.totalArtists).toBe(2);
+    });
+
+    it('excludes an artist already marked supported', async () => {
+      mockGapTables({
+        signals: [{ artist_name: 'Already Backed', play_count: 90 }],
+        saved: [{ artist_slug: 'already-backed', supported: true }],
+      });
+      expect(await gapNames()).toEqual([]);
+    });
+
+    it('keeps an artist who is saved but NOT supported — saving is not paying', async () => {
+      mockGapTables({
+        signals: [{ artist_name: 'Saved Only', play_count: 30 }],
+        saved: [{ artist_slug: 'saved-only', supported: false }],
+      });
+      expect(await gapNames()).toEqual(['Saved Only']);
+    });
+
+    // A row saved from a search result is filed under a synthetic slug the canonical one never
+    // equals. Matching on the stored slug alone would tell a fan to go support somebody they
+    // already support — so the name is re-derived too, as savedArtistIdsForUser does.
+    it('excludes a supported artist saved under a synthetic slug', async () => {
+      mockGapTables({
+        signals: [{ artist_name: 'Sufjan Stevens', play_count: 40 }],
+        saved: [{ artist_slug: 'sufjanstevens', artist_name: 'Sufjan Stevens', supported: true }],
+      });
+      expect(await gapNames()).toEqual([]);
+    });
+
+    it('excludes an artist you own a record by', async () => {
+      mockGapTables({
+        signals: [{ artist_name: 'Sufjan Stevens', play_count: 80 }],
+        collection: [{ artist_name: 'Sufjan Stevens' }],
+      });
+      expect(await gapNames()).toEqual([]);
+    });
+
+    it('matches the collection on the derived slug, not raw text', async () => {
+      // "Sigur Rós" in the library and "sigur ros" in the collection are one artist.
+      mockGapTables({
+        signals: [{ artist_name: 'Sigur Rós', play_count: 80 }],
+        collection: [{ artist_name: 'sigur ros' }],
+      });
+      expect(await gapNames()).toEqual([]);
+    });
+
+    it('merges the same artist arriving from two sources', async () => {
+      mockGapTables({
+        signals: [
+          { artist_name: 'Mirah', play_count: 30, last_played: '2026-07-01T00:00:00Z' },
+          { artist_name: 'Mirah', play_count: 20, last_played: '2026-08-01T00:00:00Z' },
+        ],
+      });
+
+      const res = await handler(getEvent());
+      const gap = JSON.parse(res!.body).gap;
+      expect(gap).toHaveLength(1);
+      expect(gap[0].playCount).toBe(50);
+      expect(gap[0].lastPlayed).toBe('2026-08-01T00:00:00Z');
+    });
+
+    it('links artists that have a page and leaves the rest unlinked', async () => {
+      mockGapTables({ signals: [{ artist_name: 'Mirah', play_count: 9 }, { artist_name: 'No Page', play_count: 8 }] });
+      mocks.mockResolveArtistPages.mockResolvedValueOnce(new Map([['Mirah', 'mirah']]));
+
+      const res = await handler(getEvent());
+      const gap = JSON.parse(res!.body).gap;
+      expect(gap.map((row: { artistUrl: string | null }) => row.artistUrl)).toEqual(['/a/mirah', null]);
+    });
+
+    it('caps the list at 100 rows rather than dumping the library', async () => {
+      mockGapTables({
+        signals: Array.from({ length: 150 }, (_, i) => ({ artist_name: `Artist ${i}`, play_count: i + 1 })),
+      });
+
+      const res = await handler(getEvent());
+      const body = JSON.parse(res!.body);
+      expect(body.gap).toHaveLength(100);
+      // The busiest artists, not the first hundred read.
+      expect(body.gap[0].artistName).toBe('Artist 149');
+      expect(body.totalArtists).toBe(150);
+    });
+
+    it('reports a failed signals read as an error, not an empty gap', async () => {
+      mockGapTables({ failing: 'listening_signals' });
+      const res = await handler(getEvent());
+      expect(res!.statusCode).toBe(500);
+    });
+
+    // The asymmetry is deliberate: without the signals there is no report, but without the
+    // exclusions there is still a useful one — narrowed, not blanked.
+    it('still reports the gap when the saved-artists read fails', async () => {
+      mockGapTables({ signals: [{ artist_name: 'Mirah', play_count: 9 }], failing: 'saved_artists' });
+      expect(await gapNames()).toEqual(['Mirah']);
+    });
+
+    it('still reports the gap when the collection read fails', async () => {
+      mockGapTables({ signals: [{ artist_name: 'Mirah', play_count: 9 }], failing: 'collection_items' });
+      expect(await gapNames()).toEqual(['Mirah']);
+    });
+
   });
 
   it('DELETE surfaces a database failure', async () => {

--- a/api/functions/__tests__/saved-artist-resolution.test.ts
+++ b/api/functions/__tests__/saved-artist-resolution.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-interface Filter { kind: 'eq' | 'in' | 'gte' | 'order' | 'limit'; column?: string; value?: unknown }
+interface Filter { kind: 'eq' | 'in' | 'gte' | 'order' | 'limit' | 'range'; column?: string; value?: unknown }
 interface Query { table: string; columns: string; filters: Filter[] }
 
 const queries: Query[] = [];
@@ -22,6 +22,9 @@ const tables: Record<string, Record<string, unknown>[]> = {
   artists: [],
   artist_slug_aliases: [],
   releases: [],
+  // Empty in every case here: the feed's collection half has its own file
+  // (feed-collection-artists.test.ts). It still has to answer, because the feed now reads it.
+  collection_items: [],
 };
 
 /** Set to a table name to make that table's read fail. */
@@ -41,6 +44,7 @@ function makeClient() {
             gte(column: string, value: unknown) { query.filters.push({ kind: 'gte', column, value }); return builder; },
             order(column: string, value: unknown) { query.filters.push({ kind: 'order', column, value }); return builder; },
             limit(value: number) { query.filters.push({ kind: 'limit', value }); return builder; },
+            range(from: number, to: number) { query.filters.push({ kind: 'range', value: [from, to] }); return builder; },
             then(resolve: (r: unknown) => unknown, reject: (e: unknown) => unknown) {
               if (failingTable === table) {
                 return Promise.resolve({ data: null, error: { message: 'connection reset' } }).then(resolve, reject);
@@ -52,6 +56,11 @@ function makeClient() {
                   const wanted = new Set(f.value as unknown[]);
                   rows = rows.filter(r => wanted.has(r[f.column as string]));
                 }
+              }
+              const range = query.filters.find(f => f.kind === 'range');
+              if (range) {
+                const [from, to] = range.value as [number, number];
+                rows = rows.slice(from, to + 1);
               }
               return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
             },

--- a/api/functions/bandcamp-sync-background.ts
+++ b/api/functions/bandcamp-sync-background.ts
@@ -43,11 +43,9 @@ interface MatchedRelease {
   artwork_url: string | null;
 }
 
+/** Just the id: matching an artist is how we find their releases, and nothing more. */
 interface MatchedArtist {
   id: string;
-  slug: string;
-  name: string;
-  imageUrl: string | null;
 }
 
 interface LibraryMatches {
@@ -86,8 +84,8 @@ function sameInstant(a: string | null, b: string | null): boolean {
  * Match imported albums to Unstream artists (by normalized name) and releases (by
  * normalized artist name + normalized title — releases.match_key is already
  * normalizeForComparison output). Conservative on purpose: an ambiguous artist name — two
- * artist rows normalizing identically — matches nothing, because a wrong release_id or a
- * wrong "supported" mark asserts the wrong fact about a user's support.
+ * artist rows normalizing identically — matches nothing, because a wrong release_id puts a
+ * record somebody else made into a fan's collection.
  */
 async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   const client = getClient();
@@ -104,8 +102,8 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
   // the real linking path and reads live — picks them up.
   const artistRead = await cacheGetOrFetch(
     'collection:artist-name-map',
-    () => readAllPages<{ id: string; slug: string; name: string; image_url: string | null }>(
-      (from, to) => client.from('artists').select('id, slug, name, image_url').order('id').range(from, to),
+    () => readAllPages<{ id: string; name: string }>(
+      (from, to) => client.from('artists').select('id, name').order('id').range(from, to),
       'artists (bandcamp-sync matching)'
     ),
     3600,
@@ -123,9 +121,7 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
     if (!norm) continue;
     artistsByNorm.set(
       norm,
-      artistsByNorm.has(norm)
-        ? 'ambiguous'
-        : { id: row.id, slug: row.slug, name: row.name, imageUrl: row.image_url }
+      artistsByNorm.has(norm) ? 'ambiguous' : { id: row.id }
     );
   }
 
@@ -173,152 +169,6 @@ async function matchLibrary(albums: SubsonicAlbum[]): Promise<LibraryMatches> {
     if (release) matches.releases.set(album.id, release);
   }
   return matches;
-}
-
-/** Artists per saved_artists read — stays far below PostgREST's 1,000-row response cap. */
-const SAVED_LOOKUP_CHUNK = 100;
-
-/** The saved_artists columns needed to decide insert vs. upgrade vs. leave alone. */
-const SAVED_SELECT = 'id, artist_id, artist_slug, supported, deleted';
-
-interface SavedRow {
-  id: string;
-  artist_id: string | null;
-  artist_slug: string | null;
-  supported: boolean;
-  deleted: boolean;
-}
-
-/**
- * Buying an artist's record IS supporting them, so a Bandcamp import marks every matched
- * artist as saved + supported (Brandon, 2026-08-09, spec open question 6). Collection and
- * saved list are two views of the same relationship.
- *
- * Three rules keep this from fighting the user:
- *   - a row the user tombstoned (deleted=true) is left completely alone — permanent
- *     dismissal is a locked spec decision and a re-sync must never resurrect it;
- *   - an already-supported row keeps its original supported_at;
- *   - only supported goes true; nothing here can ever un-support or overwrite notes.
- *
- * **An existing row is looked up by `artist_id` as well as by slug, and matching on the slug
- * alone broke the first of those rules.** `(user_id, artist_slug)` is the table's natural key
- * (migration 014), but a row saved from a search result carries a *synthetic* slug —
- * `modelactriz`, `seoulmetro`, `qobuz-robertlogan` — that the canonical slug never equals, and
- * `artist_id` is then the only thing identifying the artist. So the slug-only check found
- * nothing and inserted a **second live row for an artist already saved** (measured on
- * production 2026-08-14: Model/Actriz, Rodney Owl and Seoul Metro each duplicated by one
- * import), and it equally missed a **tombstone** filed under the other slug, resurrecting a
- * dismissal this function promises is permanent.
- *
- * Failure here degrades, not fails: items are the sync's primary artifact, and the mark
- * is derived state the next re-sync recomputes.
- */
-async function markArtistsSupported(userId: string, artists: MatchedArtist[]): Promise<void> {
-  const client = getClient();
-  if (!client || artists.length === 0) return;
-
-  const serverNow = new Date().toISOString();
-  const toInsert: Record<string, unknown>[] = [];
-  /** Row ids, not slugs: a row matched by `artist_id` may be filed under a different slug. */
-  const toSupport: string[] = [];
-
-  for (let i = 0; i < artists.length; i += SAVED_LOOKUP_CHUNK) {
-    const chunk = artists.slice(i, i + SAVED_LOOKUP_CHUNK);
-
-    // Two reads rather than one, because a saved row can name this artist either way and
-    // neither column alone finds both (see the doc comment above).
-    const [byId, bySlug] = await Promise.all([
-      client
-        .from('saved_artists')
-        .select(SAVED_SELECT)
-        .eq('user_id', userId)
-        .in('artist_id', chunk.map(a => a.id)),
-      client
-        .from('saved_artists')
-        .select(SAVED_SELECT)
-        .eq('user_id', userId)
-        .in('artist_slug', chunk.map(a => a.slug)),
-    ]);
-
-    const failure = byId.error || bySlug.error;
-    if (failure) {
-      // Without a reliable view of existing rows we can't insert safely (we might
-      // resurrect a tombstone), so skip this chunk's artists entirely.
-      console.warn('[bandcamp-sync] saved_artists read failed:', failure.message);
-      Sentry.captureException(new Error(`saved_artists read failed: ${failure.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-      continue;
-    }
-
-    const rows = [...(byId.data ?? []), ...(bySlug.data ?? [])] as SavedRow[];
-
-    for (const artist of chunk) {
-      // Both reads can return the same row, and an already-duplicated artist returns two — so
-      // decide over every candidate rather than picking one.
-      const candidates = rows.filter(
-        row => (row.artist_id && row.artist_id === artist.id) || row.artist_slug === artist.slug
-      );
-
-      if (candidates.length === 0) {
-        toInsert.push({
-          user_id: userId,
-          artist_id: artist.id,
-          artist_slug: artist.slug,
-          artist_name: artist.name,
-          artist_image_url: artist.imageUrl,
-          supported: true,
-          supported_at: serverNow,
-          // Stamped server-side on insert so the row is immediately visible to the Apple
-          // app's ?since= incremental pulls — same reasoning as saved-artists.ts.
-          last_modified: serverNow,
-        });
-        continue;
-      }
-
-      // A tombstone wins only when nothing live is left for this artist — then the dismissal
-      // is untouchable, and no row is inserted either. A tombstone sitting *beside* a live row
-      // means that row was superseded, not the artist dismissed (deduplicating an account
-      // leaves exactly that shape), and skipping there would strand the live row unsupported.
-      const live = candidates.filter(row => !row.deleted);
-      for (const row of live) {
-        if (!row.supported && !toSupport.includes(row.id)) toSupport.push(row.id);
-      }
-    }
-  }
-
-  for (let i = 0; i < toInsert.length; i += SAVED_LOOKUP_CHUNK) {
-    const { error } = await client
-      .from('saved_artists')
-      .upsert(toInsert.slice(i, i + SAVED_LOOKUP_CHUNK), { onConflict: 'user_id,artist_slug' });
-    if (error) {
-      console.warn('[bandcamp-sync] saved_artists insert failed:', error.message);
-      Sentry.captureException(new Error(`saved_artists insert failed: ${error.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-    }
-  }
-
-  for (let i = 0; i < toSupport.length; i += SAVED_LOOKUP_CHUNK) {
-    const { error } = await client
-      .from('saved_artists')
-      .update({ supported: true, supported_at: serverNow, last_modified: serverNow })
-      .eq('user_id', userId)
-      .in('id', toSupport.slice(i, i + SAVED_LOOKUP_CHUNK));
-    if (error) {
-      console.warn('[bandcamp-sync] saved_artists support update failed:', error.message);
-      Sentry.captureException(new Error(`saved_artists support update failed: ${error.message}`), {
-        tags: { function: 'bandcamp-sync' },
-        extra: { stage: 'mark-supported' },
-      });
-    }
-  }
-
-  if (toInsert.length > 0 || toSupport.length > 0) {
-    console.log(`[bandcamp-sync] marked supported: ${toInsert.length} new, ${toSupport.length} upgraded`);
-  }
 }
 
 /**
@@ -514,9 +364,11 @@ export async function handler(event: {
       }
     }
 
-    // Buying is supporting: mark every matched artist saved + supported. After the items
-    // land — the mark is derived state, and a failure inside degrades rather than throwing.
-    await markArtistsSupported(userId, [...matches.artists.values()]);
+    // An import writes collection_items and stops there. It used to also mark every matched
+    // artist saved + supported (spec OQ6) — reversed 2026-08-16: "Collection Imports should
+    // always add to the collection NOT saved artists." Saving is a deliberate act, and
+    // conscripting a whole library into someone's saved list buried the release alerts they
+    // chose. Their releases still reach the feed: getFeedReleasesForUser unions the two lists.
 
     // The public page renders these items and is CDN-cached; a sync that wrote nothing
     // changed nothing, so only a real write pays for the purge.
@@ -544,7 +396,7 @@ export async function handler(event: {
       body: {
         imported: uniqueAlbums.length,
         matched: matches.releases.size,
-        artistsMarked: matches.artists.size,
+        artistsMatched: matches.artists.size,
       },
     };
   } catch (error) {

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -4861,9 +4861,70 @@ async function savedArtistIdsForUser(
   return [...ids];
 }
 
+/** Slugs per artists lookup — keeps each response far below PostgREST's 1,000-row cap. */
+const ARTIST_SLUG_LOOKUP_CHUNK = 100;
+
 /**
- * Every release worth putting in one fan's feed: across all their saved artists, dated within
- * the trailing window or still to come.
+ * The artists a fan owns a record by, resolved to artist ids.
+ *
+ * `collection_items` stores the artist as the source spelled it, not a foreign key, so this
+ * resolves two ways: exactly, through a matched release's `artist_id`, and otherwise by
+ * deriving the slug with `artistSlug()` — the same key every other writer uses. Around 72% of a
+ * real import matches no release, so the slug path is the common one, not the fallback.
+ * Artists that resolve neither way simply contribute nothing.
+ *
+ * A read failure returns an empty list rather than null: the collection is an *addition* to the
+ * saved-artist feed, so failing here should quietly narrow the feed, never blank it.
+ */
+async function collectionArtistIdsForUser(
+  client: NonNullable<ReturnType<typeof getClient>>,
+  userId: string
+): Promise<string[]> {
+  const read = await readAllPages<{ artist_name: string | null; releases: { artist_id: string } | null }>(
+    (from, to) =>
+      client
+        .from('collection_items')
+        .select('artist_name, releases!left (artist_id)')
+        .eq('user_id', userId)
+        .range(from, to),
+    'collection_items (feed)'
+  );
+  if (!read.ok) return [];
+
+  const ids = new Set<string>();
+  const slugs = new Set<string>();
+  for (const row of read.rows) {
+    if (row.releases?.artist_id) {
+      ids.add(row.releases.artist_id);
+      continue;
+    }
+    if (!row.artist_name) continue;
+    const slug = artistSlug(row.artist_name);
+    if (slug) slugs.add(slug);
+  }
+  if (slugs.size === 0) return [...ids];
+
+  // Chunked, unlike the saved-artist lookup above: a collection is a whole record library, not
+  // a shortlist, so this one really can approach PostgREST's 1,000-row cap.
+  const pending = [...slugs];
+  for (let i = 0; i < pending.length; i += ARTIST_SLUG_LOOKUP_CHUNK) {
+    const { data, error } = await client
+      .from('artists')
+      .select('id')
+      .in('slug', pending.slice(i, i + ARTIST_SLUG_LOOKUP_CHUNK));
+    if (error) {
+      console.error('[DB] collectionArtistIdsForUser slug resolution failed:', error.message);
+      break;
+    }
+    for (const row of (data as { id: string }[]) || []) ids.add(row.id);
+  }
+
+  return [...ids];
+}
+
+/**
+ * Every release worth putting in one fan's feed: across their saved artists *and* the artists
+ * in their collection, dated within the trailing window or still to come.
  *
  * Two exclusions match the alert path for the same reasons — hidden releases are suppressed by
  * an artist and must stay invisible, and a `needs_review` tier-3 fuzzy flag means we aren't sure
@@ -4874,8 +4935,16 @@ export async function getFeedReleasesForUser(userId: string, now: Date = new Dat
   if (!client) return [];
 
   try {
-    const artistIds = await savedArtistIdsForUser(client, userId);
-    if (artistIds === null) return [];
+    // Saved artists AND artists you own a record by. Buying somebody's album says at least as
+    // much about wanting their next one as saving them does — but the two lists stay separate
+    // everywhere else, because saving is deliberate and an import is not (spec OQ6, reversed
+    // 2026-08-16). The Bandcamp import used to conscript matched artists into saved_artists,
+    // which is what made their releases show up at all; this union is what keeps that promise
+    // now that it doesn't.
+    const savedIds = await savedArtistIdsForUser(client, userId);
+    if (savedIds === null) return [];
+    const collectionIds = await collectionArtistIdsForUser(client, userId);
+    const artistIds = [...new Set([...savedIds, ...collectionIds])];
     if (artistIds.length === 0) return [];
 
     const { data, error } = await client

--- a/api/functions/me-listening.ts
+++ b/api/functions/me-listening.ts
@@ -2,20 +2,28 @@
 // POST   — imports streaming-side play counts from the Mac app's Apple Music library scan.
 //          Body: { source: 'apple_music', signals: [{ artistName: string, playCount: number }] }
 //          Upserts into listening_signals; feeds the private gap report.
+// GET    — the gap report: artists you play a lot and have never paid, ranked by plays.
 // DELETE — removes all of the user's apple_music rows (the app's "remove my data" action).
 //
 // Only apple_music is accepted today because the Mac app is the only writer. The table's
 // CHECK constraint also allows 'lastfm' and 'mac_app' — extend the POST validation and the
 // DELETE filter together when a second source ships.
+//
+// **None of this is ever public.** Listening is not support: an Apple Music play, and even an
+// iTunes purchase, maps to `owned`/`listened` rather than `purchased`, so none of it reaches
+// the public collection page. Nothing here touches saved_artists either — saving is a
+// deliberate act that subscribes you to release alerts, and a library scan choosing it for you
+// would bury the alerts that matter (the 2026-08-16 reversal of spec OQ6).
 
-import { getClient, readAllPages } from './db';
+import { artistSlug, getClient, readAllPages } from './db';
+import { resolveArtistPages } from './collection-utils';
 import { checkRateLimit, resolveAccountRequest, getClientIp } from './ratelimit';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
 };
 
 /** Rows per upsert batch — keeps each PostgREST request comfortably sized (matches bandcamp-sync). */
@@ -28,6 +36,9 @@ const MAX_ARTIST_NAME_LENGTH = 500;
 
 /** Postgres `integer` max — a play count beyond this is a client bug, not a big library. */
 const MAX_PLAY_COUNT = 2_147_483_647;
+
+/** How many gap rows to return. The list is a shopping list, not a database dump. */
+const GAP_LIMIT = 100;
 
 interface Signal {
   artistName: string;
@@ -187,6 +198,107 @@ export async function handler(event: {
       console.error('[me-listening] DELETE error:', error);
       return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Internal server error' }) };
     }
+  }
+
+  if (event.httpMethod === 'GET') {
+    // Deliberately unfiltered by source: the same artist can arrive from the library scan and
+    // (later) the now-playing monitor, and the gap should rank them on total plays. DELETE
+    // stays scoped to apple_music because it answers for the one source the app owns.
+    const signals = await readAllPages<{ artist_name: string; play_count: number; last_played: string | null }>(
+      (from, to) => client
+        .from('listening_signals')
+        .select('artist_name, play_count, last_played')
+        .eq('user_id', user.userId)
+        .order('play_count', { ascending: false })
+        .range(from, to),
+      'listening_signals (gap)'
+    );
+    if (!signals.ok) {
+      // A read that failed is not an empty gap. Reporting one would read as "you already
+      // support everyone you listen to" — the most misleading answer this endpoint can give.
+      return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Failed to load listening signals' }) };
+    }
+
+    const saved = await readAllPages<{ artist_slug: string | null; artist_name: string | null; supported: boolean }>(
+      (from, to) => client
+        .from('saved_artists')
+        .select('artist_slug, artist_name, supported')
+        .eq('user_id', user.userId)
+        .eq('deleted', false)
+        .range(from, to),
+      'saved_artists (gap)'
+    );
+    const collection = await readAllPages<{ artist_name: string }>(
+      (from, to) => client
+        .from('collection_items')
+        .select('artist_name')
+        .eq('user_id', user.userId)
+        .range(from, to),
+      'collection_items (gap)'
+    );
+
+    // Who is already covered: an artist you marked supported, or one you own a record by.
+    // Everything is compared on the derived slug — the same key the collection matcher and the
+    // feed use — so the halves cannot disagree about who counts as covered.
+    //
+    // Unlike the signals read, a failure here degrades instead of failing: the cost is a gap
+    // row for somebody already supported, where blanking the report is the bigger wrong.
+    // readAllPages has already logged the reason.
+    const covered = new Set<string>();
+    for (const row of saved.ok ? saved.rows : []) {
+      if (!row.supported) continue;
+      // Both spellings. A row saved from a search result carries a *synthetic* slug
+      // (`sufjanstevens`) that the canonical one never equals, and re-deriving from the name is
+      // the only thing that recovers it — the same two candidates `savedArtistIdsForUser`
+      // resolves in db.ts, for the same reason.
+      if (row.artist_slug) covered.add(row.artist_slug.toLowerCase());
+      if (row.artist_name) {
+        const derived = artistSlug(row.artist_name);
+        if (derived) covered.add(derived);
+      }
+    }
+    for (const row of collection.ok ? collection.rows : []) {
+      const slug = artistSlug(row.artist_name);
+      if (slug) covered.add(slug);
+    }
+
+    // One artist, one row: merge on the slug so a name arriving from two sources ranks by its
+    // combined plays rather than appearing twice.
+    const totals = new Map<string, { artistName: string; playCount: number; lastPlayed: string | null }>();
+    for (const row of signals.rows) {
+      const slug = artistSlug(row.artist_name);
+      if (!slug || covered.has(slug)) continue;
+      const existing = totals.get(slug);
+      if (!existing) {
+        totals.set(slug, {
+          artistName: row.artist_name,
+          playCount: row.play_count,
+          lastPlayed: row.last_played,
+        });
+        continue;
+      }
+      existing.playCount += row.play_count;
+      if (row.last_played && (!existing.lastPlayed || row.last_played > existing.lastPlayed)) {
+        existing.lastPlayed = row.last_played;
+      }
+    }
+
+    const ranked = [...totals.values()].sort((a, b) => b.playCount - a.playCount).slice(0, GAP_LIMIT);
+    const artistPages = await resolveArtistPages(ranked.map(r => r.artistName));
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({
+        gap: ranked.map(r => ({
+          artistName: r.artistName,
+          playCount: r.playCount,
+          lastPlayed: r.lastPlayed,
+          artistUrl: artistPages.has(r.artistName) ? `/a/${artistPages.get(r.artistName)}` : null,
+        })),
+        totalArtists: signals.rows.length,
+      }),
+    };
   }
 
   return { statusCode: 404, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Not found' }) };

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -82,6 +82,7 @@
     "functions/__tests__/me-bandcamp.test.ts",
     "functions/__tests__/me-collection.test.ts",
     "functions/__tests__/bandcamp-sync.test.ts",
+    "functions/__tests__/feed-collection-artists.test.ts",
     "functions/__tests__/credential-crypto.test.ts",
     "functions/__tests__/bandcamp-subsonic.test.ts",
     "functions/public-saved-artists.ts",


### PR DESCRIPTION
#454 was merged into the `batch/aug-16` integration branch on 2026-08-16, and that branch never reached main. Its squash commit `c498b6d` is still stranded there. #465 has already rebuilt the POST/DELETE half of `/api/me/listening` on current patterns; this PR brings the other two pieces over, **reimplemented against current main** rather than cherry-picked — `batch/aug-16` is 9 commits behind and merging it would revert #458, #463 and #464.

## 1. `GET /api/me/listening` — the private gap report

Artists you play a lot and have never paid, ranked by plays, capped at 100. It subtracts artists you marked supported and artists you own a record by, comparing on the derived slug so the two halves can't disagree about who counts as covered.

- **Auth is #465's, not the stranded version's.** `resolveAccountRequest` (local JWT verification) and the `account` rate-limit tier, so the token is verified once and GET sits behind the same gate as POST and DELETE. The stranded version used a `getUser` round trip and the shared `standard` IP bucket, which is what caused the 429 incident.
- **Never public.** It's derived from one user's own rows and returned only to that authenticated user; `listening_signals` has no INSERT/UPDATE policy and the gap is deliberately absent from the collection page.
- **A failed signals read is a 500, not an empty gap.** An empty gap would read as "you already support everyone you listen to" — the most misleading answer this endpoint can give. The two exclusion reads degrade instead: losing them costs a row for someone already supported, where blanking the report is the bigger wrong.

One deliberate improvement on the stranded code: a supported artist is matched on `artistSlug(artist_name)` as well as the stored slug. A row saved from a search result carries a synthetic slug (`sufjanstevens`) that the canonical one never equals, so slug-only matching would tell you to go support someone you already support. These are the same two candidates `savedArtistIdsForUser` resolves in `db.ts`, for the same reason.

## 2. The OQ6 reversal

> "Collection Imports should always add to the collection NOT saved artists. However, you should get upcoming/recent release information from artists both in the collection and the saved artists list." — 2026-08-16

**Main has been auto-writing `saved_artists` on every import this whole time.** `markArtistsSupported` is gone from `bandcamp-sync-background.ts`; an import now writes `collection_items` and stops.

Their releases still reach the feed: `getFeedReleasesForUser` unions saved ∪ collection, resolving collection artists through a matched release's `artist_id` or the derived slug. ~72% of a real import matches no release, so the slug path is the common one, not a fallback. A failed collection read narrows the feed rather than blanking it.

Removing the mark also drops the cached artists select to `id, name` — matching an artist is now only how we find their releases.

## ⚠️ Expect `semantic-revert-check` to flag this

It should. Deleting `markArtistsSupported` removes #445's dedup fix (looking a saved row up by `artist_id` as well as slug, so an import couldn't duplicate a row or resurrect a tombstone). That fix is correctly deleted rather than reverted: it was protecting a write that no longer happens. Nothing else calls the function.

## Not in scope

The 35 `saved_artists` rows the live import already created — Brandon: *"don't worry about deleting the 35 rows, that was only in my own account. i can clean that up later myself."* This stops new ones; it doesn't clean up old ones.

## Testing

`npm run verify` green — 1300 API tests, 781 web tests, typecheck clean.

New coverage: the gap's ranking, both exclusion paths (including the synthetic-slug case), cross-source merging, the 100 cap, and the read-failure asymmetry; the sync asserting it never touches `saved_artists`; and the feed union, ported from the stranded `feed-collection-artists.test.ts`. Every new assertion was checked against a deliberately broken implementation — dropping the collection half of the union, treating a failed read as empty, and raising the cap each fail exactly the test that names them.

`saved-artist-resolution.test.ts`'s fake client gained a `range` method so the feed's new collection read can answer; without it every test in that file would have fallen into the catch block and returned `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)