### PR TITLE
Cut Upstash Redis command volume to fit the free tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,53 @@ This is the lesson behind a run of bug fixes (#317–#328) and it applies to eve
 - Cache keys must not collide across inputs that behave differently. `query_norm` strips punctuation, but punctuation is what generates extra slug candidates — hence the `probed_slugs` column, which records which slugs were actually tried so a cached negative can't hide an artist whose name has a hyphen.
 - A silent `200` with an empty parse is a failure. Report it (Sentry) rather than letting it look like "this artist doesn't exist."
 
+### Redis is metered — count round trips, not just correctness
+
+Upstash's free tier is **500,000 commands a month** (~16,600/day), and it is a *command* budget,
+not a bandwidth or storage one. The site went through it in August 2026 at genuinely low traffic,
+because nothing here is expensive per request — there are just a lot of small requests, each
+paying a fixed Redis tax before doing any work.
+
+The arithmetic that matters, per user search: the typeahead fires on every debounced typing
+pause (4-5 requests), then `/api/search/sources`, then `/api/search/musicbrainz`, then two or
+three analytics POSTs, then an artist page. That is ~10 API requests, and *every one of them*
+went through `checkRateLimit`. So the per-request overhead is multiplied by ten before a single
+search happens.
+
+Three rules follow, and they are the reason the current shapes look the way they do:
+
+- **Every extra limiter doubles the bill.** `Ratelimit.limit()` is one round trip whose
+  sliding-window Lua script runs `GET`, `GET`, `INCRBY` and (on a new window) `PEXPIRE`.
+  `checkRateLimit` used to run a per-minute *and* a per-day limiter on every tier, so every
+  request paid twice over. Only `strict` has a daily quota now — it fronts search, which fans
+  out to a dozen partner sites, and its 500/day is a documented promise to anonymous v1 callers
+  (`docs/openapi.yaml`). `standard`, `lenient` and `account` had 1000/5000/2000-a-day quotas no
+  real person has approached; their per-minute windows (30/120/60) still bound the damage. A new
+  daily quota has to earn its round trip.
+- **Batch reads that share a request.** The search fan-out reads one cache key per platform for
+  the same query. `cachePrefetch` does them in one `MGET` and hands the result to each fetcher
+  via `cacheGetOrFetch`'s `prefetched` argument — the fetchers still own their own TTLs,
+  `shouldCache` predicates and write-backs, only the read is shared. Add a new cached platform
+  to that key list in `searchAllPlatforms` rather than letting it issue its own `GET`.
+- **Two commands to answer one question is one too many.** `checkSentryDedup` was `GET` then
+  `SET`; it is now a single `SET ... NX EX`, which is half the cost and atomic besides. Reach
+  for `SET NX`, `INCR`, `MGET` over read-then-write pairs.
+
+Two related traps:
+
+- **Don't cache a constant.** `searchAmpwall` is still a stub with no outbound request, and it
+  used to run its empty result through Redis — a `GET` per search, plus a `SET` per miss, to
+  remember a compile-time constant. Cache a value when there is a real fetch to protect.
+- **A warm container is free; Redis is not.** `getMergeOverrides` / `getLinkSuppressions` are
+  read on every search and again during Phase 2 enrichment, and they are identical for every
+  visitor. They now sit behind a 60-second in-process memo in `db.ts` as well as the Redis
+  cache. Sixty seconds is deliberately short so `invalidateAdminListCache` keeps its meaning —
+  an admin edit still lands everywhere within a minute. This is the exception, not a pattern to
+  spread: those two lists are the only values that are global, tiny, and read on every search.
+
+`.github/workflows/upstash-keepalive.yml` still exists and is unrelated — it writes one key twice
+a week so the free-tier database isn't reaped for inactivity. It costs 8 commands a month.
+
 ### Testing release ingest locally
 
 Release cataloging only runs where `RELEASE_CATALOG_ENABLED=true`, a custom env var scoped to

--- a/api/functions/__tests__/admin-list-cache.test.ts
+++ b/api/functions/__tests__/admin-list-cache.test.ts
@@ -33,12 +33,17 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({ from: () => ({ select: mocks.select }) }),
 }));
 
-const { getMergeOverrides, getLinkSuppressions, invalidateAdminListCache } = await import('../db');
+const { getMergeOverrides, getLinkSuppressions, invalidateAdminListCache, resetAdminListMemoForTests } = await import('../db');
 
 const ROW = { id: 'o1', group_name: 'Big Thief', platform_urls: [], excluded_urls: [], canonical_image_url: null };
+const SUPPRESSION_ROW = { url: 'https://example.bandcamp.com', artist_name_norm: 'someone' };
 
 beforeEach(() => {
   mocks.store.clear();
+  // Both layers, not just Redis: these lists are also memoized in-process for a minute, and a
+  // memo surviving into the next test would make every assertion below read the previous
+  // test's answer.
+  resetAdminListMemoForTests();
   mocks.select.mockReset();
   process.env.SUPABASE_URL = 'https://example.supabase.co';
   process.env.SUPABASE_SERVICE_KEY = 'test-key';
@@ -138,5 +143,53 @@ describe('getLinkSuppressions caching', () => {
 
     mocks.select.mockResolvedValue({ data: [ROW], error: null });
     expect(await getMergeOverrides()).toEqual([ROW]);
+  });
+});
+
+// The in-process memo in front of Redis. It exists because Redis is not free: these two lists
+// are read on every search and again during Phase 2 enrichment, which was two Upstash commands
+// per search for two lists that are identical for every visitor.
+describe('in-process memo', () => {
+  it('answers a repeat read without touching Redis at all', async () => {
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+    expect(await getMergeOverrides()).toEqual([ROW]);
+
+    // Emptying the Redis stub would force a Supabase re-read if the memo were not in front
+    // of it. Serving [ROW] anyway is the proof no Redis command was spent.
+    mocks.store.clear();
+    expect(await getMergeOverrides()).toEqual([ROW]);
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not memoize a failed read', async () => {
+    mocks.select.mockResolvedValue({ data: null, error: { message: 'connection reset' } });
+    expect(await getMergeOverrides()).toEqual([]);
+
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+    expect(await getMergeOverrides()).toEqual([ROW]);
+  });
+
+  it('is cleared by invalidation, so the admin who made the change sees it immediately', async () => {
+    mocks.select.mockResolvedValue({ data: [], error: null });
+    expect(await getMergeOverrides()).toEqual([]);
+
+    await invalidateAdminListCache('merge-overrides');
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+
+    expect(await getMergeOverrides()).toEqual([ROW]);
+  });
+
+  it('keeps the two lists apart', async () => {
+    mocks.select.mockResolvedValue({ data: [SUPPRESSION_ROW], error: null });
+    expect(await getLinkSuppressions()).toEqual([SUPPRESSION_ROW]);
+
+    mocks.select.mockResolvedValue({ data: [ROW], error: null });
+    expect(await getMergeOverrides()).toEqual([ROW]);
+
+    // And invalidating one must not drop the other's memo.
+    await invalidateAdminListCache('merge-overrides');
+    mocks.store.clear();
+    mocks.select.mockResolvedValue({ data: null, error: { message: 'should not be reached' } });
+    expect(await getLinkSuppressions()).toEqual([SUPPRESSION_ROW]);
   });
 });

--- a/api/functions/__tests__/cache-prefetch.test.ts
+++ b/api/functions/__tests__/cache-prefetch.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Upstash bills per command, and the search fan-out reads one key per platform for the same
+// query. Five separate GETs per search is five billed commands where MGET is one — enough,
+// at this site's traffic, to be a real share of the 500k-command free tier. These tests pin
+// the two properties that make the batch safe to substitute for those GETs: it must not
+// invent hits, and a prefetched miss must still fetch and still write back.
+//
+// A real Redis is stubbed out (see cache-should-cache.test.ts for why that matters on the
+// Netlify build, which carries production Upstash credentials).
+
+const mocks = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  mget: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  reportRedisFailure: vi.fn(),
+}));
+
+vi.mock('../redis', () => ({
+  getRedis: () => ({
+    mget: (...keys: string[]) => mocks.mget(...keys),
+    get: (key: string) => mocks.get(key),
+    set: (key: string, value: unknown, opts: unknown) => mocks.set(key, value, opts),
+  }),
+  reportRedisFailure: mocks.reportRedisFailure,
+}));
+
+const { cachePrefetch, cacheGetOrFetch } = await import('../cache');
+
+beforeEach(() => {
+  mocks.store.clear();
+  mocks.mget.mockReset();
+  mocks.get.mockReset();
+  mocks.set.mockReset();
+  mocks.reportRedisFailure.mockReset();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  mocks.mget.mockImplementation(async (...keys: string[]) =>
+    keys.map(k => (mocks.store.has(k) ? mocks.store.get(k) : null)));
+  mocks.set.mockImplementation(async (key: string, value: unknown) => {
+    mocks.store.set(key, value);
+    return 'OK';
+  });
+});
+
+describe('cachePrefetch', () => {
+  it('reads every key in a single command', async () => {
+    mocks.store.set('artist:mirlo:x', ['a']);
+    mocks.store.set('artist:even:x', ['b']);
+
+    const found = await cachePrefetch(['artist:mirlo:x', 'artist:patreon:x', 'artist:even:x']);
+
+    expect(mocks.mget).toHaveBeenCalledTimes(1);
+    expect(mocks.mget).toHaveBeenCalledWith('artist:mirlo:x', 'artist:patreon:x', 'artist:even:x');
+    // Only the keys Redis actually held. A miss is an absent key, never a null entry — the
+    // difference is what lets cacheGetOrFetch tell "cached nothing" from "not cached".
+    expect([...found.keys()]).toEqual(['artist:mirlo:x', 'artist:even:x']);
+  });
+
+  it('spends nothing when there is nothing to read', async () => {
+    expect((await cachePrefetch([])).size).toBe(0);
+    expect(mocks.mget).not.toHaveBeenCalled();
+  });
+
+  // A failed prefetch looks exactly like a cold cache to every caller, which is why — as with
+  // cacheGet — it has to reach Sentry rather than being swallowed.
+  it('degrades to a cold cache and reports the failure', async () => {
+    mocks.mget.mockRejectedValue(new Error('upstash down'));
+
+    expect((await cachePrefetch(['artist:mirlo:x'])).size).toBe(0);
+    expect(mocks.reportRedisFailure).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cacheGetOrFetch with a prefetched batch', () => {
+  it('serves a prefetched hit without a second read', async () => {
+    mocks.store.set('artist:mirlo:x', ['cached']);
+    const prefetched = await cachePrefetch(['artist:mirlo:x']);
+
+    const fetchFn = vi.fn(async () => ['fresh']);
+    const result = await cacheGetOrFetch('artist:mirlo:x', fetchFn, 60, undefined, undefined, prefetched);
+
+    expect(result).toEqual({ data: ['cached'], cached: true });
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(mocks.get).not.toHaveBeenCalled();
+  });
+
+  // The batch is authoritative for the keys it was asked for: the caller has already asked
+  // Redis about them, so an absent key is a miss and re-reading it would spend the command
+  // the batch exists to save.
+  it('treats an absent key as a miss without re-reading it', async () => {
+    const prefetched = await cachePrefetch(['artist:mirlo:x']);
+
+    const fetchFn = vi.fn(async () => ['fresh']);
+    const result = await cacheGetOrFetch('artist:mirlo:x', fetchFn, 60, undefined, undefined, prefetched);
+
+    expect(result).toEqual({ data: ['fresh'], cached: false });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(mocks.get).not.toHaveBeenCalled();
+  });
+
+  it('still writes back on a prefetched miss, so the next search hits', async () => {
+    const prefetched = await cachePrefetch(['artist:mirlo:x']);
+    await cacheGetOrFetch('artist:mirlo:x', async () => ['fresh'], 60, undefined, undefined, prefetched);
+
+    expect(mocks.set).toHaveBeenCalledWith('artist:mirlo:x', ['fresh'], { ex: 60 });
+  });
+
+  // Batching must not weaken "never cache uncertainty" — the predicate still decides.
+  it('still refuses to cache a value the predicate rejects', async () => {
+    const prefetched = await cachePrefetch(['artist:mirlo:x']);
+    await cacheGetOrFetch('artist:mirlo:x', async () => null, 60, d => d !== null, undefined, prefetched);
+
+    expect(mocks.set).not.toHaveBeenCalled();
+  });
+
+  // The search fan-out passes the MGET *promise*, not an awaited map, so the platforms with
+  // no cache don't start a round trip later than they used to. This is the production path.
+  it('accepts the in-flight batch, so the fan-out need not wait on it', async () => {
+    mocks.store.set('artist:mirlo:x', ['cached']);
+    const inFlight = cachePrefetch(['artist:mirlo:x']);
+
+    const fetchFn = vi.fn(async () => ['fresh']);
+    const result = await cacheGetOrFetch('artist:mirlo:x', fetchFn, 60, undefined, undefined, inFlight);
+
+    expect(result).toEqual({ data: ['cached'], cached: true });
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(mocks.get).not.toHaveBeenCalled();
+    // One MGET serves every reader of the same batch, which is the whole saving.
+    expect(mocks.mget).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a single GET when no batch is supplied', async () => {
+    mocks.get.mockResolvedValue(['cached']);
+
+    const result = await cacheGetOrFetch('artist:mirlo:x', async () => ['fresh'], 60);
+
+    expect(result).toEqual({ data: ['cached'], cached: true });
+    expect(mocks.get).toHaveBeenCalledWith('artist:mirlo:x');
+  });
+});

--- a/api/functions/__tests__/ratelimit-account-tier.test.ts
+++ b/api/functions/__tests__/ratelimit-account-tier.test.ts
@@ -60,8 +60,6 @@ describe('account rate limit tier', () => {
     const prefixes = limitCalls.map(c => c.prefix).sort();
     expect(prefixes).toEqual([
       'rl:account',
-      'rl:daily:account',
-      'rl:daily:standard',
       'rl:standard',
     ]);
   });
@@ -74,6 +72,36 @@ describe('account rate limit tier', () => {
     // even with a token refresh partway through.
     const perMinute = built.find(b => b.prefix === 'rl:account');
     expect(perMinute?.window).toEqual({ tokens: 60, window: '1 m' });
+  });
+});
+
+// Each limiter is one HTTP round trip to Upstash, and Upstash bills per command — so a second
+// limiter doubles the fixed Redis cost of every request that reaches checkRateLimit, before
+// the handler does any work. That is what carried a low-traffic site through the 500k-command
+// free tier. These pin which tiers are allowed to pay it.
+describe('daily quotas are only where they earn their keep', () => {
+  it('spends one Redis round trip per request on the high-frequency tiers', async () => {
+    const { checkRateLimit } = await import('../ratelimit');
+
+    for (const tier of ['standard', 'lenient', 'account'] as const) {
+      limitCalls.length = 0;
+      await checkRateLimit('1.2.3.4', tier, {});
+      expect(limitCalls.map(c => c.prefix)).toEqual([`rl:${tier}`]);
+    }
+  });
+
+  // 'strict' fronts search, which fans out to a dozen partner sites per request, and 500/day
+  // is a documented promise to anonymous v1 API callers (docs/openapi.yaml). Worth the
+  // second round trip; the other three tiers were not.
+  it('keeps the daily quota on the expensive tier', async () => {
+    const { checkRateLimit } = await import('../ratelimit');
+
+    limitCalls.length = 0;
+    await checkRateLimit('1.2.3.4', 'strict', {});
+
+    expect(limitCalls.map(c => c.prefix).sort()).toEqual(['rl:daily:strict', 'rl:strict']);
+    expect(built.find(b => b.prefix === 'rl:daily:strict')?.window)
+      .toEqual({ tokens: 500, window: '24 h' });
   });
 });
 

--- a/api/functions/cache.ts
+++ b/api/functions/cache.ts
@@ -22,6 +22,46 @@ function redactKey(key: string): string {
 }
 
 /**
+ * Values for a set of keys, read up front in a single round trip.
+ *
+ * A key is present iff Redis held a value for it, so `has()` distinguishes a hit from a
+ * miss and an absent key is a miss, not "unknown". Pass one to `cacheGetOrFetch` and it
+ * skips its own `GET` entirely.
+ */
+export type PrefetchedCache = Map<string, unknown>;
+
+/**
+ * Read many keys in one `MGET` instead of one `GET` each.
+ *
+ * Upstash charges per command, and the search fan-out reads one key per platform for the
+ * same query — five separate billed commands, five separate HTTP round trips, every search.
+ * `MGET` is one of each. Returns an empty map when Redis is unavailable, which every caller
+ * already treats as "everything missed".
+ */
+export async function cachePrefetch(keys: string[]): Promise<PrefetchedCache> {
+  const found: PrefetchedCache = new Map();
+  if (keys.length === 0) return found;
+
+  const client = getRedis();
+  if (!client) return found;
+
+  try {
+    const values = await client.mget<unknown[]>(...keys);
+    keys.forEach((key, i) => {
+      const value = values[i];
+      if (value !== null && value !== undefined) found.set(key, value);
+    });
+    console.log(`[Cache] MGET: ${keys.length} keys, ${found.size} hit`);
+  } catch (error) {
+    // A failed prefetch is indistinguishable from a cold cache to the caller, which is
+    // why — as with cacheGet — it has to be reported rather than swallowed.
+    reportRedisFailure(`cachePrefetch(${keys.length} keys)`, error);
+  }
+
+  return found;
+}
+
+/**
  * Get a value from cache
  */
 export async function cacheGet<T>(key: string): Promise<T | null> {
@@ -72,16 +112,28 @@ export async function cacheSet<T>(key: string, value: T, ttlSeconds: number = DE
  * Give it a short value (~60s) for the useful middle ground: a hiccup heals in a minute
  * instead of persisting for the full TTL, while an outage still costs one slow request per
  * minute rather than one per search.
+ *
+ * `prefetched` lets a fan-out pay for one `MGET` instead of one `GET` per key — see
+ * `cachePrefetch`. When it is supplied it is authoritative for this key: the caller has
+ * already asked Redis, so an absent key is a miss and no second read is made.
+ *
+ * It accepts the *promise* as well as the map so the caller doesn't have to await the MGET
+ * before starting its fan-out — the platforms with no cache would otherwise all start one
+ * round trip later than they used to, which is a latency regression in exchange for a cost
+ * saving they don't share in.
  */
 export async function cacheGetOrFetch<T>(
   key: string,
   fetchFn: () => Promise<T>,
   ttlSeconds: number = DEFAULT_TTL,
   shouldCache?: (data: T) => boolean,
-  failureTtlSeconds?: number
+  failureTtlSeconds?: number,
+  prefetched?: PrefetchedCache | Promise<PrefetchedCache>
 ): Promise<{ data: T; cached: boolean }> {
   // Try cache first
-  const cached = await cacheGet<T>(key);
+  const cached = prefetched
+    ? ((await prefetched).get(key) as T | undefined) ?? null
+    : await cacheGet<T>(key);
   if (cached !== null) {
     return { data: cached, cached: true };
   }

--- a/api/functions/db.ts
+++ b/api/functions/db.ts
@@ -323,6 +323,45 @@ const MERGE_OVERRIDES_CACHE_KEY = 'admin:merge-overrides';
 const LINK_SUPPRESSIONS_CACHE_KEY = 'admin:link-suppressions';
 
 /**
+ * A second, in-process layer in front of the Redis one.
+ *
+ * Redis turned two full-table reads per search into two Redis reads per search — cheaper, but
+ * still two billed Upstash commands on the hottest path, for two lists that are identical for
+ * every visitor and change only when an admin acts. A search and the Phase 2 enrichment that
+ * follows it read them again seconds apart, on the same warm container, for the same answer.
+ *
+ * So a warm container remembers the answer for a minute. That is short enough to keep the
+ * invalidation story honest — an admin merge still lands everywhere within a minute, where the
+ * Redis delete alone made it instant — and long enough that a burst of requests through one
+ * container costs one Redis read instead of one per request. `invalidateAdminListCache` clears
+ * this container's copy too, so the admin who made the change sees it immediately.
+ *
+ * Not worth generalising into `cache.ts`: these two lists are the only values in the codebase
+ * that are global, tiny, and read on every single search.
+ */
+const ADMIN_LIST_MEMO_TTL_MS = 60 * 1000;
+const adminListMemo = new Map<string, { expiresAt: number; rows: unknown[] }>();
+
+function readAdminListMemo<T>(key: string): T[] | null {
+  const entry = adminListMemo.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    adminListMemo.delete(key);
+    return null;
+  }
+  return entry.rows as T[];
+}
+
+function writeAdminListMemo<T>(key: string, rows: T[]): void {
+  adminListMemo.set(key, { expiresAt: Date.now() + ADMIN_LIST_MEMO_TTL_MS, rows });
+}
+
+/** Test seam: drop this process's memoized admin lists. */
+export function resetAdminListMemoForTests(): void {
+  adminListMemo.clear();
+}
+
+/**
  * A read that knows whether it succeeded.
  *
  * Both of these functions return `[]` on failure *and* `[]` when the table is genuinely empty,
@@ -337,12 +376,17 @@ interface CachedAdminList<T> {
 }
 
 export async function invalidateAdminListCache(list: 'merge-overrides' | 'link-suppressions'): Promise<void> {
-  await cacheDelete(list === 'merge-overrides' ? MERGE_OVERRIDES_CACHE_KEY : LINK_SUPPRESSIONS_CACHE_KEY);
+  const key = list === 'merge-overrides' ? MERGE_OVERRIDES_CACHE_KEY : LINK_SUPPRESSIONS_CACHE_KEY;
+  adminListMemo.delete(key);
+  await cacheDelete(key);
 }
 
 export async function getMergeOverrides(): Promise<MergeOverrideRow[]> {
   const client = getClient();
   if (!client) return [];
+
+  const memoized = readAdminListMemo<MergeOverrideRow>(MERGE_OVERRIDES_CACHE_KEY);
+  if (memoized) return memoized;
 
   const { data } = await cacheGetOrFetch<CachedAdminList<MergeOverrideRow>>(
     MERGE_OVERRIDES_CACHE_KEY,
@@ -366,6 +410,11 @@ export async function getMergeOverrides(): Promise<MergeOverrideRow[]> {
     ADMIN_LIST_CACHE_TTL,
     result => result.ok
   );
+
+  // Only memoize a read that succeeded — same rule as the Redis layer, for the same reason.
+  // Remembering a failed read for a minute would suppress every merge override for a minute
+  // because Supabase blipped once.
+  if (data.ok) writeAdminListMemo(MERGE_OVERRIDES_CACHE_KEY, data.rows);
 
   return data.rows;
 }
@@ -398,6 +447,9 @@ export async function getLinkSuppressions(): Promise<
   const client = getClient();
   if (!client) return [];
 
+  const memoized = readAdminListMemo<Row>(LINK_SUPPRESSIONS_CACHE_KEY);
+  if (memoized) return memoized;
+
   const { data } = await cacheGetOrFetch<CachedAdminList<Row>>(
     LINK_SUPPRESSIONS_CACHE_KEY,
     async () => {
@@ -420,6 +472,9 @@ export async function getLinkSuppressions(): Promise<
     ADMIN_LIST_CACHE_TTL,
     result => result.ok
   );
+
+  // As above: never memoize a read that failed.
+  if (data.ok) writeAdminListMemo(LINK_SUPPRESSIONS_CACHE_KEY, data.rows);
 
   return data.rows;
 }

--- a/api/functions/ratelimit.ts
+++ b/api/functions/ratelimit.ts
@@ -17,11 +17,16 @@ let strictLimiter: Ratelimit | null = null;      // 10 req/min for expensive end
 let lenientLimiter: Ratelimit | null = null;     // 120 req/min for cheap high-frequency endpoints (typeahead)
 let accountLimiter: Ratelimit | null = null;     // 60 req/min for a signed-in user's own account endpoints
 
-// Per-day quota limiters (new)
-let standardDailyLimiter: Ratelimit | null = null;  // 1000 req/day for general
+// Per-day quota limiters.
+//
+// Only the 'strict' tier has one, and that is a deliberate cost decision — see
+// "Every daily quota doubles the bill" below. 'standard', 'lenient' and 'account' used to
+// carry 1000/5000/2000-per-day quotas that no real person has ever come close to, at the
+// price of a second Redis round trip on every page view, every typeahead keystroke and every
+// account read. 'strict' keeps its quota because it fronts search, which fans out to a dozen
+// partner sites per request, and because 500/day is a documented promise to anonymous v1 API
+// callers (docs/openapi.yaml).
 let strictDailyLimiter: Ratelimit | null = null;    // 500 req/day for expensive
-let lenientDailyLimiter: Ratelimit | null = null;   // 5000 req/day for cheap high-frequency
-let accountDailyLimiter: Ratelimit | null = null;   // 2000 req/day for account endpoints
 
 // API key tiers
 let freeLimiter: Ratelimit | null = null;        // 30 req/min
@@ -86,42 +91,6 @@ function getAccountLimiter(): Ratelimit | null {
     prefix: 'rl:account',
   });
   return accountLimiter;
-}
-
-function getAccountDailyLimiter(): Ratelimit | null {
-  if (accountDailyLimiter) return accountDailyLimiter;
-  const r = getRedis();
-  if (!r) return null;
-  accountDailyLimiter = new Ratelimit({
-    redis: r,
-    limiter: Ratelimit.slidingWindow(2000, '24 h'),
-    prefix: 'rl:daily:account',
-  });
-  return accountDailyLimiter;
-}
-
-function getLenientDailyLimiter(): Ratelimit | null {
-  if (lenientDailyLimiter) return lenientDailyLimiter;
-  const r = getRedis();
-  if (!r) return null;
-  lenientDailyLimiter = new Ratelimit({
-    redis: r,
-    limiter: Ratelimit.slidingWindow(5000, '24 h'),
-    prefix: 'rl:daily:lenient',
-  });
-  return lenientDailyLimiter;
-}
-
-function getStandardDailyLimiter(): Ratelimit | null {
-  if (standardDailyLimiter) return standardDailyLimiter;
-  const r = getRedis();
-  if (!r) return null;
-  standardDailyLimiter = new Ratelimit({
-    redis: r,
-    limiter: Ratelimit.slidingWindow(1000, '24 h'),
-    prefix: 'rl:daily:standard',
-  });
-  return standardDailyLimiter;
 }
 
 function getStrictDailyLimiter(): Ratelimit | null {
@@ -308,10 +277,9 @@ export async function checkRateLimit(
     : tier === 'lenient' ? getLenientLimiter()
     : tier === 'account' ? getAccountLimiter()
     : getStandardLimiter();
-  const dailyLimiter = tier === 'strict' ? getStrictDailyLimiter()
-    : tier === 'lenient' ? getLenientDailyLimiter()
-    : tier === 'account' ? getAccountDailyLimiter()
-    : getStandardDailyLimiter();
+  // Only 'strict' has a daily quota — see the declaration block above for why the other
+  // three lost theirs.
+  const dailyLimiter = tier === 'strict' ? getStrictDailyLimiter() : null;
 
   // If Redis isn't configured, allow the request (fail open). The getRedis() call is not
   // redundant: the limiter getters above memoize, so a cached limiter cannot tell us that
@@ -323,6 +291,14 @@ export async function checkRateLimit(
     // and this check sits in front of every API request. The cost is that a request
     // already over its daily quota also consumes a per-minute token, which is
     // harmless: the request is rejected either way.
+    //
+    // Every daily quota doubles the bill. `limiter.limit()` is one HTTP round trip to
+    // Upstash whose sliding-window script runs GET, GET, INCRBY and (on a new window)
+    // PEXPIRE, and Upstash charges per command. Adding a second limiter therefore doubles
+    // the fixed Redis cost of *every* request that reaches this function, before the
+    // handler has done any work at all. That is what took a low-traffic site through the
+    // 500k-command free tier, so a daily quota now has to earn its keep rather than being
+    // the default (2026-08-24).
     const [dailyResult, result] = await Promise.all([
       dailyLimiter ? dailyLimiter.limit(identifier) : Promise.resolve(null),
       limiter.limit(identifier),
@@ -511,11 +487,13 @@ export async function checkSentryDedup(key: string, ttlSeconds: number): Promise
   const r = getRedis();
   if (!r) return true; // Redis unavailable → don't gate Sentry on it
   try {
+    // One round trip, not two. `SET ... NX EX` answers "was I the first?" and claims the
+    // window in the same command, where the old GET-then-SET pair cost twice as much and
+    // let two containers both decide they were first. Upstash bills per command and these
+    // fire on the search path, so the halving is worth having on its own.
     const cacheKey = `sentry:dedup:${key}`;
-    const seen = await r.get(cacheKey);
-    if (seen) return false;
-    await r.set(cacheKey, '1', { ex: ttlSeconds });
-    return true;
+    const claimed = await r.set(cacheKey, '1', { ex: ttlSeconds, nx: true });
+    return claimed === 'OK';
   } catch (err) {
     // On Redis error, don't block Sentry capture — fail open
     reportRedisFailure('checkSentryDedup', err);

--- a/api/functions/search-sources.ts
+++ b/api/functions/search-sources.ts
@@ -1,7 +1,7 @@
 import { parse } from 'node-html-parser';
 import { Sentry } from '../lib/sentry';
 import { findBandcampArtist } from '../search/bandcamp-probe';
-import { cacheGetOrFetch, artistCacheKey } from './cache';
+import { cacheGetOrFetch, cachePrefetch, artistCacheKey, type PrefetchedCache } from './cache';
 import { persistSearchResults, getArtistBySlug, getArtistsBySlugs, artistSlug, getMergeOverrides, getLinkSuppressions, findKnownArtistSlugsByName } from './db';
 import { checkRateLimit, checkSentryDedup, getClientIp } from './ratelimit';
 import { validateQuery } from './middleware';
@@ -381,7 +381,7 @@ interface EnrichedMusicBrainzResult {
 // artist changes rarely, and the uncached path costs 2+ rate-limit delays plus
 // several fetches — the single slowest leg of the fan-out. Failures and
 // partial enrichments are never cached (see isCacheableMbResult).
-async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResult> {
+async function searchMusicBrainz(query: string, prefetched?: Promise<PrefetchedCache>): Promise<EnrichedMusicBrainzResult> {
   const cacheKey = artistCacheKey('mb-enriched', query);
   const { data } = await cacheGetOrFetch<EnrichedMusicBrainzResult>(
     cacheKey,
@@ -389,6 +389,7 @@ async function searchMusicBrainz(query: string): Promise<EnrichedMusicBrainzResu
     PLATFORM_CACHE_TTL,
     isCacheableMbResult,
     PLATFORM_FAILURE_CACHE_TTL,
+    prefetched,
   );
   return data;
 }
@@ -713,7 +714,7 @@ async function fetchMusicBrainzEnrichment(query: string): Promise<EnrichedMusicB
 // partial queries and differently-slugged artists were invisible. The API matches
 // server-side (loosely; parseMirloArtistSearch re-filters), so "argent" now finds
 // "The Argent Grub" at mirlo.space/the-argent-grub.
-async function searchMirlo(query: string): Promise<PlatformResult[]> {
+async function searchMirlo(query: string, prefetched?: Promise<PrefetchedCache>): Promise<PlatformResult[]> {
   const cacheKey = artistCacheKey('mirlo', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on mirlo" -- see the shouldCache predicate below.
@@ -752,6 +753,7 @@ async function searchMirlo(query: string): Promise<PlatformResult[]> {
     () => !fetchFailed,
     // ...but remember it briefly so an outage doesn't cost every search the timeout.
     PLATFORM_FAILURE_CACHE_TTL,
+    prefetched,
   );
 
   return data;
@@ -928,7 +930,7 @@ async function searchJamcoop(query: string): Promise<Map<string, NameOnlyEntry>>
   return results;
 }
 
-async function searchPatreon(query: string): Promise<Map<string, NameOnlyEntry>> {
+async function searchPatreon(query: string, prefetched?: Promise<PrefetchedCache>): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('patreon', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on patreon" -- see the shouldCache predicate below.
@@ -1001,6 +1003,7 @@ async function searchPatreon(query: string): Promise<Map<string, NameOnlyEntry>>
     () => !fetchFailed,
     // ...but remember it briefly so an outage doesn't cost every search the timeout.
     PLATFORM_FAILURE_CACHE_TTL,
+    prefetched,
   );
 
   return coerceNameOnlyCache(data);
@@ -1015,54 +1018,23 @@ function coerceNameOnlyCache(data: [string, NameOnlyEntry | string][]): Map<stri
   ));
 }
 
-// Search Ampwall with Redis caching to minimize API load
-// Cache TTL: 30 minutes (1800 seconds)
-const AMPWALL_CACHE_TTL = 30 * 60;
-
-async function searchAmpwall(query: string): Promise<Map<string, string>> {
-  const cacheKey = artistCacheKey('ampwall', query);
-  // No shouldCache guard here: this is still a stub with no outbound request, so it
-  // cannot fail and its empty result is a genuine answer rather than a hidden error.
-  const { data, cached } = await cacheGetOrFetch<[string, string][]>(
-    cacheKey,
-    async () => {
-      const results: [string, string][] = [];
-
-      // TODO: Replace this with actual Ampwall API call when available
-      // Expected API format TBD - placeholder implementation
-      //
-      // Example expected implementation:
-      // const apiUrl = `https://api.ampwall.com/search?q=${encodeURIComponent(query)}`;
-      // const response = await fetchWithTimeout(apiUrl, {
-      //   headers: {
-      //     'Authorization': `Bearer ${process.env.AMPWALL_API_KEY}`,
-      //     'Accept': 'application/json',
-      //   },
-      // }, 5000);
-      //
-      // if (response.ok) {
-      //   const data = await response.json();
-      //   for (const artist of data.artists || []) {
-      //     const normalizedName = normalizeForComparison(artist.name);
-      //     results.push([normalizedName, artist.url]);
-      //   }
-      // }
-
-      return results;
-    },
-    AMPWALL_CACHE_TTL
-  );
-
-  if (cached) {
-    console.log('[Ampwall] Cache hit');
-  }
-
-  // Convert array back to Map (Redis doesn't serialize Maps well)
-  return new Map(data);
+// Ampwall has no public search API yet, so this is still a stub: it makes no outbound
+// request and returns nothing.
+//
+// It used to run that empty result through Redis, which cost a GET on every search — and a
+// SET on every miss — to remember an answer that is a compile-time constant. Upstash bills
+// per command, so that was two commands per search buying nothing. Cache it again when there
+// is a real fetch here to cache, and use the same shouldCache/failure-TTL shape the other
+// platforms use so a failed Ampwall call is never stored as "artist not on Ampwall".
+async function searchAmpwall(_query: string): Promise<Map<string, string>> {
+  // TODO: Replace with a real Ampwall API call when one exists. Expected shape:
+  //   GET https://api.ampwall.com/search?q=<query> -> { artists: [{ name, url }] }
+  // keyed into the map as [normalizeForComparison(name), url].
+  return new Map();
 }
 
 // Search Beatport via __NEXT_DATA__ JSON embedded in search page
-async function searchBeatport(query: string): Promise<Map<string, NameOnlyEntry>> {
+async function searchBeatport(query: string, prefetched?: Promise<PrefetchedCache>): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('beatport', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on beatport" -- see the shouldCache predicate below.
@@ -1139,13 +1111,14 @@ async function searchBeatport(query: string): Promise<Map<string, NameOnlyEntry>
     () => !fetchFailed,
     // ...but remember it briefly so an outage doesn't cost every search the timeout.
     PLATFORM_FAILURE_CACHE_TTL,
+    prefetched,
   );
 
   return coerceNameOnlyCache(data);
 }
 
 // Search EVEN via Algolia API (direct-to-fan marketplace)
-async function searchEven(query: string): Promise<Map<string, NameOnlyEntry>> {
+async function searchEven(query: string, prefetched?: Promise<PrefetchedCache>): Promise<Map<string, NameOnlyEntry>> {
   const cacheKey = artistCacheKey('even', query);
   // Set when the upstream did not answer. A failure must not be cached as
   // "this artist isn't on even" -- see the shouldCache predicate below.
@@ -1212,6 +1185,7 @@ async function searchEven(query: string): Promise<Map<string, NameOnlyEntry>> {
     () => !fetchFailed,
     // ...but remember it briefly so an outage doesn't cost every search the timeout.
     PLATFORM_FAILURE_CACHE_TTL,
+    prefetched,
   );
 
   return coerceNameOnlyCache(data);
@@ -1667,18 +1641,35 @@ async function searchAllPlatforms(query: string, mode: SearchMode): Promise<{ re
   // Same for admin link suppressions, applied last (Phase 5).
   const suppressionsPromise = getLinkSuppressions();
 
+  // Every Redis-cached platform reads one key derived from this same query, so read them all
+  // in one MGET rather than one GET per platform. Upstash bills per command and this is the
+  // busiest endpoint on the site: five commands and five round trips became one. The fetchers
+  // below still own their own TTLs, shouldCache predicates and write-backs — only the read is
+  // shared.
+  //
+  // Deliberately not awaited: the platforms with no cache (Bandcamp, Bandwagon, Faircamp,
+  // Jam.coop) would otherwise all start a round trip later than they do today, paying latency
+  // for a saving they have no part in. cacheGetOrFetch awaits this promise itself.
+  const prefetched = cachePrefetch([
+    artistCacheKey('mirlo', query),
+    artistCacheKey('patreon', query),
+    artistCacheKey('beatport', query),
+    artistCacheKey('even', query),
+    artistCacheKey('mb-enriched', query),
+  ]);
+
   // Phase 1: Search all platforms in parallel and aggregate Bandcamp/Mirlo results
   const [bandcampResults, bandwagonResults, mirloResults, faircampResults, jamcoopResults, patreonResults, ampwallResults, beatportResults, evenResults, musicbrainzResult] = await Promise.allSettled([
     searchBandcamp(query),
     searchBandwagon(query),
-    searchMirlo(query),
+    searchMirlo(query, prefetched),
     searchFaircamp(query),
     searchJamcoop(query),
-    searchPatreon(query),
+    searchPatreon(query, prefetched),
     searchAmpwall(query),
-    searchBeatport(query),
-    searchEven(query),
-    searchMusicBrainz(query),
+    searchBeatport(query, prefetched),
+    searchEven(query, prefetched),
+    searchMusicBrainz(query, prefetched),
   ]);
 
   // UC6: Capture partial platform failures for monitoring

--- a/apps/extension/background/service-worker.js
+++ b/apps/extension/background/service-worker.js
@@ -19,7 +19,10 @@ import {
 } from '../lib/release-alerts.js';
 
 const API_BASE = 'https://unstream.stream/api';
-const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+// 30 minutes, matching PLATFORM_CACHE_TTL in api/functions/search-sources.ts. Being fresher
+// than the backend's own platform cache buys nothing, and at five minutes this cache expired
+// faster than a song is long — so a listener changing tracks missed it every single time.
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 const DEBOUNCE_MS = 2000; // 2 seconds debounce for same artist
 const RELEASE_CHECK_ALARM = 'releaseCheck';
 
@@ -170,42 +173,47 @@ async function handleMusicDetection(data, tabId) {
   // Track extension activation with streaming service
   trackAppEvent('extension_activated', { streaming_service: source || 'unknown' });
 
-  // Fetch results
-  try {
-    const data = await searchArtist(artist);
-    const results = data.results || [];
+  // Read through the cache rather than always fetching.
+  //
+  // This used to call searchArtist() directly, which meant it *wrote* `cache:${artist}` on
+  // every track and never once read it — the cache was populated and then ignored. The
+  // content script sends MUSIC_DETECTED on every title change, so playing one artist's album
+  // fired an identical /api/search/sources for all twelve tracks, and the 2-second debounce
+  // never caught them because tracks are minutes apart. Each of those requests costs real
+  // Upstash commands on a metered free tier.
+  const { results, error } = await getResults(artist);
 
-    // Store results
-    await chrome.storage.local.set({
-      [`cache:${artist}`]: { results, timestamp: now }
-    });
-
-    // Track search (product analytics)
-    trackAppEvent('search', { has_results: results.length > 0, result_count: results.length });
-
-    // Track search appearances for claimed artists
-    for (const result of results) {
-      if (result.type === 'artist' && result.claimedSlug) {
-        trackAnalyticsEvent(result.claimedSlug, 'search');
-      }
-    }
-
-    // Update badge based on results
-    if (results.length > 0) {
-      updateBadge('found', results.length);
-
-      // Send artist detection notification if enabled
-      await maybeNotifyArtist(artist, results);
-    } else {
-      updateBadge('none');
-    }
-
-    // Trigger enrichment in background
-    enrichArtist(artist);
-  } catch (error) {
+  // getResults swallows the failure and reports it, so the error badge has to come from the
+  // reported error — treating a failed fetch as "no results" would tell the listener this
+  // artist isn't on any platform when we simply couldn't ask.
+  if (error) {
     console.error('Search error:', error);
     updateBadge('error');
+    return;
   }
+
+  // Analytics fire on every detection, cache hit or not. A listener really did play this
+  // artist, so the artist's search appearance is a real event wherever the results came
+  // from — suppressing it on a cache hit would under-report to the artist.
+  trackAppEvent('search', { has_results: results.length > 0, result_count: results.length });
+
+  for (const result of results) {
+    if (result.type === 'artist' && result.claimedSlug) {
+      trackAnalyticsEvent(result.claimedSlug, 'search');
+    }
+  }
+
+  if (results.length > 0) {
+    updateBadge('found', results.length);
+
+    // Send artist detection notification if enabled
+    await maybeNotifyArtist(artist, results);
+  } else {
+    updateBadge('none');
+  }
+
+  // Trigger enrichment in background (cached separately, see enrichArtist)
+  enrichArtist(artist);
 }
 
 // Handle when music stops playing

--- a/apps/web/tests/unit/ratelimit.test.ts
+++ b/apps/web/tests/unit/ratelimit.test.ts
@@ -4,6 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // checkSentryDedup unit tests
 // ---------------------------------------------------------------------------
 //
+// checkSentryDedup fires on the search path — zero-result searches, per-platform failures,
+// dead Bandcamp links — so its cost is paid per search, sometimes several times over. It used
+// to be a GET followed by a SET: two billed Upstash commands to answer one question, and a
+// race where two containers could both read "not seen" and both capture. `SET ... NX EX` does
+// both halves in one command, atomically. These tests pin that, and pin that Redis can never
+// silence Sentry.
+//
 // Strategy: We mock @upstash/redis at the module level. The ratelimit module
 // has a module-level `redis` variable that caches the Redis client created by
 // getRedis(). To test different scenarios (Redis configured vs not), we
@@ -54,43 +61,43 @@ describe('checkSentryDedup', () => {
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
-  it('returns true on first call (key not seen before)', async () => {
-    mockGet.mockResolvedValue(null);
+  it('claims the window in one command, not a GET then a SET', async () => {
     mockSet.mockResolvedValue('OK');
 
     const result = await checkSentryDedup('uc5:radiohead', 86400);
     expect(result).toBe(true);
-    expect(mockGet).toHaveBeenCalledWith('sentry:dedup:uc5:radiohead');
-    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc5:radiohead', '1', { ex: 86400 });
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc5:radiohead', '1', { ex: 86400, nx: true });
   });
 
+  // NX returns null when the key already exists — that is the "already captured" answer, and
+  // it costs the same single command the first occurrence did.
   it('returns false on second call (key already seen within TTL)', async () => {
-    mockGet.mockResolvedValue('1');
+    mockSet.mockResolvedValue(null);
 
     const result = await checkSentryDedup('uc5:radiohead', 86400);
     expect(result).toBe(false);
-    // Should NOT set again when already seen
-    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledTimes(1);
   });
 
+  // Redis must never be able to silence Sentry: an outage that suppressed error reporting is
+  // exactly the failure mode api/functions/redis.ts was written to prevent.
   it('returns true (fail-open) when Redis throws an error', async () => {
-    mockGet.mockRejectedValue(new Error('Redis connection failed'));
+    mockSet.mockRejectedValue(new Error('Redis connection failed'));
 
     const result = await checkSentryDedup('uc5:radiohead', 86400);
     expect(result).toBe(true);
   });
 
   it('uses the provided key and TTL correctly', async () => {
-    mockGet.mockResolvedValue(null);
     mockSet.mockResolvedValue('OK');
 
     await checkSentryDedup('uc6:bandcamp:fetch failed', 3600);
-    expect(mockGet).toHaveBeenCalledWith('sentry:dedup:uc6:bandcamp:fetch failed');
-    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc6:bandcamp:fetch failed', '1', { ex: 3600 });
+    expect(mockSet).toHaveBeenCalledWith('sentry:dedup:uc6:bandcamp:fetch failed', '1', { ex: 3600, nx: true });
   });
 
   it('handles empty key strings', async () => {
-    mockGet.mockResolvedValue(null);
     mockSet.mockResolvedValue('OK');
 
     // Edge case: empty normalizedQuery or errorMessage


### PR DESCRIPTION
The site went through Upstash's 500,000-commands-a-month free tier at
genuinely low traffic. Nothing here is expensive per request; there are
just a lot of small requests, each paying a fixed Redis tax before doing
any work. One user search is ~10 API calls (4-5 debounced typeahead
requests, the search itself, the enrichment call, two or three analytics
POSTs, an artist page), so per-request overhead is multiplied by ten
before a single search happens.

Four changes, each removing round trips rather than capability:

- checkRateLimit ran a per-minute AND a per-day limiter on every tier, so
  every request paid twice over. Only 'strict' keeps a daily quota: it
  fronts search, which fans out to a dozen partner sites, and its 500/day
  is a documented promise to anonymous v1 callers. The 1000/5000/2000-a-day
  quotas on 'standard', 'lenient' and 'account' were never close to being
  reached; their per-minute windows (30/120/60) still bound the damage.

- The search fan-out read one cache key per platform for the same query —
  five GETs, five round trips. cachePrefetch does them in one MGET, handed
  to each fetcher through cacheGetOrFetch's new `prefetched` argument. The
  fetchers keep their own TTLs, shouldCache predicates and write-backs; only
  the read is shared. It takes the in-flight promise rather than an awaited
  map so the uncached platforms don't start a round trip later than before.

- checkSentryDedup was a GET followed by a SET: two commands to answer one
  question, and a race where two containers could both decide they were
  first. Now one SET ... NX EX.

- searchAmpwall is still a stub with no outbound request, and it ran its
  empty result through Redis — a GET per search plus a SET per miss to
  remember a compile-time constant.

Also puts getMergeOverrides / getLinkSuppressions behind a 60-second
in-process memo. They are read on every search and again during Phase 2
enrichment, and are identical for every visitor. Sixty seconds keeps
invalidateAdminListCache meaningful: an admin edit still lands everywhere
within a minute, and the admin who made it sees it immediately.

The trade worth naming: dropping three daily quotas means a slow scraper
staying under the per-minute limit is no longer capped at a day's total on
those tiers. Search — the endpoint that costs partners something — keeps
its cap, which is the one that matters.

CLAUDE.md gains a section on the constraint so the next change to a limiter
or a cached lookup starts from the round-trip cost.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RJxhmjxpTnMRWRs1v5T44x