### PR TITLE
Ignore signing keys and credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,14 @@ next-env.d.ts
 
 # Supabase CLI temp
 supabase/.temp/
+
+# Signing keys and credentials. Nothing here has ever been committed, and these patterns keep it
+# that way — the App Store Connect API key (AuthKey_*.p8) and Sparkle's exported EdDSA key are
+# both plain text, and both are the kind of file that ends up in the project folder "just for a
+# minute" during a release. A leaked .p8 lets anyone upload builds as this developer.
+*.p8
+*.p12
+*.cer
+*.mobileprovision
+sparkle-private-key*.txt
+


### PR DESCRIPTION
One line of protection prompted by the missing `AuthKey_XDBZJJA474.p8`: `*.p8` was **not** gitignored. Nothing has ever been committed (checked the full history, not just the index), but both keys we're now handling are plain text and are exactly the kind of file that lands in the project folder "just for a minute" during a release.

Adds `*.p8`, `*.p12`, `*.cer`, `*.mobileprovision`, `sparkle-private-key*.txt`.

Stakes, so the patterns don't get trimmed later: a leaked `.p8` lets anyone upload builds as this developer. A leaked Sparkle EdDSA key lets anyone sign an update that **every installed copy of the Mac app would accept and install** — Sparkle verifies that signature, so it's the one credential that can push code onto users' machines.

Verified the patterns actually match (`AuthKey_TEST.p8`, `sparkle-private-key.txt` — both ignored) rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)