### PR TITLE
Stop the service worker caching signed-in API responses

### DIFF
--- a/api/functions/__tests__/analytics-dashboard.test.ts
+++ b/api/functions/__tests__/analytics-dashboard.test.ts
@@ -22,8 +22,20 @@ vi.mock('../db', () => ({
     rpc: mocks.mockRpc,
   }),
 }));
+// buildCorsHeaders is not stubbed to a constant: this endpoint used to hand back a wildcard
+// origin from a hand-rolled const, and the point of routing it through the shared helper is that
+// it no longer does. Mirrors the real helper's non-API-key behaviour (pin to the canonical
+// origin) so that stays assertable.
 vi.mock('../middleware', () => ({
   authenticateAdmin: async () => ({ userId: 'u1', email: 'admin@example.com' }),
+  buildCorsHeaders: (origin: string | undefined, apiKeyPresent: boolean) => ({
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': apiKeyPresent
+      ? '*'
+      : origin === 'https://unstream.stream'
+        ? origin
+        : 'https://unstream.stream',
+  }),
 }));
 vi.mock('../../lib/sentry', () => ({
   Sentry: { captureMessage: vi.fn(), captureException: vi.fn() },
@@ -57,8 +69,8 @@ const RPC_DATA: Record<string, unknown[]> = {
   ],
 };
 
-function get() {
-  return handler({ httpMethod: 'GET', headers: { authorization: 'Bearer t' } });
+function get(headers: Record<string, string | undefined> = {}) {
+  return handler({ httpMethod: 'GET', headers: { authorization: 'Bearer t', ...headers } });
 }
 
 async function body() {
@@ -121,6 +133,24 @@ describe('aggregation happens in Postgres', () => {
     );
     const d = await body();
     expect(d.summary.success_rate_7d).toBeNull();
+  });
+});
+
+describe('CORS', () => {
+  it('never answers an admin request with a wildcard origin', async () => {
+    // Was `'Access-Control-Allow-Origin': '*'` in a local const here, the one admin endpoint
+    // not using the shared helper. Not exploitable on its own — a cross-origin page can't get
+    // the bearer token — but it contradicted the model every sibling endpoint follows.
+    for (const origin of [undefined, 'https://unstream.stream', 'https://evil.example']) {
+      const res = await get({ origin });
+      expect(res.headers['Access-Control-Allow-Origin']).toBe('https://unstream.stream');
+    }
+  });
+
+  it('answers a preflight with the same headers', async () => {
+    const res = await handler({ httpMethod: 'OPTIONS', headers: {} });
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://unstream.stream');
   });
 });
 

--- a/api/functions/analytics-dashboard.ts
+++ b/api/functions/analytics-dashboard.ts
@@ -2,7 +2,7 @@
 // Admin-only endpoint returning aggregated product analytics for the dashboard.
 
 import { getClient } from './db';
-import { authenticateAdmin } from './middleware';
+import { authenticateAdmin, buildCorsHeaders } from './middleware';
 import { Sentry } from '../lib/sentry';
 
 // Row shapes returned by the analytics_* functions added in
@@ -13,17 +13,16 @@ interface PlatformRow { platform: string; clicks: number }
 interface StreamingRow { service: string; activations: number }
 interface SuccessRow { completed: number; with_results: number }
 
-const CORS_HEADERS = {
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-};
-
 export async function handler(event: {
   httpMethod: string;
   headers: Record<string, string | undefined>;
 }) {
+  // Restricted to unstream.stream like every other admin endpoint. The '*' this used
+  // to send wasn't exploitable — a cross-origin page can't get the bearer token — but
+  // it read as though permissive CORS were intended here, which it isn't.
+  const origin = event.headers['origin'] || event.headers['Origin'];
+  const CORS_HEADERS = buildCorsHeaders(origin, false);
+
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS, body: '' };
   }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -102,6 +102,7 @@
     "functions/__tests__/get-artists-by-slugs.test.ts",
     "functions/desktop-appcast.ts",
     "functions/desktop-version.ts",
-    "functions/__tests__/desktop-appcast.test.ts"
+    "functions/__tests__/desktop-appcast.test.ts",
+    "functions/analytics-dashboard.ts"
   ]
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import * as Sentry from '@sentry/react'
 import { initSentry } from './services/sentry'
 import { registerServiceWorker } from './services/registerServiceWorker'
+import { clearApiResponseCache } from './services/clearApiResponseCache'
 import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 import App from './App.tsx'
@@ -17,8 +18,12 @@ initSentry()
 
 // Ours rather than vite-plugin-pwa's injected registerSW.js, which reports a
 // declined registration as an unhandled rejection. Guarded on PROD because the
-// plugin only emits /sw.js for a build, exactly as the injected script was.
-if (import.meta.env.PROD) registerServiceWorker()
+// plugin only emits /sw.js for a build, exactly as the injected script was — which
+// is also the only place the `api-cache` bucket being cleared here ever existed.
+if (import.meta.env.PROD) {
+  registerServiceWorker()
+  clearApiResponseCache()
+}
 
 // Lazy-load non-critical pages to reduce initial bundle size.
 // lazyWithRetry adds a one-shot reload when a chunk belongs to a superseded deploy.

--- a/apps/web/src/services/clearApiResponseCache.ts
+++ b/apps/web/src/services/clearApiResponseCache.ts
@@ -1,0 +1,53 @@
+/**
+ * Delete the `api-cache` Cache Storage bucket the old service worker left behind.
+ *
+ * Until the runtimeCaching rule was removed from vite.config.ts, every /api/ GET that
+ * came back 200 was written into a bucket named `api-cache` — including
+ * /api/admin/verify, whose body carries claimant email addresses and their free-text
+ * messages, plus /api/me/settings, /api/me/collection and /api/analytics/dashboard.
+ * The bucket is keyed on URL alone, so those bodies were readable by any later request
+ * for the same URL, whatever bearer token it carried.
+ *
+ * Removing the rule stops new writes but clears nothing already stored, and nothing
+ * else will: Workbox's `cleanupOutdatedCaches` only touches its own `-precache-`
+ * buckets, and the 5-minute expiry was enforced by a plugin that ran as part of the
+ * route. With the route gone, that plugin never runs again, so the entries stop
+ * expiring rather than expiring sooner — left alone they would sit in Cache Storage
+ * indefinitely. Hence deleting the bucket by name.
+ *
+ * Safe to keep calling once every install is clean: `caches.delete` on a bucket that
+ * isn't there resolves false and touches nothing.
+ */
+
+const BUCKET = 'api-cache'
+
+export function clearApiResponseCache(): void {
+  if (!('caches' in window)) return
+
+  void deleteApiCacheBucket()
+
+  // Also on handoff. The page that installs the new worker stays controlled by the old
+  // one for the rest of its load, so the old rule can still write after a startup
+  // delete has run. `controllerchange` fires when the new worker claims this page
+  // (skipWaiting + clientsClaim), which is the moment those writes stop.
+  navigator.serviceWorker?.addEventListener('controllerchange', () => {
+    void deleteApiCacheBucket()
+  })
+}
+
+/**
+ * Exported so the test can await the swallowed rejection — from `clearApiResponseCache`
+ * both calls are floating, and an unhandled rejection there is precisely what this
+ * catch exists to prevent.
+ */
+export async function deleteApiCacheBucket(): Promise<void> {
+  try {
+    await caches.delete(BUCKET)
+  } catch {
+    // A browser set to block site data throws on reaching Cache Storage at all —
+    // synchronously on the `caches` get, which an async function turns into a
+    // rejection. It never wrote the bucket either, so this is a decline rather than a
+    // failure, the same reasoning as the declined registration in
+    // registerServiceWorker.ts.
+  }
+}

--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -16,12 +16,18 @@ export { Sentry }
  * This is what a deploy does to an already-open tab. Pages are lazy-loaded
  * (`lazy(() => import('./pages/LoginPage.tsx'))` and friends in main.tsx), so the
  * chunk filename carries a content hash. A tab still running build N clicks a link,
- * requests `/assets/LoginPage-<oldHash>.js`, and build N+1 doesn't have that file.
- * Netlify's SPA catch-all then answers `200 text/html` instead of 404, so the
- * browser rejects it as a module and the import promise rejects — which React
- * surfaces through the error boundary as "Unstream hit an unexpected error".
+ * requests `/assets/LoginPage-<oldHash>.js`, and build N+1 doesn't have that file, so
+ * the import promise rejects — which React surfaces through the error boundary as
+ * "Unstream hit an unexpected error".
  *
- * Each engine words it differently, hence the list.
+ * Each engine words it differently, hence the list. Two shapes of failure are in there
+ * because the missing chunk has been served two ways. Today production returns a real
+ * 404 for an unknown `/assets/*` path (verified 2026-08-23), and the browser reports
+ * that as a failed fetch — Safari's "Importing a module script failed" and the Chrome
+ * and Firefox wordings above it. The MIME clauses date from when Netlify's SPA
+ * catch-all answered `200 text/html` in place of the chunk; they're kept because a
+ * redirect change could bring that back, and because a tab caught by an older deploy
+ * still reports the old wording.
  */
 export function isStaleBuildAssetError(message: string): boolean {
   return (

--- a/apps/web/tests/unit/clear-api-response-cache.test.ts
+++ b/apps/web/tests/unit/clear-api-response-cache.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { clearApiResponseCache, deleteApiCacheBucket } from '../../src/services/clearApiResponseCache';
+
+/**
+ * The service worker used to cache every /api/ GET into a bucket named `api-cache`,
+ * authenticated ones included. Dropping the runtimeCaching rule stops new writes but
+ * leaves the bucket on every install that already has one, and with the route gone
+ * Workbox's expiry plugin never runs again — so those entries stop expiring instead of
+ * expiring sooner. Deleting the bucket by name is what actually clears them.
+ */
+
+const deleteBucket = vi.fn<(name: string) => Promise<boolean>>();
+const swListen = vi.fn<(type: string, handler: EventListener) => void>();
+
+function stubCacheStorage(value: unknown) {
+  Object.defineProperty(window, 'caches', { value, configurable: true, writable: true });
+}
+
+/** Runs the handler registered for 'controllerchange', as the new worker claiming the page would. */
+function fireControllerChange() {
+  for (const [type, handler] of swListen.mock.calls) {
+    if (type === 'controllerchange') handler(new Event('controllerchange'));
+  }
+}
+
+/** Lets the floating promise inside the delete settle. */
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  deleteBucket.mockReset().mockResolvedValue(true);
+  swListen.mockReset();
+  stubCacheStorage({ delete: deleteBucket });
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: { addEventListener: swListen },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window, 'caches');
+  Reflect.deleteProperty(navigator, 'serviceWorker');
+});
+
+describe('clearApiResponseCache', () => {
+  it('deletes the api-cache bucket', async () => {
+    clearApiResponseCache();
+    await settle();
+
+    expect(deleteBucket).toHaveBeenCalledWith('api-cache');
+  });
+
+  it('deletes it again when a new worker claims the page', async () => {
+    // The load that installs the new worker is still controlled by the old one, so the
+    // removed rule can write after the startup delete has already run.
+    clearApiResponseCache();
+    await settle();
+    expect(deleteBucket).toHaveBeenCalledTimes(1);
+
+    fireControllerChange();
+    await settle();
+
+    expect(deleteBucket).toHaveBeenCalledTimes(2);
+    expect(deleteBucket).toHaveBeenLastCalledWith('api-cache');
+  });
+
+  it('leaves other buckets alone', async () => {
+    // The precache buckets hold the app shell. Clearing those would cost every
+    // returning visitor a cold load for no privacy gain.
+    clearApiResponseCache();
+    fireControllerChange();
+    await settle();
+
+    for (const [name] of deleteBucket.mock.calls) {
+      expect(name).toBe('api-cache');
+    }
+  });
+
+  it('does nothing where the browser has no Cache Storage', async () => {
+    Reflect.deleteProperty(window, 'caches');
+
+    expect(() => clearApiResponseCache()).not.toThrow();
+    await settle();
+
+    expect(deleteBucket).not.toHaveBeenCalled();
+    // No listener either — with no Cache Storage there is nothing for a handoff to clear.
+    expect(swListen).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejection from a browser that blocks site data', async () => {
+    // Reaching Cache Storage throws outright when site data is blocked. Such a browser
+    // never wrote the bucket, so this is a decline rather than a failure — and both
+    // calls in clearApiResponseCache are floating, so a rejection escaping here becomes
+    // an unhandled rejection, which Sentry's global handler reports at error level.
+    deleteBucket.mockRejectedValue(new Error('The operation is insecure.'));
+
+    await expect(deleteApiCacheBucket()).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -131,19 +131,31 @@ export default defineConfig({
           // calendar. /a/ and /u/ above already cover the two public feed shapes.
           /^\/feed\//,
         ],
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/unstream\.stream\/api\//,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 5, // 5 minutes
-              },
-            },
-          },
-        ],
+        // No runtimeCaching, deliberately. A NetworkFirst rule used to match every
+        // /api/ GET with a 5-minute `api-cache` bucket. It earned nothing, and it
+        // stored other people's account data on disk to do it:
+        //
+        // - It bought no speed. NetworkFirst with no `networkTimeoutSeconds` always
+        //   goes to the network and reads the cache only when that fetch throws, so
+        //   a repeat search cost exactly what the first one did.
+        // - It bought no offline mode either. Nothing in the app reads Cache Storage,
+        //   checks navigator.onLine, or renders an offline state, so the fallback was
+        //   never surfaced as one — a stale body just rendered as if it were fresh.
+        // - It cached what it had no business keeping. Cache Storage is not the HTTP
+        //   cache, so the `Cache-Control: no-cache` these endpoints send was silently
+        //   overridden, and /api/admin/verify (claimant emails and their free-text
+        //   messages), /api/me/settings, /api/me/collection and
+        //   /api/analytics/dashboard all landed in a bucket keyed on URL alone. None
+        //   of them send `Vary: Authorization`, so on a shared browser one person
+        //   losing their connection could be handed the previous person's response —
+        //   and signing out cleared none of it.
+        //
+        // If an API cache comes back, it needs an explicit allowlist of genuinely
+        // public endpoints and a strategy that actually reads the cache, not a prefix
+        // match over everything — and note that the most tempting candidate, the
+        // platform list, carries the payout percentages, which are the last thing on
+        // this site worth serving stale. `clearApiResponseCache` deletes the bucket
+        // this rule left behind on installs that already have one.
       },
     }),
     // Sentry plugin for source map upload (only if DSN is configured and in production)


### PR DESCRIPTION
## The problem

`apps/web/vite.config.ts` had one PWA runtime-caching rule, matching **every** `/api/` GET:

```js
urlPattern: /^https:\/\/unstream\.stream\/api\//,
handler: 'NetworkFirst',
options: { cacheName: 'api-cache', expiration: { maxEntries: 50, maxAgeSeconds: 60 * 5 } }
```

No exclusions, so it cached authenticated responses: `/api/admin/verify` (claimant `email` and free-text `message` per verification request), `/api/me/settings`, `/api/me/collection`, `/api/analytics/dashboard`.

Three things stack up:

1. **`Cache-Control: no-cache` doesn't help.** Cache Storage is not the HTTP cache, so Workbox writes regardless and the server's own directive is silently overridden.
2. **No `Vary: Authorization`** on any of them (measured: `Vary: Origin, Accept-Encoding` on admin/verify, `Vary: Accept-Encoding` on the `me-*` endpoints). Cache Storage keys on URL, so a cached response can be matched by a request carrying a different bearer token or none. NetworkFirst only reads the cache when the network fetch rejects — so this needs a network failure to bite, but on a shared browser one person going offline can be served the previous person's response. Worse, only 200s are cacheable, so a subsequent 401 can't evict the stale entry.
3. **Sign-out cleared none of it.** `handleSignOut` touches saved-artist state, nothing else.

## What the cache was actually earning: nothing

Checked against the shipped worker rather than the docs. From `workbox-e4022e15.js` in production:

```js
this.nt = t.networkTimeoutSeconds || 0        // 0 — not configured
async rt({timeoutId,request,handler}) {
  try { r = await n.fetchAndCachePut(e) } catch(t) { i = t }
  !i && r || (r = await n.cacheMatch(e))       // cache read only on throw
}
```

`networkTimeoutSeconds` is 0, so the timeout race branch never runs. Every request goes to the network; the cache is read **only** when that fetch throws. **A repeat search cost exactly what the first one did** — there was never a latency win to preserve.

It bought no offline mode either. Nothing in the app reads Cache Storage, checks `navigator.onLine`, or renders an offline state, so the fallback was never surfaced as one — a stale body just rendered as though it were fresh.

So the rule is **removed, not narrowed**. A comment records why, and what a future API cache would need to be (explicit public allowlist, a strategy that actually reads the cache — and the note that the most tempting candidate, the platform list, carries the payout percentages, which are the last thing on this site worth serving stale).

## Cleanup is required, not just defence in depth

Removing the rule stops new writes but clears nothing already stored — and nothing else will. `cleanupOutdatedCaches` only touches Workbox's own `-precache-` buckets, and the 5-minute expiry was enforced by a plugin that ran *as part of the route*. With the route gone that plugin never runs again, so existing entries **stop expiring** rather than expiring sooner; left alone they'd sit in Cache Storage indefinitely.

`clearApiResponseCache` deletes the bucket by name, at startup and again on `controllerchange`. The second call matters: the page that installs the new worker stays controlled by the old one for the rest of its load, so the removed rule can still write after a startup delete has run.

Sign-out cleanup is deliberately not added — with nothing writing to `api-cache` any more it would be dead weight.

## Verification

- Built and confirmed the shipped worker: `grep -c "api-cache" apps/web/dist/sw.js` → **0**, and the only remaining route is the `NavigationRoute` with its denylist intact (all six patterns).
- `npm run verify` green — typecheck + 1308 API tests + 798 web unit tests (64 files).
- 5 new unit tests in `apps/web/tests/unit/clear-api-response-cache.test.ts`, **each proven to have teeth** by breaking the source: dropping the `controllerchange` listener fails the handoff test, and removing the `try/catch` fails the rejection test.
- No new lint problems (the 2 in `main.tsx` are the pre-existing baseline, confirmed against `HEAD`).

## Two nits from the same investigation

- **`api/functions/analytics-dashboard.ts`** hand-rolled `Access-Control-Allow-Origin: '*'` in a local `CORS_HEADERS` const instead of using `buildCorsHeaders`. Not exploitable on its own — a cross-origin page has no way to obtain the bearer token — but it contradicted the CORS model every other admin endpoint follows. Its only caller is the same-origin admin page, so restricting the origin breaks nothing. Added the file to `api/tsconfig.json`'s `include` while touching it, per CLAUDE.md; clean under strict mode.
- **The `isStaleBuildAssetError` docstring** still said Netlify's SPA catch-all answers `200 text/html` instead of 404. Production returns a real 404 now (verified: `/assets/index-Ch6htvZM.js` → 404). The detection list is unchanged and still correct — Safari's "Importing a module script failed" covers the 404 case — so only the explanation changed, and it now says why the MIME clauses are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)