### PR TITLE
Count the analytics dashboard's events in Postgres, not in a JS loop

### DIFF
--- a/api/functions/__tests__/analytics-dashboard.test.ts
+++ b/api/functions/__tests__/analytics-dashboard.test.ts
@@ -1,0 +1,149 @@
+// /admin/analytics reported 641 of 10,380 searches in production on 2026-08-23. Every aggregate
+// was a raw app_events read counted in a JS loop, and PostgREST silently truncated each one at
+// 1,000 rows — `by_app` and `streaming_services` both totalled *exactly* 1000, which is the tell.
+// The daily query ordered created_at ASC, so the 1,000 rows that survived were the oldest and the
+// most recent 26 days rendered as zero.
+//
+// These tests pin the two properties that fix depends on: the counts come from the analytics_*
+// SQL functions (so no row cap is in the path), and the per-group counts are *summed* rather than
+// incremented by one per row.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockRpc: vi.fn(),
+  mockSelect: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getClient: () => ({
+    // Every count query is .from().select().eq().gte()
+    from: () => ({ select: mocks.mockSelect }),
+    rpc: mocks.mockRpc,
+  }),
+}));
+vi.mock('../middleware', () => ({
+  authenticateAdmin: async () => ({ userId: 'u1', email: 'admin@example.com' }),
+}));
+vi.mock('../../lib/sentry', () => ({
+  Sentry: { captureMessage: vi.fn(), captureException: vi.fn() },
+}));
+
+import { handler } from '../analytics-dashboard';
+
+const today = new Date().toISOString().split('T')[0];
+
+// Deliberately far above 1,000 per group: any code path that counted rows one at a time under
+// the PostgREST cap could not produce these totals.
+const RPC_DATA: Record<string, unknown[]> = {
+  analytics_search_success: [{ completed: 4000, with_results: 3000 }],
+  analytics_daily_events: [
+    { day: today, event_type: 'search', events: 7400 },
+    { day: today, event_type: 'platform_click', events: 2100 },
+    { day: today, event_type: 'extension_activated', events: 1500 },
+  ],
+  analytics_events_by_app: [
+    { app: 'web', event_type: 'search', events: 5000 },
+    { app: 'web', event_type: 'platform_click', events: 2100 },
+    { app: 'extension', event_type: 'search', events: 2400 },
+  ],
+  analytics_platform_clicks: [
+    { platform: 'bandcamp', clicks: 1800 },
+    { platform: 'mirlo', clicks: 300 },
+  ],
+  analytics_streaming_services: [
+    { service: 'youtube', activations: 1200 },
+    { service: 'spotify', activations: 300 },
+  ],
+};
+
+function get() {
+  return handler({ httpMethod: 'GET', headers: { authorization: 'Bearer t' } });
+}
+
+async function body() {
+  const res = await get();
+  return JSON.parse(res.body);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockSelect.mockReturnValue({
+    eq: () => ({ gte: () => Promise.resolve({ count: 10380, error: null }) }),
+  });
+  mocks.mockRpc.mockImplementation((fn: string) =>
+    Promise.resolve({ data: RPC_DATA[fn] ?? [], error: null })
+  );
+});
+
+describe('aggregation happens in Postgres', () => {
+  it('asks the analytics_* functions for every breakdown', async () => {
+    await get();
+    expect(mocks.mockRpc.mock.calls.map(c => c[0]).sort()).toEqual([
+      'analytics_daily_events',
+      'analytics_events_by_app',
+      'analytics_platform_clicks',
+      'analytics_search_success',
+      'analytics_streaming_services',
+    ]);
+  });
+
+  it('sums the grouped counts instead of counting rows', async () => {
+    const d = await body();
+    const bucket = d.daily.find((r: { date: string }) => r.date === today);
+    // A regression to `bucket.searches++` would make these 1, 1 and 1.
+    expect(bucket).toMatchObject({ searches: 7400, clicks: 2100, activations: 1500 });
+    expect(d.by_app.find((a: { app: string }) => a.app === 'web'))
+      .toMatchObject({ searches: 5000, clicks: 2100 });
+    expect(d.platforms[0]).toEqual({ platform: 'bandcamp', clicks: 1800 });
+    expect(d.streaming_services[0]).toEqual({ service: 'youtube', activations: 1200 });
+  });
+
+  it('reports the chart total the exact count already agrees with', async () => {
+    const d = await body();
+    const charted = d.daily.reduce((n: number, r: { searches: number }) => n + r.searches, 0);
+    expect(d.summary.searches_30d).toBe(10380);
+    // The production symptom was these two disagreeing by 16x.
+    expect(charted).toBe(7400);
+  });
+
+  it('derives the success rate from the function’s two totals', async () => {
+    const d = await body();
+    expect(d.summary.success_rate_7d).toBe(75);
+  });
+
+  it('reports no success rate rather than a wrong one when nothing completed', async () => {
+    mocks.mockRpc.mockImplementation((fn: string) =>
+      Promise.resolve({
+        data: fn === 'analytics_search_success' ? [{ completed: 0, with_results: 0 }] : RPC_DATA[fn] ?? [],
+        error: null,
+      })
+    );
+    const d = await body();
+    expect(d.summary.success_rate_7d).toBeNull();
+  });
+});
+
+describe('a failed query fails the response', () => {
+  it('500s instead of rendering zeros when one aggregate errors', async () => {
+    mocks.mockRpc.mockImplementation((fn: string) =>
+      Promise.resolve(
+        fn === 'analytics_daily_events'
+          ? { data: null, error: { message: 'function analytics_daily_events does not exist' } }
+          : { data: RPC_DATA[fn] ?? [], error: null }
+      )
+    );
+    const res = await get();
+    // The old code logged a partial failure and returned 200 with a chart full of zeros.
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Failed to fetch analytics' });
+  });
+
+  it('500s when a count query errors', async () => {
+    mocks.mockSelect.mockReturnValue({
+      eq: () => ({ gte: () => Promise.resolve({ count: null, error: { message: 'timeout' } }) }),
+    });
+    const res = await get();
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -3,6 +3,15 @@
 
 import { getClient } from './db';
 import { authenticateAdmin } from './middleware';
+import { Sentry } from '../lib/sentry';
+
+// Row shapes returned by the analytics_* functions added in
+// supabase/migrations/20260823120000_analytics-dashboard-aggregates.sql.
+interface DailyRow { day: string; event_type: string; events: number }
+interface ByAppRow { app: string; event_type: string; events: number }
+interface PlatformRow { platform: string; clicks: number }
+interface StreamingRow { service: string; activations: number }
+interface SuccessRow { completed: number; with_results: number }
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -40,12 +49,16 @@ export async function handler(event: {
   const todayStart = `${today}T00:00:00.000Z`;
 
   try {
-    // Run all queries in parallel
+    // Every aggregate is computed in Postgres. It used to pull raw app_events rows and count
+    // them in a JS loop, which PostgREST silently truncated at 1,000 rows — the dashboard
+    // reported 641 of 10,380 searches, and because the daily query ordered created_at ASC the
+    // surviving rows were the oldest, so the most recent 26 days rendered as zero. See
+    // supabase/migrations/20260823120000_analytics-dashboard-aggregates.sql.
     const [
       searchesToday,
       searches7d,
       searches30d,
-      successfulSearches7d,
+      searchSuccess7d,
       daily30d,
       byApp30d,
       platforms30d,
@@ -72,58 +85,46 @@ export async function handler(event: {
         .eq('event_type', 'search')
         .gte('created_at', ago30),
 
-      // All search events (with context) last 7 days — filtered in JS for success rate.
-      // The web app writes one 'search' event per query, on completion (has_results:
-      // true/false). Rows from before 2026-08-19 include a second, context-free initiation
-      // event per query — the JS filter below excludes those from the success rate, and it's
-      // why search counts stepped down (and became accurate) on that date.
-      client
-        .from('app_events')
-        .select('context')
-        .eq('event_type', 'search')
-        .gte('created_at', ago7),
+      // Completed searches and how many found something, last 7 days. Searches from before
+      // 2026-08-19 wrote a second, context-free initiation event per query; the function counts
+      // only events carrying a has_results key, so those sit outside both sides of the ratio.
+      // That is why search counts stepped down (and became accurate) on that date.
+      client.rpc('analytics_search_success', { p_since: ago7 }),
 
-      // Daily event counts for last 30 days (searches + clicks)
-      client
-        .from('app_events')
-        .select('created_at, event_type')
-        .in('event_type', ['search', 'platform_click', 'extension_activated'])
-        .gte('created_at', ago30)
-        .order('created_at', { ascending: true }),
+      // Daily event counts for last 30 days (searches + clicks + activations)
+      client.rpc('analytics_daily_events', { p_since: ago30 }),
 
       // Breakdown by app (last 30 days)
-      client
-        .from('app_events')
-        .select('app, event_type')
-        .in('event_type', ['search', 'platform_click'])
-        .gte('created_at', ago30),
+      client.rpc('analytics_events_by_app', { p_since: ago30 }),
 
-      // Platform click breakdown (last 30 days)
-      client
-        .from('app_events')
-        .select('context')
-        .eq('event_type', 'platform_click')
-        .gte('created_at', ago30),
+      // Platform click breakdown (last 30 days), most-clicked first
+      client.rpc('analytics_platform_clicks', { p_since: ago30 }),
 
-      // Extension streaming service breakdown (last 30 days)
-      client
-        .from('app_events')
-        .select('context')
-        .eq('event_type', 'extension_activated')
-        .gte('created_at', ago30),
+      // Extension streaming service breakdown (last 30 days), most-active first
+      client.rpc('analytics_streaming_services', { p_since: ago30 }),
     ]);
 
-    // Surface query errors early — Supabase returns { error } rather than throwing
+    // Any failure fails the whole response. Supabase returns { error } rather than throwing, and
+    // the old code logged a partial failure and carried on — which is how a dashboard ends up
+    // rendering confident zeros for a query that never ran. Wrong numbers are worse here than
+    // no numbers: these drive product decisions.
     const queryErrors = [
-      searchesToday.error, searches7d.error, searches30d.error,
-      successfulSearches7d.error, daily30d.error,
+      searchesToday.error, searches7d.error, searches30d.error, searchSuccess7d.error,
+      daily30d.error, byApp30d.error, platforms30d.error, streamingServices30d.error,
     ].filter(Boolean);
     if (queryErrors.length > 0) {
-      console.error('[Analytics Dashboard] Query errors:', queryErrors.map(e => e?.message));
-      // If the core count queries all errored (e.g. app_events table missing), surface it
-      if (queryErrors.length >= 3) {
-        return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'Analytics table unavailable — migration may not have been applied' }) };
-      }
+      const messages = queryErrors.map(e => e?.message).join('; ');
+      console.error('[Analytics Dashboard] Query errors:', messages);
+      Sentry.captureMessage('Analytics dashboard query failed', {
+        level: 'error',
+        extra: { messages, failed: queryErrors.length },
+        tags: { context: 'analytics.dashboard' },
+      });
+      return {
+        statusCode: 500,
+        headers: CORS_HEADERS,
+        body: JSON.stringify({ error: 'Failed to fetch analytics' }),
+      };
     }
 
     // --- Build daily chart data (last 30 days) ---
@@ -136,12 +137,14 @@ export async function handler(event: {
       dailyMap[dateStr] = { searches: 0, clicks: 0, activations: 0 };
     }
 
-    for (const row of (daily30d.data || [])) {
-      const dateStr = row.created_at.split('T')[0];
-      if (!dailyMap[dateStr]) continue;
-      if (row.event_type === 'search') dailyMap[dateStr].searches++;
-      else if (row.event_type === 'platform_click') dailyMap[dateStr].clicks++;
-      else if (row.event_type === 'extension_activated') dailyMap[dateStr].activations++;
+    // `day` is a Postgres DATE, so it arrives as a bare 'YYYY-MM-DD' string — the same shape
+    // the pre-filled keys above use.
+    for (const row of (daily30d.data || []) as DailyRow[]) {
+      const bucket = dailyMap[row.day];
+      if (!bucket) continue;
+      if (row.event_type === 'search') bucket.searches += row.events;
+      else if (row.event_type === 'platform_click') bucket.clicks += row.events;
+      else if (row.event_type === 'extension_activated') bucket.activations += row.events;
     }
 
     const daily = Object.entries(dailyMap).map(([date, counts]) => ({ date, ...counts }));
@@ -152,45 +155,26 @@ export async function handler(event: {
       extension: { searches: 0, clicks: 0 },
       mac: { searches: 0, clicks: 0 },
     };
-    for (const row of (byApp30d.data || [])) {
+    for (const row of (byApp30d.data || []) as ByAppRow[]) {
       if (!appMap[row.app]) appMap[row.app] = { searches: 0, clicks: 0 };
-      if (row.event_type === 'search') appMap[row.app].searches++;
-      else if (row.event_type === 'platform_click') appMap[row.app].clicks++;
+      if (row.event_type === 'search') appMap[row.app].searches += row.events;
+      else if (row.event_type === 'platform_click') appMap[row.app].clicks += row.events;
     }
     const byApp = Object.entries(appMap)
       .map(([app, counts]) => ({ app, ...counts }))
       .sort((a, b) => (b.searches + b.clicks) - (a.searches + a.clicks));
 
     // --- Platform breakdown ---
-    const platformMap: Record<string, number> = {};
-    for (const row of (platforms30d.data || [])) {
-      const platform = (row.context as Record<string, string>)?.platform;
-      if (platform) platformMap[platform] = (platformMap[platform] || 0) + 1;
-    }
-    const platforms = Object.entries(platformMap)
-      .map(([platform, clicks]) => ({ platform, clicks }))
-      .sort((a, b) => b.clicks - a.clicks)
-      .slice(0, 10);
+    // Already grouped and ordered most-clicked first by the function.
+    const platforms = ((platforms30d.data || []) as PlatformRow[]).slice(0, 10);
 
     // --- Streaming service breakdown ---
-    const serviceMap: Record<string, number> = {};
-    for (const row of (streamingServices30d.data || [])) {
-      const service = (row.context as Record<string, string>)?.streaming_service;
-      if (service) serviceMap[service] = (serviceMap[service] || 0) + 1;
-    }
-    const streamingServices = Object.entries(serviceMap)
-      .map(([service, activations]) => ({ service, activations }))
-      .sort((a, b) => b.activations - a.activations);
+    const streamingServices = (streamingServices30d.data || []) as StreamingRow[];
 
     // --- Success rate ---
-    // Filter in JS: only count events where has_results is present (completion events).
-    // Initiation events have no has_results field and are excluded from both sides.
-    const allSearchRows7d = (successfulSearches7d.data || []) as Array<{ context: Record<string, unknown> | null }>;
-    const completedRows = allSearchRows7d.filter(r => r.context != null && 'has_results' in r.context);
-    const completedCount = completedRows.length;
-    const successCount = completedRows.filter(r => r.context?.has_results === true).length;
-    const successRate7d = completedCount > 0
-      ? Math.round((successCount / completedCount) * 100)
+    const success = ((searchSuccess7d.data || []) as SuccessRow[])[0];
+    const successRate7d = success && success.completed > 0
+      ? Math.round((success.with_results / success.completed) * 100)
       : null;
 
     return {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -95,6 +95,8 @@
     "functions/__tests__/collection-matching.test.ts",
     "functions/__tests__/sentry-environment.test.ts",
     "functions/analytics-event.ts",
+    "functions/analytics-dashboard.ts",
+    "functions/__tests__/analytics-dashboard.test.ts",
     "functions/__tests__/analytics-event.test.ts",
     "functions/__tests__/persist-release-detail-churn.test.ts",
     "functions/__tests__/get-artists-by-slugs.test.ts",

--- a/supabase/migrations/20260823120000_analytics-dashboard-aggregates.sql
+++ b/supabase/migrations/20260823120000_analytics-dashboard-aggregates.sql
@@ -1,0 +1,119 @@
+-- Migration: aggregate the admin dashboard's analytics in Postgres, not in JS
+--
+-- `/admin/analytics` was reporting numbers that were wrong by more than 16x, and reporting them
+-- confidently. Measured against production on 2026-08-23:
+--
+--   searches_30d (count: 'exact')              10,380
+--   searches summed from the 30-day chart          641
+--   by_app searches + clicks                 exactly 1000
+--   streaming_services activations           exactly 1000
+--   days with any data in the chart            4 of 30
+--
+-- Cause is the PostgREST 1,000-row cap. Four of the endpoint's queries pulled raw `app_events`
+-- rows and counted them in a JS loop; PostgREST silently returned the first 1,000 and stopped.
+-- The two "exactly 1000" totals are the tell.
+--
+-- The daily chart was the worst of it because its query ordered `created_at` ASCENDING, so the
+-- surviving 1,000 rows were the OLDEST in the window: every bar sat at the far left of the chart
+-- and the most recent 26 days rendered as zero. Truncation that looks like a data outage.
+--
+-- Paging the rows instead (readAllPages) would fix the arithmetic and make the Disk IO Budget
+-- problem worse — 10,000+ rows shipped out of Postgres on every dashboard load, to be counted
+-- one at a time in a serverless function. Counting in Postgres reads the same index ranges and
+-- returns ~40 rows total.
+--
+-- These all filter `event_type` then range-scan `created_at`, which is exactly what
+-- idx_app_events_type_created (2026-08-11) was added to serve.
+--
+-- The window start is passed in rather than computed here on purpose: the endpoint already owns
+-- the definition of "last 30 days" (and pre-fills every day in the range so gaps render as zero),
+-- so the SQL stays dumb and the two can't disagree about the boundary.
+
+-- Buckets by UTC date to match what the endpoint did with the raw rows, which was
+-- `row.created_at.split('T')[0]` on an ISO-8601 UTC string. `created_at::date` would silently
+-- follow the session TimeZone instead.
+CREATE OR REPLACE FUNCTION analytics_daily_events(p_since TIMESTAMPTZ)
+RETURNS TABLE (day DATE, event_type TEXT, events BIGINT) AS $$
+  SELECT (e.created_at AT TIME ZONE 'UTC')::date, e.event_type, count(*)
+  FROM app_events e
+  WHERE e.event_type IN ('search', 'platform_click', 'extension_activated')
+    AND e.created_at >= p_since
+  GROUP BY 1, 2;
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION analytics_events_by_app(p_since TIMESTAMPTZ)
+RETURNS TABLE (app TEXT, event_type TEXT, events BIGINT) AS $$
+  SELECT e.app, e.event_type, count(*)
+  FROM app_events e
+  WHERE e.event_type IN ('search', 'platform_click')
+    AND e.created_at >= p_since
+  GROUP BY 1, 2;
+$$ LANGUAGE sql STABLE;
+
+-- Rows whose context carries no platform were skipped by the JS loop; the WHERE clause here is
+-- that same skip. Ordering is done in SQL so the endpoint's top-10 slice means something.
+CREATE OR REPLACE FUNCTION analytics_platform_clicks(p_since TIMESTAMPTZ)
+RETURNS TABLE (platform TEXT, clicks BIGINT) AS $$
+  SELECT e.context->>'platform', count(*)
+  FROM app_events e
+  WHERE e.event_type = 'platform_click'
+    AND e.created_at >= p_since
+    AND e.context->>'platform' IS NOT NULL
+  GROUP BY 1
+  ORDER BY 2 DESC;
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION analytics_streaming_services(p_since TIMESTAMPTZ)
+RETURNS TABLE (service TEXT, activations BIGINT) AS $$
+  SELECT e.context->>'streaming_service', count(*)
+  FROM app_events e
+  WHERE e.event_type = 'extension_activated'
+    AND e.created_at >= p_since
+    AND e.context->>'streaming_service' IS NOT NULL
+  GROUP BY 1
+  ORDER BY 2 DESC;
+$$ LANGUAGE sql STABLE;
+
+-- Success rate. `completed` counts only events carrying a has_results key, which is how the
+-- endpoint separates a completed search from the context-free initiation events written before
+-- 2026-08-19 — both sides of the ratio exclude those. jsonb_exists() is the `?` operator spelled
+-- out, and comparing against 'true'::jsonb matches a JSON boolean specifically, so a string
+-- "true" is not counted — the same thing `=== true` did in JS.
+CREATE OR REPLACE FUNCTION analytics_search_success(p_since TIMESTAMPTZ)
+RETURNS TABLE (completed BIGINT, with_results BIGINT) AS $$
+  SELECT
+    count(*) FILTER (WHERE jsonb_exists(e.context, 'has_results')),
+    count(*) FILTER (WHERE e.context->'has_results' = 'true'::jsonb)
+  FROM app_events e
+  WHERE e.event_type = 'search'
+    AND e.created_at >= p_since;
+$$ LANGUAGE sql STABLE;
+
+-- SECURITY INVOKER (the default) is deliberate. app_events has RLS enabled and no policies at
+-- all — service-role reads bypass RLS, everyone else gets nothing — so these functions inherit
+-- that and cannot become a read hole in it. SECURITY DEFINER would turn each one into exactly
+-- that, since PostgREST exposes every public-schema function at /rest/v1/rpc/<name>.
+--
+-- EXECUTE is granted to PUBLIC by default on a new function, so revoking is not optional here.
+REVOKE EXECUTE ON FUNCTION analytics_daily_events(TIMESTAMPTZ) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION analytics_events_by_app(TIMESTAMPTZ) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION analytics_platform_clicks(TIMESTAMPTZ) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION analytics_streaming_services(TIMESTAMPTZ) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION analytics_search_success(TIMESTAMPTZ) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION analytics_daily_events(TIMESTAMPTZ) TO service_role;
+GRANT EXECUTE ON FUNCTION analytics_events_by_app(TIMESTAMPTZ) TO service_role;
+GRANT EXECUTE ON FUNCTION analytics_platform_clicks(TIMESTAMPTZ) TO service_role;
+GRANT EXECUTE ON FUNCTION analytics_streaming_services(TIMESTAMPTZ) TO service_role;
+GRANT EXECUTE ON FUNCTION analytics_search_success(TIMESTAMPTZ) TO service_role;
+
+COMMENT ON FUNCTION analytics_daily_events(TIMESTAMPTZ) IS
+  'Per-UTC-day counts of search / platform_click / extension_activated since a cutoff, for /admin/analytics.';
+COMMENT ON FUNCTION analytics_events_by_app(TIMESTAMPTZ) IS
+  'Search and click counts per client app since a cutoff, for /admin/analytics.';
+COMMENT ON FUNCTION analytics_platform_clicks(TIMESTAMPTZ) IS
+  'Platform click counts since a cutoff, most-clicked first, for /admin/analytics.';
+COMMENT ON FUNCTION analytics_streaming_services(TIMESTAMPTZ) IS
+  'Extension activation counts per streaming service since a cutoff, most-active first, for /admin/analytics.';
+COMMENT ON FUNCTION analytics_search_success(TIMESTAMPTZ) IS
+  'Completed searches and how many returned results since a cutoff; the /admin/analytics success rate.';


### PR DESCRIPTION
`/admin/analytics` has been reporting numbers wrong by more than 16x, confidently. Measured against production on 2026-08-23:

| | value |
|---|---|
| `searches_30d` (`count: 'exact'`) | **10,380** |
| searches summed from the 30-day chart | **641** |
| `by_app` searches + clicks | **exactly 1000** |
| `streaming_services` activations | **exactly 1000** |
| days with any data in the chart | **4 of 30** |

## What was wrong

Four of the endpoint's eight queries pulled raw `app_events` rows and counted them in a JS loop. PostgREST silently caps every response at 1,000 rows, so each of those loops was counting a tenth of the data and reporting the result as fact. The two totals landing on *exactly* 1000 are the tell.

The daily chart was the worst of it. Its query ordered `created_at` **ascending**, so the 1,000 rows that survived were the *oldest* in the window — every bar sat at the far left and the most recent 26 days rendered as zero. Truncation that reads as a data outage.

`success_rate_7d` was computed from 1,000 of 4,029 search rows, so 29% was not a real number either. The three `count: 'exact', head: true` queries were the only accurate figures on the page.

## The fix

Five SQL functions do the grouping in Postgres, over the `idx_app_events_type_created` index added on 2026-08-11. Paging the rows instead (`readAllPages`) would fix the arithmetic and make the [Disk IO Budget](https://github.com/brandonlucasgreen/unstream/pull/464) problem worse — 10,000+ rows out of Postgres on every dashboard load, counted one at a time in a serverless function. These return ~40 rows total.

The window start is passed in rather than computed in SQL, so the endpoint keeps owning the definition of "last 30 days" and the two can't disagree about the boundary.

Also: **a failed query now fails the response.** It used to log the error and carry on, which is how a dashboard ends up rendering confident zeros for a query that never ran. Wrong numbers are worse than no numbers here — these drive product decisions.

The response shape is unchanged, so `AdminAnalyticsPage.tsx` needs no edit.

## Verification

Against a throwaway `postgres:16` seeded with 12,500 events over 30 days, front-loaded so an ascending truncation reproduces the production symptom:

- the old 1,000-row read saw **3 distinct days**; every new aggregate matches ground truth exactly
- context-less rows stay excluded (2000 clicks, not 2001), and a JSON *string* `"true"` is not counted as a result — the same thing `=== true` did in JS
- `EXPLAIN` confirms `Bitmap Index Scan on idx_app_events_type_created`
- a role without `BYPASSRLS` gets `permission denied for function` — `SECURITY INVOKER` keeps these inside `app_events`' RLS rather than becoming a read hole in it, which `SECURITY DEFINER` would

And through **real PostgREST** against that database: the `bigint` counts serialize as JSON numbers, and `day` arrives as a bare `'YYYY-MM-DD'` matching the endpoint's pre-filled buckets.

Tests pin both properties and were confirmed to have teeth by reverting each one — regressing the sum back to `bucket.searches++` fails with `expected 1 to be 7400`, the production failure verbatim. `npm run verify` green: typecheck + 1315 API tests + 793 web unit tests. `analytics-dashboard.ts` is now in `api/tsconfig.json`'s typecheck include.

## On merge

This pairs a migration with a reader, so the [deploy race](https://github.com/brandonlucasgreen/unstream/pull/411) applies: Netlify and `supabase-migrate.yml` both fire on push to `main` and nothing orders them. **It fails loudly** — if the functions go live first, `/admin/analytics` returns a 500 until the migration lands, rather than showing zeros. That's the deliberate choice given this is a fix for wrong numbers. Worth checking the page a couple of minutes after merge, and confirming `supabase-migrate.yml` went green.

The migration is additive and idempotent (`CREATE OR REPLACE`), and touches no table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)