### PR TITLE
Stop pinning returning visitors to a build that no longer exists

### DIFF
--- a/apps/web/src/services/registerServiceWorker.ts
+++ b/apps/web/src/services/registerServiceWorker.ts
@@ -41,12 +41,67 @@ export function registerServiceWorker(): void {
 }
 
 function register(): void {
-  navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((error: unknown) => {
-    Sentry.addBreadcrumb({
-      category: 'pwa',
-      level: 'info',
-      message: 'Service worker registration declined',
-      data: { reason: error instanceof Error ? error.message : String(error) },
+  navigator.serviceWorker
+    .register('/sw.js', { scope: '/' })
+    .then(watchForUpdates)
+    .catch((error: unknown) => {
+      Sentry.addBreadcrumb({
+        category: 'pwa',
+        level: 'info',
+        message: 'Service worker registration declined',
+        data: { reason: error instanceof Error ? error.message : String(error) },
+      })
     })
+}
+
+/**
+ * Never re-check more often than this. A tab flipped between repeatedly shouldn't ask on every
+ * flip; half an hour is far quicker than deploys land and costs a conditional request that the
+ * ETag answers with a 304.
+ */
+const MIN_CHECK_INTERVAL_MS = 30 * 60 * 1000
+
+/**
+ * Re-check `/sw.js` whenever the tab comes back to the foreground.
+ *
+ * `register()` above already triggers one check per page load — but this is a single-page app,
+ * so moving between routes is not a navigation and never triggers another. A tab left open for
+ * days therefore asks exactly once, on the load that opened it, and then keeps serving whatever
+ * that worker precached no matter how many deploys go out. When the precached build's chunks
+ * are eventually deleted from the CDN, its routes render deleted code or fail to open at all.
+ *
+ * Coming back to a tab is the moment worth spending a request on: it is when someone is about
+ * to use the page, and it is exactly the long-idle case that a per-load check cannot reach.
+ * It also means the refresh offered by StaleBuildBanner can deliver a new build — a reload with
+ * a stale worker is served the same precached shell, so the banner would otherwise reappear
+ * forever having changed nothing.
+ *
+ * Registration has just performed its own check, so the clock starts now rather than at zero.
+ */
+function watchForUpdates(registration: ServiceWorkerRegistration): void {
+  let lastCheck = Date.now()
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'visible') return
+    if (Date.now() - lastCheck < MIN_CHECK_INTERVAL_MS) return
+    lastCheck = Date.now()
+    void checkForUpdate(registration)
   })
+}
+
+/**
+ * Ask the browser to re-fetch `/sw.js` and install a new worker if one is there.
+ *
+ * Exported so the test can await the swallowed rejection — at the call site above the promise
+ * is floating, and an unhandled rejection is precisely what this catch exists to prevent:
+ * Sentry's global handler reports one at error level, which is how the declined-registration
+ * bug in the docstring above reached the issue tracker in the first place.
+ */
+export async function checkForUpdate(registration: ServiceWorkerRegistration): Promise<void> {
+  try {
+    await registration.update()
+  } catch {
+    // Offline, or a browser that refuses the check. Nothing to do and nothing worth
+    // reporting — the next time they focus the tab, we ask again.
+  }
 }

--- a/apps/web/tests/unit/register-service-worker.test.ts
+++ b/apps/web/tests/unit/register-service-worker.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { addBreadcrumb } from '@sentry/react';
-import { registerServiceWorker } from '../../src/services/registerServiceWorker';
+import { registerServiceWorker, checkForUpdate } from '../../src/services/registerServiceWorker';
 
 vi.mock('@sentry/react', () => ({ addBreadcrumb: vi.fn() }));
 
@@ -13,10 +13,14 @@ vi.mock('@sentry/react', () => ({ addBreadcrumb: vi.fn() }));
  * a breadcrumb, not an event.
  */
 const register = vi.fn();
+const update = vi.fn<() => Promise<unknown>>();
+/** The registration register() resolves with; watchForUpdates calls .update() on it. */
+const registration = { update } as unknown as ServiceWorkerRegistration;
 // Registration is deferred to window 'load'. Capturing the listener beats
 // dispatching the real event, which would also re-run listeners left behind by
 // earlier tests, against a navigator they no longer expect.
 const listen = vi.spyOn(window, 'addEventListener');
+const docListen = vi.spyOn(document, 'addEventListener');
 
 function stubServiceWorker(value: unknown) {
   Object.defineProperty(navigator, 'serviceWorker', {
@@ -44,8 +48,27 @@ async function settle() {
   await Promise.resolve();
 }
 
+/**
+ * Sets the tab's visibility and runs the listener registered by THIS test.
+ *
+ * Captured rather than dispatched, for the same reason as `fireLoad` above: every test
+ * registers another listener on the shared jsdom document, and a real event would re-run all
+ * of them against a registration they no longer expect.
+ */
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+  const handlers = docListen.mock.calls.filter(([type]) => type === 'visibilitychange');
+  const latest = handlers[handlers.length - 1];
+  if (latest) (latest[1] as EventListener)(new Event('visibilitychange'));
+}
+
 beforeEach(() => {
-  register.mockReset().mockResolvedValue({});
+  register.mockReset().mockResolvedValue(registration);
+  update.mockReset().mockResolvedValue(registration);
+  vi.useRealTimers();
+  listen.mockClear();
+  docListen.mockClear();
+  Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
   vi.mocked(addBreadcrumb).mockClear();
   listen.mockClear();
   stubServiceWorker({ register });
@@ -102,5 +125,74 @@ describe('registerServiceWorker', () => {
     await fireLoad();
 
     expect(register).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * register() triggers one check per page load, but this is a SPA — route changes are not
+ * navigations, so a tab left open never asks again. That is how a browser ends up serving a
+ * precached build whose chunks the CDN has since deleted.
+ */
+describe('checking for a new service worker', () => {
+  it('re-checks when the tab comes back to the foreground', async () => {
+    registerServiceWorker();
+    await fireLoad();
+    expect(update).not.toHaveBeenCalled();
+
+    // Long enough to clear the throttle that starts at registration.
+    vi.setSystemTime(new Date(Date.now() + 31 * 60 * 1000));
+    setVisibility('hidden');
+    setVisibility('visible');
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not check while the tab is going into the background', async () => {
+    registerServiceWorker();
+    await fireLoad();
+    vi.setSystemTime(new Date(Date.now() + 31 * 60 * 1000));
+
+    setVisibility('hidden');
+
+    // Spending a request on a tab nobody is looking at is the one case this shouldn't cover.
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('throttles a tab being flipped between repeatedly', async () => {
+    registerServiceWorker();
+    await fireLoad();
+    vi.setSystemTime(new Date(Date.now() + 31 * 60 * 1000));
+
+    for (let i = 0; i < 5; i++) {
+      setVisibility('hidden');
+      setVisibility('visible');
+    }
+
+    // Five flips, one request — the throttle re-arms on the first.
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks again once the throttle window has passed', async () => {
+    registerServiceWorker();
+    await fireLoad();
+
+    vi.setSystemTime(new Date(Date.now() + 31 * 60 * 1000));
+    setVisibility('hidden');
+    setVisibility('visible');
+    vi.setSystemTime(new Date(Date.now() + 31 * 60 * 1000));
+    setVisibility('hidden');
+    setVisibility('visible');
+
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it('survives a check that fails offline', async () => {
+    // update() rejects when the browser can't reach the network. The call site lets that promise
+    // float, so an escaping rejection becomes an unhandled rejection — which Sentry's global
+    // handler reports at error level, turning someone's train journey into an issue.
+    update.mockRejectedValue(new Error('Failed to fetch'));
+
+    await expect(checkForUpdate(registration)).resolves.toBeUndefined();
+    expect(update).toHaveBeenCalled();
   });
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,25 @@
   [headers.values]
     Cache-Control = "no-store, max-age=0"
 
+# The one file that must never be answered from cache, for the same reason as the one above —
+# and the pair belongs together. `/build-id.json` is how staleness is DETECTED; this is how it
+# gets RESOLVED. The browser discovers a new worker only by re-fetching /sw.js, so under
+# Netlify's default `max-age=14400` that check can be satisfied by a four-hour-old copy while
+# the installed worker keeps serving its precached build.
+#
+# That is not theoretical: on 2026-08-24 a Safari session was pinned to a build whose
+# /assets/* had all been deleted, running that dead code until it threw. Protecting only the
+# detector is the worst of both — the banner appears, and the refresh behind it re-serves the
+# very build it is warning about.
+#
+# `max-age=0, must-revalidate` rather than `no-store`: it still forces a check on every
+# request, but lets the ETag answer 304 instead of resending the file. It is also exactly what
+# Netlify already serves for index.html, which has the identical requirement.
+[[headers]]
+  for = "/sw.js"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
 [[headers]]
   for = "/*"
   # connect-src note: Sentry's ingest host is region-scoped — ours is


### PR DESCRIPTION
Fixes the `/admin/analytics` crash reported against Safari. **This is the actual fix for that** — #476, despite being found during the same investigation, was a separate privacy defect and never addressed this.

## What was happening

A Safari session was running these files:

| | that browser | the server |
|---|---|---|
| entry bundle | `index-Ch6htvZM.js` | **404** |
| analytics chunk | `AdminAnalyticsPage-DOGB72rb.js` | **404** |

Both 404 (`/assets/*` has returned a real 404 since #472), so the browser was executing **deleted code** served out of the service worker's precache. That dead code threw `undefined is not an object (evaluating 'u.map')` on every visit to `/admin/analytics`.

The same account in Firefox worked perfectly, which is what ruled out the server.

Nothing about the endpoint was wrong. Ruled out along the way, each by checking rather than reasoning: the migration #475 depends on is applied (`supabase-migrate` green on its merge commit); `ADMIN_EMAIL` is set in production and matches the frontend's hardcoded constant; the migration grants EXECUTE to `service_role`; routing is fine (`/api/analytics/dashboard` returns a clean JSON 401 unauthenticated); and the success response shape is **byte-identical** before and after #475.

The worker had simply never updated. Two reasons, both fixed here.

## 1. `/sw.js` was cached for four hours

There was no header rule for it, so it inherited Netlify's default:

```
cache-control: public, max-age=14400, must-revalidate
```

The browser discovers a new worker *only* by re-fetching that file. Under a four-hour cache, that check can be answered from cache while the installed worker keeps serving its precached build.

`netlify.toml` already does exactly this for `/build-id.json`, with a comment reading *"A cached response would echo the tab's own build back to it forever."* Same reasoning, one file over. And protecting only the detector is the worst of both: `StaleBuildBanner` appears, and the reload behind it is served the same precached shell — so it can nag indefinitely having changed nothing.

Uses `max-age=0, must-revalidate` rather than `no-store`: still a guaranteed check, but the ETag can answer 304 instead of resending. It's also exactly what Netlify already serves for `index.html`, which has the identical requirement.

## 2. Nothing ever called `registration.update()`

`register()` triggers one check per page load — but this is a SPA, so route changes aren't navigations and never trigger another. A tab open for days asked exactly once, on the load that opened it.

It now re-checks when the tab returns to the foreground: the moment someone is about to use the page, and precisely the long-idle case a per-load check can't reach. Throttled to 30 minutes — far quicker than deploys land, and a conditional request the ETag answers with a 304.

This also makes the banner's Refresh button able to deliver on its promise, since by the time someone clicks it the tab has been foregrounded and the worker has had its chance to update.

`checkForUpdate` is exported so the test can await the rejection it swallows — at the call site the promise floats, and an unhandled rejection is exactly what the catch prevents. Sentry reports those at error level, which is how the declined-registration bug in this file's own docstring was originally found.

## Verification

- `npm run verify` green — **1332** API tests, **803** web unit tests.
- **5 new tests, each checked against a mutated source.** Removing the visibility guard, the throttle, the `.catch()`, or the `.then(watchForUpdates)` each fails at least one test. (My first version of the offline test was toothless — it passed with the `.catch()` removed — so it was restructured until it bit.)
- Verified **without deploying**: `netlify.toml` parses and registers the rule, and `/build-id.json` proves this rule shape already overrides Netlify's default on this site — it serves `no-store,max-age=0` rather than the 4h default.

## Not fixed here

`AppErrorFallback` is passed as a static element (`fallback={<AppErrorFallback />}`), so it never receives the error — yet it tells everyone *"that normally means a new version shipped while this page was open"* for **every** crash anywhere in the app. It was right this time by luck, and it cost real time during this investigation by asserting a cause it hadn't checked. Wiring it to `isStaleBuildAssetError`, which already exists in `sentry.ts`, would make it honest. Happy to do it as a follow-up.

Anyone already stuck needs to clear the worker once — in Safari, Develop → Service Workers → unregister, or Settings → Privacy → Manage Website Data. This change prevents it recurring; it can't reach a browser that's already pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)