### PR TITLE
Bump the Apple app to 3.6.0 (build 16)

### DIFF
--- a/apps/mac/Unstream/Info-iOS.plist
+++ b/apps/mac/Unstream/Info-iOS.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.0</string>
+	<string>3.6.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/mac/Unstream/Info-macOS.plist
+++ b/apps/mac/Unstream/Info-macOS.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.0</string>
+	<string>3.6.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/mac/UnstreamShareExtension/Info.plist
+++ b/apps/mac/UnstreamShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.0</string>
+	<string>3.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/mac/project.yml
+++ b/apps/mac/project.yml
@@ -94,8 +94,8 @@ targets:
         CFBundleName: UnstreamShare
         CFBundleDisplayName: Share to Unstream
         CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
-        CFBundleVersion: "15"
-        CFBundleShortVersionString: "3.5.0"
+        CFBundleVersion: "16"
+        CFBundleShortVersionString: "3.6.0"
         CFBundlePackageType: XPC!
         NSExtension:
           NSExtensionAttributes:


### PR DESCRIPTION
Bumps the Apple app 3.5.0 → **3.6.0**, build **15 → 16**, ahead of the first Sparkle-enabled release.

Minor rather than patch because self-updating is a capability a user notices.

## The build number is the load-bearing half

Sparkle compares the appcast's `sparkle:version` against the installed `CFBundleVersion` — not the marketing version. A 3.5.0 → 3.6.0 release that left the build at `15` would be invisible to every installed copy, which for the release that *introduces* Sparkle would be a silent, total failure. `api/functions/__tests__/desktop-appcast.test.ts` guards the appcast side of this; nothing can guard the plist side, hence the care here.

## All four files that have to agree

| File | |
|---|---|
| `apps/mac/Unstream/Info-macOS.plist` | 3.6.0 / 16 |
| `apps/mac/Unstream/Info-iOS.plist` | 3.6.0 / 16 |
| `apps/mac/project.yml` (share-extension block) | 3.6.0 / 16 |
| `apps/mac/UnstreamShareExtension/Info.plist` | 3.6.0 / 16 — generated from `project.yml`, committed, so bumped and confirmed by `xcodegen` rather than left to diverge |

`xcodegen generate` re-run. macOS and iOS both build. The built bundle reports `3.6.0` / `16`.

## Deliberately *not* touched: `api/shared/desktop-release.ts`

It still says 3.5.0, and has to until the 3.6.0 DMG actually exists on GitHub. It feeds `/api/desktop/version`, which installs on 3.5.0 and earlier poll and which links straight to a download — bumping it now points people at a release that isn't there. It takes the version, URL, byte length and EdDSA signature together at release time, per step 7 of `apps/mac/docs/sparkle-updates.md`.

That also keeps this PR out of a Netlify build: `apps/mac/` alone is in `netlify-ignore-build.sh`'s skip list, so merging this costs nothing.

## Key check, while nearby

Confirmed the EdDSA private key in the login keychain still matches the public key shipping in `Info-macOS.plist` (`generate_keys -p` vs `SUPublicEDKey` — identical). If those ever diverge, every signed update is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
