### PR TITLE
Fix the Mac app crashing at launch on a missing Sparkle framework

### DIFF
--- a/apps/mac/Unstream.xcodeproj/project.pbxproj
+++ b/apps/mac/Unstream.xcodeproj/project.pbxproj
@@ -812,6 +812,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lol.bgreen.Unstream;
 				PRODUCT_NAME = Unstream;
 				SDKROOT = auto;
@@ -840,6 +841,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lol.bgreen.Unstream;
 				PRODUCT_NAME = Unstream;
 				SDKROOT = auto;

--- a/apps/mac/project.yml
+++ b/apps/mac/project.yml
@@ -65,6 +65,14 @@ targets:
       "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": Unstream/Unstream-iOS.entitlements
       "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": Unstream/Unstream-iOS.entitlements
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      # XcodeGen emits one LD_RUNPATH_SEARCH_PATHS for this multi-platform target and picks
+      # the iOS layout (@executable_path/Frameworks). A macOS app keeps embedded frameworks in
+      # Contents/Frameworks, one level ABOVE Contents/MacOS, so with only the iOS path dyld
+      # can't find Sparkle and the app dies at launch with "Library not loaded:
+      # @rpath/Sparkle.framework". A Debug build hides this (everything links through
+      # Unstream.debug.dylib) and CI only compiles, so nothing but launching an exported
+      # Release build catches it.
+      "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": "$(inherited) @executable_path/../Frameworks"
     dependencies:
       - target: UnstreamShareExtension
         destinationFilters: [iOS]


### PR DESCRIPTION
## The bug

Every exported Release build of 3.6.0 died in dyld before drawing anything — a process appears, no menu-bar icon, three `.ips` crash reports:

```
Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
tried: '…/Unstream.app/Contents/MacOS/Frameworks/Sparkle.framework/Versions/B/Sparkle' (no such file)
```

XcodeGen emits **one** `LD_RUNPATH_SEARCH_PATHS` for the multi-platform `Unstream` target and picks the iOS layout, `@executable_path/Frameworks`. A macOS app keeps embedded frameworks in `Contents/Frameworks` — one level *above* `Contents/MacOS` — so dyld searched a directory that doesn't exist.

## The fix

An sdk-conditional runpath, the pattern `project.yml` already uses for `INFOPLIST_FILE` and `CODE_SIGN_ENTITLEMENTS`, so iOS keeps its own layout:

```yaml
"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": "$(inherited) @executable_path/../Frameworks"
```

## Verification

Exported Developer ID build, not a Debug build:

- `otool -l …/MacOS/Unstream | grep -A2 LC_RPATH` → `@executable_path/../Frameworks` present
- App launches and stays up; `lsof -p <pid> | grep Sparkle` shows the framework mapped
- No new crash reports

## Why nothing caught it

- **Debug builds don't reproduce it** — they link through `Unstream.debug.dylib`, which resolves differently.
- **`mac-build.yml` only compiles.** A link-and-launch failure is invisible to it.
- **The Sparkle PR was verified by inspecting the bundle**, where `Contents/Frameworks/Sparkle.framework` is present and correct. The bundle was never the problem; the binary's search path was.

Worth considering separately: a launch smoke test in `mac-build.yml` (export Release, confirm the process survives ~5s) would have caught this, and would catch missing frameworks, bad entitlements, and crashes in `applicationDidFinishLaunching`.

## Blast radius

**Not shipped to anyone.** `MAC_RELEASE` in `api/shared/desktop-release.ts` is still 3.5.0 with an empty `edSignature`, so no 3.6.0 was ever published. Had it shipped, Sparkle would have downloaded and installed an update that then failed to launch — near-undiagnosable from a user's side.

`apps/mac` is in `netlify-ignore-build.sh`, so this costs no deploy.