### PR TITLE
Stop guessing MIME sentences, and tell a day-old tab to refresh

### DIFF
--- a/apps/web/src/components/StaleBuildBanner.tsx
+++ b/apps/web/src/components/StaleBuildBanner.tsx
@@ -1,0 +1,45 @@
+import { useBuildFreshness } from '../hooks/useBuildFreshness'
+
+/**
+ * Offers a refresh to a tab that's more than a day behind the live build.
+ *
+ * Prompts rather than reloads. A forced reload would throw away whatever the person was in the
+ * middle of — this route list is reachable from a half-finished edit form — and the failure it
+ * prevents is already recovered from by `lazyWithRetry` if they walk into it. So the deal is:
+ * tell them, let them pick the moment, and stay out of the way if they'd rather not.
+ */
+export function StaleBuildBanner() {
+  const { isStale, dismiss } = useBuildFreshness()
+
+  if (!isStale) return null
+
+  return (
+    <div
+      // polite, not assertive: this is worth reading at the next natural pause, and it is not
+      // an error. assertive would interrupt a screen reader mid-sentence for a housekeeping note.
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-0 bottom-0 z-50 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t border-border bg-bg-secondary px-4 py-3 text-center"
+    >
+      <p className="text-sm text-text-muted">
+        A newer version of Unstream is available.
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-lg bg-accent-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-primary/90"
+        >
+          Refresh
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="rounded-lg px-3 py-1.5 text-sm font-medium text-text-muted transition-colors hover:text-text-primary"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useBuildFreshness.ts
+++ b/apps/web/src/hooks/useBuildFreshness.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  fetchDeployedBuild,
+  freshnessVerdict,
+  runningBuildId,
+  type FreshnessVerdict,
+} from '../services/buildFreshness'
+
+/** How often a visible tab re-checks. Cheap: one no-store GET of a two-field JSON file. */
+const POLL_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * True once this tab is more than a day behind the live build, until the person dismisses it.
+ *
+ * Checks on mount, whenever the tab is brought back to the foreground, and hourly while it
+ * stays visible. The foreground check is the one that matters on a phone: iOS suspends timers
+ * in background tabs, so a tab that sat in the app switcher for a week fires no interval at all
+ * — but it does fire `visibilitychange` the moment the person returns to it, which is exactly
+ * when they're about to navigate into a chunk that no longer exists.
+ */
+export function useBuildFreshness(): { isStale: boolean; dismiss: () => void } {
+  const [verdict, setVerdict] = useState<FreshnessVerdict>('unknown')
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const running = runningBuildId()
+    // A local or unversioned build has nothing to compare against, so don't poll at all —
+    // otherwise every `npm run dev` session fetches a file that isn't there once an hour.
+    if (!running) return
+
+    const controller = new AbortController()
+    // Kept in the closure rather than read back off state: the effect runs once, and reading
+    // the latest verdict from render would mean either re-running the effect (tearing down its
+    // own listeners) or writing a ref during render.
+    let settled = false
+
+    const check = async () => {
+      // Once stale, stop asking. The answer can only change by this tab reloading, which ends
+      // this component's life anyway.
+      if (settled) return
+      const deployed = await fetchDeployedBuild(controller.signal)
+      if (controller.signal.aborted) return
+      // A null probe yields 'unknown', which leaves the banner hidden. Not folded into 'fresh':
+      // see the note on FreshnessVerdict.
+      const next = freshnessVerdict(running, deployed, Date.now())
+      if (next === 'stale') settled = true
+      setVerdict(next)
+    }
+
+    const checkIfVisible = () => {
+      if (document.visibilityState === 'visible') void check()
+    }
+
+    void check()
+    document.addEventListener('visibilitychange', checkIfVisible)
+    const interval = setInterval(checkIfVisible, POLL_INTERVAL_MS)
+
+    return () => {
+      controller.abort()
+      document.removeEventListener('visibilitychange', checkIfVisible)
+      clearInterval(interval)
+    }
+  }, [])
+
+  const dismiss = useCallback(() => setDismissed(true), [])
+
+  return { isStale: verdict === 'stale' && !dismissed, dismiss }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,7 @@ import { ArtistPage } from './pages/ArtistPage.tsx'
 import { AppLoadingFallback, AppErrorFallback } from './components/AppFallback'
 import { ScrollToTop } from './components/ScrollToTop'
 import { lazyWithRetry } from './utils/lazyWithRetry'
+import { StaleBuildBanner } from './components/StaleBuildBanner'
 
 initSentry()
 
@@ -72,6 +73,10 @@ createRoot(document.getElementById('root')!).render(
         scope.setTag('route', window.location.pathname)
       }}
     >
+      {/* Outside the router and Suspense on purpose: it needs neither, and this way it stays
+          mounted across navigations and is still visible while a route chunk is downloading —
+          including the download that is about to fail because this build is the stale one. */}
+      <StaleBuildBanner />
       <AuthProvider>
         <BrowserRouter>
           <ScrollToTop />

--- a/apps/web/src/services/buildFreshness.ts
+++ b/apps/web/src/services/buildFreshness.ts
@@ -1,0 +1,97 @@
+/**
+ * Detect that this tab is running a build the site has since replaced.
+ *
+ * Nothing tells a long-lived tab that it went out of date. The service worker is
+ * `registerType: 'autoUpdate'`, so a new deploy's worker claims the live page without
+ * reloading it — the page keeps its old JavaScript while the precache holds the new build.
+ * The first thing the person notices is a route that won't open, because the chunk its old
+ * `index.html` named no longer exists.
+ *
+ * `lazyWithRetry` already recovers from that *reactively*, once they've hit it. This module is
+ * the proactive half: it asks which build is live and, when we're a day behind it, lets the UI
+ * offer a refresh before they walk into the failure.
+ */
+import { BUILD_ID_URL, STALE_AFTER_MS } from './buildFreshnessConstants'
+
+export { BUILD_ID_URL, STALE_AFTER_MS }
+
+/** The shape of the `/build-id.json` emitted by the `unstream-build-id` plugin in vite.config.ts. */
+export interface DeployedBuild {
+  id: string
+  builtAt: string
+}
+
+/**
+ * `unknown` is a first-class answer, not an error to be flattened into `fresh`.
+ *
+ * A failed probe — offline, a 500, a body we can't parse — says nothing about whether this tab
+ * is current, and the caller must not act on it either way. Collapsing it into `stale` nags
+ * people whose connection blipped; collapsing it into `fresh` is the "never cache uncertainty"
+ * bug this codebase keeps relearning. Keeping it separate makes the caller decide on purpose.
+ */
+export type FreshnessVerdict = 'fresh' | 'stale' | 'unknown'
+
+/** The build baked into this bundle at build time, or null when there isn't a real one. */
+export function runningBuildId(): string | null {
+  const id = import.meta.env.VITE_APP_VERSION
+  // 'dev' is the vite.config fallback when no COMMIT_REF exists, and 'unknown' is what
+  // sentry.ts reports without one. Neither identifies a deploy, so neither can be compared
+  // against one — a local build must never decide it is stale.
+  if (!id || id === 'dev' || id === 'unknown') return null
+  return id
+}
+
+/**
+ * Is `running` behind `deployed`, and has it been for longer than `staleAfterMs`?
+ *
+ * The clock runs from the deployed build's own `builtAt`, not from when this tab first noticed
+ * it. A backgrounded iOS tab has its timers suspended, so "how long have I been watching"
+ * undercounts by however long the phone was in a pocket — the exact case this is for. Reading
+ * the live build's age instead makes the answer independent of whether any interval ever fired.
+ *
+ * With several deploys in a day this measures from the newest one, so it under-reports how long
+ * we've been stale. That direction is deliberate: it means "you are a day behind the build
+ * that's live now", which is the thing worth interrupting someone for, and it can't nag about a
+ * deploy that went out minutes ago.
+ */
+export function freshnessVerdict(
+  running: string | null,
+  deployed: DeployedBuild | null,
+  now: number,
+  staleAfterMs: number = STALE_AFTER_MS
+): FreshnessVerdict {
+  if (!running || !deployed?.id) return 'unknown'
+  if (running === deployed.id) return 'fresh'
+
+  const builtAt = Date.parse(deployed.builtAt)
+  // A build we can't date can't be aged. Reporting 'unknown' rather than 'stale' keeps a
+  // malformed file from turning into a banner nobody can explain; we emit this file ourselves,
+  // so in practice it means the emitter broke and wants fixing, not that the user should act.
+  if (Number.isNaN(builtAt)) return 'unknown'
+
+  return now - builtAt > staleAfterMs ? 'stale' : 'fresh'
+}
+
+/**
+ * Ask which build is live. Resolves null on any failure — see `FreshnessVerdict`.
+ *
+ * `cache: 'no-store'` keeps the browser cache out of it, and netlify.toml sends
+ * `Cache-Control: no-store` so the CDN can't hand back this tab's own build either. Without
+ * both, the probe eventually answers with the very build it's meant to detect a change from.
+ */
+export async function fetchDeployedBuild(signal?: AbortSignal): Promise<DeployedBuild | null> {
+  try {
+    const response = await fetch(BUILD_ID_URL, { cache: 'no-store', signal })
+    if (!response.ok) return null
+    const body: unknown = await response.json()
+    if (!body || typeof body !== 'object') return null
+    const { id, builtAt } = body as Partial<DeployedBuild>
+    if (typeof id !== 'string' || typeof builtAt !== 'string') return null
+    return { id, builtAt }
+  } catch {
+    // Offline, aborted, or a body that isn't JSON. All of them mean "no answer", which is
+    // what null says. Deliberately not reported: a probe that fails while someone is on a
+    // train is routine, and it changes nothing about what we show them.
+    return null
+  }
+}

--- a/apps/web/src/services/buildFreshnessConstants.ts
+++ b/apps/web/src/services/buildFreshnessConstants.ts
@@ -1,0 +1,16 @@
+/**
+ * Split out from buildFreshness.ts so tests can import the thresholds without pulling in
+ * `import.meta.env`, which only exists once Vite has transformed the module.
+ */
+
+/** Emitted by the `unstream-build-id` plugin in vite.config.ts. */
+export const BUILD_ID_URL = '/build-id.json'
+
+/**
+ * How far behind the live build this tab has to be before it's worth interrupting someone.
+ *
+ * Not zero on purpose. `lazyWithRetry` already catches the failure this prevents, so the banner
+ * is the slower, politer layer — a prompt the moment any deploy lands would interrupt people
+ * mid-edit several times a week to protect them from something already handled.
+ */
+export const STALE_AFTER_MS = 24 * 60 * 60 * 1000

--- a/apps/web/tests/unit/build-freshness.test.ts
+++ b/apps/web/tests/unit/build-freshness.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  fetchDeployedBuild,
+  freshnessVerdict,
+  BUILD_ID_URL,
+  STALE_AFTER_MS,
+} from '../../src/services/buildFreshness'
+
+const HOUR = 60 * 60 * 1000
+const NOW = Date.parse('2026-08-22T12:00:00.000Z')
+
+/** A deployed build whose `builtAt` is `ageMs` old relative to NOW. */
+function deployed(id: string, ageMs: number) {
+  return { id, builtAt: new Date(NOW - ageMs).toISOString() }
+}
+
+describe('freshnessVerdict', () => {
+  it('is fresh when this tab is running the deployed build', () => {
+    expect(freshnessVerdict('abc123', deployed('abc123', 90 * HOUR), NOW)).toBe('fresh')
+  })
+
+  it('is stale when a different build has been live for more than a day', () => {
+    expect(freshnessVerdict('old', deployed('new', 25 * HOUR), NOW)).toBe('stale')
+  })
+
+  it('holds off while the newer build is younger than the threshold', () => {
+    // The whole point of the delay: a deploy that just landed must not interrupt anyone,
+    // because lazyWithRetry already recovers if they walk into a missing chunk.
+    expect(freshnessVerdict('old', deployed('new', 1 * HOUR), NOW)).toBe('fresh')
+    expect(freshnessVerdict('old', deployed('new', 23 * HOUR), NOW)).toBe('fresh')
+  })
+
+  it('reads the threshold from the deployed build age, not from elapsed polling time', () => {
+    // Teeth: these two bracket STALE_AFTER_MS exactly. An implementation that ignored the
+    // threshold, compared against a hardcoded different number, or measured from "when this
+    // tab first noticed" would fail one of them.
+    expect(freshnessVerdict('old', deployed('new', STALE_AFTER_MS - 1), NOW)).toBe('fresh')
+    expect(freshnessVerdict('old', deployed('new', STALE_AFTER_MS + 1), NOW)).toBe('stale')
+  })
+
+  it('honours a caller-supplied threshold', () => {
+    expect(freshnessVerdict('old', deployed('new', 2 * HOUR), NOW, 1 * HOUR)).toBe('stale')
+    expect(freshnessVerdict('old', deployed('new', 2 * HOUR), NOW, 3 * HOUR)).toBe('fresh')
+  })
+
+  it('is unknown, never stale, when there is nothing to compare', () => {
+    // A local or unversioned build must never decide it is out of date.
+    expect(freshnessVerdict(null, deployed('new', 99 * HOUR), NOW)).toBe('unknown')
+    // A probe that came back empty says nothing about this tab. Folding this into 'fresh' or
+    // 'stale' is the "never cache uncertainty" bug; keep it its own answer.
+    expect(freshnessVerdict('old', null, NOW)).toBe('unknown')
+  })
+
+  it('is unknown when the deployed build cannot be dated', () => {
+    expect(freshnessVerdict('old', { id: 'new', builtAt: 'not-a-date' }, NOW)).toBe('unknown')
+    expect(freshnessVerdict('old', { id: 'new', builtAt: '' }, NOW)).toBe('unknown')
+  })
+
+  it('does not treat a clock skewed behind the deploy as stale', () => {
+    // A device clock set in the past makes builtAt look like the future. Negative age must not
+    // sail past a positive threshold.
+    expect(freshnessVerdict('old', deployed('new', -50 * HOUR), NOW)).toBe('fresh')
+  })
+})
+
+describe('fetchDeployedBuild', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function stubFetch(impl: typeof fetch) {
+    const spy = vi.fn(impl)
+    vi.stubGlobal('fetch', spy)
+    return spy
+  }
+
+  it('returns the build and bypasses every cache on the way', async () => {
+    const spy = stubFetch(async () =>
+      new Response(JSON.stringify({ id: 'abc', builtAt: '2026-08-22T00:00:00.000Z' }), {
+        status: 200,
+      })
+    )
+
+    await expect(fetchDeployedBuild()).resolves.toEqual({
+      id: 'abc',
+      builtAt: '2026-08-22T00:00:00.000Z',
+    })
+
+    // Load-bearing: a cached response echoes this tab's own build back to it forever, so the
+    // banner would never appear. Pin the option rather than trusting a comment about it.
+    const [url, init] = spy.mock.calls[0]
+    expect(url).toBe(BUILD_ID_URL)
+    expect(init).toMatchObject({ cache: 'no-store' })
+  })
+
+  it('answers null — not a guess — for every kind of failure', async () => {
+    stubFetch(async () => new Response('', { status: 500 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+
+    stubFetch(async () => new Response('', { status: 404 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+
+    stubFetch(async () => new Response('<!doctype html>', { status: 200 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+
+    stubFetch(async () => {
+      throw new TypeError('Load failed')
+    })
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+  })
+
+  it('rejects a body missing either field rather than half-trusting it', async () => {
+    stubFetch(async () => new Response(JSON.stringify({ id: 'abc' }), { status: 200 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+
+    stubFetch(async () => new Response(JSON.stringify({ builtAt: 'x' }), { status: 200 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+
+    stubFetch(async () => new Response(JSON.stringify({ id: 7, builtAt: 8 }), { status: 200 }))
+    await expect(fetchDeployedBuild()).resolves.toBeNull()
+  })
+
+  it('a failed probe cannot produce a banner', async () => {
+    // The two halves together: this is the property that matters, so assert it end to end.
+    stubFetch(async () => {
+      throw new TypeError('Load failed')
+    })
+    const build = await fetchDeployedBuild()
+    expect(freshnessVerdict('old-build', build, NOW)).toBe('unknown')
+  })
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
@@ -35,11 +35,44 @@ if (sentryEnabled && !env.SENTRY_AUTH_TOKEN) {
 // maps land on the same release the client reports.
 const release = env.VITE_APP_VERSION || env.COMMIT_REF || 'dev'
 
+/**
+ * Emit `/build-id.json` naming the build that produced this bundle.
+ *
+ * A tab left open across a deploy keeps running old JavaScript, and nothing tells it so — the
+ * service worker is `autoUpdate`, which claims the live page without reloading it, so the page
+ * is old while the precache is new. `buildFreshness.ts` polls this file and compares `id`
+ * against the `VITE_APP_VERSION` baked into the bundle; a mismatch means this tab has been
+ * superseded.
+ *
+ * It reuses the `release` constant above rather than reading COMMIT_REF again, so the id here
+ * and the release the client reports to Sentry can never disagree about which build this is.
+ *
+ * `builtAt` is what makes "stale for more than 24 hours" answerable without a timer having run:
+ * a suspended mobile tab can miss every interval it was scheduled for, so the client subtracts
+ * this timestamp instead of measuring how long it has personally been watching.
+ */
+function emitBuildId(): Plugin {
+  return {
+    name: 'unstream-build-id',
+    apply: 'build',
+    generateBundle() {
+      // Written through generateBundle so it lands in the bundle Vite is already emitting;
+      // a file written to dist/ by hand would race the build's own output cleanup.
+      this.emitFile({
+        type: 'asset',
+        fileName: 'build-id.json',
+        source: JSON.stringify({ id: release, builtAt: new Date().toISOString() }),
+      })
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
+    emitBuildId(),
     VitePWA({
       registerType: 'autoUpdate',
       // The generated registerSW.js calls navigator.serviceWorker.register()

--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,15 @@
   framework = "#custom"
   autoLaunch = false
 
+# The staleness probe in buildFreshness.ts compares this file's id against the one baked into
+# the running bundle. A cached response would echo the tab's own build back to it forever, so
+# the banner would never appear. `no-store` on the request isn't enough on its own — the CDN
+# would still be free to hand out a stale copy.
+[[headers]]
+  for = "/build-id.json"
+  [headers.values]
+    Cache-Control = "no-store, max-age=0"
+
 [[headers]]
   for = "/*"
   # connect-src note: Sentry's ingest host is region-scoped — ours is
@@ -407,6 +416,25 @@
   from = "/plus"
   to = "/support"
   status = 301
+
+# Build assets must 404 when they're missing, instead of falling through to the SPA
+# catch-all below. Without this rule a request for a superseded chunk gets `200 text/html`,
+# and the browser rejects it as a MIME error whose wording differs per engine — Chromium says
+# "Expected a JavaScript module script...", WebKit says "'text/html' is not a valid JavaScript
+# MIME type." We chased those strings twice (PR #390, then #417 for WebKit's) and every new
+# engine wording silently broke the auto-reload in `lazyWithRetry` until someone noticed in
+# Sentry. A real 404 is a fetch failure instead of a MIME failure, which every engine already
+# reports in wording `isStaleBuildAssetError` matches, so the reload no longer depends on
+# guessing sentences.
+#
+# `force` is deliberately absent: Netlify serves a matching file from the publish directory
+# ahead of any unforced redirect rule, so real assets are untouched and only genuinely missing
+# ones reach this. The `/*` rule below is the proof — every asset request matches it too, and
+# assets are still served as themselves.
+[[redirects]]
+  from = "/assets/*"
+  to = "/index.html"
+  status = 404
 
 # SPA catch-all: serve index.html for all routes (must be last)
 [[redirects]]


### PR DESCRIPTION
Fixes the class of bug behind Sentry **UNSTREAM-WEB-14** (`'text/html' is not a valid JavaScript MIME type.`).

## Why

A tab left open across a deploy asks for a chunk hash the new deploy doesn't have. Netlify's SPA catch-all answers `200 text/html` instead of 404, so the browser rejects it as a **MIME error whose wording differs per engine**. We've chased those strings twice already — #390 added Chromium's, #417 added WebKit's after every iOS visitor caught by a deploy got the error screen instead of the auto-reload.

Worth stating up front, since it changes how you read the Sentry issue: **that event was not a regression.** Its `release` tag was `07b06cb4` (#415, Aug 5) and the WebKit fix landed in `56a88f7` (#417, Aug 6), so the tab was running a build that predated the clause. Production already classifies the wording — verified by grepping the live entry chunk. This PR is about not having to add a fifth string next time.

## What changed

**1. `/assets/*` 404s when the file is missing**, ahead of the SPA catch-all. A 404 is a *fetch* failure rather than a MIME failure, and every engine reports that in wording `isStaleBuildAssetError` matched before either of those PRs.

The rule is deliberately **unforced**. Netlify serves a matching file from the publish directory ahead of an unforced redirect, so real assets are untouched — and the catch-all is the proof, since every asset request already matches `/*` today and is still served as itself.

**2. A refresh prompt for a tab that's fallen behind.** Nothing ever told a long-lived tab it had gone stale: the service worker is `autoUpdate`, so a new deploy's worker claims the live page *without* reloading it — the page keeps its old JavaScript while the precache holds the new build. A Vite plugin now emits `/build-id.json` (reusing the existing `release` constant, so the build id and the Sentry release can't drift), and a banner offers a refresh once this tab is more than a day behind.

## Decisions worth a reviewer's attention

- **The 24h clock runs from the deployed build's `builtAt`**, not from when this tab noticed. iOS suspends timers in background tabs, so "how long have I been watching" undercounts by however long the phone was in a pocket — the exact case this is for.
- **A failed probe is `unknown`, never `stale`.** Offline or a 500 shows nothing. Folding it into `stale` nags anyone whose connection blipped; folding it into `fresh` is the never-cache-uncertainty bug this repo keeps relearning.
- **It prompts and never force-reloads.** That would discard a half-finished edit, and `lazyWithRetry` already recovers reactively if someone walks into the failure.
- **`build-id.json` must stay out of the precache.** Verified against the real `sw.js` (41 precache entries, none of them this file). If Workbox ever picks it up, the probe echoes the tab's own build back forever and the banner silently never appears.

## Verification

`npm run verify` green — typecheck, 1308 API tests, 793 web tests. 12 new tests, mutation-tested: dropping the threshold, dropping `cache: 'no-store'`, and collapsing `unknown` into `fresh` each fail the suite.

Against a real production build served through a Netlify-faithful local harness:

| Scenario | Result |
|---|---|
| Running the deployed build | no banner |
| Deploy 1h old | still silent |
| Deploy 25h old | banner appears |
| "Not now" | dismisses, stays dismissed |
| Missing chunk under `/assets/` | 404; `lazyWithRetry` reloads **once**, no loop |
| Chunk restored | route renders, reload flag self-clears |

The reload flag is only set inside the `isStaleBuildAssetError` branch, so the 404 path being classified is measured, not assumed.

## Two honest gaps

- **Redirect precedence has not been confirmed on real Netlify** — it's reasoned from the catch-all's existing behaviour and exercised through the local harness. A draft `netlify deploy` (no `--prod`; builds locally, 0 build minutes) would close this. Deploy Previews are disabled repo-wide, so there's no preview URL on this PR.
- **The WebKit half is reasoned, not measured.** In Chromium a failed dynamic import reports `Failed to fetch dynamically imported module` as the outer message for *both* a 404 and a `200 text/html` — the MIME sentence is only the `cause`. A MIME rejection requires a 2xx with the wrong type, so a 404 can't produce one, but I could only verify that in Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
